### PR TITLE
docs: bootstrap project with roadmap, ADRs, CI, and release infrastructure

### DIFF
--- a/.github/.markdownlint.json
+++ b/.github/.markdownlint.json
@@ -1,0 +1,7 @@
+{
+  "default": true,
+  "MD013": false,
+  "MD033": false,
+  "MD041": false,
+  "MD060": false
+}

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @kafkade

--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,4 @@
+github: kafkade
+buy_me_a_coffee: kafkade
+patreon: kafkade
+ko_fi: kafkade

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,76 @@
+name: Bug Report
+description: Report a bug in Toku
+title: "[Bug]: "
+labels: ["bug", "triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reporting a bug! Please fill out the form below to help us investigate.
+  - type: dropdown
+    id: component
+    attributes:
+      label: Crate / Component
+      description: Which part of Toku is affected?
+      options:
+        - CLI (toku-cli)
+        - Core library (toku-core)
+        - Database / search (toku-db)
+        - Import (toku-import)
+        - Metadata fetch (toku-meta)
+        - Export (toku-export)
+        - Documentation
+        - Other
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: Version
+      description: "Toku version or commit hash (`toku --version`)"
+      placeholder: "0.1.0 or abc1234"
+  - type: dropdown
+    id: os
+    attributes:
+      label: Operating system
+      options:
+        - macOS
+        - Linux
+        - Windows
+        - Other
+    validations:
+      required: true
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: Describe the bug. What did you observe?
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      description: How can we reproduce this behavior?
+      placeholder: |
+        1. Run `toku add --isbn 9780441013593`
+        2. Run `toku show "Dune"`
+        3. See error
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: What did you expect to happen?
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant log output
+      description: Paste any relevant terminal output or error messages
+      render: shell
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Any other information that might help (library size, import source, etc.)

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security Vulnerability
+    url: https://github.com/kafkade/toku/security/advisories/new
+    about: Report security vulnerabilities via GitHub's private reporting (do not open a public issue)

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,66 @@
+name: Feature Request
+description: Suggest a new feature or improvement
+title: "[Feature]: "
+labels: ["enhancement", "triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for suggesting a feature! Please describe your idea below.
+
+        **Note:** Toku is a personal, offline-first tool with no social features.
+        Features that require a server for core functionality or add social
+        interactions (friends, feeds, shared reviews) are out of scope.
+  - type: textarea
+    id: problem
+    attributes:
+      label: Is this related to a problem?
+      description: A clear description of the problem this would solve
+      placeholder: "I'm frustrated when..."
+  - type: textarea
+    id: solution
+    attributes:
+      label: Describe the feature
+      description: A clear description of what you'd like to happen
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Describe any alternatives you've considered
+  - type: dropdown
+    id: component
+    attributes:
+      label: Crate / Component
+      description: Which part of Toku would this affect?
+      options:
+        - CLI (toku-cli)
+        - Core library (toku-core)
+        - Database / search (toku-db)
+        - Import (toku-import) — new import source
+        - Metadata fetch (toku-meta)
+        - Export (toku-export) — new export format
+        - Documentation
+        - Not sure
+  - type: dropdown
+    id: phase
+    attributes:
+      label: Which roadmap phase does this relate to?
+      description: See ROADMAP.md for phase details
+      options:
+        - "Phase 0: First Book"
+        - "Phase 1: MVP"
+        - "Phase 2: Reading Tracker"
+        - "Phase 3: Analytics & Polish (1.0)"
+        - "Phase 4: Web Interface"
+        - "Phase 5: Native Apps"
+        - "Phase 6: File Management"
+        - "Phase 7: Sync"
+        - "Phase 8: Moonshots"
+        - "Not sure"
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Any other information, mockups, or screenshots

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,68 @@
+# Copilot Instructions for Toku
+
+## Project Overview
+
+Toku (読く — Japanese for "to read") is a private, offline-first personal book manager. It combines the metadata depth of Calibre, the reading tracking of Goodreads, and the analytics of StoryGraph — without any social features. The project is in early development (Phase 0).
+
+## Non-Negotiable Constraints
+
+Every code contribution, architecture decision, and feature design must uphold these:
+
+1. **Local-first** — The app must work fully offline. All core features (library management, reading tracking, statistics, search, import, export) function without an internet connection. Network access is only for optional metadata enrichment.
+2. **No social features** — No friends, followers, feeds, book clubs, or shared reviews. This is a personal tool. The user is the sole audience for their data.
+3. **User data ownership** — The user owns 100% of their data in portable, open formats. Full export at any time. No vendor lock-in.
+4. **Import as a superpower** — Importing from Goodreads, Calibre, and StoryGraph must be frictionless, idempotent, and lossless. Import quality is a first-impression feature.
+5. **CLI-first** — The CLI is the primary interface and a first-class product. Web, iOS, macOS, and Windows are future platforms built on the same core library.
+
+## Architecture
+
+Cargo workspace with 6 crates:
+
+- `toku-core/` — Domain models, traits, state machine, statistics engine. Pure Rust, no I/O. Compiles to native, WASM, FFI.
+- `toku-db/` — SQLite persistence, schema migrations (refinery), FTS5 full-text search.
+- `toku-import/` — Import implementations: Goodreads CSV, Calibre metadata.db, StoryGraph.
+- `toku-meta/` — Metadata fetching: Open Library API (primary), Google Books (fallback). Cover image downloading.
+- `toku-cli/` — CLI binary (clap v4). The main entry point.
+- `toku-export/` — Export implementations: CSV, JSON, Markdown, BibTeX, canonical backup.
+
+### Data Boundary Rule
+
+| Data Type | Storage | Network? |
+|---|---|---|
+| User's book library, reading sessions, notes, ratings | Local SQLite (encrypted at rest if sync enabled) | Never sent unless sync opted in |
+| Book metadata from APIs | Cached locally after fetch | Open Library / Google Books (optional) |
+| Cover images | Local filesystem, content-addressed (SHA-256) | Fetched once, stored locally forever |
+| Import source data (Goodreads CSV, Calibre DB) | Parsed on-device, stored in local DB | Never leaves device |
+| Statistics and analytics | Computed locally from user data | Never sent anywhere |
+
+### Key Data Model Decisions
+
+- **Book = Edition** for MVP. A nullable `work_id` column enables Work grouping in Phase 3.
+- **Ratings**: 0–10 integer, displayed as 5★ with half-star increments. Goodreads-compatible.
+- **Identifiers**: ISBN-10, ISBN-13, ASIN, Open Library ID, Goodreads ID. Books without ISBNs are fully supported.
+- **Contributors**: Author, Editor, Translator, Illustrator, Narrator (audiobooks) — via BookAuthor join table with role enum.
+- **Provenance**: Every metadata field tracks its source (user entry, Goodreads import, Open Library API) and timestamp. User edits always take precedence.
+
+## Conventions
+
+- **License**: MIT — all contributions must be compatible
+- **PR title format**: `feat:`, `fix:`, `docs:`, `test:`, `refactor:`, `chore:`
+- **Commit trailer**: Include `Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>` when Copilot contributes
+- **Error handling**: `thiserror` for library crates, `anyhow` for CLI binary. No `unwrap()` in user-facing paths.
+- **CLI output**: Respect `NO_COLOR` env var. Support `--format table|json|csv` for all list commands.
+- **Database migrations**: Use `refinery` with embedded SQL migrations. Migrations are idempotent.
+- **Import idempotency**: Every importer stores source IDs (e.g., `goodreads_id`) for dedup on re-import. User edits are never overwritten.
+
+## Git Policy
+
+**Never execute Git commands that modify history or submit code.** This includes `git commit`, `git push`, `git rebase`, `git merge`, `git reset`, `git cherry-pick`, `git revert`, and `git tag`. Read-only commands like `git status`, `git diff`, `git log`, and `git branch` are fine. The maintainer must always review and commit changes themselves.
+
+## CI / Infrastructure Dependency
+
+**Branch protection for this repo is managed via Terraform in `kafkade/github-infra` (`repo_toku.tf`).** The `required_status_checks` list must match the job names in `.github/workflows/ci.yml`. If you rename, add, or remove CI jobs that are used as merge gates (currently `Validate`), the corresponding IaC config must be updated or PRs will be permanently blocked. Always flag this when proposing workflow changes.
+
+## Reference Documents
+
+- Full product roadmap: `ROADMAP.md`
+- Architecture Decision Records: `docs/adr/`
+- CLI command reference: see ADR-003 (`docs/adr/003-cli-design.md`)

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,27 @@
+version: 2
+
+updates:
+  # GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    commit-message:
+      prefix: "ci"
+    labels:
+      - "ci"
+      - "dependencies"
+    open-pull-requests-limit: 5
+
+  # Rust (Cargo)
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    commit-message:
+      prefix: "deps"
+    labels:
+      - "dependencies"
+    open-pull-requests-limit: 10

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,46 @@
+## Description
+
+<!-- What does this PR do? Provide a brief summary of the changes. -->
+
+## Related Issues
+
+<!-- Link related issues: "Closes #123" or "Relates to #456" -->
+
+## Type of Change
+
+- [ ] Bug fix (non-breaking change that fixes an issue)
+- [ ] New feature (non-breaking change that adds functionality)
+- [ ] Documentation update
+- [ ] Refactoring (no functional changes)
+- [ ] CI / infrastructure
+- [ ] Other (describe below)
+
+## Crate
+
+<!-- Which crate(s) does this touch? -->
+
+- [ ] `toku-core` — Domain models, traits, state machine
+- [ ] `toku-db` — SQLite persistence, migrations, FTS5
+- [ ] `toku-import` — Importers (Goodreads, Calibre, StoryGraph)
+- [ ] `toku-meta` — Metadata fetching (Open Library, Google Books)
+- [ ] `toku-cli` — CLI binary
+- [ ] `toku-export` — Exporters (CSV, JSON, Markdown, BibTeX)
+- [ ] `docs/` — Documentation
+
+## Data Integrity Checklist
+
+<!-- Toku is a local-first tool — user data ownership is non-negotiable -->
+
+- [ ] No user data is sent to any server without explicit opt-in
+- [ ] Import operations are idempotent (re-importing the same file creates no duplicates)
+- [ ] User edits to metadata are never overwritten by auto-enrichment
+- [ ] New fields track provenance (source + timestamp)
+- [ ] Export round-trip is preserved (if applicable)
+
+## Checklist
+
+- [ ] I have read [CONTRIBUTING.md](CONTRIBUTING.md)
+- [ ] `cargo fmt --check` passes
+- [ ] `cargo clippy --workspace -- -D warnings` passes
+- [ ] `cargo test --workspace` passes
+- [ ] I have updated documentation (if applicable)

--- a/.github/skills/md-lint/SKILL.md
+++ b/.github/skills/md-lint/SKILL.md
@@ -1,0 +1,121 @@
+---
+name: md-lint
+description: >
+  Lint markdown documents using markdownlint rules. This skill should run
+  automatically every time you create or edit a markdown file. Invoke explicitly
+  when the user asks to "lint markdown", "check markdown", "fix markdown",
+  or "validate docs".
+---
+
+# Markdown Lint
+
+Lint markdown files after every create or edit using markdownlint rules, respecting the project's `.github/.markdownlint.json` configuration.
+
+## When to Run
+
+Run this skill automatically:
+
+- After creating any `.md` file
+- After editing any `.md` file
+- When the user explicitly asks to lint or validate markdown
+
+## Steps
+
+### 1. Read the project configuration
+
+Read `.github/.markdownlint.json` to know which rules are disabled for this project. Current config:
+
+```json
+{
+  "default": true,
+  "MD013": false,
+  "MD033": false,
+  "MD041": false
+}
+```
+
+This means:
+
+- **MD013 disabled** — No line length limit enforced
+- **MD033 disabled** — Inline HTML is allowed (tables, GitHub alerts, etc.)
+- **MD041 disabled** — First line does not need to be a top-level heading
+
+All other rules are **enabled by default**.
+
+### 2. Check the document against enabled rules
+
+For every markdown file you just created or edited, verify compliance with these rules (grouped by category):
+
+#### Headings
+
+- **MD001** — Heading levels increment by one (no skipping from `#` to `###`)
+- **MD003** — Consistent heading style (use ATX `#` style throughout)
+- **MD018** — Space after `#` in headings (`# Heading`, not `#Heading`)
+- **MD019** — Single space after `#` (not `#  Heading`)
+- **MD022** — Blank line before and after headings
+- **MD024** — No duplicate heading text within the same nesting level
+- **MD025** — Single top-level heading (`# Title`) per document (when MD041 is enabled — currently disabled)
+
+#### Lists
+
+- **MD004** — Consistent unordered list style (use `-` throughout)
+- **MD005** — Consistent indentation for list items at the same level
+- **MD007** — Unordered list indentation (2 spaces)
+- **MD030** — Spaces after list markers (single space after `-`, `*`, or `1.`)
+- **MD032** — Blank line before and after lists
+
+#### Whitespace
+
+- **MD009** — No trailing spaces at end of lines
+- **MD010** — No hard tabs (use spaces)
+- **MD012** — No multiple consecutive blank lines
+- **MD027** — No multiple spaces after blockquote marker `>`
+- **MD047** — Files should end with a single newline character
+
+#### Links and Images
+
+- **MD011** — No reversed link syntax (`[text](url)` not `(text)[url]`)
+- **MD034** — No bare URLs (use `<url>` or `[text](url)`)
+- **MD042** — No empty links (`[text]()` is invalid)
+- **MD045** — Images should have alt text (`![alt](image.png)`)
+- **MD053** — Link and image reference definitions must be used (no orphaned references)
+
+#### Code
+
+- **MD014** — Don't prefix all shell commands with `$` unless showing output
+- **MD031** — Blank line before and after fenced code blocks
+- **MD038** — No spaces inside code spans (`` `code` `` not `` ` code ` ``)
+- **MD040** — Fenced code blocks should specify a language (` ```json ` not ` ``` `)
+- **MD046** — Consistent code block style (use fenced ` ``` `, not indented)
+- **MD048** — Consistent fenced code block style (use backticks `` ` ``, not tildes `~`)
+
+#### Structure
+
+- **MD028** — No blank line inside a blockquote (looks like separate blockquotes)
+- **MD036** — Don't use emphasis instead of a heading (`**Not a heading**` on its own line)
+
+#### Tables
+
+- **MD055** — Consistent table pipe style (leading and trailing pipes)
+- **MD056** — Table column count should be consistent across rows
+
+### 3. Fix violations
+
+When you find violations:
+
+1. Fix them directly in the same edit pass — do not just report them
+2. If a fix would change the meaning or intent of the content, note it to the user instead of auto-fixing
+3. Common auto-fixes:
+   - Add missing blank lines around headings, lists, and code blocks
+   - Remove trailing whitespace
+   - Remove consecutive blank lines (keep one)
+   - Add language identifiers to fenced code blocks
+   - Fix heading level increments
+   - Ensure file ends with a single newline
+
+### 4. Do NOT flag these (disabled rules)
+
+- Long lines (MD013 is off) — do not wrap or warn about long lines
+- Inline HTML (MD033 is off) — `<details>`, `<summary>`, GitHub `> [!NOTE]` alerts are all fine
+- First line not being a heading (MD041 is off) — files can start with anything
+- Table pipe spacing style (MD060 is off) — compact pipe style `|---|---|` is acceptable

--- a/.github/skills/pr-ready/SKILL.md
+++ b/.github/skills/pr-ready/SKILL.md
@@ -46,6 +46,9 @@ Prepare a branch for pull request: generate a PR description from the diff AND u
    npx markdownlint-cli2 "**/*.md"
    ```
 
+   The repo-root `.markdownlint-cli2.jsonc` auto-configures rules and excludes
+   build artifacts (`target/`, `node_modules/`, `pkg/`).
+
    If there are errors, **fix them before proceeding**. Do not generate the PR description until linting passes.
 
 2. **Always run Rust checks if any Rust file changed** (or if any Cargo workspace member is affected):

--- a/.github/skills/pr-ready/SKILL.md
+++ b/.github/skills/pr-ready/SKILL.md
@@ -1,0 +1,147 @@
+---
+name: pr-ready
+description: >
+  Prepare a pull request: generate a PR description using the repo's template,
+  update the Unreleased section of CHANGELOG.md with user-facing changes, and
+  copy the PR description to the clipboard. Invoke when the user asks to
+  "generate a PR description", "describe this PR", "write PR notes",
+  "prepare a PR", "pr ready", or "prep this PR".
+---
+
+# PR Ready — Description + Changelog
+
+Prepare a branch for pull request: generate a PR description from the diff AND update the changelog, then copy the PR description to the clipboard.
+
+## Steps
+
+### Phase 1: Gather context
+
+1. **Detect the base branch**
+   Run `git remote show origin` or check for `main` / `master` to determine the default branch.
+
+2. **Identify the current branch**
+   Run `git branch --show-current` to get the feature branch name.
+
+3. **Gather the diff context**
+   - Run `git log <base>..<current> --oneline` to get the commit list.
+   - Run `git diff <base>..<current> --stat` to get the file change summary.
+   - For each changed source file, read the diff to understand what changed.
+   - Skip binary files, lock files, and generated files.
+   - Note which crates are affected: `toku-core/`, `toku-db/`, `toku-import/`, `toku-meta/`, `toku-cli/`, `toku-export/`, `docs/`.
+
+4. **Read the PR template**
+   - Look for `.github/pull_request_template.md` in the repository.
+   - Use its exact structure (sections, checkboxes) as the PR description format.
+   - The template has a **Crate** section and a **Data Integrity Checklist** — fill both accurately.
+
+5. **Read the current changelog**
+   - Read `CHANGELOG.md` and note the existing `## [Unreleased]` section contents.
+   - Understand the Keep a Changelog format used (Added, Changed, Deprecated, Removed, Fixed, Security).
+
+### Phase 2: Run quality checks
+
+1. **Always run markdown linting first** (every PR touches or could touch docs):
+
+   ```sh
+   npx markdownlint-cli2 "**/*.md"
+   ```
+
+   If there are errors, **fix them before proceeding**. Do not generate the PR description until linting passes.
+
+2. **Always run Rust checks if any Rust file changed** (or if any Cargo workspace member is affected):
+
+   Run each step separately so failures are easy to identify:
+
+   ```sh
+   cargo fmt --check
+   cargo clippy --workspace -- -D warnings
+   cargo test --workspace
+   ```
+
+   If `cargo fmt --check` fails, run `cargo fmt` to fix, then re-run all three
+   checks from the top. If `cargo clippy` fails, fix the warning, then re-run
+   **all three checks from the top** (including `cargo fmt --check` — code fixes
+   can introduce formatting changes). Only proceed once all three pass in a
+   single run with no fixes in between.
+
+   **Toolchain version gap:** CI uses the latest stable Rust, which may have
+   newer clippy lints than the local toolchain. If CI fails with a clippy error
+   that passed locally, fix it immediately — do not assume local-passing means
+   CI-passing.
+
+3. **If any check fails**: fix the issues, then **re-run ALL checks from step 1** — not just the one that failed. A clippy fix can break formatting; a formatting fix can break tests. Only proceed to Phase 3 once every check passes in a clean run with no intervening edits.
+
+### Phase 3: Generate the PR description
+
+1. **Write the PR description** using the PR template structure:
+   - **Description section**: Write a clear summary of what the PR does. Include:
+     - A one-line summary of the purpose
+     - A "What's included" subsection listing key changes with brief explanations
+     - Reference specific files/modules only when it adds clarity
+   - **Related Issues**: Check commit messages for issue references (#123). If none, leave placeholder.
+   - **Type of Change**: Check the appropriate box(es) based on diff content.
+   - **Crate**: Check the appropriate box(es) based on which workspace crates were touched.
+   - **Data Integrity Checklist**: Evaluate each item:
+     - Does the change send user data to a server? (must not without opt-in)
+     - Are import operations idempotent? (must be)
+     - Are user metadata edits protected from auto-overwrite? (must be)
+     - Do new fields track provenance? (must)
+     - Is export round-trip preserved? (must be, if applicable)
+     - If the PR is documentation-only or infrastructure-only, check all data integrity items as passing.
+   - **Checklist**: Mark items based on the results from the quality checks step.
+
+2. **Quality guidelines for the PR description**
+   - Do NOT reference internal planning documents (roadmap phases, ADR numbers) — describe actual changes
+   - Write from the user/contributor perspective
+   - Be specific about what was added/changed
+   - Keep the description concise but complete — aim for 15-30 lines
+
+### Phase 4: Update the changelog
+
+1. **Identify user-facing changes** from the diff. A change is user-facing if it:
+   - Adds a feature the user can see or interact with
+   - Fixes a bug the user could encounter
+   - Changes behavior the user would notice (CLI output, search results, import behavior)
+   - Adds or changes configuration options
+   - **Is NOT user-facing**: refactoring, CI changes, test additions, internal restructuring, dependency updates, code style fixes, documentation-only changes
+
+2. **Categorize each change** using Keep a Changelog categories:
+   - **Added** — new features or capabilities
+   - **Changed** — changes to existing functionality
+   - **Deprecated** — features that will be removed
+   - **Removed** — features that were removed
+   - **Fixed** — bug fixes
+   - **Security** — vulnerability fixes
+
+3. **Update the `## [Unreleased]` section** of `CHANGELOG.md`:
+   - **Append** new entries to the existing Unreleased section — do NOT delete what's already there
+   - If a category header (e.g., `### Added`) already exists with entries, add new entries below the existing ones
+   - If a category header doesn't exist yet, add it
+   - Write entries as concise, user-facing descriptions — no implementation details
+   - Each entry starts with a `-` list marker (markdown list item)
+   - Do NOT include entries for: CI changes, refactoring, dependency bumps, test-only changes, documentation-only changes
+
+4. **Changelog entry style guide**
+   - ✅ Good: `- Goodreads CSV import with dry-run, dedup, and field mapping report`
+   - ✅ Good: `- Fixed ISBN-13 validation rejecting valid checksums`
+   - ✅ Good: `- Reading progress tracking with page, percentage, and chapter modes`
+   - ❌ Bad: `- Refactored toku-db query layer` (not user-facing)
+   - ❌ Bad: `- Added unit tests for import dedup` (not user-facing)
+   - ❌ Bad: `- Implements Phase 1 from roadmap` (references internals)
+
+### Phase 5: Output
+
+1. **Copy the PR description to the clipboard**
+   - Use PowerShell `Set-Clipboard` (Windows), `pbcopy` (macOS), or `xclip` (Linux)
+   - Confirm to the user that the description has been copied
+
+2. **Suggest a PR title**
+   - Based on the changes, suggest a conventional-commit-style PR title
+   - Format: `feat: add Goodreads CSV import` or `fix: correct ISBN-13 checksum validation`
+   - For multi-crate changes, use the primary crate: `feat(import): add Calibre metadata.db parser`
+
+3. **Show a summary** to the user:
+   - The suggested PR title
+   - Confirmation that the PR description is on the clipboard
+   - A summary of what was added to CHANGELOG.md (list the new entries)
+   - Note any changelog entries that were already present and preserved

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,152 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    name: Build ${{ matrix.target }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: x86_64-unknown-linux-gnu
+            os: ubuntu-latest
+          - target: aarch64-unknown-linux-gnu
+            os: ubuntu-latest
+            cross: true
+          - target: x86_64-apple-darwin
+            os: macos-latest
+          - target: aarch64-apple-darwin
+            os: macos-latest
+          - target: x86_64-pc-windows-msvc
+            os: windows-latest
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: stable
+          targets: ${{ matrix.target }}
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: ${{ matrix.target }}
+
+      - name: Install cross (for cross-compilation)
+        if: matrix.cross
+        run: cargo install cross --locked
+
+      - name: Build release binary
+        run: |
+          if [ "${{ matrix.cross }}" = "true" ]; then
+            cross build --release --target ${{ matrix.target }} -p toku-cli
+          else
+            cargo build --release --target ${{ matrix.target }} -p toku-cli
+          fi
+        shell: bash
+
+      - name: Package binary (unix)
+        if: runner.os != 'Windows'
+        run: |
+          cd target/${{ matrix.target }}/release
+          tar czf ../../../toku-${{ github.ref_name }}-${{ matrix.target }}.tar.gz toku
+          cd ../../..
+          sha256sum toku-${{ github.ref_name }}-${{ matrix.target }}.tar.gz > toku-${{ github.ref_name }}-${{ matrix.target }}.tar.gz.sha256
+
+      - name: Package binary (windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          Compress-Archive -Path "target/${{ matrix.target }}/release/toku.exe" -DestinationPath "toku-${{ github.ref_name }}-${{ matrix.target }}.zip"
+          $hash = (Get-FileHash "toku-${{ github.ref_name }}-${{ matrix.target }}.zip" -Algorithm SHA256).Hash.ToLower()
+          "$hash  toku-${{ github.ref_name }}-${{ matrix.target }}.zip" | Out-File -Encoding ascii "toku-${{ github.ref_name }}-${{ matrix.target }}.zip.sha256"
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: toku-${{ matrix.target }}
+          path: |
+            toku-*.tar.gz
+            toku-*.zip
+            toku-*.sha256
+
+  release:
+    name: Create GitHub Release
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+          merge-multiple: true
+
+      - name: Extract release notes from CHANGELOG.md
+        id: extract
+        uses: ffurrer2/extract-release-notes@v3
+
+      - name: Determine pre-release status
+        id: prerelease
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          MAJOR="${VERSION%%.*}"
+          if [ "$MAJOR" = "0" ]; then
+            echo "flag=--prerelease" >> "$GITHUB_OUTPUT"
+          else
+            echo "flag=" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Create GitHub Release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_NOTES: ${{ steps.extract.outputs.release_notes }}
+        run: |
+          gh release create "${{ github.ref_name }}" \
+            --title "${{ github.ref_name }}" \
+            --notes "$RELEASE_NOTES" \
+            ${{ steps.prerelease.outputs.flag }} \
+            artifacts/*
+
+  publish:
+    name: Publish to crates.io
+    needs: release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: stable
+
+      # Publish crates in dependency order:
+      # toku-core (no deps) → toku-db → toku-import, toku-meta, toku-export → toku-cli
+      # Each `cargo publish` needs a brief pause for crates.io index to update.
+      - name: Publish workspace crates
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        run: |
+          publish_crate() {
+            local crate=$1
+            echo "📦 Publishing $crate..."
+            cargo publish -p "$crate" --no-verify
+            echo "⏳ Waiting for crates.io index to update..."
+            sleep 30
+          }
+
+          publish_crate toku-core
+          publish_crate toku-db
+          publish_crate toku-import
+          publish_crate toku-meta
+          publish_crate toku-export
+          publish_crate toku-cli
+          echo "✅ All crates published"

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,0 +1,39 @@
+name: Validate
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  validate:
+    name: Validate
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Lint markdown
+        uses: DavidAnson/markdownlint-cli2-action@v23
+        with:
+          globs: "**/*.md"
+
+  # NOTE: The Rust job uses a matrix that produces check names like
+  # "Rust (ubuntu-latest)", "Rust (macos-latest)", "Rust (windows-latest)".
+  # Adding any of these as required status checks requires updating
+  # kafkade/github-infra → repo_toku.tf (required_status_checks).
+  rust:
+    name: Rust (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy, rustfmt
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo fmt --check
+      - run: cargo clippy --workspace -- -D warnings
+      - run: cargo test --workspace

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -18,22 +18,19 @@ jobs:
         with:
           globs: "**/*.md"
 
-  # NOTE: The Rust job uses a matrix that produces check names like
-  # "Rust (ubuntu-latest)", "Rust (macos-latest)", "Rust (windows-latest)".
-  # Adding any of these as required status checks requires updating
-  # kafkade/github-infra → repo_toku.tf (required_status_checks).
-  rust:
-    name: Rust (${{ matrix.os }})
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
-    steps:
-      - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@stable
-        with:
-          components: clippy, rustfmt
-      - uses: Swatinem/rust-cache@v2
-      - run: cargo fmt --check
-      - run: cargo clippy --workspace -- -D warnings
-      - run: cargo test --workspace
+  # TODO: Uncomment when Cargo workspace is scaffolded (PR #1)
+  # rust:
+  #   name: Rust (${{ matrix.os }})
+  #   runs-on: ${{ matrix.os }}
+  #   strategy:
+  #     matrix:
+  #       os: [ubuntu-latest, macos-latest, windows-latest]
+  #   steps:
+  #     - uses: actions/checkout@v6
+  #     - uses: dtolnay/rust-toolchain@stable
+  #       with:
+  #         components: clippy, rustfmt
+  #     - uses: Swatinem/rust-cache@v2
+  #     - run: cargo fmt --check
+  #     - run: cargo clippy --workspace -- -D warnings
+  #     - run: cargo test --workspace

--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -1,0 +1,6 @@
+{
+  "config": {
+    "extends": ".github/.markdownlint.json"
+  },
+  "ignores": ["target/", "node_modules/", "pkg/"]
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Project scaffold: README, ROADMAP, ADRs, GitHub configuration
-- Architecture Decision Records (ADR-001 through ADR-006)
+- Project README with "Why Toku?" naming rationale and CLI usage examples
+- Product roadmap covering 9 phases from MVP to moonshots
+- Architecture Decision Records: core language (ADR-001), database schema (ADR-002), CLI design (ADR-003), metadata sources (ADR-004), import architecture (ADR-005), sync strategy (ADR-006)
+- CI workflow: markdown linting + Rust build/test/clippy on Linux, macOS, and Windows
+- Release workflow: cross-platform binary builds + crates.io publishing
+- Release script for automated version bumping, changelog stamping, and tagging
+- Contributing guide with importer contribution instructions
+- GitHub issue templates for bug reports and feature requests
+- PR template with data integrity checklist
 
 [Unreleased]: https://github.com/kafkade/toku/compare/v0.1.0...HEAD

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+
+- Project scaffold: README, ROADMAP, ADRs, GitHub configuration
+- Architecture Decision Records (ADR-001 through ADR-006)
+
+[Unreleased]: https://github.com/kafkade/toku/compare/v0.1.0...HEAD

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,65 @@
+# Contributing to Toku
+
+Thank you for your interest in contributing to Toku!
+
+## Code of Conduct
+
+Be respectful, constructive, and inclusive. We're building a tool for readers — let's treat each other well.
+
+## How to Contribute
+
+### Reporting Bugs
+
+- Open an issue using the bug report template
+- Include steps to reproduce, expected behavior, and actual behavior
+- Include platform (Linux/macOS/Windows) and version information
+
+### Suggesting Features
+
+- Open an issue using the feature request template
+- Describe the use case and how it aligns with Toku's local-first, no-social principles
+- Note: features that require a server for core functionality will not be accepted
+
+### Adding an Importer
+
+- Importers are a great way to contribute! Check the `importer` label for requested sources
+- Each importer lives in `toku-import/` and implements the `ImportEngine` trait
+- Importers must support: `--dry-run`, idempotent re-import via source IDs, and provenance tracking
+- Include test fixtures (real or anonymized export files) in `tests/fixtures/`
+
+### Pull Requests
+
+1. Fork the repository
+2. Create a feature branch (`git checkout -b feature/my-feature`)
+3. Make your changes
+4. Ensure all checks pass: `cargo fmt --check && cargo clippy --workspace -- -D warnings && cargo test --workspace`
+5. Submit a pull request with a clear description
+
+### Security Vulnerabilities
+
+If you discover a security vulnerability, **do not open a public issue**. Instead, please use GitHub's private vulnerability reporting feature.
+
+## Development Setup
+
+```sh
+# Clone the repo
+git clone https://github.com/kafkade/toku.git
+cd toku
+
+# Build all crates
+cargo build --workspace
+
+# Run tests
+cargo test --workspace
+
+# Run the CLI
+cargo run -p toku-cli -- --help
+```
+
+## Architecture
+
+See `.github/copilot-instructions.md` for the full architecture overview and `docs/adr/` for Architecture Decision Records.
+
+## License
+
+By contributing, you agree that your contributions will be licensed under the [MIT License](LICENSE).

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ toku stats --year 2025                 # See your reading stats
 
 ## Why "Toku"?
 
-**Toku** (読く) comes from the Japanese kanji **読** — meaning *to read*.
+**Toku** (読く) comes from the Japanese kanji **読** — meaning _to read_.
 
 The name is also a nod to **積ん読 (tsundoku)** — a Japanese word with no English
 equivalent that describes the act of acquiring books and letting them pile up unread.
@@ -79,4 +79,4 @@ their ever-growing libraries.
 
 ---
 
-*Built by [kafkade](https://github.com/kafkade).*
+_Built by [kafkade](https://github.com/kafkade)._

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,1640 @@
+# 📚 Toku — Product Roadmap
+
+> **A private, offline-first, multi-platform personal book manager.**
+> CLI-first. Your data, your rules. No social features. No cloud dependency.
+
+**Repository**: `kafkade/toku`
+**Core Language**: Rust
+**Primary Interface**: CLI
+**Date**: July 2025
+**Author**: kafkade
+
+---
+
+## Section 0: Assumptions Table
+
+| # | Question | Default | Reasoning | Risk if Wrong |
+|---|----------|---------|-----------|---------------|
+| 1 | Team size | Solo developer + community contributions | User-confirmed. Phases limited to 3–5 deliverables. | Overscoped phases stall development |
+| 2 | Timeline | Open-ended, ship when ready | Solo developer — milestone-driven deadlines create burnout. Quality > speed. | No external pressure to ship, risk of infinite polishing |
+| 3 | Budget | $0 — no paid APIs, no paid infra | Open source project. Use only free-tier APIs (Open Library, Google Books free quota). | Must fall back to manual entry if free APIs degrade |
+| 4 | MVP focus | CLI only | Web UI adds weeks of work and a JS build chain. CLI validates the data model and core library first. | Audience limited to terminal users until Phase 4 |
+| 5 | Distribution | `cargo install` + pre-built binaries (GitHub Releases) | Cargo reaches the Rust community. Pre-built binaries reach everyone else. Homebrew tap in Phase 2. | Users without Rust toolchain need binaries — CI must cross-compile |
+| 6 | File management | Defer to post-1.0 (Phase 6) | File management (ebook storage, conversion, OPDS) is a separate product concern. MVP is a reading tracker, not a file manager. | Power Calibre users may wait for file features before switching |
+| 7 | Primary persona | Privacy-Conscious Power Reader | Confirmed: 100–500 books, Goodreads user, values data ownership. CLI-comfortable. | If casual readers are the real audience, CLI-first is wrong |
+| 8 | Wedge persona | Goodreads refugee who lives in the terminal | Switching trigger: "Amazon owns my reading data and Goodreads is rotting" | If Goodreads improves, switching motivation weakens |
+| 9 | Book formats tracked | Physical books, Ebooks (Kindle/Kobo), Audiobooks | User-confirmed. Data model must handle page-based and time-based progress from day one. | Audiobook support adds complexity to progress tracking |
+| 10 | Import priority | Goodreads CSV first (user's current tool) | User-confirmed. This is the first-impression feature. | If Goodreads changes CSV format, MVP import breaks |
+| 11 | Primary metadata source | Open Library (primary) + Google Books (fallback) | Open Library: free, no key required, community-maintained. Google Books: broader coverage, 1,000 req/day free. | Open Library has gaps for non-English and niche titles |
+| 12 | Edition model | Start with Book = Edition, add Work grouping in Phase 3 | Full FRBR is overengineered for MVP. 100–500 books rarely has edition conflicts. | Migration from flat to hierarchical requires careful schema design |
+| 13 | Core language | Rust | User-confirmed. Excellent CLI ecosystem (clap), cross-compilation, WASM target, strong community. | Higher contribution barrier than Go/Python |
+| 14 | Database | SQLite with FTS5 | Battle-tested embedded DB. Single-file. Cross-platform. FTS5 for search. | No issues at 500 books. At 50k+ books, may need query optimization |
+| 15 | Rating scale | 5-star with half-star increments (stored as 0–10 integer) | Matches Goodreads import (1–5 stars), allows more precision. Simpler than 10-point for casual use. | Half-stars complicate CLI input slightly |
+| 16 | License | MIT | Maximum contributor friendliness, no copyleft friction, standard in Rust ecosystem. | No copyleft protection — forks can close source |
+| 17 | GitHub org | kafkade | User-confirmed. Repo: `kafkade/toku`. | Name must work as `kafkade/<name>` on GitHub |
+| 18 | Project name | Toku (recommended — see Section 17) | Short, punchy, non-English, terminal-friendly. Japanese 読く (to read). | May have pronunciation ambiguity outside East Asian contexts |
+
+---
+
+## Section 1: User Personas
+
+### 1. Mara — The Privacy-Conscious Power Reader ⭐ Primary Persona
+
+- **Archetype**: 30s, reads 40–60 books/year across physical and Kindle. Software engineer.
+- **Library**: 300 books tracked in Goodreads, wants to leave Amazon's ecosystem.
+- **Technical comfort**: High — lives in the terminal, uses Neovim, loves CLI tools.
+- **Platforms**: macOS terminal (primary), iPhone (future — quick progress updates).
+- **Pain point**: "Goodreads is owned by Amazon, the UI is stuck in 2012, and I can't export my reading history cleanly. My data isn't mine."
+- **Switching trigger**: `toku import goodreads ~/export.csv` → full library in seconds → never opens Goodreads again.
+- **Phase alignment**: MVP (Phase 1) — this is the launch user.
+
+### 2. Dex — The Calibre Power User
+
+- **Archetype**: 40s, 1,200+ ebooks managed in Calibre. Reads 30 books/year.
+- **Library**: Massive ebook collection, meticulously tagged, uses Calibre daily for metadata.
+- **Technical comfort**: Very high — runs Calibre server, uses command-line tools.
+- **Platforms**: Linux terminal, potentially web UI for browsing.
+- **Pain point**: "Calibre manages my files but can't track reading progress. I use a spreadsheet alongside it. It's 2025 and I have two systems."
+- **Switching trigger**: Calibre import + reading progress tracking in one tool.
+- **Phase alignment**: Phase 2 (Calibre import) — needs file management features in Phase 6 for full switch.
+
+### 3. Lena — The Casual Tracker
+
+- **Archetype**: 20s, reads 15 books/year, currently uses Goodreads sporadically.
+- **Library**: ~80 books. Doesn't care about metadata depth. Wants "what did I read this year?"
+- **Technical comfort**: Low-to-medium — can install an app, won't use a terminal.
+- **Platforms**: Web UI (Phase 4), iOS (Phase 5).
+- **Pain point**: "Goodreads is too social. I just want a private list."
+- **Switching trigger**: Web UI with simple "add book, mark as read" flow.
+- **Phase alignment**: Phase 4 (Web) — not reachable via CLI.
+
+### 4. Prof. Navarro — The Academic Researcher
+
+- **Archetype**: 50s, tracks 200+ academic books and papers alongside recreational reading.
+- **Library**: Needs custom fields (course, semester, citation key), BibTeX export.
+- **Technical comfort**: Medium — uses Zotero, LaTeX, comfortable with structured tools.
+- **Platforms**: macOS terminal, web UI.
+- **Pain point**: "Zotero is great for papers but awkward for novels. Goodreads can't handle textbooks properly."
+- **Switching trigger**: Custom fields + BibTeX export + standard book tracking in one tool.
+- **Phase alignment**: Phase 3 (custom fields, BibTeX export) — niche but vocal community.
+
+### 5. Kai — The Data Nerd / Quantified Reader
+
+- **Archetype**: 20s, reads 80+ books/year, obsessed with reading analytics.
+- **Library**: 400 books, currently on StoryGraph for mood tracking and stats.
+- **Technical comfort**: High — developer, loves dashboards and data visualization.
+- **Platforms**: CLI + web stats dashboard.
+- **Pain point**: "StoryGraph's stats are good but I can't customize them or run my own queries. I want SQL access to my reading data."
+- **Switching trigger**: SQLite database they own + rich stats engine + CLI scriptability.
+- **Phase alignment**: Phase 3 (full analytics) — will tolerate minimal stats in Phase 2.
+
+### 6. Sam — The Developer / Contributor
+
+- **Archetype**: 30s, primarily interested in the architecture. Reads 20 books/year.
+- **Library**: Small. Main interest is contributing to the codebase.
+- **Technical comfort**: Very high — Rust developer, wants clean APIs and good docs.
+- **Platforms**: Whatever the project uses.
+- **Pain point**: "I want to build something cool in Rust. Most book apps are proprietary or poorly architected."
+- **Switching trigger**: Clean crate architecture, good documentation, welcoming contribution model.
+- **Phase alignment**: Phase 0+ — contributor from the start.
+
+---
+
+## Section 2: Cross-Platform Architecture & Core Library Design
+
+### 2.1 — Layered Architecture
+
+```
+┌─────────────────────────────────────────────────┐
+│                  Frontend Adapters               │
+│  ┌─────┐  ┌─────┐  ┌──────┐  ┌──────┐  ┌─────┐│
+│  │ CLI │  │ Web │  │ iOS  │  │macOS │  │ Win ││
+│  └──┬──┘  └──┬──┘  └──┬───┘  └──┬───┘  └──┬──┘│
+├─────┴────────┴───────┴────────┴─────────┴──────┤
+│            Metadata Enrichment Layer             │
+│  Open Library API · Google Books · Cover fetch   │
+│  (optional — requires network)                   │
+├─────────────────────────────────────────────────┤
+│                  Data Layer                       │
+│  SQLite + FTS5 · Migrations · Import/Export       │
+│  Cover image storage · Data validation            │
+├─────────────────────────────────────────────────┤
+│                Domain Core Layer                  │
+│  Book model · Reading sessions · Shelves/Tags     │
+│  State machine · Stats engine · Search/Filter     │
+│  Import/Export traits · No I/O, no network        │
+└─────────────────────────────────────────────────┘
+```
+
+**Domain core layer** — Pure Rust, no I/O dependencies. Compiles to native, WASM, and C FFI. Contains:
+- Book/Author/Series models with validation
+- Reading state machine (WantToRead → Reading → Read | Abandoned | OnHold)
+- Statistics computation engine (all calculations are pure functions over data)
+- Search and filter logic
+- Import/export trait definitions (not implementations)
+
+**Data layer** — SQLite via `rusqlite`. Compiles to native (WASM via `sql.js` in future).
+- Schema management with `refinery` for migrations
+- FTS5 full-text search index
+- Import implementations (Goodreads CSV, Calibre DB)
+- Cover image filesystem management
+
+**Metadata enrichment layer** — Network-dependent, always optional.
+- Open Library and Google Books API clients
+- Cover image downloading
+- Rate limiting + response caching
+- Merge logic: fill empty fields only; never overwrite user edits
+
+**Frontend adapters** — Each is a separate crate/binary:
+- `toku-cli`: Primary interface (Phase 0+)
+- `toku-web`: Axum server + HTMX or Leptos frontend (Phase 4)
+- `toku-ffi`: C FFI bindings for Swift/Kotlin (Phase 5)
+
+### 2.2 — Workspace Layout
+
+**Recommendation**: Monorepo with Cargo workspace from day one.
+
+The crate count is small enough (4–6 crates) that the overhead is minimal, and the boundaries enforce the layered architecture. A monolith-first approach risks coupling the CLI to the core in ways that are painful to untangle when the web UI arrives.
+
+```
+kafkade/toku/
+├── Cargo.toml              # Workspace root
+├── crates/
+│   ├── toku-core/          # Domain: models, traits, state machine, stats
+│   ├── toku-db/            # SQLite, migrations, FTS5, queries
+│   ├── toku-import/        # Goodreads CSV, Calibre, StoryGraph parsers
+│   ├── toku-meta/          # Open Library, Google Books API clients
+│   ├── toku-cli/           # CLI binary (clap-based)
+│   └── toku-export/        # CSV, JSON, Markdown, BibTeX exporters
+├── docs/                   # User and developer documentation
+├── tests/                  # Integration tests, test fixtures
+│   └── fixtures/           # Sample Goodreads CSVs, Calibre DBs
+├── .github/
+│   └── workflows/          # CI: test, lint, build, release
+├── README.md
+├── LICENSE                 # MIT
+└── CONTRIBUTING.md
+```
+
+### 2.3 — Database Architecture
+
+**Primary database**: SQLite 3 with FTS5 extension.
+
+- **Schema philosophy**: Normalized core entities (books, authors, series) with join tables for relationships. Denormalized FTS5 virtual table for search (rebuilt on import, updated on edit). This balances query simplicity with search performance.
+- **Edition handling**: MVP uses a single `books` table where each row is an edition. A `work_id` nullable column is reserved — initially NULL, populated when Work grouping is added in Phase 3.
+- **Cover images**: Stored on the filesystem in a `covers/` subdirectory, referenced by content hash (`sha256.jpg`). Thumbnails generated on first display. Rationale: keeps the SQLite file small and portable; cover files are large and binary.
+- **Database location**:
+  - Linux: `$XDG_DATA_HOME/toku/` (default `~/.local/share/toku/`)
+  - macOS: `~/Library/Application Support/toku/`
+  - Windows: `%APPDATA%\toku\`
+  - Overridable via `TOKU_DATA_DIR` env var or `--data-dir` flag
+- **Migration strategy**: `refinery` crate for versioned SQL migrations embedded in the binary. Each migration is idempotent. Migration runs automatically on app start.
+- **Backup**: The entire `toku/` directory (SQLite file + covers/) is the backup. `toku export backup` creates a self-contained archive (see Section 3.1.2).
+
+### 2.4 — Platform Compilation Targets
+
+| Platform | Target | UI Framework | Database | Phase |
+|----------|--------|-------------|----------|-------|
+| Linux CLI | `x86_64-unknown-linux-gnu`, `aarch64-unknown-linux-gnu` | Terminal (clap + tabled) | SQLite (rusqlite) | **MVP** |
+| macOS CLI | `x86_64-apple-darwin`, `aarch64-apple-darwin` | Terminal | SQLite | **MVP** |
+| Windows CLI | `x86_64-pc-windows-msvc` | Terminal | SQLite | **MVP** |
+| Web | Server-rendered (Axum + templates) | HTMX or Leptos | SQLite (server-side) | Phase 4 |
+| iOS | `aarch64-apple-ios` | SwiftUI via FFI | SQLite | Phase 5 |
+| macOS App | Native | SwiftUI | SQLite | Phase 5 |
+| Windows App | Native | Tauri v2 | SQLite | Phase 5 |
+
+### 2.5 — Sync Strategy
+
+Sync is opt-in. Toku must work fully offline on a single device forever. Sync adds
+convenience — it never adds capability. A user who never enables sync loses nothing.
+
+#### Phase 1 (MVP): No sync — manual archive
+
+Single-device. The `toku/` data directory can be manually backed up or synced via
+Syncthing, iCloud Drive, or Dropbox. `toku export backup` creates a self-contained
+archive (see Section 3.1.2) that can be imported on another machine. Document this as
+a supported workflow for power users who want multi-device today.
+
+#### Phase 7: Toku Sync — Lightweight REST sync with optional encryption
+
+**Architecture**: Changeset-based sync over a thin REST API.
+
+```
+┌──────────┐    ┌──────────┐    ┌──────────┐
+│ CLI      │    │ iOS App  │    │ Web App  │
+│ (local   │    │ (local   │    │(connected│
+│  SQLite) │    │  SQLite) │    │  client) │
+└────┬─────┘    └────┬─────┘    └────┬─────┘
+     │               │               │
+     └───────┬───────┘               │
+             │ push/pull ops          │ API calls
+             ▼                        ▼
+     ┌───────────────────────────────────┐
+     │         Toku Sync Server          │
+     │  (Axum · SQLite · Docker/fly.io)  │
+     │                                   │
+     │  Stores: encrypted changesets,    │
+     │  sync cursors, device registry,   │
+     │  snapshots                        │
+     └───────────────────────────────────┘
+```
+
+**How it works**:
+
+1. **Every mutation is an operation (op)**. When a native client changes a book's rating,
+   adds a reading session, or creates a shelf, it writes to the local SQLite AND appends
+   an op to a local `sync_ops` table with a unique op ID + hybrid logical clock (HLC)
+   timestamp.
+
+2. **Push**: Client sends new ops since its last push cursor to the server. Ops are
+   optionally encrypted client-side before upload (see encryption below).
+
+3. **Pull**: Client requests ops since its last pull cursor. Applies them to local
+   SQLite using entity-specific merge rules.
+
+4. **The server is a dumb relay** — it stores ops, manages cursors per device, and
+   serves snapshots. It does not need to understand the data (especially when encrypted).
+
+5. **Snapshots**: Periodically, the server (or a client) compacts the op log into a
+   full snapshot. New devices pull the latest snapshot + ops since snapshot, avoiding
+   unbounded log replay.
+
+**Entity-specific merge rules** — not one-size-fits-all:
+
+| Entity | Merge Strategy | Rationale |
+|--------|---------------|-----------|
+| Books (metadata) | Last-write-wins per field (HLC) | User edits one field at a time; field-level LWW avoids overwriting unrelated changes |
+| Reading sessions | Append-only | Sessions are immutable facts ("I read pages 50–100 on April 15"). No conflicts possible. |
+| Reading progress | Monotonic — highest page/latest timestamp wins | Progress only moves forward. If two devices report page 145 and page 200, page 200 wins. |
+| Shelves / Tags | Last-write-wins per entity | Renames and deletes are rare; LWW is sufficient. |
+| Notes / Reviews | Last-write-wins with conflict detection | If two devices edit the same note, keep the later edit but store the earlier as a conflict version the user can review. |
+| Reading status | State machine constraint — valid transitions only | Enforce: WantToRead → Reading → Read/Abandoned. Invalid transitions rejected. |
+| Deletes | Soft delete with tombstone + 30-day retention | Tombstones prevent deleted books from reappearing after sync. Purge after 30 days. |
+| Cover images | Content-addressed (hash), lazy-fetch | Not in the critical sync path. Metadata syncs the hash; images download on demand. |
+| Import logs | Never sync | Device-local only. |
+| Settings | Last-write-wins per key | Settings changes are infrequent and intentional. |
+
+**Web app model** — the web app is a **connected companion**, not a full local-first
+client:
+
+- Web v1 talks directly to the sync server's API — it reads/writes via REST, not local
+  SQLite. This avoids the complexity of browser-based SQLite (OPFS/sql.js) for a solo
+  developer.
+- The server is the web app's "database." Native clients are authoritative; the web is
+  a convenient window.
+- Future: if browser-local SQLite matures (via OPFS + sqlite-wasm), the web app can
+  adopt the same local-first model as native clients. This is not required for v1.
+
+**Device management**:
+
+- Each device registers with a device ID (UUID) and a human-readable name ("Javier's
+  MacBook", "iPhone").
+- Devices are listed in `toku sync devices` and can be deregistered.
+- No concept of "revoking" a device's data — if a device is lost, the user changes
+  their sync passphrase, which re-encrypts all server-side data with a new key.
+
+#### Encryption: lighter than Pildora, still private
+
+Book data is personal but not health-critical. Toku does **not** need Pildora's
+zero-knowledge architecture (SRP, vault hierarchy, per-item keys, asymmetric key
+exchange). Instead:
+
+**Optional symmetric encryption with a user passphrase.**
+
+- The user sets a sync passphrase during setup: `toku sync init --passphrase`.
+- A key is derived from the passphrase using **Argon2id** (memory-hard KDF).
+- All ops are encrypted client-side with **AES-256-GCM** before upload.
+- The server stores only opaque encrypted blobs + unencrypted metadata (op ID,
+  device ID, timestamp, entity type — not entity content).
+- The server **cannot** read book titles, ratings, notes, or any content.
+
+**What the server CAN see** (metadata leakage — accepted trade-off):
+- How many books are in the library (op count)
+- When sync happens (timestamps)
+- Which devices sync (device IDs)
+- Entity types being synced (book, session, shelf — but not content)
+
+**What the server CANNOT see**:
+- Book titles, authors, ISBNs
+- Ratings, reviews, notes
+- Reading progress
+- Shelf names, tag names
+- Any content field
+
+**This is NOT zero-knowledge** — the server knows *that* you have books, but not
+*which* books. For a personal book manager, this is a reasonable trade-off. Users who
+want stronger privacy can self-host the server.
+
+**Key lifecycle** (kept simple):
+- **Setup**: User picks a passphrase → Argon2id → encryption key stored in OS keychain.
+- **New device**: User enters their passphrase on the new device. No key exchange
+  protocol — the passphrase IS the shared secret.
+- **Passphrase change**: Client pulls all ops, re-encrypts with new key, pushes a
+  re-encrypted snapshot. Old ops are purged.
+- **Forgotten passphrase**: **Data on the server is unrecoverable.** The local SQLite
+  on any device is the recovery path. This is documented clearly: "Your passphrase is
+  your key. We cannot recover it."
+- **No passphrase (opt-out)**: If the user skips encryption, ops are stored as plaintext
+  JSON on the server. Self-hosters may prefer this for simplicity.
+
+**Comparison to Pildora**:
+
+| Concern | Pildora (health data) | Toku (book data) |
+|---------|----------------------|------------------|
+| Threat model | Server compromise exposes medications | Server compromise exposes reading list |
+| Encryption | Mandatory E2E, zero-knowledge, per-vault keys | Optional symmetric, single passphrase |
+| Key exchange | SRP + asymmetric wrapping | Passphrase-based (symmetric only) |
+| Key hierarchy | Master → Vault → Item | Single derived key |
+| Sharing | Encrypted vault sharing with roles | No sharing (personal tool) |
+| Recovery | Recovery key + emergency access | Local SQLite is the recovery |
+| Server knowledge | Nothing — can't even see metadata structure | Knows op count, timestamps, entity types |
+| Complexity | ~3 months of crypto engineering | ~2–3 weeks for a working sync |
+
+#### Deployment options
+
+- **Self-hosted (recommended)**: Docker image, single binary, SQLite backend. Run on a
+  VPS, NAS, or Raspberry Pi. `docker run -p 8080:8080 kafkade/toku-sync`.
+- **Managed (future, maybe)**: A hosted instance at `sync.toku.dev` for users who don't
+  want to self-host. Free tier for small libraries. This is optional and deferred — the
+  self-hosted path must work first.
+
+Rejected sync alternatives:
+- **cr-sqlite**: Elegant but experimental. iOS/WASM support is unproven. Kept as a
+  research branch — if it matures, it could replace the op-log approach for native
+  clients. Not the roadmap bet.
+- **File-based sync (iCloud/Dropbox)**: SQLite files + cloud sync = corruption risk.
+  Documented as a manual backup workflow, not a sync strategy.
+- **Turso/libSQL**: Adds a mandatory cloud dependency. Conflicts with local-first.
+- **Full zero-knowledge (Pildora model)**: Overkill for book data. 3x the engineering
+  effort for marginal privacy gain.
+
+#### Sync protocol — technical summary
+
+```
+POST /sync/push     — Client sends new ops (encrypted or plaintext)
+GET  /sync/pull     — Client receives ops since cursor
+GET  /sync/snapshot — Client downloads latest compacted snapshot
+POST /sync/register — Register a new device
+GET  /sync/devices  — List registered devices
+DELETE /sync/device — Deregister a device
+POST /sync/rekey    — Upload re-encrypted snapshot after passphrase change
+```
+
+Each op:
+```json
+{
+  "op_id": "uuid-v7",
+  "device_id": "uuid",
+  "hlc": "2025-07-14T10:30:00.000Z-0001-deviceA",
+  "entity_type": "book",
+  "entity_id": "uuid",
+  "op_type": "update",
+  "payload": "<encrypted-or-plaintext JSON>",
+  "checksum": "sha256"
+}
+```
+
+---
+
+## Section 3: Data Sources, Import & Export
+
+### 3.1 — Import Source Matrix
+
+| Source | Format | Key Data | Complexity | Phase | Validation |
+|--------|--------|----------|-----------|-------|------------|
+| **Goodreads** | CSV export | Title, author, ISBN, rating (1–5), date read, shelves, review, page count, Goodreads ID | 🟢 | **MVP** | `[Validation Required]` — verify current CSV column names |
+| **Calibre** | SQLite `metadata.db` + OPF | Full metadata, tags, custom columns, series, publisher, covers, file paths | 🟡 | Phase 2 | `[Validated]` — well-documented, stable schema |
+| **StoryGraph** | CSV export | Title, author, rating, moods, pace, dates, content warnings | 🟡 | Phase 3 | `[Validation Required]` — verify export availability and format |
+| **Manual entry** | CLI flags | User-supplied fields | 🟢 | **MVP** | N/A |
+| **ISBN list** | Plain text | ISBNs only → metadata fetch | 🟢 | **MVP** | N/A |
+| **Generic CSV** | User-mapped CSV | Flexible column mapping | 🟡 | Phase 2 | N/A |
+| **LibraryThing** | CSV/JSON | Full metadata, tags, ratings | 🟡 | Phase 3 | `[Validation Required]` |
+| **BibTeX** | `.bib` files | Academic citations | 🟡 | Phase 3 | N/A |
+
+**Goodreads import detail** — This is the MVP killer feature. The Goodreads CSV export `[Validation Required]` typically contains these columns: Book Id, Title, Author, Author l-f, Additional Authors, ISBN, ISBN13, My Rating, Average Rating, Publisher, Binding, Number of Pages, Year Published, Original Publication Year, Date Read, Date Added, Bookshelves, Bookshelves with positions, Exclusive Shelf, My Review, Spoiler, Private Notes, Read Count, Owned Copies.
+
+**Mapping strategy**:
+- `Exclusive Shelf` → Reading status (read, currently-reading, to-read)
+- `Bookshelves` → User shelves/tags
+- `My Rating` → Rating (multiply by 2 for 0–10 scale)
+- `Date Read` → Reading session end date
+- `Date Added` → Date added to library
+- `My Review` → Review text
+- `ISBN13` → Primary identifier for metadata enrichment
+- `Book Id` → Stored as `goodreads_id` for dedup on re-import
+
+### 3.1.1 — Import Fidelity & Migration UX
+
+Every importer implements the `ImportEngine` trait with these capabilities:
+
+- **Dry-run mode** 🟢: `toku import goodreads ~/export.csv --dry-run` → shows what would happen without writing.
+- **Idempotent re-import** 🟡: Source ID stored per book (`goodreads_id`, `calibre_id`). Re-importing the same file skips existing entries, updates changed fields (respecting user edits).
+- **Match confidence** 🟡:
+  - **Exact**: ISBN match → auto-merge
+  - **High**: Title + Author exact match → auto-merge with confirmation summary
+  - **Fuzzy**: Partial title match → flagged for user review
+  - **None**: New entry created
+- **Partial failure handling** 🟡: Import progress checkpointed every 100 books. On failure, `toku import --resume` continues from last checkpoint.
+- **Field mapping report** 🟢: Post-import summary showing fields imported, matched, skipped.
+- **Provenance tracking** 🟢: Every imported field records `(source, date)`. User edits clear provenance and mark the field as `user_override`.
+- **Rollback** 🟡: `toku import undo <import-id>` removes all books added by that import.
+- **Import log** 🟢: `import_logs` table records every import operation.
+
+### 3.1.2 — Canonical Lossless Export Format
+
+**Recommendation**: ZIP archive containing JSON + cover images.
+
+```
+toku-backup-2025-07-14.zip
+├── manifest.json          # Version, export date, book count
+├── library.json           # Full data model as structured JSON
+├── covers/                # Cover images by content hash
+│   ├── a1b2c3d4.jpg
+│   └── ...
+└── schema-version.txt     # Data model version for forward compatibility
+```
+
+- **Self-contained**: Single ZIP file, no external dependencies.
+- **Documented**: JSON schema published in `docs/export-format.md`.
+- **Versioned**: `schema-version.txt` enables future parsers to handle old exports.
+- **Round-trip**: `toku export backup` → `toku import backup toku-backup.zip` = identical library.
+
+Rejected alternatives:
+- SQLite dump: portable but opaque — users can't inspect without SQLite tools.
+- JSON-only: doesn't include cover images.
+
+### 3.2 — Export System
+
+| Format | Use Case | Phase | Complexity |
+|--------|----------|-------|-----------|
+| JSON (full) | Backup, programmatic access | **MVP** | 🟢 |
+| CSV | Spreadsheet users | **MVP** | 🟢 |
+| Markdown | Blog posts, reading lists | Phase 2 | 🟢 |
+| ZIP backup (canonical) | Full backup/migration | Phase 2 | 🟡 |
+| BibTeX | Academic citations | Phase 3 | 🟡 |
+| OPDS | E-reader catalog | Phase 6 | 🟡 |
+| HTML | Static reading list site | Phase 3 | 🟡 |
+
+### 3.3 — Book Metadata Sources
+
+**Primary: Open Library API** `[Validated]`
+- Free, no API key required, community-maintained.
+- REST API: `https://openlibrary.org/isbn/{isbn}.json`
+- Good coverage for popular titles. Gaps for non-English, self-published, and niche academic works.
+- Cover API: `https://covers.openlibrary.org/b/isbn/{isbn}-L.jpg`
+- Rate limits: generous (100 req/min stated, practically higher) `[Validation Required]`
+
+**Fallback: Google Books API** `[Validation Required]`
+- 1,000 requests/day free tier (no key), higher with API key.
+- Broader coverage than Open Library, especially for recent releases.
+- Terms of service: allows caching for offline use `[Validation Required]`
+- Better cover image quality in many cases.
+
+**Merge strategy**: Query Open Library first. If no result or missing fields, query Google Books. User edits always take precedence. Empty fields filled from the highest-quality available source.
+
+Rejected alternatives:
+- ISBNdb: paid — violates $0 budget constraint.
+- WorldCat: Search API terms unclear for open-source use `[Validation Required]`.
+- BookBrainz: growing but sparse coverage.
+
+### 3.4 — Cover Image Strategy
+
+- **Sources**: Open Library Covers API (primary), Google Books thumbnail (fallback), user upload via `toku cover set <book> <path>`.
+- **Storage**: Filesystem, content-addressed. `covers/{sha256_first_16_chars}.jpg`. Thumbnails generated on first display (200px width) and cached as `covers/thumb/{hash}.jpg`.
+- **Offline**: Covers fetched once, stored locally forever. App works without covers (text-only display in CLI).
+- **No cover placeholder**: Color-coded rectangle derived from genre/title hash. Visually distinct per book.
+- **Resolution**: Store original as fetched (typically 300–600px). Generate thumbnails on demand.
+
+### 3.5 — Non-Goals & Red Lines
+
+- ❌ **No piracy features**: No ebook downloading, no DRM stripping, no torrent integration.
+- ❌ **No scraping**: No Goodreads web scraping (Goodreads has no public API since 2020), no Amazon scraping.
+- ❌ **No write-back**: Import is one-directional. Toku does not update Goodreads, StoryGraph, or any external service.
+- ❌ **No social features**: No user accounts for sharing, no activity feeds, no book clubs.
+- ❌ **No cloud dependency for core features**: Metadata fetch is enrichment, not requirement.
+
+---
+
+## Section 3A: Bibliographic Domain Complexity & Canonical Modeling
+
+### 3A.1 — Work / Edition / Copy Model
+
+**Recommendation**: Start with **Book = Edition** (flat model), add Work grouping in Phase 3.
+
+**MVP (Phases 0–2)**: Each book row represents a specific edition. The schema includes a nullable `work_id` column (UUID) that is NULL initially. When two books are the "same work" (e.g., hardcover and Kindle edition of Dune), they can be linked later.
+
+**Phase 3 migration**: Introduce a `works` table. Run a migration that groups books by normalized title + primary author. Present ambiguous matches for user confirmation. This is a batch operation, not an ongoing workflow — most users with 100–500 books have few duplicate works.
+
+**Why not full FRBR from day one?** FRBR (Functional Requirements for Bibliographic Records) is designed for libraries serving millions of patrons. For a personal library of 100–500 books, the work/expression/manifestation/item hierarchy adds UI complexity without matching value. A user adding "Dune" doesn't want to navigate a work tree — they want one book entry they can refine.
+
+**How Goodreads handles this**: Goodreads conflates work and edition — a "book" page aggregates all editions, but reviews and ratings are per-work. This causes problems: the page count shown may not match the user's edition, and edition-specific metadata is lossy. Toku avoids this by making each entry an edition with optional work grouping.
+
+### 3A.2 — Contributor Modeling
+
+**Data model** (MVP):
+```
+contributors (id, name, sort_name, external_ids_json)
+book_contributors (book_id, contributor_id, role, position)
+```
+
+**Roles** (enum): `author`, `co_author`, `editor`, `translator`, `illustrator`, `narrator`, `foreword`, `compiler`, `contributor`.
+
+**Name handling**:
+- `name`: Display name ("Ursula K. Le Guin")
+- `sort_name`: Sort key ("Le Guin, Ursula K.")
+- Pseudonyms: stored as separate contributor entries linked via `alias_of` nullable FK.
+- "Various Authors" / "Anonymous": special-cased with a flag, not string matching.
+
+**MVP simplification**: Most imported books have one author. The multi-contributor model exists in the schema but the CLI defaults to `--author "Name"` for the common case. Complex contributor entry is available via `toku contributor add` and flags.
+
+### 3A.3 — Identifier Systems
+
+| Identifier | Column | Validation | Notes |
+|------------|--------|-----------|-------|
+| ISBN-13 | `isbn13` (TEXT) | Check digit validation | Primary identifier |
+| ISBN-10 | `isbn10` (TEXT) | Check digit, auto-convert to ISBN-13 | Legacy, stored alongside ISBN-13 |
+| ASIN | `asin` (TEXT) | Format check (B0...) | Common for Kindle books |
+| Goodreads ID | `goodreads_id` (TEXT) | Numeric string | Import dedup key |
+| Open Library ID | `openlibrary_id` (TEXT) | /works/OL... or /editions/OL... | Metadata enrichment link |
+| Internal UUID | `id` (TEXT, UUID v7) | Always present | Primary key, sortable by creation time |
+
+**Books without identifiers**: Fully supported. Manual entry creates a book with only a UUID. Title + Author are the minimum fields. ISBNs are optional. The app prompts for ISBN enrichment but never requires it.
+
+**Source-of-truth precedence**: User edit > Import source data > API-fetched metadata. Per-field provenance tracks this chain.
+
+### 3A.4 — Edge Cases
+
+| Edge Case | MVP Handling | Full Handling (Phase 3+) |
+|-----------|-------------|------------------------|
+| Anthologies | Single book entry, multiple authors via roles | Nested works within a parent book |
+| Omnibus editions | Single book entry with note | Link to constituent works |
+| Translations | Separate book entry per language | Linked as editions of same work |
+| Revised editions | Separate entries | Linked as editions of same work |
+| Audiobooks | Book entry with `format=audiobook`, duration field, narrator as contributor | Full audiobook metadata (chapters, bitrate) |
+| Comics/manga | Book entry with `format=comic`, volume number in series | Artist/writer role distinction |
+| Partial dates | Year-only stored as `YYYY-01-01` with `date_precision` flag | Same |
+| Series complexity | `series_name` + `series_position` (decimal for sub-numbering) | Multiple series membership |
+| No-ISBN books | Manual entry, title+author as dedup key | Same |
+
+### 3A.5 — Metadata Correction & Provenance
+
+Every mutable metadata field on a book has an associated provenance record:
+
+```sql
+metadata_provenance (
+  book_id TEXT,
+  field_name TEXT,
+  source TEXT,        -- 'user', 'goodreads_import', 'openlibrary_api', etc.
+  source_date TEXT,   -- ISO 8601
+  is_user_override BOOLEAN DEFAULT FALSE,
+  PRIMARY KEY (book_id, field_name)
+)
+```
+
+**Rules**:
+1. User edits set `is_user_override = TRUE`. Auto-enrichment skips fields where `is_user_override = TRUE`.
+2. Re-import updates non-overridden fields with newer source data.
+3. `toku book provenance "Dune"` shows the source of every field.
+
+### 3A.6 — Internationalization
+
+- **MVP**: English-only UI. Book metadata in any language/script (UTF-8 throughout).
+- **Title handling**: Single `title` field. `original_title` as optional separate field for translations.
+- **Sorting**: ICU collation via SQLite ICU extension `[Validation Required]` — needed for correct CJK, Arabic, Cyrillic sort order. Fallback: binary sort (acceptable for MVP).
+- **App i18n**: Deferred to post-1.0. Design for it (externalize strings) but don't implement.
+
+---
+
+## Section 4: Core Feature Set
+
+### 4.1 — Book Entry & Metadata Management
+
+| Feature | MVP | Full | Complexity |
+|---------|-----|------|-----------|
+| Add book manually (title, author) | ✅ | ✅ | 🟢 |
+| Add by ISBN with metadata fetch | ✅ | ✅ | 🟢 |
+| Add by title/author search | ❌ | ✅ | 🟡 |
+| Edit any metadata field | ✅ | ✅ | 🟢 |
+| Custom user-defined fields | ❌ | ✅ (Phase 3) | 🟡 |
+| Series management | ✅ (basic) | ✅ | 🟢 |
+| Edition tracking (work grouping) | ❌ | ✅ (Phase 3) | 🟡 |
+| Author page (all books by author) | ❌ | ✅ (Phase 2) | 🟢 |
+| Cover image auto-fetch | ✅ | ✅ | 🟢 |
+| Merge duplicate books | ❌ | ✅ (Phase 3) | 🟡 |
+
+### 4.2 — Reading Status & Progress Tracking
+
+| Feature | MVP | Full | Complexity |
+|---------|-----|------|-----------|
+| Reading states (want/reading/read/abandoned/on-hold) | ✅ | ✅ | 🟢 |
+| Start and finish dates | ✅ | ✅ | 🟢 |
+| Page-based progress | ❌ | ✅ (Phase 2) | 🟢 |
+| Time-based progress (audiobooks) | ❌ | ✅ (Phase 2) | 🟡 |
+| Multiple reading sessions (re-reads) | ❌ | ✅ (Phase 2) | 🟡 |
+| Reading log entries | ❌ | ✅ (Phase 2) | 🟢 |
+| Reading speed calculation | ❌ | ✅ (Phase 3) | 🟡 |
+| Daily/weekly page targets | ❌ | ✅ (Phase 3) | 🟡 |
+
+### 4.3 — Library Organization
+
+| Feature | MVP | Full | Complexity |
+|---------|-----|------|-----------|
+| Shelves / collections | ✅ | ✅ | 🟢 |
+| Tags (free-form) | ✅ | ✅ | 🟢 |
+| Smart shelves (saved filters) | ❌ | ✅ (Phase 3) | 🟡 |
+| Sorting (title, author, date, rating) | ✅ | ✅ | 🟢 |
+| Filtering (status, tag, shelf) | ✅ | ✅ | 🟢 |
+
+### 4.4 — Ratings, Reviews & Notes
+
+| Feature | MVP | Full | Complexity |
+|---------|-----|------|-----------|
+| Star rating (0–10, displayed as 0–5 with halves) | ✅ | ✅ | 🟢 |
+| Written review (markdown) | ✅ | ✅ | 🟢 |
+| Per-book notes | ❌ | ✅ (Phase 2) | 🟢 |
+| Mood tags | ❌ | ✅ (Phase 3) | 🟢 |
+| Pace rating (fast/medium/slow) | ❌ | ✅ (Phase 3) | 🟢 |
+| Content warnings (user-defined) | ❌ | ✅ (Phase 3) | 🟢 |
+
+### 4.5 — Search & Discovery
+
+| Feature | MVP | Full | Complexity |
+|---------|-----|------|-----------|
+| Full-text search (FTS5) | ✅ | ✅ | 🟢 |
+| Fuzzy search (typo-tolerant) | ❌ | ✅ (Phase 3) | 🟡 |
+| Faceted search (filter by status, tag, shelf) | ✅ (basic) | ✅ | 🟡 |
+| Random book picker ("what should I read?") | ❌ | ✅ (Phase 2) | 🟢 |
+| "More like this" | ❌ | ✅ (Phase 3) | 🟡 |
+
+### 4.6 — Reading Statistics & Analytics
+
+| Feature | MVP | Full | Complexity |
+|---------|-----|------|-----------|
+| Books read this year/month | ❌ | ✅ (Phase 2) | 🟢 |
+| Reading pace (books/month) | ❌ | ✅ (Phase 2) | 🟢 |
+| Genre/tag distribution | ❌ | ✅ (Phase 3) | 🟡 |
+| Rating distribution | ❌ | ✅ (Phase 3) | 🟢 |
+| Author diversity stats | ❌ | ✅ (Phase 3) | 🟡 |
+| Reading streaks | ❌ | ✅ (Phase 3) | 🟡 |
+| Time-to-finish averages | ❌ | ✅ (Phase 3) | 🟡 |
+| Mood trends over time | ❌ | ✅ (Phase 3) | 🟡 |
+| Format breakdown (physical/ebook/audio) | ❌ | ✅ (Phase 3) | 🟢 |
+| Yearly wrap-up report | ❌ | ✅ (Phase 3) | 🔴 |
+| Goal tracking (52 books/year) | ❌ | ✅ (Phase 3) | 🟡 |
+
+All statistics computed locally from SQLite queries. No server needed.
+
+### 4.7 — Reading Goals & Challenges
+
+| Feature | Phase | Complexity |
+|---------|-------|-----------|
+| Annual book count goal | Phase 3 | 🟢 |
+| Page count goal | Phase 3 | 🟢 |
+| Custom challenges | Phase 3 | 🟡 |
+| Challenge templates | Post-1.0 | 🟡 |
+
+---
+
+## Section 5: Features You May Have Missed
+
+| # | Feature | Why It Matters | Phase | Complexity |
+|---|---------|---------------|-------|-----------|
+| 1 | **Lending tracker** | "Lent Dune to Alex on March 5 — remind me in 30 days." Tracks who has your books. | Phase 2 | 🟢 |
+| 2 | **Quotes / highlights** | Save favorite passages with page refs. High-value for re-reads. | Phase 2 | 🟢 |
+| 3 | **TBR priority ranking** | Numbered priority for the to-read pile. `toku tbr next` returns the top pick. | Phase 2 | 🟢 |
+| 4 | **Reading journal** | Date-stamped free-form entries while reading — not reviews, but in-progress thoughts. | Phase 3 | 🟢 |
+| 5 | **Book timeline** | Visual timeline: when did I read what? Rendered as ASCII art in CLI, SVG in web. | Phase 3 | 🟡 |
+| 6 | **DNF tracking** | "Stopped at page 142 because the pacing fell apart." Abandoned status + reason + page. | Phase 2 | 🟢 |
+| 7 | **Batch operations** | `toku tag add "sci-fi" --shelf "2024 Reads"` — tag 50 books in one command. | Phase 2 | 🟡 |
+| 8 | **Data integrity checks** | `toku doctor` — find orphaned records, missing covers, invalid ISBNs. | Phase 2 | 🟡 |
+| 9 | **Reading time estimation** | "Based on your average speed, this 400-page book will take ~8 hours." | Phase 3 | 🟡 |
+| 10 | **Location tracking** | "Bedroom shelf, row 2." Physical book locations. Simple text field per book. | Phase 2 | 🟢 |
+| 11 | **Re-read tracking with separate ratings** | Different rating per read. "I rated Dune 4★ in 2019 and 5★ on re-read in 2024." | Phase 2 | 🟡 |
+| 12 | **Library value tracking** | Purchase price field. Total library value report for collectors/insurance. | Phase 3 | 🟢 |
+| 13 | **Barcode/ISBN scanning** | Camera-based ISBN scan on mobile. Key feature for iOS app. | Phase 5 | 🟡 |
+| 14 | **Dark mode / accessibility** | All interfaces respect system theme. Screen reader support. `NO_COLOR` env var. | Phase 1+ | 🟢 |
+| 15 | **Shell completions** | bash, zsh, fish, PowerShell completions auto-generated from clap. | Phase 1 | 🟢 |
+
+---
+
+## Section 6: Ebook File Management (Future — Phase 6)
+
+**Recommendation**: Defer file management to Phase 6 (post-1.0). The MVP is a reading tracker, not a file manager. The architecture accommodates file management through the modular crate design, but the feature set is not committed.
+
+### 6.1 — File Management (Phase 6)
+
+- Associate ebook files (.epub, .pdf, .mobi, .azw3) with book entries 🟡
+- Organize files on disk using configurable templates (`{author}/{title}.{format}`) 🟡
+- Multiple formats per book 🟢
+- File integrity checking (SHA-256 checksums) 🟢
+- Disk usage reporting 🟢
+
+### 6.2 — Format Conversion (Phase 6)
+
+**Recommendation**: Shell out to Calibre's `ebook-convert` CLI tool.
+
+Building a format converter in Rust is a multi-month project. Calibre's converter is mature, handles edge cases, and is free. The dependency is optional — `toku convert` checks for `ebook-convert` in `$PATH` and provides installation instructions if missing. 🟡
+
+DRM note: Only DRM-free files are supported. No DRM stripping.
+
+### 6.3 — OPDS Server (Phase 6)
+
+- Serve the library as an OPDS catalog for e-readers (KOReader, Moon+ Reader) 🟡
+- Local network only by default
+- Optional basic authentication
+
+### 6.4 — Architecture Note
+
+File management lives in a new `toku-files` crate that depends on `toku-core` and `toku-db`. It adds file path columns to the book table and a `files` table for multi-format tracking. This does NOT affect the metadata sync strategy — file sync is a separate, harder problem deferred to Phase 7.
+
+---
+
+## Section 7: Moonshot Features
+
+### 7.1 — AI-Powered Personal Recommendations 🔴
+
+- On-device only. No cloud, no data sharing.
+- Approach: TF-IDF or lightweight embeddings over book descriptions + user ratings. Not deep learning.
+- Feasibility: A Rust-native recommendation engine using `ndarray` + cosine similarity over user taste vectors is viable for 500 books. Full ML is overkill.
+- Phase: Post-1.0 research.
+
+### 7.2 — Reading Session Timer 🟡
+
+- `toku timer start "Dune"` → `toku timer stop` → auto-log pages read and duration.
+- Useful for reading speed statistics.
+- Phase: Phase 3 (simple), Phase 5 for mobile widget.
+
+### 7.3 — Web Clipper / Article Saver ⛔
+
+- **Recommendation: Out of scope.** This overlaps with Pocket/Omnivore/Readwise. Adding it dilutes the book focus. Users who want article tracking should use a dedicated tool.
+
+### 7.4 — Ebook Reader Integration 🔴
+
+- Kindle Clippings.txt: parseable, well-documented format `[Validation Required]`. Import highlights/notes.
+- Kobo SQLite DB: `KoboReader.sqlite` on device `[Validation Required]`. Reading progress sync.
+- Apple Books: annotations in `~/Library/Containers/com.apple.iBooksX/` `[Validation Required]`.
+- Phase: Post-1.0 research. High value but each reader is a separate integration effort.
+
+### 7.5 — Self-Hosted Sync Server 🔴
+
+- Deferred to Phase 7. cr-sqlite is the preferred approach (see Section 2.5).
+- Alternative: lightweight Axum server with REST API + Docker deployment.
+- All data encrypted at rest on server.
+
+---
+
+## Section 8: Data Model
+
+### Entity Relationship Diagram (Text)
+
+```
+works (1) ──── (M) books
+books (1) ──── (M) book_contributors ──── (M) contributors
+books (1) ──── (M) book_series ──── (M) series
+books (1) ──── (M) reading_sessions
+books (1) ──── (M) reading_progress
+books (1) ──── (M) book_shelves ──── (M) shelves
+books (1) ──── (M) book_tags ──── (M) tags
+books (1) ──── (M) reviews
+books (1) ──── (M) notes
+books (1) ──── (M) custom_fields
+books (1) ──── (M) identifiers
+books (1) ──── (1) cover_images
+books (1) ──── (M) metadata_provenance
+import_logs (standalone)
+reading_goals (standalone)
+```
+
+### Core Tables
+
+```sql
+-- Books (each row is an edition)
+CREATE TABLE books (
+  id TEXT PRIMARY KEY,              -- UUID v7
+  work_id TEXT,                      -- nullable FK to works (Phase 3)
+  title TEXT NOT NULL,
+  subtitle TEXT,
+  description TEXT,
+  page_count INTEGER,
+  duration_minutes INTEGER,          -- audiobooks: total duration
+  publication_date TEXT,             -- ISO 8601 (YYYY, YYYY-MM, or YYYY-MM-DD)
+  date_precision TEXT DEFAULT 'day', -- 'year', 'month', 'day'
+  language TEXT,                     -- ISO 639-1
+  format TEXT DEFAULT 'physical',    -- physical, ebook, audiobook, comic
+  publisher TEXT,
+  cover_hash TEXT,                   -- references covers/{hash}.jpg
+  status TEXT DEFAULT 'want_to_read', -- want_to_read, reading, read, abandoned, on_hold
+  rating INTEGER,                    -- 0-10 (displayed as 0-5 stars with halves)
+  date_added TEXT NOT NULL,          -- ISO 8601
+  date_started TEXT,
+  date_finished TEXT,
+  location TEXT,                     -- physical location ("bedroom shelf, row 2")
+  purchase_price REAL,              -- optional, for collectors
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL
+);
+
+-- Contributors (authors, translators, narrators, etc.)
+CREATE TABLE contributors (
+  id TEXT PRIMARY KEY,
+  name TEXT NOT NULL,
+  sort_name TEXT,
+  alias_of TEXT,                     -- FK to contributors.id for pseudonyms
+  bio TEXT,
+  birth_year INTEGER,
+  death_year INTEGER,
+  external_ids TEXT                  -- JSON: {"openlibrary": "OL...", "isni": "..."}
+);
+
+CREATE TABLE book_contributors (
+  book_id TEXT NOT NULL REFERENCES books(id),
+  contributor_id TEXT NOT NULL REFERENCES contributors(id),
+  role TEXT NOT NULL DEFAULT 'author',
+  position INTEGER NOT NULL DEFAULT 0,  -- display order
+  PRIMARY KEY (book_id, contributor_id, role)
+);
+
+-- Identifiers
+CREATE TABLE identifiers (
+  book_id TEXT NOT NULL REFERENCES books(id),
+  id_type TEXT NOT NULL,             -- isbn13, isbn10, asin, goodreads_id, openlibrary_id, etc.
+  id_value TEXT NOT NULL,
+  PRIMARY KEY (book_id, id_type, id_value)
+);
+
+-- Series
+CREATE TABLE series (
+  id TEXT PRIMARY KEY,
+  name TEXT NOT NULL,
+  total_books INTEGER               -- NULL if unknown
+);
+
+CREATE TABLE book_series (
+  book_id TEXT NOT NULL REFERENCES books(id),
+  series_id TEXT NOT NULL REFERENCES series(id),
+  position REAL,                     -- decimal for sub-numbering (1.5 for novellas)
+  PRIMARY KEY (book_id, series_id)
+);
+
+-- Reading sessions (supports re-reads)
+CREATE TABLE reading_sessions (
+  id TEXT PRIMARY KEY,
+  book_id TEXT NOT NULL REFERENCES books(id),
+  start_date TEXT,
+  end_date TEXT,
+  status TEXT NOT NULL,              -- reading, read, abandoned, on_hold
+  rating INTEGER,                    -- per-session rating (may differ from book rating)
+  review_text TEXT,
+  created_at TEXT NOT NULL
+);
+
+-- Reading progress log
+CREATE TABLE reading_progress (
+  id TEXT PRIMARY KEY,
+  session_id TEXT NOT NULL REFERENCES reading_sessions(id),
+  logged_at TEXT NOT NULL,
+  page_number INTEGER,
+  percentage REAL,
+  duration_minutes INTEGER,          -- for audiobooks: minutes listened
+  notes TEXT
+);
+
+-- Shelves and tags
+CREATE TABLE shelves (
+  id TEXT PRIMARY KEY,
+  name TEXT NOT NULL UNIQUE,
+  description TEXT,
+  is_smart BOOLEAN DEFAULT FALSE,
+  smart_filter TEXT                  -- JSON filter definition for smart shelves
+);
+
+CREATE TABLE book_shelves (
+  book_id TEXT NOT NULL REFERENCES books(id),
+  shelf_id TEXT NOT NULL REFERENCES shelves(id),
+  PRIMARY KEY (book_id, shelf_id)
+);
+
+CREATE TABLE tags (
+  id TEXT PRIMARY KEY,
+  name TEXT NOT NULL UNIQUE,
+  tag_type TEXT DEFAULT 'general'    -- general, mood, pace, content_warning
+);
+
+CREATE TABLE book_tags (
+  book_id TEXT NOT NULL REFERENCES books(id),
+  tag_id TEXT NOT NULL REFERENCES tags(id),
+  PRIMARY KEY (book_id, tag_id)
+);
+
+-- Reviews and notes
+CREATE TABLE reviews (
+  id TEXT PRIMARY KEY,
+  book_id TEXT NOT NULL REFERENCES books(id),
+  session_id TEXT REFERENCES reading_sessions(id),
+  rating INTEGER,
+  text TEXT,
+  date_written TEXT NOT NULL,
+  updated_at TEXT
+);
+
+CREATE TABLE notes (
+  id TEXT PRIMARY KEY,
+  book_id TEXT NOT NULL REFERENCES books(id),
+  page_reference TEXT,               -- page number, chapter, or timestamp
+  text TEXT NOT NULL,
+  note_type TEXT DEFAULT 'note',     -- note, quote, highlight
+  created_at TEXT NOT NULL
+);
+
+-- Custom fields (key-value per book)
+CREATE TABLE custom_fields (
+  book_id TEXT NOT NULL REFERENCES books(id),
+  field_name TEXT NOT NULL,
+  field_value TEXT NOT NULL,
+  PRIMARY KEY (book_id, field_name)
+);
+
+-- Reading goals
+CREATE TABLE reading_goals (
+  id TEXT PRIMARY KEY,
+  year INTEGER NOT NULL,
+  goal_type TEXT NOT NULL,           -- books, pages
+  target INTEGER NOT NULL,
+  created_at TEXT NOT NULL
+);
+
+-- Metadata provenance
+CREATE TABLE metadata_provenance (
+  book_id TEXT NOT NULL REFERENCES books(id),
+  field_name TEXT NOT NULL,
+  source TEXT NOT NULL,
+  source_date TEXT NOT NULL,
+  is_user_override BOOLEAN DEFAULT FALSE,
+  PRIMARY KEY (book_id, field_name)
+);
+
+-- Import logs
+CREATE TABLE import_logs (
+  id TEXT PRIMARY KEY,
+  source TEXT NOT NULL,
+  file_path TEXT,
+  imported_at TEXT NOT NULL,
+  total_records INTEGER,
+  imported_count INTEGER,
+  skipped_count INTEGER,
+  error_count INTEGER,
+  errors_json TEXT,
+  status TEXT DEFAULT 'completed'    -- in_progress, completed, failed, rolled_back
+);
+
+-- FTS5 virtual table for full-text search
+CREATE VIRTUAL TABLE books_fts USING fts5(
+  title, subtitle, description,
+  content='books', content_rowid='rowid'
+);
+```
+
+**Audiobook support**: The `books` table includes `duration_minutes` for total audiobook length. `reading_progress` includes `duration_minutes` for per-session listening time. The `contributor` role `narrator` handles audiobook narrators. This avoids a separate audiobook table.
+
+**Custom fields**: Implemented as a key-value join table — no schema changes per field. Queryable via `SELECT * FROM custom_fields WHERE field_name = 'course'`.
+
+**Migration strategy**: `refinery` crate manages versioned migrations (`V001__initial_schema.sql`, `V002__add_work_id.sql`, etc.). Migrations run automatically on startup. Schema version stored in SQLite `PRAGMA user_version`.
+
+---
+
+## Section 9: Design Brief
+
+### 9.1 — Design Principles
+
+1. **Personal & Private** — No login screens, no accounts, no "sign in to continue." The app opens directly to your library.
+2. **Information-Dense** — Show maximum useful data per screen. Terminal real estate is precious. Avoid sparse layouts.
+3. **Keyboard-First** — Every action reachable via keyboard. CLI is the primary interface. Web UI uses keyboard shortcuts.
+4. **Your Data, Readable** — The underlying SQLite database is a feature, not an implementation detail. Users can query it directly with `sqlite3`.
+5. **Fast & Responsive** — <200ms CLI startup. Instant search. No loading spinners for local operations.
+6. **Graceful Degradation** — Works without network (no metadata fetch). Works without covers (text mode). Works on a 80-column terminal.
+
+### 9.2 — CLI Design
+
+**Command structure**:
+
+```bash
+# Book management
+toku add "Dune" --author "Frank Herbert"
+toku add --isbn 9780441013593
+toku edit "Dune" --rating 9 --tag "sci-fi" --tag "classic"
+toku show "Dune"                          # detailed view
+toku list                                  # all books, default sort
+toku list --status reading --sort progress
+toku search "herbert"                      # full-text search
+toku remove "Dune" --confirm
+
+# Reading tracking
+toku start "Dune"                          # set status to 'reading'
+toku update "Dune" --page 145              # log progress
+toku finish "Dune" --rating 9              # mark as read
+toku abandon "Dune" --page 87 --reason "Too slow"
+
+# Organization
+toku shelf create "Beach Reads"
+toku shelf add "Beach Reads" "Dune" "Neuromancer"
+toku tag add "sci-fi" "Dune" "Neuromancer" "Snow Crash"
+
+# Import / Export
+toku import goodreads ~/goodreads_export.csv
+toku import goodreads ~/goodreads_export.csv --dry-run
+toku import calibre ~/Calibre\ Library/
+toku export csv --output ~/my-library.csv
+toku export json --output ~/library.json
+toku export backup --output ~/toku-backup.zip
+
+# Statistics
+toku stats                                 # current year summary
+toku stats --year 2024
+toku stats --author "Frank Herbert"
+
+# Utilities
+toku doctor                                # data integrity check
+toku config                                # show/edit configuration
+toku enrich --isbn-only                    # fetch metadata for books with ISBNs but missing data
+```
+
+**Output formatting**:
+- Default: rich terminal tables with color (via `tabled` or `comfy-table` crate)
+- `--format json`: machine-readable JSON output
+- `--format csv`: CSV output
+- `--format markdown`: markdown table
+- `--no-color` / `NO_COLOR` env var: plain text
+
+**CLI framework**: `clap` v4 with derive macros. Auto-generates help, shell completions (bash/zsh/fish/PowerShell), and man pages.
+
+**Configuration**: TOML file at `{data_dir}/config.toml`:
+```toml
+[display]
+default_format = "table"
+color = true
+date_format = "%Y-%m-%d"
+
+[metadata]
+auto_fetch = true
+primary_source = "openlibrary"
+fallback_source = "google_books"
+
+[library]
+default_status = "want_to_read"
+```
+
+### 9.3 — Web UI Design (Phase 4)
+
+- **Technology**: Axum backend serving HTMX + minimal JS, or Leptos for full Rust stack.
+- **Key screens**: Library grid/list, book detail, progress dashboard, statistics, import wizard, search.
+- **Dark mode**: System-preference detection + toggle.
+- **PWA**: Service worker for offline browsing of cached library data.
+- **Responsive**: Mobile-friendly layouts.
+
+### 9.4 — Key Screens Per Platform
+
+| Platform | Key Screens |
+|----------|------------|
+| **CLI** | `list` (table), `show` (detail), `stats` (summary), `search` (results), `import` (progress) |
+| **Web** | Library grid, book detail + progress, stats dashboard with charts, import wizard, search with facets |
+| **iOS** | Library grid, book detail, quick progress update, barcode scanner, stats glance |
+| **macOS** | Sidebar + content, multi-column library, stats with charts |
+
+### 9.5 — Information Architecture
+
+- **CLI navigation**: Command-based. `toku list` → `toku show "Dune"` → `toku edit "Dune" --rating 9`. No stateful navigation — each command is independent.
+- **Search UX**: `toku search` uses FTS5. Instant results. Filters via flags (`--status`, `--tag`, `--shelf`).
+- **Onboarding**: First run detects empty library → suggests `toku import goodreads <file>` or `toku add --isbn <isbn>`. Interactive welcome message.
+
+---
+
+## Section 10: Competitive Analysis
+
+### 10.1 — Direct Competitors
+
+| App | Privacy | Platforms | Export | Offline | Open Source | Key Weakness |
+|-----|---------|-----------|--------|---------|-------------|-------------|
+| **Goodreads** | Poor (Amazon) | Web, mobile | CSV (lossy) | No | No | Stagnant UI, Amazon data harvesting, declining API |
+| **StoryGraph** | Moderate | Web, mobile | CSV | No | No | No offline mode, limited customization, no CLI |
+| **Bookwyrm** | Good (federated) | Web | JSON-LD | Self-host only | Yes (AGPL) | Social-first (opposite philosophy), complex setup |
+| **Hardcover** | Moderate | Web | API | No | Partially | Young platform, limited export |
+| **Oku** | Good | Web | Limited | No | Yes | Minimal features, small community |
+| **BookTracker** | Good (local) | iOS only | None | Yes | No | Apple-only, no CLI, no export |
+
+### 10.2 — Library Managers
+
+| App | Strengths | Weaknesses for Our User |
+|-----|-----------|------------------------|
+| **Calibre** | Unmatched metadata engine, format conversion, plugin ecosystem | No reading tracking, dated UI, desktop-only |
+| **Kavita** | Self-hosted reading server, good UI | Focused on serving files, not tracking reading |
+| **Audiobookshelf** | Excellent audiobook management | Audiobook-specific, not general book tracking |
+
+### 10.3 — Differentiation Matrix
+
+```
+                    High Data Ownership
+                          │
+              Toku ●      │
+                          │      ● Calibre
+                          │
+    Minimal ──────────────┼────────────── Feature Rich
+    Features              │               Features
+                          │
+              ● Oku       │      ● StoryGraph
+                          │      ● Goodreads
+                          │
+                    Low Data Ownership
+```
+
+**Why Toku wins now**:
+1. **Goodreads is rotting**: No API since 2020, UI unchanged for years, Amazon integration concerns growing.
+2. **Privacy wave**: Post-GDPR, readers increasingly care about data ownership.
+3. **CLI renaissance**: Tools like `ripgrep`, `fd`, `bat`, `jq` prove terminal-first tools find audiences.
+4. **No competitor combines**: Calibre-grade metadata + StoryGraph-grade analytics + offline-first + open source + CLI.
+
+---
+
+## Section 11: Licensing & Open Source Strategy
+
+### 11.1 — License Selection
+
+**Recommendation: MIT License**
+
+| License | Verdict | Reasoning |
+|---------|---------|-----------|
+| **MIT** ✅ | **Selected** | Maximum contributor friendliness. Standard in Rust ecosystem. No friction for forks, integrations, or commercial use. |
+| Apache 2.0 | Runner-up | Patent grant is nice but adds legal complexity contributors don't expect in a book manager. |
+| GPL v3 | Rejected | Copyleft friction reduces contributions. FFI consumers (iOS app) face licensing complexity. |
+| AGPL v3 | Rejected | Strongest copyleft — overkill. Deters casual contributors. |
+| Dual MIT+Apache | Rejected | Unnecessary complexity for a personal tool. |
+
+### 11.2 — Contribution Model
+
+- **DCO (Developer Certificate of Origin)** — recommended over CLA. Lightweight: contributors sign off commits with `Signed-off-by`. No legal entity needed.
+- **CONTRIBUTING.md**: Code style (rustfmt + clippy), PR process, test requirements.
+- **Issue templates**: Bug report, feature request, importer request, documentation improvement.
+- **"Good first issue" strategy**: Label importer edge cases, documentation gaps, and CLI output improvements. These are self-contained and well-scoped.
+- **Code of Conduct**: Contributor Covenant v2.1.
+
+### 11.3 — Monetization & Sustainability
+
+**Recommendation: GitHub Sponsors + voluntary donations.**
+
+This is a personal tool, not a SaaS. There is no natural paywall that doesn't betray the open-source philosophy. GitHub Sponsors is the lowest-friction option: no infrastructure, no premium features to maintain, no user segmentation.
+
+Rejected alternatives:
+- Premium features: What feature would be premium? Every core feature must be free (principles 1–3).
+- Hosted sync server: Possible post-1.0, but premature to plan.
+- Open Collective: viable alternative, but GitHub Sponsors has better discoverability.
+
+---
+
+## Section 12: Tech Stack Recommendations
+
+| Component | Choice | Justification |
+|-----------|--------|--------------|
+| **Core language** | **Rust** | User-confirmed. Excellent CLI ecosystem, cross-compilation, WASM, C FFI. `clap` is best-in-class. |
+| **CLI framework** | **clap v4** (derive) | Industry standard in Rust. Auto-completions, man pages, typed arguments. |
+| **Database** | **SQLite via rusqlite** | Battle-tested, single-file, FTS5, cross-platform. `rusqlite` is mature with bundled SQLite. |
+| **Migrations** | **refinery** | Embedded SQL migrations, version tracking, type-safe. |
+| **HTTP client** | **reqwest** | Async, well-maintained, TLS support. Used for metadata API calls. |
+| **JSON** | **serde + serde_json** | De facto standard in Rust. |
+| **CSV** | **csv crate** | Fast, streaming, handles Goodreads CSV edge cases (quoted fields, newlines in reviews). |
+| **TOML** | **toml crate** | Config file parsing. |
+| **CLI output** | **tabled** or **comfy-table** | Terminal table formatting with color support. |
+| **UUID** | **uuid v7** (time-sortable) | Sortable by creation time, globally unique. |
+| **Async runtime** | **tokio** (minimal features) | Only for HTTP requests. Core library is sync. |
+| **Testing** | **Built-in + insta** (snapshot) | Snapshot tests for CLI output. Property-based tests via `proptest` for ISBN validation. |
+| **CI/CD** | **GitHub Actions** | Multi-platform matrix (Linux, macOS, Windows). Release binaries via `cargo-dist`. |
+| **Documentation** | **mdBook** (user docs) + **rustdoc** (API docs) | mdBook for the user guide. Rustdoc for crate documentation. |
+| **Distribution** | **cargo install** + **GitHub Releases** (pre-built binaries) | `cargo-dist` automates cross-compilation and release. Homebrew tap in Phase 2. |
+
+**Web stack (Phase 4)**: **Axum** (backend) + **HTMX** (frontend) or **Leptos** (full Rust). Decision deferred — both are viable. HTMX is simpler; Leptos keeps the entire stack in Rust.
+
+**iOS/macOS (Phase 5)**: **SwiftUI** consuming Rust core via C FFI (`toku-ffi` crate using `cbindgen`). Rejected React Native / Tauri for iOS due to UX quality concerns.
+
+**Windows (Phase 5)**: **Tauri v2** — wraps the web UI in a native window. Avoids building a separate WinUI app.
+
+### 12.1 — Proof-of-Concept Gates (Weeks 1–2)
+
+Before committing to the architecture, validate:
+
+| Gate | What to Prove | Success Criteria |
+|------|--------------|-----------------|
+| SQLite + FTS5 | Full-text search performance | <100ms query on 10,000 books |
+| Goodreads CSV | Parse a real export | All documented fields extracted correctly |
+| Open Library API | ISBN lookup + cover fetch | Successful lookup for 10 ISBNs, cover images downloaded |
+| CLI output | Rich table formatting | Responsive to terminal width, color support, JSON fallback |
+| Cargo workspace | Multi-crate build | `toku-core` compiles independently, `toku-cli` depends on all crates |
+| Cross-compilation | Linux + macOS + Windows | CI builds pass on all three platforms |
+
+---
+
+## Section 13: Phased Roadmap with Milestones
+
+### Phase 0: First Book 🟢
+
+**Theme**: "One book, stored and retrieved."
+**Goal**: Add one book from the CLI, store it in SQLite, retrieve it. Validate the entire stack.
+
+**Deliverables** (3):
+1. Cargo workspace with `toku-core`, `toku-db`, `toku-cli` crates
+2. `toku add --isbn <isbn>` → fetch metadata from Open Library → store in SQLite
+3. `toku show <title>` and `toku list` → display book details
+
+**Acceptance criteria**:
+- `toku add --isbn 9780441013593` fetches "Dune" metadata and stores it
+- `toku show "Dune"` displays title, author, ISBN, page count, cover status
+- `toku list` displays a formatted table of all books
+- All three work offline (with manually entered data, no fetch)
+
+**Definition of done**: The developer can add, view, and list books. The data model is validated.
+
+**Cut line**: Cover image display in CLI (text-only is fine for Phase 0).
+
+---
+
+### Phase 1: Minimum Usable Library (MVP) 🟡
+
+**Theme**: "My Goodreads library is here. I use this daily."
+**Goal**: Import a full Goodreads library, track reading status, search and organize.
+
+**Deliverables** (5):
+1. **Goodreads CSV import** with dry-run, dedup, field mapping report
+2. **Reading status management** (`toku start`, `toku finish`, `toku abandon`)
+3. **Shelves and tags** (`toku shelf create`, `toku tag add`)
+4. **Full-text search** (`toku search` with FTS5)
+5. **Configuration file** + shell completions + `--format json` output
+
+**Acceptance criteria**:
+- Import 300 books from Goodreads CSV in <10 seconds, >95% field accuracy
+- `toku start "Dune"` → `toku finish "Dune" --rating 9` works end-to-end
+- `toku search "sci-fi"` returns relevant results in <100ms
+- `toku import goodreads --dry-run` shows import preview without writing
+
+**Dependencies**: Phase 0 complete.
+
+**Risks**: Goodreads CSV format instability. **Mitigation**: test against multiple real exports, store raw CSV alongside parsed data.
+
+**Cut line**: Cover image auto-fetch (can be Phase 2). Metadata enrichment for imported books (ISBNs are in the CSV — enrichment can happen later).
+
+**Definition of done**: The developer has migrated their Goodreads library and uses `toku` daily for 2+ weeks.
+
+---
+
+### Phase 2: Reading Tracker 🟡
+
+**Theme**: "I track my reading progress and can see my history."
+**Goal**: Page-by-page progress tracking, reading sessions (including re-reads), basic statistics, Calibre import, export.
+
+**Deliverables** (5):
+1. **Reading progress logging** (`toku update "Dune" --page 145`) with session tracking
+2. **Re-read support** with separate sessions and per-session ratings
+3. **Basic statistics** (`toku stats` — books read this year, reading pace, format breakdown)
+4. **Calibre import** (parse `metadata.db`, import books + metadata + covers)
+5. **Export** (CSV, JSON, canonical ZIP backup)
+
+**Acceptance criteria**:
+- `toku update "Dune" --page 145` logs progress with timestamp
+- `toku stats --year 2025` shows books read, pages read, average rating
+- Calibre import handles 1,000+ book library with covers
+- `toku export backup` → `toku import backup` round-trips perfectly
+
+**Dependencies**: Phase 1 complete.
+
+**Cut line**: Audiobook duration-based progress (page-based only in Phase 2).
+
+---
+
+### Phase 3: Analytics & Polish (1.0 Release) 🟡
+
+**Theme**: "This is genuinely better than Goodreads for personal use."
+**Goal**: Full statistics, mood/pace tags, goals, work grouping, smart shelves, StoryGraph import.
+
+**Deliverables** (5):
+1. **Full statistics engine** (genre distribution, rating histogram, reading streaks, mood trends, yearly wrap-up)
+2. **Mood tags, pace ratings, content warnings**
+3. **Work grouping** (link editions of the same book) + merge duplicates
+4. **Smart shelves** (saved filter rules that auto-populate)
+5. **StoryGraph import** `[Validation Required]`
+
+**Acceptance criteria**:
+- `toku stats --year 2024` produces a comprehensive report rivaling StoryGraph
+- Mood tags from StoryGraph import are preserved
+- Smart shelf "Unread sci-fi over 300 pages" auto-updates when new books match
+
+**Cut line**: Custom challenges (templates can wait). Fuzzy search (FTS5 is good enough).
+
+---
+
+### Phase 4: Web Interface 🟡
+
+**Theme**: "Non-CLI users can use Toku."
+**Goal**: Web UI for library browsing, book management, statistics, and import.
+
+**Deliverables** (4):
+1. Axum web server serving the library as a web app
+2. Library grid/list view with search and filters
+3. Statistics dashboard with charts
+4. Import wizard (Goodreads, Calibre)
+
+**Dependencies**: Phase 3 (stable data model). Web framework decision (Axum + HTMX vs Leptos).
+
+---
+
+### Phase 5: Native Apps 🔴
+
+**Theme**: "Toku on every device."
+**Deliverables** (3):
+1. iOS app (SwiftUI) with barcode scanning
+2. macOS app (SwiftUI)
+3. Windows app (Tauri v2 wrapping web UI)
+
+**Dependencies**: Phase 4 (web UI provides the Tauri shell). `toku-ffi` crate for Swift bindings.
+
+---
+
+### Phase 6: File Management 🔴
+
+**Theme**: "Calibre-grade ebook management."
+**Deliverables**: File association, disk organization, format conversion (via Calibre), OPDS server.
+
+---
+
+### Phase 7: Sync & Multi-Device 🔴
+
+**Theme**: "My library everywhere."
+**Deliverables**: cr-sqlite integration, multi-device sync, conflict resolution UI.
+
+---
+
+### Phase 8: Moonshots 🔴
+
+**Theme**: "Beyond tracking."
+**Deliverables**: On-device recommendations, ebook reader integration, reading timer.
+
+---
+
+## Section 14: First 90 Days — Execution Plan
+
+### 14.1 — Technical Spikes (Weeks 1–2)
+
+| Spike | Purpose | Success? |
+|-------|---------|----------|
+| Cargo workspace + `toku-core` model | Validate layered architecture | Core compiles independently |
+| SQLite + FTS5 via `rusqlite` | Validate search performance | <100ms on 10k books |
+| Goodreads CSV parse | Validate import fidelity | All fields from a real export mapped |
+| Open Library API call | Validate metadata fetch | ISBN lookup + cover download works |
+| clap CLI with `tabled` output | Validate CLI UX | Formatted table responsive to terminal width |
+| GitHub Actions CI | Validate cross-platform builds | Linux + macOS + Windows green |
+
+### 14.2 — First 10 Epics
+
+| # | Epic | Acceptance Criteria | Effort | Dependency | Complexity |
+|---|------|-------------------|--------|-----------|-----------|
+| 1 | Project scaffold | Cargo workspace, CI, README, LICENSE, linting | S | None | 🟢 |
+| 2 | Book model + SQLite persistence | Add book → store → retrieve round-trip | M | Epic 1 | 🟢 |
+| 3 | Open Library metadata fetch | `add --isbn` fetches and stores metadata | M | Epic 2 | 🟢 |
+| 4 | CLI: list, show, search | `toku list`, `toku show`, `toku search` with FTS5 | M | Epic 2 | 🟢 |
+| 5 | Goodreads CSV import | Import 300+ books, dedup, dry-run, field mapping report | L | Epic 2 | 🟡 |
+| 6 | Reading status management | `start`, `finish`, `abandon`, status transitions | M | Epic 2 | 🟢 |
+| 7 | Shelves and tags | Create shelves, tag books, filter by shelf/tag | M | Epic 2 | 🟢 |
+| 8 | Cover image pipeline | Fetch covers, store on disk, display status in CLI | M | Epic 3 | 🟡 |
+| 9 | Configuration + shell completions | `config.toml`, bash/zsh/fish completions | S | Epic 4 | 🟢 |
+| 10 | Export (CSV, JSON) | `toku export csv`, `toku export json` | S | Epic 2 | 🟢 |
+
+### 14.3 — Due Diligence Backlog
+
+| Task | Priority | Status |
+|------|----------|--------|
+| Download real Goodreads CSV export, document all columns | P0 | `[Validation Required]` |
+| Test Open Library API: rate limits, non-English books, old editions | P0 | `[Validation Required]` |
+| Google Books API: ToS for open-source, quota limits | P1 | `[Validation Required]` |
+| StoryGraph: verify export availability and format | P1 | `[Validation Required]` |
+| Calibre `metadata.db` schema: document all useful tables | P1 | `[Validated]` — schema is stable |
+| ISBN-10 ↔ ISBN-13 conversion: verify algorithm, edge cases | P0 | `[Validated]` — well-documented standard |
+| Cover image licensing: caching Open Library covers locally | P1 | `[Validation Required]` |
+| `crates.io` name availability: "toku" | P0 | `[Validation Required]` |
+
+### 14.4 — Architecture Decision Records
+
+| ADR | Decision | Rationale |
+|-----|----------|-----------|
+| ADR-001 | Core language: Rust | User-confirmed. Best CLI ecosystem, cross-compilation, WASM, FFI. |
+| ADR-002 | Database: SQLite + FTS5, normalized schema, Book=Edition with deferred Work grouping | Balance between metadata richness and MVP simplicity. |
+| ADR-003 | CLI: clap v4 + subcommands, table/json/csv output, NO_COLOR support | Industry standard. Auto-generates completions and man pages. |
+| ADR-004 | Metadata: Open Library primary, Google Books fallback, user edits always win | Free, open, no API key. Fallback for coverage gaps. |
+| ADR-005 | Import: streaming with checkpoints, idempotent via source IDs, provenance tracking | Import is the first-impression feature. Must be rock-solid. |
+
+---
+
+## Section 15: Dependency Map
+
+```
+Phase 0: First Book
+  ├── toku-core (models, traits)
+  ├── toku-db (SQLite, migrations)
+  ├── toku-meta (Open Library client)
+  └── toku-cli (basic commands)
+        │
+Phase 1: MVP ──────────── toku-import (Goodreads CSV)
+  ├── Reading status       │
+  ├── Shelves/tags         │
+  ├── FTS5 search          │
+  └── Config + completions │
+        │                  │
+Phase 2: Reading Tracker   │
+  ├── Progress logging     │
+  ├── Reading sessions     │
+  ├── Basic stats          │
+  ├── Calibre import ──────┘ (extends toku-import)
+  └── Export (CSV/JSON/ZIP)
+        │
+Phase 3: Analytics & Polish (1.0)
+  ├── Full statistics engine
+  ├── Mood/pace tags
+  ├── Work grouping
+  ├── Smart shelves
+  └── StoryGraph import
+        │
+        ├─── Phase 4: Web UI (depends on stable data model)
+        │       │
+        │       ├─── Phase 5: Native Apps (depends on web + FFI)
+        │       │
+        │       └─── Phase 6: File Management (independent of web)
+        │
+        └─── Phase 7: Sync (depends on stable schema)
+                │
+                └─── Phase 8: Moonshots
+```
+
+**Critical path**: `toku-core` → `toku-db` → `toku-cli` → Goodreads import → daily use validation.
+
+**Parallelizable**: Documentation, CI setup, cover image pipeline, due diligence research can all proceed alongside core development.
+
+**FFI timeline**: `toku-ffi` crate work should begin in Phase 3 as a spike to validate Swift interop before Phase 5 depends on it.
+
+---
+
+## Section 16: Feasibility & Compromise Matrix
+
+| Challenge | Ideal Solution | Compromise | Impact | Recommendation |
+|-----------|---------------|-----------|--------|---------------|
+| Cross-platform core | Single Rust codebase → native + WASM + FFI | CLI-only initially; WASM/FFI validated via spikes | Delays web/mobile but de-risks architecture | **Compromise for MVP, ideal by Phase 5** |
+| Goodreads import fidelity | Map every field perfectly | Accept 95% coverage, document gaps | Minor data loss for edge cases | **95% is acceptable** — document missing fields |
+| Book deduplication | ISBN + fuzzy title+author + user confirmation | ISBN-only matching in MVP | Misses no-ISBN books | **ISBN-only for MVP** — add fuzzy in Phase 3 |
+| Offline metadata | Bundle Open Library subset locally | Require network for first-time fetch; manual entry always works offline | First book add is richer with network | **Network for enrichment, manual entry offline** |
+| Stats on large libraries | Pre-computed aggregates, incremental updates | Recompute on demand via SQL | Slow for 10k+ books | **Recompute on demand** — fast enough for <5k books |
+| Multi-device sync | CRDT-based conflict-free merge | Manual file copy + last-write-wins | Data loss risk on conflicts | **File copy documented for MVP; CRDTs in Phase 7** |
+| Format conversion | Built-in Rust converter | Shell out to Calibre's `ebook-convert` | External dependency | **Shell out** — Calibre is mature and free |
+
+---
+
+## Section 17: Naming & Branding
+
+### 17.1 — Naming Criteria
+
+The name must satisfy:
+- ≤6 characters (ideal for CLI: `toku add "Dune"`)
+- Pronounceable, memorable, unique on GitHub and crates.io
+- Evokes reading, books, or personal knowledge
+- Works as `kafkade/<name>` on GitHub
+- No existing major project conflicts
+- Logo/brand potential
+
+### 17.2 — Name Candidates
+
+| # | Name | Origin/Meaning | CLI Feel | Conflicts | Notes |
+|---|------|---------------|----------|-----------|-------|
+| 1 | **toku** | Japanese 読く (to read) — phonetic shortening of "doku" (読, reading) | `toku add "Dune"` ✅ | `[Validation Required]` crates.io | **Recommended.** Short, punchy, non-English, memorable. |
+| 2 | **lira** | Portuguese/Italian for "to read" (ler/leggere) + evokes lyrical | `lira add "Dune"` ✅ | `[Validation Required]` | Beautiful, international, 4 chars. Runner-up. |
+| 3 | **codex** | Latin: "book" (historical — bound manuscript vs scroll) | `codex add "Dune"` ✅ | Multiple projects named Codex `[Validation Required]` | Strong meaning but likely namespace collision. |
+| 4 | **folio** | Latin: "leaf" (page of a book), also a book size format | `folio add "Dune"` ✅ | Several projects `[Validation Required]` | Elegant but common. |
+| 5 | **tome** | Large or scholarly book | `tome add "Dune"` ✅ | Multiple projects `[Validation Required]` | Evokes heaviness. CLI alias could be `tm`. |
+| 6 | **hylde** | Old English: "shelf" | `hylde add "Dune"` ❌ (spelling) | Likely available | Obscure. Spelling is a barrier. |
+| 7 | **regal** | German: "shelf" (bookshelf = Bücherregal) | `regal add "Dune"` ✅ | `[Validation Required]` | Nice dual meaning (English: royal). |
+| 8 | **stiva** | Romanian: "stack" (of books) | `stiva add "Dune"` ✅ | Likely available | Obscure but musical. |
+| 9 | **pila** | Latin: "pile, stack" | `pila add "Dune"` ✅ | `[Validation Required]` | Very short. Could confuse with "pill." |
+| 10 | **libro** | Spanish/Italian: "book" | `libro add "Dune"` ✅ | Several projects `[Validation Required]` | Recognizable but probably taken. |
+| 11 | **biblio** | Greek: "book" (root of bibliography) | `biblio add "Dune"` ✅ | Likely taken | Too common, longer than ideal. |
+| 12 | **verso** | The left-hand page of a book (opposite of recto) | `verso add "Dune"` ✅ | `[Validation Required]` | Typographic, elegant. |
+| 13 | **shubi** | Swahili-inspired, phonetic play on "shufu" (to read/look) | `shubi add "Dune"` ✅ | Likely available | Unique, playful. Pronunciation clear. |
+| 14 | **tsundoku** | Japanese 積ん読: buying books and never reading them | Too long for CLI | N/A | Great concept but >6 chars. Inspiration for `toku`. |
+| 15 | **reki** | Japanese 歴: "history, record" | `reki add "Dune"` ✅ | `[Validation Required]` | Short, punchy, relates to tracking/recording. |
+
+### 17.3 — Recommendation: **Toku**
+
+**Why Toku?**
+
+1. **Meaning**: Derived from Japanese 読 (doku/toku — to read). Directly evokes reading. Also echoes 積ん読 (tsundoku — buying books you don't read), which is deeply relatable for the target audience.
+2. **CLI ergonomics**: 4 characters. `toku add "Dune"` is fast to type. No special characters.
+3. **Memorability**: Short, distinctive, not a common English word — highly memorable.
+4. **Uniqueness**: Less likely to collide with existing projects than `codex`, `folio`, or `libro` `[Validation Required]`.
+5. **Brand potential**: Clean, modern feel. Works for logo design (the 読 kanji could be a subtle brand element). Works as `kafkade/toku`.
+6. **International**: Non-English origin satisfies the developer's explicit request. Pronounceable in most languages (TOH-koo).
+
+**Runner-ups**:
+- **Lira** — beautiful, international, 4 chars. Risk: may collide with cryptocurrency "Lira" or music terms.
+- **Verso** — typographic elegance, 5 chars. Risk: niche reference, less immediately evocative of "reading."
+
+### 17.4 — Naming Discussion
+
+**Abstract vs descriptive**: Abstract wins. "BookTracker" is forgettable. "Toku" is distinctive. When mobile apps exist, the abstract name translates seamlessly — "Toku for iOS" works; "BookTracker for iOS" is generic.
+
+**Non-English**: Explicitly requested and strongly recommended. Non-English names create distinctiveness in the English-dominated open-source ecosystem. Japanese origin connects to a literary culture. The name doesn't need to be understood — it needs to be memorable and searchable.
+
+**Product name vs CLI binary**: Keep them the same. `toku` is the binary, the product, the brand. No separate `tk` or `bk` alias needed — 4 characters is already fast enough. Aliases can be added by users who want them.
+
+**Domain**: For an open-source project, `.dev` or GitHub Pages is sufficient. `toku.dev` `[Validation Required]`. A `.com` domain is unnecessary for a CLI tool distributed via GitHub and crates.io.
+
+**The kafkade connection**: `kafkade` is itself a literary reference (Kafka + -ade, or Turkish "kafkade" meaning Kafkaesque). `kafkade/toku` as a GitHub path has a subtle literary resonance — a Kafkaesque reading tool. This is an asset, not a conflict.
+
+---
+
+## Section 17A: Success Metrics & Adoption Signals
+
+### Phase 0 Success
+
+| Metric | Target |
+|--------|--------|
+| `toku add --isbn` → `toku show` round-trip | Works on 10 different ISBNs |
+| CLI startup time | <200ms |
+| CI: all platforms green | Linux + macOS + Windows |
+
+### Phase 1 (MVP) Success
+
+| Metric | Target |
+|--------|--------|
+| Goodreads import: field accuracy | >95% for title/author/rating/date, >80% for all fields |
+| Import speed: 300 books from CSV | <5 seconds |
+| FTS5 search latency | <100ms on 500 books |
+| Developer daily use | Uses `toku` instead of Goodreads for 2+ consecutive weeks |
+| Database size | <5MB for 500 books (without covers) |
+
+### Phase 2 Success
+
+| Metric | Target |
+|--------|--------|
+| Reading progress logged weekly | Developer logs progress ≥1x/week for 4 weeks |
+| Calibre import: 1,000 books | Completes in <30 seconds, >90% metadata preserved |
+| Export round-trip | backup → import into fresh DB = identical library |
+
+### Phase 3 (1.0) Success
+
+| Metric | Target |
+|--------|--------|
+| GitHub stars | 100+ (awareness signal) |
+| Issues filed by external users | 10+ (engagement signal) |
+| First external PR merged | 1+ (contribution model works) |
+| Stats engine: all core metrics computed | 12+ statistics types available |
+
+### Quality Metrics (Ongoing)
+
+| Metric | Target |
+|--------|--------|
+| CLI startup time | <200ms |
+| FTS5 search on 10k books | <100ms |
+| Zero data loss on import/export round-trip | 100% fidelity |
+| No panics in production | Zero unwrap-on-None in user-facing paths |
+
+---
+
+## Section 18: Failure Mode Analysis
+
+| # | Failure Mode | Likelihood | Impact | Mitigation |
+|---|-------------|-----------|--------|-----------|
+| 1 | **Goodreads CSV format changes** | Low (Amazon neglects Goodreads) | High — MVP import breaks | Store raw CSV alongside parsed data. Version the parser. Monitor format via community reports. |
+| 2 | **CLI-only is too niche** | Medium | High — no user growth | Phase 4 (Web) planned early. CLI-first builds the core; web expands the audience. Avoid spending >12 months CLI-only. |
+| 3 | **Metadata APIs degrade** | Medium (free tiers shrink) | Medium — enrichment degrades, core works | Multi-source fallback. Manual entry always works. Cache aggressively. |
+| 4 | **Feature creep** | High (the prompt itself is ambitious) | High — nothing ships | Strict phase boundaries. 3–5 deliverables per phase. Cut line defined per phase. Ship Phase 1 in <90 days. |
+| 5 | **Cross-platform is too ambitious** | Medium | Medium — delays mobile/web | CLI + core library are the product for 1.0. Mobile/web is post-1.0 expansion, not a requirement. |
+| 6 | **Data model is wrong** | Medium | High — cascading rewrites | Phase 0 spike validates the model. Book=Edition with deferred Work grouping is conservative. Migration tooling built from day one. |
+| 7 | **Solo developer burnout** | High | Fatal | Phase scope is aggressive but realistic. Ship incrementally. Use the app daily — dogfooding sustains motivation. Accept community PRs early. |
+
+---
+
+## Section 19: Decision Log
+
+| # | Decision | Options Considered | Recommendation | Status |
+|---|----------|-------------------|----------------|--------|
+| 1 | Core language | Rust / Go / TypeScript / Python / Swift | **Rust** — user-confirmed, best CLI ecosystem + FFI + WASM | Decided |
+| 2 | Database | SQLite / DuckDB / Flat files | **SQLite + FTS5** — battle-tested, embedded, single-file | Decided |
+| 3 | Workspace structure | Monolith-first / Multi-crate workspace | **Multi-crate workspace from day one** — enforces layer boundaries | Decided |
+| 4 | CLI framework | clap / structopt / argh | **clap v4 (derive)** — industry standard, auto-completions, man pages | Decided |
+| 5 | Metadata source | Open Library / Google Books / ISBNdb / Multi-source | **Open Library primary + Google Books fallback** — both free | Decided |
+| 6 | Work vs edition model | Full FRBR / Book=Edition / Deferred | **Book=Edition for MVP, Work grouping Phase 3** — pragmatic | Decided |
+| 7 | Rating scale | 5-star / 10-point / 5-star with halves | **0–10 integer (displayed as 5★ with halves)** — Goodreads-compatible | Decided |
+| 8 | Sync strategy | File copy / REST server / CRDTs / SQLite replication | **Changeset-based REST sync with optional symmetric encryption** — lighter than Pildora's ZK, privacy-respecting | Deferred (Phase 7) |
+| 9 | License | MIT / Apache 2.0 / GPL / Dual | **MIT** — maximum contributor friendliness | Decided |
+| 10 | Web framework | Axum+HTMX / Leptos / SvelteKit / Next.js | **Axum + HTMX or Leptos** — full Rust stack | Deferred (Phase 4) |
+| 11 | Cover storage | Filesystem / Database blobs / Content-addressed | **Filesystem, content-addressed (SHA-256)** — keeps DB small | Decided |
+| 12 | Project name | 15 candidates evaluated | **Toku** — short, non-English, evokes reading, terminal-friendly | Decided `[Validation Required]` crates.io |
+| 13 | File management | MVP / Post-1.0 / Never | **Deferred to Phase 6 (post-1.0)** — MVP is a tracker, not file manager | Decided |
+| 14 | Import priority | Goodreads-first / Calibre-first / Both MVP | **Goodreads first** — user's current tool, MVP killer feature | Decided |
+| 15 | iOS approach | Native SwiftUI / React Native / Tauri | **SwiftUI via C FFI** — best UX for Apple platforms | Deferred (Phase 5) |
+
+---
+
+*This roadmap is a living document. Decisions marked `[Validation Required]` should be validated before implementation begins. Phase boundaries are guidelines — ship when the acceptance criteria are met, not when the calendar says so.*
+
+*The single most important milestone: the developer migrates their Goodreads library and uses Toku daily. Everything else follows from that.*

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -104,7 +104,7 @@
 
 ### 2.1 — Layered Architecture
 
-```
+```text
 ┌─────────────────────────────────────────────────┐
 │                  Frontend Adapters               │
 │  ┌─────┐  ┌─────┐  ┌──────┐  ┌──────┐  ┌─────┐│
@@ -127,6 +127,7 @@
 ```
 
 **Domain core layer** — Pure Rust, no I/O dependencies. Compiles to native, WASM, and C FFI. Contains:
+
 - Book/Author/Series models with validation
 - Reading state machine (WantToRead → Reading → Read | Abandoned | OnHold)
 - Statistics computation engine (all calculations are pure functions over data)
@@ -134,18 +135,21 @@
 - Import/export trait definitions (not implementations)
 
 **Data layer** — SQLite via `rusqlite`. Compiles to native (WASM via `sql.js` in future).
+
 - Schema management with `refinery` for migrations
 - FTS5 full-text search index
 - Import implementations (Goodreads CSV, Calibre DB)
 - Cover image filesystem management
 
 **Metadata enrichment layer** — Network-dependent, always optional.
+
 - Open Library and Google Books API clients
 - Cover image downloading
 - Rate limiting + response caching
 - Merge logic: fill empty fields only; never overwrite user edits
 
 **Frontend adapters** — Each is a separate crate/binary:
+
 - `toku-cli`: Primary interface (Phase 0+)
 - `toku-web`: Axum server + HTMX or Leptos frontend (Phase 4)
 - `toku-ffi`: C FFI bindings for Swift/Kotlin (Phase 5)
@@ -156,7 +160,7 @@
 
 The crate count is small enough (4–6 crates) that the overhead is minimal, and the boundaries enforce the layered architecture. A monolith-first approach risks coupling the CLI to the core in ways that are painful to untangle when the web UI arrives.
 
-```
+```sh
 kafkade/toku/
 ├── Cargo.toml              # Workspace root
 ├── crates/
@@ -219,7 +223,7 @@ a supported workflow for power users who want multi-device today.
 
 **Architecture**: Changeset-based sync over a thin REST API.
 
-```
+```text
 ┌──────────┐    ┌──────────┐    ┌──────────┐
 │ CLI      │    │ iOS App  │    │ Web App  │
 │ (local   │    │ (local   │    │(connected│
@@ -304,36 +308,32 @@ exchange). Instead:
 - The user sets a sync passphrase during setup: `toku sync init --passphrase`.
 - A key is derived from the passphrase using **Argon2id** (memory-hard KDF).
 - All ops are encrypted client-side with **AES-256-GCM** before upload.
-- The server stores only opaque encrypted blobs + unencrypted metadata (op ID,
-  device ID, timestamp, entity type — not entity content).
+- The server stores only opaque encrypted blobs + unencrypted metadata (op ID, device ID, timestamp, entity type — not entity content).
 - The server **cannot** read book titles, ratings, notes, or any content.
 
 **What the server CAN see** (metadata leakage — accepted trade-off):
+
 - How many books are in the library (op count)
 - When sync happens (timestamps)
 - Which devices sync (device IDs)
 - Entity types being synced (book, session, shelf — but not content)
 
 **What the server CANNOT see**:
+
 - Book titles, authors, ISBNs
 - Ratings, reviews, notes
 - Reading progress
 - Shelf names, tag names
 - Any content field
 
-**This is NOT zero-knowledge** — the server knows *that* you have books, but not
-*which* books. For a personal book manager, this is a reasonable trade-off. Users who
-want stronger privacy can self-host the server.
+**This is NOT zero-knowledge** — the server knows *that* you have books, but not *which* books. For a personal book manager, this is a reasonable trade-off. Users who want stronger privacy can self-host the server.
 
 **Key lifecycle** (kept simple):
+
 - **Setup**: User picks a passphrase → Argon2id → encryption key stored in OS keychain.
-- **New device**: User enters their passphrase on the new device. No key exchange
-  protocol — the passphrase IS the shared secret.
-- **Passphrase change**: Client pulls all ops, re-encrypts with new key, pushes a
-  re-encrypted snapshot. Old ops are purged.
-- **Forgotten passphrase**: **Data on the server is unrecoverable.** The local SQLite
-  on any device is the recovery path. This is documented clearly: "Your passphrase is
-  your key. We cannot recover it."
+- **New device**: User enters their passphrase on the new device. No key exchange protocol — the passphrase IS the shared secret.
+- **Passphrase change**: Client pulls all ops, re-encrypts with new key, pushes a re-encrypted snapshot. Old ops are purged.
+- **Forgotten passphrase**: **Data on the server is unrecoverable.** The local SQLite on any device is the recovery path. This is documented clearly: "Your passphrase is your key. We cannot recover it."
 - **No passphrase (opt-out)**: If the user skips encryption, ops are stored as plaintext
   JSON on the server. Self-hosters may prefer this for simplicity.
 
@@ -359,18 +359,15 @@ want stronger privacy can self-host the server.
   self-hosted path must work first.
 
 Rejected sync alternatives:
-- **cr-sqlite**: Elegant but experimental. iOS/WASM support is unproven. Kept as a
-  research branch — if it matures, it could replace the op-log approach for native
-  clients. Not the roadmap bet.
-- **File-based sync (iCloud/Dropbox)**: SQLite files + cloud sync = corruption risk.
-  Documented as a manual backup workflow, not a sync strategy.
+
+- **cr-sqlite**: Elegant but experimental. iOS/WASM support is unproven. Kept as a research branch — if it matures, it could replace the op-log approach for native clients. Not the roadmap bet.
+- **File-based sync (iCloud/Dropbox)**: SQLite files + cloud sync = corruption risk. Documented as a manual backup workflow, not a sync strategy.
 - **Turso/libSQL**: Adds a mandatory cloud dependency. Conflicts with local-first.
-- **Full zero-knowledge (Pildora model)**: Overkill for book data. 3x the engineering
-  effort for marginal privacy gain.
+- **Full zero-knowledge (Pildora model)**: Overkill for book data. 3x the engineering effort for marginal privacy gain.
 
 #### Sync protocol — technical summary
 
-```
+```sh
 POST /sync/push     — Client sends new ops (encrypted or plaintext)
 GET  /sync/pull     — Client receives ops since cursor
 GET  /sync/snapshot — Client downloads latest compacted snapshot
@@ -381,6 +378,7 @@ POST /sync/rekey    — Upload re-encrypted snapshot after passphrase change
 ```
 
 Each op:
+
 ```json
 {
   "op_id": "uuid-v7",
@@ -414,6 +412,7 @@ Each op:
 **Goodreads import detail** — This is the MVP killer feature. The Goodreads CSV export `[Validation Required]` typically contains these columns: Book Id, Title, Author, Author l-f, Additional Authors, ISBN, ISBN13, My Rating, Average Rating, Publisher, Binding, Number of Pages, Year Published, Original Publication Year, Date Read, Date Added, Bookshelves, Bookshelves with positions, Exclusive Shelf, My Review, Spoiler, Private Notes, Read Count, Owned Copies.
 
 **Mapping strategy**:
+
 - `Exclusive Shelf` → Reading status (read, currently-reading, to-read)
 - `Bookshelves` → User shelves/tags
 - `My Rating` → Rating (multiply by 2 for 0–10 scale)
@@ -444,7 +443,7 @@ Every importer implements the `ImportEngine` trait with these capabilities:
 
 **Recommendation**: ZIP archive containing JSON + cover images.
 
-```
+```text
 toku-backup-2025-07-14.zip
 ├── manifest.json          # Version, export date, book count
 ├── library.json           # Full data model as structured JSON
@@ -460,6 +459,7 @@ toku-backup-2025-07-14.zip
 - **Round-trip**: `toku export backup` → `toku import backup toku-backup.zip` = identical library.
 
 Rejected alternatives:
+
 - SQLite dump: portable but opaque — users can't inspect without SQLite tools.
 - JSON-only: doesn't include cover images.
 
@@ -478,6 +478,7 @@ Rejected alternatives:
 ### 3.3 — Book Metadata Sources
 
 **Primary: Open Library API** `[Validated]`
+
 - Free, no API key required, community-maintained.
 - REST API: `https://openlibrary.org/isbn/{isbn}.json`
 - Good coverage for popular titles. Gaps for non-English, self-published, and niche academic works.
@@ -485,6 +486,7 @@ Rejected alternatives:
 - Rate limits: generous (100 req/min stated, practically higher) `[Validation Required]`
 
 **Fallback: Google Books API** `[Validation Required]`
+
 - 1,000 requests/day free tier (no key), higher with API key.
 - Broader coverage than Open Library, especially for recent releases.
 - Terms of service: allows caching for offline use `[Validation Required]`
@@ -493,6 +495,7 @@ Rejected alternatives:
 **Merge strategy**: Query Open Library first. If no result or missing fields, query Google Books. User edits always take precedence. Empty fields filled from the highest-quality available source.
 
 Rejected alternatives:
+
 - ISBNdb: paid — violates $0 budget constraint.
 - WorldCat: Search API terms unclear for open-source use `[Validation Required]`.
 - BookBrainz: growing but sparse coverage.
@@ -532,7 +535,8 @@ Rejected alternatives:
 ### 3A.2 — Contributor Modeling
 
 **Data model** (MVP):
-```
+
+```sql
 contributors (id, name, sort_name, external_ids_json)
 book_contributors (book_id, contributor_id, role, position)
 ```
@@ -540,6 +544,7 @@ book_contributors (book_id, contributor_id, role, position)
 **Roles** (enum): `author`, `co_author`, `editor`, `translator`, `illustrator`, `narrator`, `foreword`, `compiler`, `contributor`.
 
 **Name handling**:
+
 - `name`: Display name ("Ursula K. Le Guin")
 - `sort_name`: Sort key ("Le Guin, Ursula K.")
 - Pseudonyms: stored as separate contributor entries linked via `alias_of` nullable FK.
@@ -592,6 +597,7 @@ metadata_provenance (
 ```
 
 **Rules**:
+
 1. User edits set `is_user_override = TRUE`. Auto-enrichment skips fields where `is_user_override = TRUE`.
 2. Re-import updates non-overridden fields with newer source data.
 3. `toku book provenance "Dune"` shows the source of every field.
@@ -787,7 +793,7 @@ File management lives in a new `toku-files` crate that depends on `toku-core` an
 
 ### Entity Relationship Diagram (Text)
 
-```
+```text
 works (1) ──── (M) books
 books (1) ──── (M) book_contributors ──── (M) contributors
 books (1) ──── (M) book_series ──── (M) series
@@ -1059,6 +1065,7 @@ toku enrich --isbn-only                    # fetch metadata for books with ISBNs
 ```
 
 **Output formatting**:
+
 - Default: rich terminal tables with color (via `tabled` or `comfy-table` crate)
 - `--format json`: machine-readable JSON output
 - `--format csv`: CSV output
@@ -1068,6 +1075,7 @@ toku enrich --isbn-only                    # fetch metadata for books with ISBNs
 **CLI framework**: `clap` v4 with derive macros. Auto-generates help, shell completions (bash/zsh/fish/PowerShell), and man pages.
 
 **Configuration**: TOML file at `{data_dir}/config.toml`:
+
 ```toml
 [display]
 default_format = "table"
@@ -1131,7 +1139,7 @@ default_status = "want_to_read"
 
 ### 10.3 — Differentiation Matrix
 
-```
+```text
                     High Data Ownership
                           │
               Toku ●      │
@@ -1147,6 +1155,7 @@ default_status = "want_to_read"
 ```
 
 **Why Toku wins now**:
+
 1. **Goodreads is rotting**: No API since 2020, UI unchanged for years, Amazon integration concerns growing.
 2. **Privacy wave**: Post-GDPR, readers increasingly care about data ownership.
 3. **CLI renaissance**: Tools like `ripgrep`, `fd`, `bat`, `jq` prove terminal-first tools find audiences.
@@ -1158,7 +1167,7 @@ default_status = "want_to_read"
 
 ### 11.1 — License Selection
 
-**Recommendation: MIT License**
+#### Recommendation: MIT License
 
 | License | Verdict | Reasoning |
 |---------|---------|-----------|
@@ -1183,6 +1192,7 @@ default_status = "want_to_read"
 This is a personal tool, not a SaaS. There is no natural paywall that doesn't betray the open-source philosophy. GitHub Sponsors is the lowest-friction option: no infrastructure, no premium features to maintain, no user segmentation.
 
 Rejected alternatives:
+
 - Premium features: What feature would be premium? Every core feature must be free (principles 1–3).
 - Hosted sync server: Possible post-1.0, but premature to plan.
 - Open Collective: viable alternative, but GitHub Sponsors has better discoverability.
@@ -1238,11 +1248,13 @@ Before committing to the architecture, validate:
 **Goal**: Add one book from the CLI, store it in SQLite, retrieve it. Validate the entire stack.
 
 **Deliverables** (3):
+
 1. Cargo workspace with `toku-core`, `toku-db`, `toku-cli` crates
 2. `toku add --isbn <isbn>` → fetch metadata from Open Library → store in SQLite
 3. `toku show <title>` and `toku list` → display book details
 
 **Acceptance criteria**:
+
 - `toku add --isbn 9780441013593` fetches "Dune" metadata and stores it
 - `toku show "Dune"` displays title, author, ISBN, page count, cover status
 - `toku list` displays a formatted table of all books
@@ -1260,6 +1272,7 @@ Before committing to the architecture, validate:
 **Goal**: Import a full Goodreads library, track reading status, search and organize.
 
 **Deliverables** (5):
+
 1. **Goodreads CSV import** with dry-run, dedup, field mapping report
 2. **Reading status management** (`toku start`, `toku finish`, `toku abandon`)
 3. **Shelves and tags** (`toku shelf create`, `toku tag add`)
@@ -1267,6 +1280,7 @@ Before committing to the architecture, validate:
 5. **Configuration file** + shell completions + `--format json` output
 
 **Acceptance criteria**:
+
 - Import 300 books from Goodreads CSV in <10 seconds, >95% field accuracy
 - `toku start "Dune"` → `toku finish "Dune" --rating 9` works end-to-end
 - `toku search "sci-fi"` returns relevant results in <100ms
@@ -1288,6 +1302,7 @@ Before committing to the architecture, validate:
 **Goal**: Page-by-page progress tracking, reading sessions (including re-reads), basic statistics, Calibre import, export.
 
 **Deliverables** (5):
+
 1. **Reading progress logging** (`toku update "Dune" --page 145`) with session tracking
 2. **Re-read support** with separate sessions and per-session ratings
 3. **Basic statistics** (`toku stats` — books read this year, reading pace, format breakdown)
@@ -1295,6 +1310,7 @@ Before committing to the architecture, validate:
 5. **Export** (CSV, JSON, canonical ZIP backup)
 
 **Acceptance criteria**:
+
 - `toku update "Dune" --page 145` logs progress with timestamp
 - `toku stats --year 2025` shows books read, pages read, average rating
 - Calibre import handles 1,000+ book library with covers
@@ -1312,6 +1328,7 @@ Before committing to the architecture, validate:
 **Goal**: Full statistics, mood/pace tags, goals, work grouping, smart shelves, StoryGraph import.
 
 **Deliverables** (5):
+
 1. **Full statistics engine** (genre distribution, rating histogram, reading streaks, mood trends, yearly wrap-up)
 2. **Mood tags, pace ratings, content warnings**
 3. **Work grouping** (link editions of the same book) + merge duplicates
@@ -1319,6 +1336,7 @@ Before committing to the architecture, validate:
 5. **StoryGraph import** `[Validation Required]`
 
 **Acceptance criteria**:
+
 - `toku stats --year 2024` produces a comprehensive report rivaling StoryGraph
 - Mood tags from StoryGraph import are preserved
 - Smart shelf "Unread sci-fi over 300 pages" auto-updates when new books match
@@ -1333,6 +1351,7 @@ Before committing to the architecture, validate:
 **Goal**: Web UI for library browsing, book management, statistics, and import.
 
 **Deliverables** (4):
+
 1. Axum web server serving the library as a web app
 2. Library grid/list view with search and filters
 3. Statistics dashboard with charts
@@ -1345,7 +1364,9 @@ Before committing to the architecture, validate:
 ### Phase 5: Native Apps 🔴
 
 **Theme**: "Toku on every device."
+
 **Deliverables** (3):
+
 1. iOS app (SwiftUI) with barcode scanning
 2. macOS app (SwiftUI)
 3. Windows app (Tauri v2 wrapping web UI)
@@ -1430,7 +1451,7 @@ Before committing to the architecture, validate:
 
 ## Section 15: Dependency Map
 
-```
+```text
 Phase 0: First Book
   ├── toku-core (models, traits)
   ├── toku-db (SQLite, migrations)
@@ -1495,6 +1516,7 @@ Phase 3: Analytics & Polish (1.0)
 ### 17.1 — Naming Criteria
 
 The name must satisfy:
+
 - ≤6 characters (ideal for CLI: `toku add "Dune"`)
 - Pronounceable, memorable, unique on GitHub and crates.io
 - Evokes reading, books, or personal knowledge
@@ -1534,6 +1556,7 @@ The name must satisfy:
 6. **International**: Non-English origin satisfies the developer's explicit request. Pronounceable in most languages (TOH-koo).
 
 **Runner-ups**:
+
 - **Lira** — beautiful, international, 4 chars. Risk: may collide with cryptocurrency "Lira" or music terms.
 - **Verso** — typographic elegance, 5 chars. Risk: niche reference, less immediately evocative of "reading."
 

--- a/docs/adr/001-core-language-rust.md
+++ b/docs/adr/001-core-language-rust.md
@@ -1,0 +1,42 @@
+# ADR-001: Core Language — Rust
+
+**Status**: Accepted
+**Date**: 2026-04-26
+**Decision**: Use Rust as the core language for all shared libraries and the CLI.
+
+## Context
+
+Toku is a multi-platform personal book manager. The core library must compile to native
+binaries (Linux, macOS, Windows), WASM (web), and C FFI (iOS/macOS via Swift). The CLI
+is the primary interface and must be fast, cross-platform, and distributable via
+`cargo install` and pre-built binaries.
+
+## Decision
+
+**Rust** is the core language for all shared crates and the CLI binary.
+
+## Rationale
+
+- **CLI ecosystem**: clap v4 is the industry standard for Rust CLI tools — auto-generated
+  completions, man pages, and help text.
+- **Cross-compilation**: Native binaries for Linux/macOS/Windows from a single codebase.
+  WASM via `wasm-pack`. C FFI via `cbindgen` or UniFFI for mobile.
+- **SQLite**: `rusqlite` is mature and well-maintained, with FTS5 support.
+- **Performance**: Sub-200ms CLI startup, <100ms search on 10k books.
+- **Community**: Rust attracts contributors who value correctness and clean architecture.
+- **Developer confirmed**: The maintainer's primary language is Rust.
+
+## Alternatives Considered
+
+| Language | Rejected Because |
+|----------|-----------------|
+| Go | Weaker FFI story, no WASM for shared-core, GC pauses |
+| TypeScript/Node | Runtime dependency, cold start latency, poor FFI |
+| Python | Too slow for CLI, no native cross-compilation, poor FFI |
+| Swift | Apple-only for CLI, poor Windows/Linux story |
+
+## Consequences
+
+- Higher contribution barrier than Go or Python — mitigated by good documentation,
+  clear module boundaries, and "good first issue" labels.
+- Longer compile times — mitigated by workspace caching and incremental compilation.

--- a/docs/adr/002-database-schema.md
+++ b/docs/adr/002-database-schema.md
@@ -1,0 +1,47 @@
+# ADR-002: Database — SQLite with FTS5, Book=Edition Model
+
+**Status**: Accepted
+**Date**: 2026-04-26
+**Decision**: Use SQLite with FTS5 for the local database. Start with a flat
+Book=Edition model; add Work grouping in Phase 3.
+
+## Context
+
+Toku needs an embedded, cross-platform database that supports full-text search, works
+offline, and stores all library data in a single portable directory. The book domain has
+a well-known modeling challenge: a "book" can mean a work (abstract), an edition
+(specific publication), or a copy (the user's item).
+
+## Decision
+
+- **SQLite 3** via `rusqlite` as the primary database.
+- **FTS5** virtual table for full-text search across titles, authors, descriptions,
+  notes, and reviews.
+- **Normalized schema** with join tables for book-author, book-series, book-shelf, and
+  book-tag relationships.
+- **Book = Edition** for MVP: each row in the `books` table represents a specific edition.
+  A nullable `work_id` column is reserved from day one but not populated until Phase 3.
+- **Schema migrations** via the `refinery` crate, embedded in the binary.
+
+## Rationale
+
+- Full FRBR (Work → Expression → Manifestation → Item) is overengineered for a personal
+  library of 100–500 books. Most users think in terms of editions, not works.
+- The deferred `work_id` column allows grouping editions later without a schema migration.
+- SQLite is battle-tested, single-file, cross-platform, and embeddable in WASM.
+- FTS5 provides sub-100ms full-text search on 10k+ books.
+
+## Alternatives Considered
+
+| Option | Rejected Because |
+|--------|-----------------|
+| DuckDB | Analytical focus, not designed for transactional CRUD |
+| Flat files (JSON/TOML) | No full-text search, poor query performance at scale |
+| Full FRBR from day one | Over-engineered for MVP, slows iteration |
+
+## Consequences
+
+- Migration from flat Book=Edition to Work grouping in Phase 3 requires careful schema
+  evolution. The `refinery` migration system handles this.
+- Cover images stored on filesystem (content-addressed by SHA-256), not in SQLite, to
+  keep the database file small and portable.

--- a/docs/adr/003-cli-design.md
+++ b/docs/adr/003-cli-design.md
@@ -24,7 +24,7 @@ well-documented. It is a first-class product, not a debug tool.
 
 ## Command Hierarchy
 
-```
+```sh
 toku add [--isbn <isbn> | --title <title> --author <author>]
 toku show <book>
 toku list [--status <status>] [--shelf <shelf>] [--sort <field>]

--- a/docs/adr/003-cli-design.md
+++ b/docs/adr/003-cli-design.md
@@ -1,0 +1,55 @@
+# ADR-003: CLI Design — clap v4 with Subcommands
+
+**Status**: Accepted
+**Date**: 2026-04-26
+**Decision**: Use clap v4 (derive macros) for CLI parsing with a subcommand-based
+structure. Support table, JSON, and CSV output formats.
+
+## Context
+
+The CLI is Toku's primary interface. It must be pleasant to use, scriptable, and
+well-documented. It is a first-class product, not a debug tool.
+
+## Decision
+
+- **clap v4** with derive macros for argument parsing.
+- **Subcommand structure**: `toku <verb> [args]` — e.g., `toku add`, `toku list`,
+  `toku search`, `toku import`, `toku stats`.
+- **Output formats**: `--format table` (default), `--format json`, `--format csv`.
+  Respects `NO_COLOR` environment variable.
+- **Shell completions**: Auto-generated for bash, zsh, fish, PowerShell via
+  `clap_complete`.
+- **Man pages**: Auto-generated via `clap_mangen`.
+- **Rich table output**: via the `tabled` crate, responsive to terminal width.
+
+## Command Hierarchy
+
+```
+toku add [--isbn <isbn> | --title <title> --author <author>]
+toku show <book>
+toku list [--status <status>] [--shelf <shelf>] [--sort <field>]
+toku search <query>
+toku reading start|update|finish|abandon <book> [--page N] [--rating N]
+toku import goodreads|calibre|storygraph <path> [--dry-run]
+toku export csv|json|backup [--output <path>]
+toku stats [--year <year>]
+toku shelf create|add|remove|list <shelf> [<books>...]
+toku tag add|remove|list <tag> [<books>...]
+toku config [--edit]
+```
+
+## Rationale
+
+- clap v4 is the Rust CLI standard — well-documented, actively maintained, generates
+  completions and man pages for free.
+- Subcommand structure is familiar to users of `git`, `cargo`, `gh`, etc.
+- JSON output enables scripting and integration with `jq`, pipes, etc.
+- `tabled` provides attractive table output without pulling in a TUI framework.
+
+## Alternatives Considered
+
+| Option | Rejected Because |
+|--------|-----------------|
+| structopt | Merged into clap v4 — use clap directly |
+| argh | Smaller ecosystem, no completions/man pages |
+| Custom parser | Unnecessary reinvention |

--- a/docs/adr/004-metadata-sources.md
+++ b/docs/adr/004-metadata-sources.md
@@ -1,0 +1,47 @@
+# ADR-004: Metadata Sources — Open Library Primary, Google Books Fallback
+
+**Status**: Accepted
+**Date**: 2026-04-26
+**Decision**: Use Open Library as the primary metadata source. Google Books as fallback.
+User edits always take precedence over fetched data.
+
+## Context
+
+When a user adds a book by ISBN, the app should fetch metadata (title, author, page
+count, description, cover image) to avoid manual entry. The metadata source must be free,
+reliable, and compatible with open-source use.
+
+## Decision
+
+- **Primary**: Open Library REST API (`openlibrary.org/isbn/{isbn}.json`).
+- **Fallback**: Google Books API (free tier, 1,000 req/day without key).
+- **Cover images**: Open Library Covers API, Google Books thumbnails as fallback.
+- **Merge strategy**: Query Open Library first. If no result or missing fields, query
+  Google Books. Fill empty fields only — never overwrite existing data.
+- **User edits always win**: Once a user modifies a field, auto-enrichment marks it as
+  `user_override` and will not overwrite it.
+- **Caching**: API responses cached locally for 30 days to reduce API calls and enable
+  offline re-enrichment.
+
+## Rationale
+
+- Open Library is free, requires no API key, and is community-maintained.
+- Google Books has broader coverage (especially recent releases and non-English titles)
+  but has rate limits.
+- Both are compatible with open-source use (no restrictive ToS for caching).
+- The "user wins" rule prevents data corruption from bad metadata sources.
+
+## Alternatives Considered
+
+| Source | Rejected Because |
+|--------|-----------------|
+| ISBNdb | Paid — violates $0 budget constraint |
+| WorldCat | API terms unclear for open-source `[Validation Required]` |
+| BookBrainz | Sparse coverage, growing but not ready as primary |
+| Hardcover | API availability uncertain `[Validation Required]` |
+
+## Open Validations
+
+- [ ] Open Library rate limits (stated 100 req/min — verify in practice)
+- [ ] Google Books ToS for open-source caching
+- [ ] Cover image licensing for local caching

--- a/docs/adr/005-import-architecture.md
+++ b/docs/adr/005-import-architecture.md
@@ -1,0 +1,60 @@
+# ADR-005: Import Architecture — Streaming, Idempotent, with Provenance
+
+**Status**: Accepted
+**Date**: 2026-04-26
+**Decision**: Import is a first-class feature with dry-run, idempotent re-import,
+provenance tracking, match confidence levels, and rollback support.
+
+## Context
+
+Many readers have years of data in Goodreads, Calibre, or StoryGraph. Import is a
+first-impression feature: if it fails or loses data, users leave immediately. Import
+quality is a competitive differentiator.
+
+## Decision
+
+Every importer implements a common `ImportEngine` trait with these capabilities:
+
+1. **Dry-run mode**: `--dry-run` shows what would happen without writing to the database.
+2. **Idempotent re-import**: Each imported record stores a source identifier (e.g.,
+   `goodreads_id`, `calibre_id`). Re-importing the same file skips existing entries and
+   updates changed fields (respecting user edits).
+3. **Match confidence levels**:
+   - Exact: ISBN match → auto-merge
+   - High: Title + Author exact match → auto-merge with summary
+   - Fuzzy: Partial title match → flagged for user review
+   - None: New entry created
+4. **Partial failure handling**: Progress checkpointed every 100 books. `--resume`
+   continues from last checkpoint.
+5. **Field mapping report**: Post-import summary of fields imported, matched, and skipped.
+6. **Provenance tracking**: Every imported field records `(source, timestamp)`. User
+   edits clear provenance and set `user_override`.
+7. **Rollback**: `toku import undo <import-id>` removes books added by that import.
+8. **Import log**: `import_logs` table records every operation.
+
+### Import priority
+
+| # | Source | Phase | Rationale |
+|---|--------|-------|-----------|
+| 1 | Goodreads CSV | MVP (Phase 1) | User's current tool, largest user base |
+| 2 | Manual entry + ISBN lookup | MVP (Phase 1) | Always available |
+| 3 | Calibre metadata.db | Phase 2 | Power users, large libraries |
+| 4 | StoryGraph CSV | Phase 3 | Growing community `[Validation Required]` |
+| 5 | LibraryThing | Phase 3+ | Niche but vocal `[Validation Required]` |
+| 6 | Generic CSV | Phase 2 | Catch-all for custom formats |
+| 7 | BibTeX | Phase 3 | Academic persona |
+
+## Rationale
+
+- Import failures are the #1 reason users abandon a new tool.
+- Idempotent re-import lets users keep their Goodreads account as a backup during
+  transition without creating duplicates.
+- Provenance tracking enables future re-enrichment without overwriting user corrections.
+- The `ImportEngine` trait enables community-contributed importers.
+
+## Consequences
+
+- Each importer needs dedicated test fixtures (real export files from each source).
+- The match confidence system adds complexity but prevents silent data corruption.
+- Goodreads CSV format instability is a risk — mitigate by storing raw CSV alongside
+  parsed data and versioning the parser.

--- a/docs/adr/006-sync-strategy.md
+++ b/docs/adr/006-sync-strategy.md
@@ -1,0 +1,77 @@
+# ADR-006: Sync Strategy — Changeset-Based REST with Optional Encryption
+
+**Status**: Accepted (implementation deferred to Phase 7)
+**Date**: 2026-04-26
+**Decision**: Multi-device sync via a lightweight changeset-based REST API with optional
+client-side symmetric encryption. Lighter than Pildora's zero-knowledge model.
+
+## Context
+
+Toku must work fully offline on a single device. Sync is opt-in and additive. Users
+want to sync between a desktop CLI, iOS app, and web app. Book data is personal but not
+health-critical — it does not require the zero-knowledge architecture used in Pildora.
+
+## Decision
+
+- **Protocol**: Append-only changeset (op-log) synced via REST API.
+- **Server**: Thin Axum service storing encrypted or plaintext changesets + sync cursors.
+- **Encryption**: Optional client-side symmetric encryption using Argon2id (KDF) +
+  AES-256-GCM. User sets a passphrase; server stores opaque blobs.
+- **Web app**: Connected companion (server-backed), not full local-first. Native clients
+  are authoritative.
+- **Deployment**: Self-hosted Docker image first. Managed instance optional and deferred.
+
+### Entity-specific merge rules
+
+| Entity | Strategy |
+|--------|---------|
+| Books (metadata) | Last-write-wins per field (HLC timestamp) |
+| Reading sessions | Append-only (immutable facts, no conflicts) |
+| Reading progress | Monotonic (highest page / latest timestamp wins) |
+| Notes / Reviews | LWW with conflict detection (store both versions) |
+| Deletes | Soft delete with 30-day tombstone retention |
+| Cover images | Content-addressed, lazy-fetch (not in critical sync path) |
+
+### What the server can vs. cannot see (with encryption enabled)
+
+| Server CAN see | Server CANNOT see |
+|----------------|------------------|
+| Op count, timestamps | Book titles, authors, ISBNs |
+| Device IDs | Ratings, reviews, notes |
+| Entity types (book, session) | Reading progress, shelf names |
+
+### Comparison to Pildora
+
+| Aspect | Pildora | Toku |
+|--------|---------|------|
+| Encryption | Mandatory E2E, zero-knowledge | Optional symmetric |
+| Key hierarchy | Master → Vault → Item | Single derived key |
+| Auth | SRP (zero-knowledge) | Standard auth (or passphrase only) |
+| Sharing | Encrypted vault sharing | None (personal tool) |
+| Recovery | Recovery key + emergency access | Local SQLite is recovery |
+| Engineering cost | ~3 months crypto work | ~2–3 weeks sync work |
+
+## Rationale
+
+- Book data is personal but a reading list leak is not a health crisis. Optional
+  encryption is the right trade-off.
+- A single passphrase → single key avoids the complexity of key hierarchies, SRP, and
+  asymmetric wrapping.
+- Entity-specific merge rules prevent the "one merge strategy for everything" trap.
+- The web app as a connected companion avoids browser-SQLite complexity for a solo dev.
+
+## Alternatives Considered
+
+| Option | Rejected Because |
+|--------|-----------------|
+| cr-sqlite (CRDTs) | Experimental, unproven on iOS/WASM — kept as research branch |
+| File-based sync (iCloud/Dropbox) | SQLite + cloud sync = corruption risk |
+| Turso/libSQL | Mandatory cloud dependency conflicts with local-first |
+| Full zero-knowledge (Pildora model) | 3x engineering effort for marginal privacy gain |
+
+## Open Questions (to resolve before Phase 7)
+
+- [ ] cr-sqlite maturity — re-evaluate as potential native-client optimization
+- [ ] Snapshot compaction strategy for large op logs
+- [ ] Device provisioning UX (first-time sync setup flow)
+- [ ] Schema migration during sync (how do ops from different app versions coexist?)

--- a/scripts/release.ps1
+++ b/scripts/release.ps1
@@ -1,0 +1,236 @@
+#!/usr/bin/env pwsh
+#Requires -Version 7.0
+<#
+.SYNOPSIS
+    Prepare and cut a Toku release.
+.DESCRIPTION
+    Automates the release process:
+    1. Reads current version from workspace Cargo.toml
+    2. Bumps the specified semver component (major, minor, or patch)
+    3. Updates version in all workspace member Cargo.toml files
+    4. Validates there are unreleased changelog entries
+    5. Stamps the [Unreleased] section in CHANGELOG.md with version and date
+    6. Runs cargo check to update Cargo.lock
+    7. Commits, tags, and (optionally) pushes
+
+    The release workflow (.github/workflows/release.yml) then:
+    - Builds cross-platform binaries (Linux x86_64/aarch64, macOS x86_64/aarch64, Windows)
+    - Creates a GitHub Release with binaries and SHA-256 checksums
+    - Publishes all crates to crates.io in dependency order
+.PARAMETER Bump
+    Which semver component to bump: major, minor, or patch.
+.PARAMETER Push
+    Push the commit and tag to origin after creating them.
+.PARAMETER DryRun
+    Show what would happen without making changes.
+.EXAMPLE
+    ./scripts/release.ps1 patch
+    ./scripts/release.ps1 minor -Push
+    ./scripts/release.ps1 major -DryRun
+#>
+param(
+    [Parameter(Mandatory, Position = 0)]
+    [ValidateSet("major", "minor", "patch")]
+    [string]$Bump,
+
+    [switch]$Push,
+    [switch]$DryRun
+)
+
+$ErrorActionPreference = "Stop"
+Set-StrictMode -Version Latest
+
+$RepoRoot = git rev-parse --show-toplevel 2>$null
+if (-not $RepoRoot) { Write-Error "Not in a git repository"; exit 1 }
+Set-Location $RepoRoot
+
+# --- Workspace crate members (in publish order) ---
+
+$WorkspaceMembers = @(
+    "crates/toku-core",
+    "crates/toku-db",
+    "crates/toku-import",
+    "crates/toku-meta",
+    "crates/toku-export",
+    "crates/toku-cli"
+)
+
+# --- Read and bump version from workspace root ---
+
+$cargoToml = Get-Content Cargo.toml -Raw
+$currentMatch = [regex]::Match($cargoToml, '(?m)^version = "(\d+)\.(\d+)\.(\d+)"')
+if (-not $currentMatch.Success) {
+    Write-Error "Could not parse version from Cargo.toml"
+    exit 1
+}
+
+$major = [int]$currentMatch.Groups[1].Value
+$minor = [int]$currentMatch.Groups[2].Value
+$patch = [int]$currentMatch.Groups[3].Value
+$currentVersion = "$major.$minor.$patch"
+
+switch ($Bump) {
+    "major" { $major++; $minor = 0; $patch = 0 }
+    "minor" { $minor++; $patch = 0 }
+    "patch" { $patch++ }
+}
+
+$Version = "$major.$minor.$patch"
+$Tag = "v$Version"
+$Today = Get-Date -Format "yyyy-MM-dd"
+
+Write-Host "`n📦 Release: $currentVersion → $Version ($Bump bump)" -ForegroundColor Cyan
+
+# --- Preflight checks ---
+
+Write-Host "`n🔍 Preflight checks" -ForegroundColor Cyan
+
+# Clean working tree
+$status = git status --porcelain
+if ($status) {
+    Write-Error "Working tree is not clean. Commit or stash changes first."
+    exit 1
+}
+Write-Host "  ✓ Working tree clean" -ForegroundColor Green
+
+# On main branch
+$branch = git branch --show-current
+if ($branch -ne "main") {
+    Write-Error "Must be on 'main' branch (currently on '$branch')."
+    exit 1
+}
+Write-Host "  ✓ On main branch" -ForegroundColor Green
+
+# Tag doesn't already exist
+$existing = git tag -l $Tag
+if ($existing) {
+    Write-Error "Tag '$Tag' already exists."
+    exit 1
+}
+Write-Host "  ✓ Tag $Tag is available" -ForegroundColor Green
+
+# Changelog has unreleased entries
+$changelog = Get-Content CHANGELOG.md -Raw
+if ($changelog -notmatch '## \[Unreleased\]\s*\n+### ') {
+    Write-Error "No entries found under [Unreleased] in CHANGELOG.md."
+    exit 1
+}
+Write-Host "  ✓ Changelog has unreleased entries" -ForegroundColor Green
+
+# All workspace member Cargo.toml files exist
+foreach ($member in $WorkspaceMembers) {
+    $memberToml = Join-Path $member "Cargo.toml"
+    if (-not (Test-Path $memberToml)) {
+        Write-Error "Workspace member '$memberToml' not found."
+        exit 1
+    }
+}
+Write-Host "  ✓ All workspace members found" -ForegroundColor Green
+
+# Tests pass
+Write-Host "`n🧪 Running tests..." -ForegroundColor Cyan
+$testOutput = cargo test --workspace 2>&1
+$testExitCode = $LASTEXITCODE
+if ($testExitCode -ne 0) {
+    $testOutput | Write-Host
+    Write-Error "Tests failed. Fix before releasing."
+    exit 1
+}
+Write-Host "  ✓ All tests pass" -ForegroundColor Green
+
+# Clippy clean
+$clippyOutput = cargo clippy --workspace -- -D warnings 2>&1
+$clippyExitCode = $LASTEXITCODE
+if ($clippyExitCode -ne 0) {
+    $clippyOutput | Write-Host
+    Write-Error "Clippy warnings found. Fix before releasing."
+    exit 1
+}
+Write-Host "  ✓ Clippy clean" -ForegroundColor Green
+
+if ($DryRun) {
+    Write-Host "`n📋 Dry run — would perform:" -ForegroundColor Yellow
+    Write-Host "  1. Bump version to $Version in:"
+    Write-Host "     - Cargo.toml (workspace root)"
+    foreach ($member in $WorkspaceMembers) {
+        Write-Host "     - $member/Cargo.toml"
+    }
+    Write-Host "  2. Stamp CHANGELOG.md [Unreleased] → [$Version] - $Today"
+    Write-Host "  3. Update Cargo.lock"
+    Write-Host "  4. Commit: 'chore: release v$Version'"
+    Write-Host "  5. Tag: $Tag"
+    if ($Push) { Write-Host "  6. Push to origin with tag" }
+    Write-Host "  7. Release workflow builds binaries + publishes all crates to crates.io"
+    exit 0
+}
+
+# --- Apply changes ---
+
+Write-Host "`n📦 Preparing release $Tag" -ForegroundColor Cyan
+
+# 1. Bump workspace root Cargo.toml version
+$cargoToml = Get-Content Cargo.toml -Raw
+$cargoToml = $cargoToml -replace '(?m)^version = "[^"]*"', "version = `"$Version`""
+Set-Content Cargo.toml -Value $cargoToml -NoNewline
+Write-Host "  ✓ Cargo.toml (root) → $Version" -ForegroundColor Green
+
+# 2. Bump each workspace member Cargo.toml
+foreach ($member in $WorkspaceMembers) {
+    $memberToml = Join-Path $member "Cargo.toml"
+    $content = Get-Content $memberToml -Raw
+
+    # Update the crate's own version
+    $content = $content -replace '(?m)^version = "[^"]*"', "version = `"$Version`""
+
+    # Update workspace sibling dependency versions (e.g., toku-core = { version = "0.1.0", path = ... })
+    foreach ($sibling in $WorkspaceMembers) {
+        $siblingName = Split-Path $sibling -Leaf
+        $content = $content -replace "($siblingName\s*=\s*\{\s*version\s*=\s*)`"[^`"]*`"", "`$1`"$Version`""
+    }
+
+    Set-Content $memberToml -Value $content -NoNewline
+    Write-Host "  ✓ $memberToml → $Version" -ForegroundColor Green
+}
+
+# 3. Update Cargo.lock
+cargo check --quiet 2>$null
+Write-Host "  ✓ Cargo.lock updated" -ForegroundColor Green
+
+# 4. Stamp CHANGELOG.md
+$changelog = Get-Content CHANGELOG.md -Raw
+
+# Add empty [Unreleased] and rename old one
+$changelog = $changelog -replace '## \[Unreleased\]', "## [Unreleased]`n`n## [$Version] - $Today"
+
+# Update comparison links at bottom (if they exist)
+$prevVersionMatch = [regex]::Match($changelog, '\[(\d+\.\d+\.\d+)\]:\s*https://')
+if ($prevVersionMatch.Success) {
+    $prevVersion = $prevVersionMatch.Groups[1].Value
+    $newLinks = "[Unreleased]: https://github.com/kafkade/toku/compare/v$Version...HEAD`n[$Version]: https://github.com/kafkade/toku/compare/v$prevVersion...v$Version"
+    $changelog = $changelog -replace '\[Unreleased\]:\s*https://github.com/kafkade/toku/compare/v[\d.]+\.\.\.HEAD', $newLinks
+}
+
+Set-Content CHANGELOG.md -Value $changelog -NoNewline
+Write-Host "  ✓ CHANGELOG.md stamped" -ForegroundColor Green
+
+# 5. Collect all modified files and commit
+$filesToAdd = @("Cargo.toml", "Cargo.lock", "CHANGELOG.md")
+foreach ($member in $WorkspaceMembers) {
+    $filesToAdd += Join-Path $member "Cargo.toml"
+}
+git add @filesToAdd
+git commit -m "chore: release v$Version"
+git tag -a $Tag -m "Release $Version"
+Write-Host "  ✓ Committed and tagged $Tag" -ForegroundColor Green
+
+# 6. Push (optional)
+if ($Push) {
+    Write-Host "`n🚀 Pushing to origin..." -ForegroundColor Cyan
+    git push origin main --follow-tags
+    Write-Host "  ✓ Pushed — release workflow will build binaries + publish to crates.io" -ForegroundColor Green
+} else {
+    Write-Host "`n📌 Ready to push. Run:" -ForegroundColor Yellow
+    Write-Host "  git push origin main --follow-tags" -ForegroundColor White
+}
+
+Write-Host "`n✅ Release $Tag prepared successfully!`n" -ForegroundColor Green


### PR DESCRIPTION
## Description

Bootstrap the Toku project with all foundational documentation, GitHub configuration, CI/CD pipelines, and release infrastructure.

### What's included

- **README.md** — project overview with "Why Toku?" naming rationale (tsundoku connection), CLI usage examples, core principles, planned features, and tech stack summary
- **ROADMAP.md** — comprehensive product roadmap: 6 user personas, layered architecture design, data model, import/export strategy, bibliographic domain deep-dive, CLI command hierarchy, competitive analysis, sync architecture with optional encryption, 9 phased milestones, first 90 days execution plan, naming analysis (15 candidates), success metrics, and failure mode analysis
- **6 Architecture Decision Records** — Rust as core language, SQLite + FTS5 with Book=Edition model, clap v4 CLI, Open Library + Google Books metadata, idempotent import with provenance tracking, changeset-based sync with optional symmetric encryption
- **CI workflow** (`validate.yml`) — markdown linting + Rust fmt/clippy/test on Linux, macOS, and Windows matrix
- **Release workflow** (`release.yml`) — triggered on `v*` tags: cross-compilation for 5 targets (Linux x86/arm64, macOS x86/arm64, Windows), GitHub Release with SHA-256 checksums, sequential crates.io publishing for all workspace crates
- **Release script** (`scripts/release.ps1`) — version bump across workspace Cargo.toml files, changelog stamping, commit + tag, optional push
- **GitHub config** — issue templates (bug report, feature request), PR template with data integrity checklist, CODEOWNERS, dependabot (Actions + Cargo), FUNDING, markdownlint config, copilot instructions, md-lint and pr-ready skills
- **CONTRIBUTING.md** — contribution guide with importer development instructions and dev setup
- **CHANGELOG.md** — initialized with Keep a Changelog format

## Related Issues

Relates to #1

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [x] CI / infrastructure
- [ ] Other (describe below)

## Crate

- [ ] `toku-core` — Domain models, traits, state machine
- [ ] `toku-db` — SQLite persistence, migrations, FTS5
- [ ] `toku-import` — Importers (Goodreads, Calibre, StoryGraph)
- [ ] `toku-meta` — Metadata fetching (Open Library, Google Books)
- [ ] `toku-cli` — CLI binary
- [ ] `toku-export` — Exporters (CSV, JSON, Markdown, BibTeX)
- [x] `docs/` — Documentation

## Data Integrity Checklist

- [x] No user data is sent to any server without explicit opt-in
- [x] Import operations are idempotent (re-importing the same file creates no duplicates)
- [x] User edits to metadata are never overwritten by auto-enrichment
- [x] New fields track provenance (source + timestamp)
- [x] Export round-trip is preserved (if applicable)

> All items pass — this PR is documentation and infrastructure only. No code handles user data.

## Checklist

- [x] I have read [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] `cargo fmt --check` passes (no Rust source files)
- [x] `cargo clippy --workspace -- -D warnings` passes (no Rust source files)
- [x] `cargo test --workspace` passes (no Rust source files)
- [x] I have updated documentation (if applicable)