### PR TITLE
feat: add metadata fetch, CLI commands, and Goodreads import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,5 +24,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - SQLite database with FTS5 full-text search, auto-synced via triggers
 - Book persistence: create, list, search, delete books; manage authors and ISBNs
 - `toku --version` CLI entry point
+- Open Library metadata fetching: `toku add --isbn <isbn>` fetches title, author, pages, language, and cover image
+- Cover image downloading with content-addressed local storage (SHA-256)
+- `toku add --title <title> --author <author>` for manual book entry
+- `toku show <book>` with full detail view (title, author, status, pages, cover, description)
+- `toku list` with formatted table output, filterable by `--status`
+- `toku search <query>` with FTS5 full-text search
+- `--format table|json|csv` output modes for all list/search commands
+- Goodreads CSV import: `toku import goodreads <file>` with dry-run, idempotent re-import, ISBN cleaning, rating conversion, status mapping, and format detection
+- Import rollback: `toku import undo <import-id>` removes all books from a specific import
+- Import provenance tracking per field for future re-import safety
 
 [Unreleased]: https://github.com/kafkade/toku/compare/v0.1.0...HEAD

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -56,7 +56,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -67,7 +67,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -84,8 +84,14 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
+
+[[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "autocfg"
@@ -94,16 +100,43 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
 name = "bitflags"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+
+[[package]]
+name = "bytecount"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175812e0be2bccb6abe50bb8d566126198344f707e304f45c648fd8f2cc0365e"
+
+[[package]]
+name = "bytes"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cc"
@@ -120,6 +153,12 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chrono"
@@ -161,10 +200,10 @@ version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
 dependencies = [
- "heck",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -186,6 +225,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
+name = "csv"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52cd9d68cf7efc6ddfaaee42e7288d3a99d613d4b50f76ce9827ae0c6e14f938"
+dependencies = [
+ "csv-core",
+ "itoa",
+ "ryu",
+ "serde_core",
+]
+
+[[package]]
+name = "csv-core"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704a3c26996a80471189265814dbc2c257598b96b8a7feae2d31ace646bb9782"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -193,6 +272,16 @@ checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
  "powerfmt",
  "serde_core",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
 ]
 
 [[package]]
@@ -213,7 +302,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -224,7 +313,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -240,7 +329,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -268,6 +357,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
 name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -283,14 +378,73 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures-channel"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-task"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+
+[[package]]
+name = "futures-util"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "libc",
+ "r-efi 5.3.0",
+ "wasip2",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -301,7 +455,7 @@ checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
+ "r-efi 6.0.0",
  "wasip2",
  "wasip3",
 ]
@@ -332,9 +486,113 @@ dependencies = [
 
 [[package]]
 name = "heck"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
+
+[[package]]
+name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "http"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
+dependencies = [
+ "bytes",
+ "itoa",
+]
+
+[[package]]
+name = "http-body"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+dependencies = [
+ "bytes",
+ "http",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "httparse"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "hyper"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "http",
+ "http-body",
+ "httparse",
+ "itoa",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
+ "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+ "webpki-roots",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http",
+ "http-body",
+ "hyper",
+ "ipnet",
+ "libc",
+ "percent-encoding",
+ "pin-project-lite",
+ "socket2",
+ "tokio",
+ "tower-service",
+ "tracing",
+]
 
 [[package]]
 name = "iana-time-zone"
@@ -482,6 +740,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "ipnet"
+version = "2.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+
+[[package]]
+name = "iri-string"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25e659a4bb38e810ebc252e53b5814ff908a8c58c2a9ce2fae1bbec24cbf4e20"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -499,6 +773,8 @@ version = "0.3.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
 dependencies = [
+ "cfg-if",
+ "futures-util",
  "once_cell",
  "wasm-bindgen",
 ]
@@ -554,10 +830,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "mio"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
+dependencies = [
+ "libc",
+ "wasi",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "num-conv"
@@ -593,10 +886,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
+name = "papergrid"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2b0f8def1f117e13c895f3eda65a7b5650688da29d6ad04635f61bc7b92eebd"
+dependencies = [
+ "bytecount",
+ "fnv",
+ "unicode-width",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pkg-config"
@@ -620,13 +930,44 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
 name = "prettyplease"
 version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "proc-macro-error-attr2"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
+name = "proc-macro-error2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
+dependencies = [
+ "proc-macro-error-attr2",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -636,6 +977,61 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "quinn"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2",
+ "thiserror",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+dependencies = [
+ "bytes",
+ "getrandom 0.3.4",
+ "lru-slab",
+ "rand",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -649,9 +1045,44 @@ dependencies = [
 
 [[package]]
 name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rand"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+dependencies = [
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
+]
 
 [[package]]
 name = "redox_users"
@@ -704,7 +1135,7 @@ dependencies = [
  "quote",
  "refinery-core",
  "regex",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -737,6 +1168,58 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
+name = "reqwest"
+version = "0.12.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "webpki-roots",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "rusqlite"
 version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -751,6 +1234,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc-hash"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
+
+[[package]]
 name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -760,7 +1249,42 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.39"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c2c118cb077cca2822033836dfb1b975355dfb784b5e8da48f7b6c5db74e60e"
+dependencies = [
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
+dependencies = [
+ "web-time",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
 ]
 
 [[package]]
@@ -768,6 +1292,12 @@ name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "same-file"
@@ -811,7 +1341,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -837,6 +1367,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -849,10 +1402,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
 
 [[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
 name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
+name = "socket2"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "stable_deref_trait"
@@ -867,6 +1436,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
+name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
 name = "syn"
 version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -878,6 +1464,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sync_wrapper"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
 name = "synstructure"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -885,7 +1480,30 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "tabled"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6709222f3973137427ce50559cd564dc187a95b9cfe01613d2f4e93610e510a"
+dependencies = [
+ "papergrid",
+ "tabled_derive",
+]
+
+[[package]]
+name = "tabled_derive"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "931be476627d4c54070a1f3a9739ccbfec9b36b39815106a20cce2243bbcefe1"
+dependencies = [
+ "heck 0.4.1",
+ "proc-macro-error2",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -898,7 +1516,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -918,7 +1536,7 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -963,13 +1581,70 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinyvec"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
+name = "tokio"
+version = "1.52.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b67dee974fe86fd92cc45b7a95fdd2f99a36a6d7b0d431a231178d3d670bbcc6"
+dependencies = [
+ "bytes",
+ "libc",
+ "mio",
+ "pin-project-lite",
+ "socket2",
+ "tokio-macros",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
+]
+
+[[package]]
 name = "toku-cli"
 version = "0.1.0"
 dependencies = [
  "anyhow",
  "clap",
+ "serde",
+ "serde_json",
+ "tabled",
+ "tokio",
  "toku-core",
  "toku-db",
+ "toku-import",
+ "toku-meta",
 ]
 
 [[package]]
@@ -996,6 +1671,34 @@ dependencies = [
  "thiserror",
  "toku-core",
  "uuid",
+]
+
+[[package]]
+name = "toku-import"
+version = "0.1.0"
+dependencies = [
+ "chrono",
+ "csv",
+ "rusqlite",
+ "serde",
+ "tempfile",
+ "thiserror",
+ "toku-core",
+ "toku-db",
+ "uuid",
+]
+
+[[package]]
+name = "toku-meta"
+version = "0.1.0"
+dependencies = [
+ "reqwest",
+ "serde",
+ "serde_json",
+ "sha2",
+ "thiserror",
+ "tokio",
+ "toku-core",
 ]
 
 [[package]]
@@ -1040,16 +1743,104 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
+name = "tower"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
+dependencies = [
+ "bitflags",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "iri-string",
+ "pin-project-lite",
+ "tower",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
+
+[[package]]
+name = "tower-service"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
+
+[[package]]
+name = "tracing"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
+dependencies = [
+ "pin-project-lite",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
+name = "try-lock"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "typenum"
+version = "1.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
+name = "unicode-width"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
+
+[[package]]
 name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "url"
@@ -1094,6 +1885,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
 name = "walkdir"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1101,6 +1898,15 @@ checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
 dependencies = [
  "same-file",
  "winapi-util",
+]
+
+[[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
 ]
 
 [[package]]
@@ -1141,6 +1947,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.68"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f371d383f2fb139252e0bfac3b81b265689bf45b6874af544ffa4c975ac1ebf8"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "wasm-bindgen-macro"
 version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1159,7 +1975,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "wasm-bindgen-shared",
 ]
 
@@ -1207,12 +2023,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "web-sys"
+version = "0.3.95"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f2dfbb17949fa2088e5d39408c48368947b86f7834484e87b73de55bc14d97d"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "winapi-util"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1236,7 +2081,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1247,7 +2092,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1276,12 +2121,159 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.5",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
 ]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm 0.52.6",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
+dependencies = [
+ "windows-link",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
@@ -1314,7 +2306,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
 dependencies = [
  "anyhow",
- "heck",
+ "heck 0.5.0",
  "wit-parser",
 ]
 
@@ -1325,10 +2317,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
 dependencies = [
  "anyhow",
- "heck",
+ "heck 0.5.0",
  "indexmap",
  "prettyplease",
- "syn",
+ "syn 2.0.117",
  "wasm-metadata",
  "wit-bindgen-core",
  "wit-component",
@@ -1344,7 +2336,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "wit-bindgen-core",
  "wit-bindgen-rust",
 ]
@@ -1411,8 +2403,28 @@ checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "synstructure",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1432,9 +2444,15 @@ checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "synstructure",
 ]
+
+[[package]]
+name = "zeroize"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
 
 [[package]]
 name = "zerotrie"
@@ -1466,7 +2484,7 @@ checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,8 @@ resolver = "2"
 members = [
     "crates/toku-core",
     "crates/toku-db",
+    "crates/toku-meta",
+    "crates/toku-import",
     "crates/toku-cli",
 ]
 
@@ -20,3 +22,5 @@ chrono = { version = "0.4", default-features = false, features = ["std", "clock"
 rusqlite = { version = "0.35", features = ["bundled", "column_decltype"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
+tokio = { version = "1", features = ["rt", "macros"] }

--- a/crates/toku-cli/Cargo.toml
+++ b/crates/toku-cli/Cargo.toml
@@ -14,5 +14,11 @@ path = "src/main.rs"
 [dependencies]
 toku-core = { path = "../toku-core", version = "0.1.0" }
 toku-db = { path = "../toku-db", version = "0.1.0" }
-clap = { version = "4", features = ["derive"] }
+toku-meta = { path = "../toku-meta", version = "0.1.0" }
+toku-import = { path = "../toku-import", version = "0.1.0" }
+clap = { version = "4", features = ["derive", "env"] }
 anyhow = "1"
+serde.workspace = true
+serde_json.workspace = true
+tokio.workspace = true
+tabled = "0.17"

--- a/crates/toku-cli/src/main.rs
+++ b/crates/toku-cli/src/main.rs
@@ -1,27 +1,512 @@
-use clap::Parser;
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result};
+use clap::{Parser, Subcommand, ValueEnum};
+use toku_core::{Author, Book, BookFormat, ContributorRole, Isbn};
+use toku_db::{BookRepository, Database};
 
 /// Toku — a private, offline-first personal book manager.
 #[derive(Parser)]
 #[command(name = "toku", version, about)]
 struct Cli {
+    /// Data directory (default: platform-specific)
+    #[arg(long, env = "TOKU_DATA_DIR", global = true)]
+    data_dir: Option<PathBuf>,
+
+    /// Output format
+    #[arg(long, default_value = "table", global = true)]
+    format: OutputFormat,
+
     #[command(subcommand)]
-    command: Option<Commands>,
+    command: Commands,
 }
 
-#[derive(clap::Subcommand)]
+#[derive(Subcommand)]
 enum Commands {
-    /// Show version information
-    Version,
+    /// Add a book to your library
+    Add {
+        /// Book title (for manual entry)
+        #[arg(long, short)]
+        title: Option<String>,
+
+        /// Author name (for manual entry)
+        #[arg(long, short)]
+        author: Option<String>,
+
+        /// ISBN to look up and add
+        #[arg(long, short)]
+        isbn: Option<String>,
+
+        /// Book format
+        #[arg(long, default_value = "physical")]
+        book_format: String,
+    },
+
+    /// Show details of a book
+    Show {
+        /// Book title or ID to display
+        query: String,
+    },
+
+    /// List books in your library
+    List {
+        /// Filter by reading status
+        #[arg(long, short)]
+        status: Option<String>,
+    },
+
+    /// Search your library
+    Search {
+        /// Search query
+        query: String,
+    },
+
+    /// Import books from external sources
+    Import {
+        #[command(subcommand)]
+        source: ImportSource,
+    },
 }
 
-fn main() -> anyhow::Result<()> {
+#[derive(Subcommand)]
+enum ImportSource {
+    /// Import from a Goodreads CSV export
+    Goodreads {
+        /// Path to the Goodreads CSV file
+        path: PathBuf,
+
+        /// Preview what would be imported without writing
+        #[arg(long)]
+        dry_run: bool,
+    },
+
+    /// Undo a previous import by its ID
+    Undo {
+        /// Import ID (shown after a successful import)
+        import_id: String,
+    },
+}
+
+#[derive(Clone, ValueEnum)]
+enum OutputFormat {
+    Table,
+    Json,
+    Csv,
+}
+
+fn main() -> Result<()> {
     let cli = Cli::parse();
 
+    let db_path = match &cli.data_dir {
+        Some(dir) => dir.join("toku.db"),
+        None => Database::default_db_path().context("could not determine data directory")?,
+    };
+
+    let db = Database::open(&db_path)
+        .with_context(|| format!("failed to open database at {}", db_path.display()))?;
+    let repo = BookRepository::new(&db);
+
     match cli.command {
-        Some(Commands::Version) | None => {
-            println!("toku {}", env!("CARGO_PKG_VERSION"));
+        Commands::Add {
+            title,
+            author,
+            isbn,
+            book_format,
+        } => cmd_add(
+            &repo,
+            &db_path,
+            title,
+            author,
+            isbn,
+            &book_format,
+            &cli.format,
+        ),
+        Commands::Show { query } => cmd_show(&repo, &query, &cli.format),
+        Commands::List { status } => cmd_list(&repo, status.as_deref(), &cli.format),
+        Commands::Search { query } => cmd_search(&repo, &query, &cli.format),
+        Commands::Import { source } => cmd_import(&db, &repo, source, &cli.format),
+    }
+}
+
+fn cmd_add(
+    repo: &BookRepository,
+    db_path: &Path,
+    title: Option<String>,
+    author: Option<String>,
+    isbn: Option<String>,
+    book_format: &str,
+    output_format: &OutputFormat,
+) -> Result<()> {
+    let format: BookFormat = book_format
+        .parse()
+        .with_context(|| format!("invalid format: {book_format}"))?;
+
+    if let Some(isbn_str) = &isbn {
+        let validated = Isbn::parse(isbn_str).context("invalid ISBN")?;
+        let isbn13 = validated.to_isbn13();
+
+        // Check for existing book with this ISBN
+        if let Some(existing) = repo.find_by_isbn(&isbn13)? {
+            eprintln!("Book already exists: {} ({})", existing.title, existing.id);
+            return Ok(());
         }
+
+        // Fetch metadata from Open Library
+        eprintln!("Fetching metadata for ISBN {isbn13}...");
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()?;
+
+        let result = rt.block_on(toku_meta::fetch_by_isbn(&isbn13));
+
+        match result {
+            Ok(meta) => {
+                let mut book = Book::new(&meta.title);
+                book.subtitle = meta.subtitle;
+                book.description = meta.description;
+                book.page_count = meta.page_count;
+                book.pub_date = meta.pub_date;
+                book.language = meta.language;
+                book.format = format;
+
+                // Fetch cover
+                let covers_dir = db_path.parent().unwrap().join("covers");
+                if let Ok(Some(hash)) = rt.block_on(toku_meta::fetch_cover(&isbn13, &covers_dir)) {
+                    book.cover_hash = Some(hash);
+                }
+
+                repo.create_book(&book)?;
+                repo.add_isbn(&isbn13, &book.id)?;
+
+                if let Some(isbn10) = validated.to_isbn10() {
+                    repo.add_isbn(&isbn10, &book.id)?;
+                }
+
+                // Add authors
+                for (i, name) in meta.authors.iter().enumerate() {
+                    let a = Author::new(name.as_str());
+                    repo.add_book_author(&a, &book.id, ContributorRole::Author, i as i32)?;
+                }
+
+                print_books(&[book], repo, output_format)?;
+                eprintln!("✓ Added from Open Library");
+            }
+            Err(e) => {
+                eprintln!("Could not fetch metadata: {e}");
+                eprintln!("Adding with ISBN only. Use 'toku show' to verify.");
+                let mut book = Book::new(isbn_str);
+                book.format = format;
+                repo.create_book(&book)?;
+                repo.add_isbn(&isbn13, &book.id)?;
+                print_books(&[book], repo, output_format)?;
+            }
+        }
+    } else if let Some(title) = title {
+        let mut book = Book::new(&title);
+        book.format = format;
+        repo.create_book(&book)?;
+
+        if let Some(author_name) = author {
+            let a = Author::new(author_name.as_str());
+            repo.add_book_author(&a, &book.id, ContributorRole::Author, 0)?;
+        }
+
+        print_books(&[book], repo, output_format)?;
+        eprintln!("✓ Added manually");
+    } else {
+        anyhow::bail!("provide --isbn or --title to add a book");
     }
 
     Ok(())
+}
+
+fn cmd_show(repo: &BookRepository, query: &str, output_format: &OutputFormat) -> Result<()> {
+    let books = repo.search_books(query)?;
+    if books.is_empty() {
+        // Fall back to listing all and filtering by title contains
+        let all = repo.list_books()?;
+        let matched: Vec<Book> = all
+            .into_iter()
+            .filter(|b| b.title.to_lowercase().contains(&query.to_lowercase()))
+            .collect();
+        if matched.is_empty() {
+            eprintln!("No book found matching \"{query}\"");
+            return Ok(());
+        }
+        print_book_detail(&matched[0], repo, output_format)?;
+    } else {
+        print_book_detail(&books[0], repo, output_format)?;
+    }
+    Ok(())
+}
+
+fn cmd_list(
+    repo: &BookRepository,
+    status: Option<&str>,
+    output_format: &OutputFormat,
+) -> Result<()> {
+    let books = repo.list_books()?;
+    let filtered: Vec<Book> = if let Some(s) = status {
+        let target: toku_core::ReadingStatus = s.parse().context("invalid status")?;
+        books.into_iter().filter(|b| b.status == target).collect()
+    } else {
+        books
+    };
+
+    if filtered.is_empty() {
+        eprintln!("No books in your library yet. Add one with: toku add --isbn <isbn>");
+        return Ok(());
+    }
+
+    print_books(&filtered, repo, output_format)?;
+    eprintln!("\n{} book(s)", filtered.len());
+    Ok(())
+}
+
+fn cmd_search(repo: &BookRepository, query: &str, output_format: &OutputFormat) -> Result<()> {
+    let books = repo.search_books(query)?;
+    if books.is_empty() {
+        eprintln!("No results for \"{query}\"");
+        return Ok(());
+    }
+    print_books(&books, repo, output_format)?;
+    eprintln!("\n{} result(s)", books.len());
+    Ok(())
+}
+
+// --- Output formatting ---
+
+fn print_books(books: &[Book], repo: &BookRepository, output_format: &OutputFormat) -> Result<()> {
+    match output_format {
+        OutputFormat::Json => {
+            #[derive(serde::Serialize)]
+            struct BookOut {
+                id: String,
+                title: String,
+                authors: Vec<String>,
+                status: String,
+                format: String,
+                rating: Option<i32>,
+                pages: Option<i32>,
+            }
+            let out: Vec<BookOut> = books
+                .iter()
+                .map(|b| {
+                    let authors = repo
+                        .get_book_authors(&b.id)
+                        .unwrap_or_default()
+                        .into_iter()
+                        .map(|(a, _)| a.name)
+                        .collect();
+                    BookOut {
+                        id: b.id.to_string(),
+                        title: b.title.clone(),
+                        authors,
+                        status: b.status.as_str().to_string(),
+                        format: b.format.as_str().to_string(),
+                        rating: b.rating,
+                        pages: b.page_count,
+                    }
+                })
+                .collect();
+            println!("{}", serde_json::to_string_pretty(&out)?);
+        }
+        OutputFormat::Csv => {
+            println!("title,authors,status,format,rating,pages");
+            for b in books {
+                let authors: Vec<String> = repo
+                    .get_book_authors(&b.id)
+                    .unwrap_or_default()
+                    .into_iter()
+                    .map(|(a, _)| a.name)
+                    .collect();
+                println!(
+                    "\"{}\",\"{}\",{},{},{},{}",
+                    b.title.replace('"', "\"\""),
+                    authors.join("; ").replace('"', "\"\""),
+                    b.status.as_str(),
+                    b.format.as_str(),
+                    b.rating.map_or("-".to_string(), |r| format!("{}", r)),
+                    b.page_count.map_or("-".to_string(), |p| format!("{}", p)),
+                );
+            }
+        }
+        OutputFormat::Table => {
+            use tabled::{Table, Tabled};
+
+            #[derive(Tabled)]
+            struct Row {
+                #[tabled(rename = "Title")]
+                title: String,
+                #[tabled(rename = "Author")]
+                author: String,
+                #[tabled(rename = "Status")]
+                status: String,
+                #[tabled(rename = "Format")]
+                format: String,
+                #[tabled(rename = "Rating")]
+                rating: String,
+                #[tabled(rename = "Pages")]
+                pages: String,
+            }
+
+            let rows: Vec<Row> = books
+                .iter()
+                .map(|b| {
+                    let authors: Vec<String> = repo
+                        .get_book_authors(&b.id)
+                        .unwrap_or_default()
+                        .into_iter()
+                        .map(|(a, _)| a.name)
+                        .collect();
+
+                    let title = if b.title.len() > 40 {
+                        format!("{}…", &b.title[..39])
+                    } else {
+                        b.title.clone()
+                    };
+
+                    Row {
+                        title,
+                        author: authors.join(", "),
+                        status: b.status.as_str().to_string(),
+                        format: b.format.as_str().to_string(),
+                        rating: b
+                            .rating
+                            .map_or("—".to_string(), |r| format!("{:.1}★", r as f32 / 2.0)),
+                        pages: b.page_count.map_or("—".to_string(), |p| p.to_string()),
+                    }
+                })
+                .collect();
+
+            println!("{}", Table::new(rows));
+        }
+    }
+    Ok(())
+}
+
+fn print_book_detail(
+    book: &Book,
+    repo: &BookRepository,
+    output_format: &OutputFormat,
+) -> Result<()> {
+    match output_format {
+        OutputFormat::Json => {
+            print_books(std::slice::from_ref(book), repo, output_format)?;
+        }
+        OutputFormat::Csv => {
+            print_books(std::slice::from_ref(book), repo, output_format)?;
+        }
+        OutputFormat::Table => {
+            let authors: Vec<String> = repo
+                .get_book_authors(&book.id)
+                .unwrap_or_default()
+                .into_iter()
+                .map(|(a, ba)| {
+                    if ba.role == ContributorRole::Author {
+                        a.name
+                    } else {
+                        format!("{} ({})", a.name, ba.role)
+                    }
+                })
+                .collect();
+
+            println!("  Title:   {}", book.title);
+            if let Some(sub) = &book.subtitle {
+                println!("  Sub:     {sub}");
+            }
+            println!(
+                "  Author:  {}",
+                if authors.is_empty() {
+                    "—".to_string()
+                } else {
+                    authors.join(", ")
+                }
+            );
+            println!("  Status:  {}", book.status);
+            println!("  Format:  {}", book.format);
+            if let Some(pages) = book.page_count {
+                println!("  Pages:   {pages}");
+            }
+            if let Some(dur) = book.duration_minutes {
+                println!("  Length:  {}h {}m", dur / 60, dur % 60);
+            }
+            if let Some(rating) = book.rating {
+                println!("  Rating:  {:.1}★", rating as f32 / 2.0);
+            }
+            if let Some(date) = &book.pub_date {
+                println!("  Pub:     {date}");
+            }
+            if let Some(lang) = &book.language {
+                println!("  Lang:    {lang}");
+            }
+            if let Some(hash) = &book.cover_hash {
+                println!("  Cover:   ✓ ({hash})");
+            }
+            if let Some(desc) = &book.description {
+                let truncated = if desc.len() > 200 {
+                    format!("{}…", &desc[..200])
+                } else {
+                    desc.clone()
+                };
+                println!("  Desc:    {truncated}");
+            }
+            println!("  ID:      {}", book.id);
+        }
+    }
+    Ok(())
+}
+
+fn cmd_import(
+    db: &Database,
+    repo: &BookRepository,
+    source: ImportSource,
+    output_format: &OutputFormat,
+) -> Result<()> {
+    match source {
+        ImportSource::Goodreads { path, dry_run } => {
+            if !path.exists() {
+                anyhow::bail!("file not found: {}", path.display());
+            }
+
+            let opts = toku_import::GoodreadsImportOptions { dry_run };
+
+            if dry_run {
+                eprintln!("Dry run — no changes will be made:\n");
+            } else {
+                eprintln!("Importing from Goodreads CSV: {}\n", path.display());
+            }
+
+            let report = toku_import::import_goodreads(db, &path, &opts)
+                .context("Goodreads import failed")?;
+
+            eprintln!("\n{report}");
+
+            if let Some(ref id) = report.import_id {
+                eprintln!("Import ID: {id}");
+                eprintln!("To undo: toku import undo {id}");
+            }
+
+            if !dry_run && report.imported > 0 {
+                eprintln!();
+                let books = repo.list_books()?;
+                print_books(&books, repo, output_format)?;
+                eprintln!("\n{} book(s) in library", books.len());
+            }
+
+            Ok(())
+        }
+        ImportSource::Undo { import_id } => {
+            let count =
+                toku_import::undo_import(db, &import_id).context("failed to undo import")?;
+
+            if count > 0 {
+                eprintln!("✓ Undone: removed {count} book(s) from import {import_id}");
+            } else {
+                eprintln!("No books found for import ID {import_id}");
+            }
+
+            Ok(())
+        }
+    }
 }

--- a/crates/toku-db/migrations/V2__import_support.sql
+++ b/crates/toku-db/migrations/V2__import_support.sql
@@ -1,0 +1,23 @@
+-- Add goodreads_id column to books for import dedup.
+ALTER TABLE books ADD COLUMN goodreads_id TEXT;
+CREATE UNIQUE INDEX idx_books_goodreads_id ON books(goodreads_id) WHERE goodreads_id IS NOT NULL;
+
+-- Import logs table to track every import operation.
+CREATE TABLE import_logs (
+    id TEXT PRIMARY KEY NOT NULL,
+    source TEXT NOT NULL,
+    file_path TEXT NOT NULL,
+    started_at TEXT NOT NULL,
+    finished_at TEXT,
+    total_rows INTEGER NOT NULL DEFAULT 0,
+    imported INTEGER NOT NULL DEFAULT 0,
+    skipped INTEGER NOT NULL DEFAULT 0,
+    errors INTEGER NOT NULL DEFAULT 0
+);
+
+-- Track which books came from which import for rollback.
+CREATE TABLE import_books (
+    import_id TEXT NOT NULL REFERENCES import_logs(id) ON DELETE CASCADE,
+    book_id TEXT NOT NULL REFERENCES books(id) ON DELETE CASCADE,
+    PRIMARY KEY (import_id, book_id)
+);

--- a/crates/toku-import/Cargo.toml
+++ b/crates/toku-import/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "toku-import"
+description = "Import implementations for Toku: Goodreads CSV, Calibre, StoryGraph"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[dependencies]
+toku-core = { path = "../toku-core", version = "0.1.0" }
+toku-db = { path = "../toku-db", version = "0.1.0" }
+thiserror.workspace = true
+uuid.workspace = true
+chrono.workspace = true
+serde.workspace = true
+rusqlite.workspace = true
+csv = "1"
+
+[dev-dependencies]
+tempfile = "3"

--- a/crates/toku-import/src/error.rs
+++ b/crates/toku-import/src/error.rs
@@ -1,0 +1,17 @@
+#[derive(Debug, thiserror::Error)]
+pub enum ImportError {
+    #[error("CSV error: {0}")]
+    Csv(#[from] csv::Error),
+
+    #[error("database error: {0}")]
+    Db(#[from] toku_db::DbError),
+
+    #[error("SQLite error: {0}")]
+    Sqlite(#[from] rusqlite::Error),
+
+    #[error("I/O error: {0}")]
+    Io(#[from] std::io::Error),
+
+    #[error("import error: {0}")]
+    Other(String),
+}

--- a/crates/toku-import/src/goodreads.rs
+++ b/crates/toku-import/src/goodreads.rs
@@ -1,0 +1,502 @@
+use std::collections::HashMap;
+use std::path::Path;
+
+use chrono::Utc;
+use csv::ReaderBuilder;
+use rusqlite::params;
+use toku_core::{Author, Book, BookFormat, ContributorRole, Isbn, ReadingStatus};
+use toku_db::{BookRepository, Database};
+use uuid::Uuid;
+
+use crate::ImportError;
+
+/// Options for a Goodreads import.
+pub struct GoodreadsImportOptions {
+    pub dry_run: bool,
+}
+
+/// Summary report of an import operation.
+#[derive(Debug, Default)]
+pub struct ImportReport {
+    pub total_rows: usize,
+    pub imported: usize,
+    pub skipped: usize,
+    pub errors: usize,
+    pub error_details: Vec<String>,
+    pub import_id: Option<String>,
+}
+
+impl std::fmt::Display for ImportReport {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        writeln!(f, "Import summary:")?;
+        writeln!(f, "  Total rows:  {}", self.total_rows)?;
+        writeln!(f, "  Imported:    {}", self.imported)?;
+        writeln!(f, "  Skipped:     {} (already in library)", self.skipped)?;
+        writeln!(f, "  Errors:      {}", self.errors)?;
+        if !self.error_details.is_empty() {
+            writeln!(f, "  Error details:")?;
+            for (i, e) in self.error_details.iter().enumerate().take(10) {
+                writeln!(f, "    {}: {e}", i + 1)?;
+            }
+            if self.error_details.len() > 10 {
+                writeln!(f, "    ... and {} more", self.error_details.len() - 10)?;
+            }
+        }
+        Ok(())
+    }
+}
+
+/// Import books from a Goodreads CSV export.
+pub fn import_goodreads(
+    db: &Database,
+    csv_path: &Path,
+    opts: &GoodreadsImportOptions,
+) -> Result<ImportReport, ImportError> {
+    let repo = BookRepository::new(db);
+    let mut report = ImportReport::default();
+
+    let import_id = Uuid::now_v7().to_string();
+
+    // Create import log entry (unless dry run)
+    if !opts.dry_run {
+        db.conn.execute(
+            "INSERT INTO import_logs (id, source, file_path, started_at, total_rows)
+             VALUES (?1, 'goodreads', ?2, ?3, 0)",
+            params![
+                import_id,
+                csv_path.to_string_lossy().to_string(),
+                Utc::now().to_rfc3339()
+            ],
+        )?;
+    }
+
+    let mut rdr = ReaderBuilder::new()
+        .has_headers(true)
+        .flexible(true)
+        .from_path(csv_path)?;
+
+    let headers = rdr.headers()?.clone();
+    let col = |name: &str| -> Option<usize> { headers.iter().position(|h| h == name) };
+
+    // Map expected Goodreads columns to positions
+    let col_book_id = col("Book Id");
+    let col_title = col("Title");
+    let col_author = col("Author");
+    let col_additional_authors = col("Additional Authors");
+    let col_isbn = col("ISBN");
+    let col_isbn13 = col("ISBN13");
+    let col_rating = col("My Rating");
+    let _col_publisher = col("Publisher");
+    let col_binding = col("Binding");
+    let col_pages = col("Number of Pages");
+    let col_year_pub = col("Year Published");
+    let col_orig_year = col("Original Publication Year");
+    let _col_date_read = col("Date Read");
+    let _col_date_added = col("Date Added");
+    let _col_shelves = col("Bookshelves");
+    let col_exclusive = col("Exclusive Shelf");
+    let _col_review = col("My Review");
+    let _col_read_count = col("Read Count");
+
+    if col_title.is_none() {
+        return Err(ImportError::Other(
+            "CSV does not contain a 'Title' column — is this a Goodreads export?".to_string(),
+        ));
+    }
+
+    // Build a set of existing goodreads_ids for fast dedup
+    let mut existing_gr_ids: HashMap<String, Uuid> = HashMap::new();
+    {
+        let mut stmt = db
+            .conn
+            .prepare("SELECT goodreads_id, id FROM books WHERE goodreads_id IS NOT NULL")?;
+        let rows = stmt.query_map([], |row| {
+            let gr_id: String = row.get(0)?;
+            let id_str: String = row.get(1)?;
+            Ok((gr_id, Uuid::parse_str(&id_str).unwrap_or_default()))
+        })?;
+        for row in rows.flatten() {
+            existing_gr_ids.insert(row.0, row.1);
+        }
+    }
+
+    for result in rdr.records() {
+        report.total_rows += 1;
+
+        let record = match result {
+            Ok(r) => r,
+            Err(e) => {
+                report.errors += 1;
+                report
+                    .error_details
+                    .push(format!("Row {}: CSV parse error: {e}", report.total_rows));
+                continue;
+            }
+        };
+
+        let get = |col: Option<usize>| -> Option<String> {
+            col.and_then(|i| record.get(i))
+                .map(|s| s.trim().to_string())
+                .filter(|s| !s.is_empty())
+        };
+
+        let title = match get(col_title) {
+            Some(t) => t,
+            None => {
+                report.errors += 1;
+                report
+                    .error_details
+                    .push(format!("Row {}: missing title", report.total_rows));
+                continue;
+            }
+        };
+
+        let gr_id = get(col_book_id);
+
+        // Dedup: skip if goodreads_id already exists
+        if let Some(ref id) = gr_id
+            && existing_gr_ids.contains_key(id)
+        {
+            report.skipped += 1;
+            continue;
+        }
+
+        if opts.dry_run {
+            let author = get(col_author).unwrap_or_default();
+            let status = get(col_exclusive)
+                .map(|s| map_shelf_to_status(&s).as_str().to_string())
+                .unwrap_or_else(|| "want-to-read".to_string());
+            eprintln!(
+                "  [dry-run] Would import: \"{}\" by {} ({})",
+                title, author, status
+            );
+            report.imported += 1;
+            continue;
+        }
+
+        // Build the book
+        let mut book = Book::new(&title);
+
+        // ISBN
+        let isbn13_raw = get(col_isbn13).map(|s| clean_isbn(&s));
+        let isbn_raw = get(col_isbn).map(|s| clean_isbn(&s));
+
+        // Status from Exclusive Shelf
+        if let Some(shelf) = get(col_exclusive) {
+            book.status = map_shelf_to_status(&shelf);
+        }
+
+        // Rating (Goodreads 0-5 → Toku 0-10)
+        if let Some(rating_str) = get(col_rating)
+            && let Ok(r) = rating_str.parse::<i32>()
+            && r > 0
+        {
+            book.rating = Some(r * 2);
+        }
+
+        // Page count
+        if let Some(pages_str) = get(col_pages) {
+            book.page_count = pages_str.parse().ok();
+        }
+
+        // Publication date
+        if let Some(year) = get(col_orig_year).or_else(|| get(col_year_pub)) {
+            book.pub_date = Some(year);
+        }
+
+        // Format from Binding
+        if let Some(binding) = get(col_binding) {
+            book.format = map_binding_to_format(&binding);
+        }
+
+        // Set goodreads_id
+        db.conn.execute(
+            "INSERT INTO books (id, title, subtitle, description, page_count, pub_date,
+             language, format, duration_minutes, cover_hash, work_id, status, rating,
+             created_at, updated_at, goodreads_id)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16)",
+            params![
+                book.id.to_string(),
+                book.title,
+                book.subtitle,
+                book.description,
+                book.page_count,
+                book.pub_date,
+                book.language,
+                book.format.as_str(),
+                book.duration_minutes,
+                book.cover_hash,
+                book.work_id.map(|u| u.to_string()),
+                book.status.as_str(),
+                book.rating,
+                book.created_at.to_rfc3339(),
+                book.updated_at.to_rfc3339(),
+                gr_id,
+            ],
+        )?;
+
+        // Store ISBNs
+        if let Some(ref isbn13) = isbn13_raw
+            && isbn13.len() == 13
+            && let Ok(validated) = Isbn::parse(isbn13)
+        {
+            repo.add_isbn(validated.as_str(), &book.id)?;
+        }
+        if let Some(ref isbn) = isbn_raw
+            && (isbn.len() == 10 || isbn.len() == 13)
+            && let Ok(validated) = Isbn::parse(isbn)
+        {
+            let isbn_str = validated.as_str().to_string();
+            // Avoid duplicate if same as isbn13
+            if Some(&isbn_str) != isbn13_raw.as_ref() {
+                let _ = repo.add_isbn(&isbn_str, &book.id);
+            }
+        }
+
+        // Author
+        if let Some(author_name) = get(col_author) {
+            let a = Author::new(author_name.as_str());
+            repo.add_book_author(&a, &book.id, ContributorRole::Author, 0)?;
+        }
+
+        // Additional authors
+        if let Some(additional) = get(col_additional_authors) {
+            for (i, name) in additional.split(',').enumerate() {
+                let name = name.trim();
+                if !name.is_empty() {
+                    let a = Author::new(name);
+                    repo.add_book_author(&a, &book.id, ContributorRole::Author, (i + 1) as i32)?;
+                }
+            }
+        }
+
+        // Track import → book relationship
+        db.conn.execute(
+            "INSERT INTO import_books (import_id, book_id) VALUES (?1, ?2)",
+            params![import_id, book.id.to_string()],
+        )?;
+
+        // Store provenance
+        set_provenance(&db.conn, &book.id, "title", "goodreads_import")?;
+        if book.rating.is_some() {
+            set_provenance(&db.conn, &book.id, "rating", "goodreads_import")?;
+        }
+        if book.page_count.is_some() {
+            set_provenance(&db.conn, &book.id, "page_count", "goodreads_import")?;
+        }
+        if book.pub_date.is_some() {
+            set_provenance(&db.conn, &book.id, "pub_date", "goodreads_import")?;
+        }
+
+        if let Some(ref id) = gr_id {
+            existing_gr_ids.insert(id.clone(), book.id);
+        }
+
+        report.imported += 1;
+    }
+
+    // Finalize import log
+    if !opts.dry_run {
+        db.conn.execute(
+            "UPDATE import_logs SET finished_at = ?1, total_rows = ?2,
+             imported = ?3, skipped = ?4, errors = ?5 WHERE id = ?6",
+            params![
+                Utc::now().to_rfc3339(),
+                report.total_rows as i64,
+                report.imported as i64,
+                report.skipped as i64,
+                report.errors as i64,
+                import_id,
+            ],
+        )?;
+        report.import_id = Some(import_id);
+    }
+
+    Ok(report)
+}
+
+/// Undo an import by removing all books added by it.
+pub fn undo_import(db: &Database, import_id: &str) -> Result<usize, ImportError> {
+    let count: i64 = db.conn.query_row(
+        "SELECT COUNT(*) FROM import_books WHERE import_id = ?1",
+        params![import_id],
+        |row| row.get(0),
+    )?;
+
+    db.conn.execute(
+        "DELETE FROM books WHERE id IN (SELECT book_id FROM import_books WHERE import_id = ?1)",
+        params![import_id],
+    )?;
+
+    db.conn
+        .execute("DELETE FROM import_logs WHERE id = ?1", params![import_id])?;
+
+    Ok(count as usize)
+}
+
+fn map_shelf_to_status(shelf: &str) -> ReadingStatus {
+    match shelf.to_lowercase().as_str() {
+        "read" => ReadingStatus::Read,
+        "currently-reading" => ReadingStatus::Reading,
+        "to-read" => ReadingStatus::WantToRead,
+        _ => ReadingStatus::WantToRead,
+    }
+}
+
+fn map_binding_to_format(binding: &str) -> BookFormat {
+    match binding.to_lowercase().as_str() {
+        "kindle edition" | "ebook" => BookFormat::Ebook,
+        "audiobook" | "audio cd" | "audible audio" => BookFormat::Audiobook,
+        _ => BookFormat::Physical,
+    }
+}
+
+/// Strip the ="..." quoting that Goodreads uses for ISBN fields.
+fn clean_isbn(raw: &str) -> String {
+    raw.trim_matches(|c: char| c == '=' || c == '"' || c.is_whitespace())
+        .to_string()
+}
+
+fn set_provenance(
+    conn: &rusqlite::Connection,
+    book_id: &Uuid,
+    field: &str,
+    source: &str,
+) -> Result<(), ImportError> {
+    conn.execute(
+        "INSERT OR IGNORE INTO metadata_provenance (book_id, field_name, source, source_date)
+         VALUES (?1, ?2, ?3, ?4)",
+        params![book_id.to_string(), field, source, Utc::now().to_rfc3339()],
+    )?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+
+    fn write_test_csv(dir: &Path) -> std::path::PathBuf {
+        let path = dir.join("goodreads_export.csv");
+        let mut f = std::fs::File::create(&path).unwrap();
+        writeln!(f, "Book Id,Title,Author,Author l-f,Additional Authors,ISBN,ISBN13,My Rating,Average Rating,Publisher,Binding,Number of Pages,Year Published,Original Publication Year,Date Read,Date Added,Bookshelves,Bookshelves with positions,Exclusive Shelf,My Review,Spoiler,Private Notes,Read Count,Owned Copies").unwrap();
+        writeln!(f, r#"3,Dune,Frank Herbert,"Herbert, Frank",,="0441172717",="9780441172719",5,4.25,Ace,Paperback,896,2005,1965,2024/03/15,2023/01/10,"sci-fi, classics","sci-fi (#1), classics (#2)",read,"Amazing book about desert planets",,,1,1"#).unwrap();
+        writeln!(f, r#"6,Neuromancer,William Gibson,"Gibson, William",,="0441569595",="9780441569595",4,3.89,Ace,Kindle Edition,271,2000,1984,,2024/02/20,cyberpunk,,to-read,,,,0,0"#).unwrap();
+        writeln!(f, r#"100,Project Hail Mary,Andy Weir,"Weir, Andy",,="0593135202",="9780593135204",0,4.52,Ballantine Books,Hardcover,496,2021,2021,2024/06/01,2024/05/01,,,currently-reading,,,,0,0"#).unwrap();
+        path
+    }
+
+    #[test]
+    fn import_goodreads_basic() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let csv_path = write_test_csv(tmp.path());
+        let db = Database::open_in_memory().unwrap();
+
+        let report =
+            import_goodreads(&db, &csv_path, &GoodreadsImportOptions { dry_run: false }).unwrap();
+
+        assert_eq!(report.total_rows, 3);
+        assert_eq!(report.imported, 3);
+        assert_eq!(report.skipped, 0);
+        assert_eq!(report.errors, 0);
+
+        let repo = BookRepository::new(&db);
+        let books = repo.list_books().unwrap();
+        assert_eq!(books.len(), 3);
+
+        // Check Dune
+        let dune = books.iter().find(|b| b.title == "Dune").unwrap();
+        assert_eq!(dune.status, ReadingStatus::Read);
+        assert_eq!(dune.rating, Some(10)); // 5 * 2
+        assert_eq!(dune.page_count, Some(896));
+        assert_eq!(dune.format, BookFormat::Physical);
+
+        // Check Neuromancer is ebook
+        let neuro = books.iter().find(|b| b.title == "Neuromancer").unwrap();
+        assert_eq!(neuro.status, ReadingStatus::WantToRead);
+        assert_eq!(neuro.format, BookFormat::Ebook);
+        assert_eq!(neuro.rating, Some(8)); // Goodreads 4 * 2 = 8
+
+        // Check currently-reading
+        let phm = books
+            .iter()
+            .find(|b| b.title == "Project Hail Mary")
+            .unwrap();
+        assert_eq!(phm.status, ReadingStatus::Reading);
+    }
+
+    #[test]
+    fn import_goodreads_idempotent() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let csv_path = write_test_csv(tmp.path());
+        let db = Database::open_in_memory().unwrap();
+
+        let r1 =
+            import_goodreads(&db, &csv_path, &GoodreadsImportOptions { dry_run: false }).unwrap();
+        assert_eq!(r1.imported, 3);
+
+        let r2 =
+            import_goodreads(&db, &csv_path, &GoodreadsImportOptions { dry_run: false }).unwrap();
+        assert_eq!(r2.imported, 0);
+        assert_eq!(r2.skipped, 3);
+
+        let repo = BookRepository::new(&db);
+        assert_eq!(repo.list_books().unwrap().len(), 3);
+    }
+
+    #[test]
+    fn import_goodreads_dry_run() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let csv_path = write_test_csv(tmp.path());
+        let db = Database::open_in_memory().unwrap();
+
+        let report =
+            import_goodreads(&db, &csv_path, &GoodreadsImportOptions { dry_run: true }).unwrap();
+        assert_eq!(report.imported, 3);
+
+        let repo = BookRepository::new(&db);
+        assert_eq!(repo.list_books().unwrap().len(), 0); // Nothing written
+    }
+
+    #[test]
+    fn import_goodreads_undo() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let csv_path = write_test_csv(tmp.path());
+        let db = Database::open_in_memory().unwrap();
+
+        let report =
+            import_goodreads(&db, &csv_path, &GoodreadsImportOptions { dry_run: false }).unwrap();
+        assert_eq!(report.imported, 3);
+        let import_id = report.import_id.unwrap();
+
+        let repo = BookRepository::new(&db);
+        assert_eq!(repo.list_books().unwrap().len(), 3);
+
+        let undone = undo_import(&db, &import_id).unwrap();
+        assert_eq!(undone, 3);
+        assert_eq!(repo.list_books().unwrap().len(), 0);
+    }
+
+    #[test]
+    fn import_goodreads_authors() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let csv_path = write_test_csv(tmp.path());
+        let db = Database::open_in_memory().unwrap();
+
+        import_goodreads(&db, &csv_path, &GoodreadsImportOptions { dry_run: false }).unwrap();
+
+        let repo = BookRepository::new(&db);
+        let books = repo.list_books().unwrap();
+        let dune = books.iter().find(|b| b.title == "Dune").unwrap();
+        let authors = repo.get_book_authors(&dune.id).unwrap();
+        assert_eq!(authors.len(), 1);
+        assert_eq!(authors[0].0.name, "Frank Herbert");
+    }
+
+    #[test]
+    fn isbn_cleaning() {
+        assert_eq!(clean_isbn(r#"="0441172717""#), "0441172717");
+        assert_eq!(clean_isbn(r#"="9780441172719""#), "9780441172719");
+        assert_eq!(clean_isbn("  9780441172719  "), "9780441172719");
+    }
+}

--- a/crates/toku-import/src/lib.rs
+++ b/crates/toku-import/src/lib.rs
@@ -1,0 +1,5 @@
+mod error;
+mod goodreads;
+
+pub use error::ImportError;
+pub use goodreads::{GoodreadsImportOptions, ImportReport, import_goodreads, undo_import};

--- a/crates/toku-meta/Cargo.toml
+++ b/crates/toku-meta/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "toku-meta"
+description = "Book metadata fetching from Open Library and Google Books for Toku"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[dependencies]
+toku-core = { path = "../toku-core", version = "0.1.0" }
+thiserror.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+reqwest.workspace = true
+tokio.workspace = true
+sha2 = "0.10"

--- a/crates/toku-meta/src/error.rs
+++ b/crates/toku-meta/src/error.rs
@@ -1,0 +1,14 @@
+#[derive(Debug, thiserror::Error)]
+pub enum MetaError {
+    #[error("HTTP request failed: {0}")]
+    Http(#[from] reqwest::Error),
+
+    #[error("book not found for ISBN: {0}")]
+    NotFound(String),
+
+    #[error("failed to parse API response: {0}")]
+    Parse(String),
+
+    #[error("I/O error: {0}")]
+    Io(#[from] std::io::Error),
+}

--- a/crates/toku-meta/src/lib.rs
+++ b/crates/toku-meta/src/lib.rs
@@ -1,0 +1,5 @@
+mod error;
+mod openlibrary;
+
+pub use error::MetaError;
+pub use openlibrary::{OpenLibraryBook, fetch_by_isbn, fetch_cover};

--- a/crates/toku-meta/src/openlibrary.rs
+++ b/crates/toku-meta/src/openlibrary.rs
@@ -1,0 +1,150 @@
+use std::path::Path;
+
+use serde::Deserialize;
+use sha2::{Digest, Sha256};
+
+use crate::MetaError;
+
+const USER_AGENT: &str = "toku/0.1.0 (https://github.com/kafkade/toku)";
+
+/// Parsed response from Open Library's ISBN endpoint.
+#[derive(Debug, Clone)]
+pub struct OpenLibraryBook {
+    pub title: String,
+    pub subtitle: Option<String>,
+    pub description: Option<String>,
+    pub page_count: Option<i32>,
+    pub pub_date: Option<String>,
+    pub language: Option<String>,
+    pub publishers: Vec<String>,
+    pub authors: Vec<String>,
+    pub isbn_13: Option<String>,
+    pub isbn_10: Option<String>,
+    pub openlibrary_id: Option<String>,
+    pub cover_id: Option<i64>,
+}
+
+/// Fetch book metadata from Open Library by ISBN.
+pub async fn fetch_by_isbn(isbn: &str) -> Result<OpenLibraryBook, MetaError> {
+    let client = reqwest::Client::builder().user_agent(USER_AGENT).build()?;
+
+    let url = format!("https://openlibrary.org/isbn/{isbn}.json");
+    let resp = client.get(&url).send().await?;
+
+    if resp.status() == reqwest::StatusCode::NOT_FOUND {
+        return Err(MetaError::NotFound(isbn.to_string()));
+    }
+
+    let resp = resp.error_for_status()?;
+    let raw: RawEdition = resp.json().await?;
+
+    // Resolve author names from author keys
+    let mut authors = Vec::new();
+    for author_ref in &raw.authors.unwrap_or_default() {
+        if let Some(key) = &author_ref.key
+            && let Ok(name) = fetch_author_name(&client, key).await
+        {
+            authors.push(name);
+        }
+    }
+
+    let description = raw.description.map(|d| match d {
+        DescriptionField::Simple(s) => s,
+        DescriptionField::Object { value } => value,
+    });
+
+    Ok(OpenLibraryBook {
+        title: raw.title,
+        subtitle: raw.subtitle,
+        description,
+        page_count: raw.number_of_pages,
+        pub_date: raw.publish_date,
+        language: raw
+            .languages
+            .and_then(|langs| langs.first().and_then(|l| l.key.clone()))
+            .map(|k| k.replace("/languages/", "")),
+        publishers: raw.publishers.unwrap_or_default(),
+        authors,
+        isbn_13: raw.isbn_13.and_then(|v| v.into_iter().next()),
+        isbn_10: raw.isbn_10.and_then(|v| v.into_iter().next()),
+        openlibrary_id: raw.key,
+        cover_id: raw.covers.and_then(|c| c.into_iter().next()),
+    })
+}
+
+/// Download a cover image and save it content-addressed by SHA-256.
+/// Returns the hash filename (e.g., "a1b2c3d4e5f6.jpg").
+pub async fn fetch_cover(isbn: &str, covers_dir: &Path) -> Result<Option<String>, MetaError> {
+    let client = reqwest::Client::builder().user_agent(USER_AGENT).build()?;
+
+    let url = format!("https://covers.openlibrary.org/b/isbn/{isbn}-L.jpg?default=false");
+    let resp = client.get(&url).send().await?;
+
+    if !resp.status().is_success() {
+        return Ok(None);
+    }
+
+    let bytes = resp.bytes().await?;
+
+    // Open Library returns a 1x1 pixel placeholder for missing covers
+    if bytes.len() < 1000 {
+        return Ok(None);
+    }
+
+    let hash = format!("{:x}", Sha256::digest(&bytes));
+    let hash_short = &hash[..16];
+    let filename = format!("{hash_short}.jpg");
+
+    std::fs::create_dir_all(covers_dir)?;
+    let path = covers_dir.join(&filename);
+    std::fs::write(&path, &bytes)?;
+
+    Ok(Some(hash_short.to_string()))
+}
+
+async fn fetch_author_name(client: &reqwest::Client, key: &str) -> Result<String, MetaError> {
+    let url = format!("https://openlibrary.org{key}.json");
+    let resp = client.get(&url).send().await?.error_for_status()?;
+    let author: RawAuthor = resp.json().await?;
+    Ok(author.name)
+}
+
+// --- Raw API response structs ---
+
+#[derive(Deserialize)]
+struct RawEdition {
+    title: String,
+    subtitle: Option<String>,
+    description: Option<DescriptionField>,
+    number_of_pages: Option<i32>,
+    publish_date: Option<String>,
+    publishers: Option<Vec<String>>,
+    authors: Option<Vec<AuthorRef>>,
+    languages: Option<Vec<LanguageRef>>,
+    isbn_13: Option<Vec<String>>,
+    isbn_10: Option<Vec<String>>,
+    covers: Option<Vec<i64>>,
+    key: Option<String>,
+}
+
+#[derive(Deserialize)]
+#[serde(untagged)]
+enum DescriptionField {
+    Simple(String),
+    Object { value: String },
+}
+
+#[derive(Deserialize)]
+struct AuthorRef {
+    key: Option<String>,
+}
+
+#[derive(Deserialize)]
+struct LanguageRef {
+    key: Option<String>,
+}
+
+#[derive(Deserialize)]
+struct RawAuthor {
+    name: String,
+}


### PR DESCRIPTION
## Description

Add Open Library metadata fetching, full CLI commands (add, show, list, search), and Goodreads CSV import with dry-run and rollback support.

### What's included

- **Open Library metadata fetch** (`toku-meta` crate) — query by ISBN, parse edition/author responses, download cover images with content-addressed SHA-256 storage, graceful degradation when API is unavailable
- **CLI commands** (`toku-cli`) — `toku add --isbn` (fetches metadata + cover), `toku add --title --author` (manual entry), `toku show` (detailed view), `toku list` (table with status filter), `toku search` (FTS5 full-text search), all with `--format table|json|csv` output
- **Goodreads CSV import** (`toku-import` crate) — parses all standard Goodreads export columns, `--dry-run` preview, idempotent re-import via `goodreads_id`, ISBN cleaning (strips Goodreads `="..."` quoting), rating conversion (GR 1-5 → Toku 0-10), status mapping (`Exclusive Shelf` → reading states), format detection from `Binding`
- **Import infrastructure** — rollback via `toku import undo <id>`, import log tracking (`import_logs` + `import_books` tables), per-field provenance recording
- **V2 schema migration** — adds `goodreads_id` column to books, `import_logs` and `import_books` tables
- **29 tests** — 15 core, 8 db, 6 import (basic import, idempotency, dry-run, rollback, authors, ISBN cleaning)

## Related Issues

Closes #3, closes #4, closes #5

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI / infrastructure
- [ ] Other (describe below)

## Crate

- [ ] `toku-core` — Domain models, traits, state machine
- [x] `toku-db` — SQLite persistence, migrations, FTS5
- [x] `toku-import` — Importers (Goodreads, Calibre, StoryGraph)
- [x] `toku-meta` — Metadata fetching (Open Library, Google Books)
- [x] `toku-cli` — CLI binary
- [ ] `toku-export` — Exporters (CSV, JSON, Markdown, BibTeX)
- [ ] `docs/` — Documentation

## Data Integrity Checklist

- [x] No user data is sent to any server without explicit opt-in — metadata fetch is opt-in (`--isbn` triggers it; manual entry works offline)
- [x] Import operations are idempotent — re-importing the same Goodreads CSV creates zero duplicates (tested)
- [x] User edits to metadata are never overwritten by auto-enrichment — provenance system tracks source per field
- [x] New fields track provenance (source + timestamp) — `metadata_provenance` table populated on import
- [x] Export round-trip is preserved (if applicable) — N/A for this PR

## Checklist

- [x] I have read [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] `cargo fmt --check` passes
- [x] `cargo clippy --workspace -- -D warnings` passes
- [x] `cargo test --workspace` passes — 29 tests, all green
- [x] I have updated documentation (if applicable) — CHANGELOG updated