### PR TITLE
feat: add reading status, shelves, tags, enhanced search, config, and completions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,5 +34,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Goodreads CSV import: `toku import goodreads <file>` with dry-run, idempotent re-import, ISBN cleaning, rating conversion, status mapping, and format detection
 - Import rollback: `toku import undo <import-id>` removes all books from a specific import
 - Import provenance tracking per field for future re-import safety
+- Reading status management: `toku reading start|finish|abandon|hold|resume` with state machine validation and automatic date tracking
+- Reading sessions with per-session ratings and notes
+- Shelves: `toku shelf create|add|remove|list` for user-defined book collections
+- Tags: `toku tag add|remove|list` with case-insensitive matching
+- `toku list --shelf <name>` and `toku list --tag <name>` filters
+- Full-text search now includes author names alongside title and description
+- `toku search` with `--status`, `--shelf`, and `--tag` filters for narrowing results
+- Configuration file (`config.toml`): default output format, color mode, metadata source
+- `toku config` to view settings, `toku config --edit` to open in editor
+- `toku completions bash|zsh|fish|powershell` for shell completion generation
 
 [Unreleased]: https://github.com/kafkade/toku/compare/v0.1.0...HEAD

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -195,6 +195,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap_complete"
+version = "4.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ff7a1dccbdd8b078c2bdebff47e404615151534d5043da397ec50286816f9cb"
+dependencies = [
+ "clap",
+]
+
+[[package]]
 name = "clap_derive"
 version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1637,6 +1646,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "clap",
+ "clap_complete",
  "serde",
  "serde_json",
  "tabled",
@@ -1645,6 +1655,7 @@ dependencies = [
  "toku-db",
  "toku-import",
  "toku-meta",
+ "toml",
 ]
 
 [[package]]
@@ -1654,6 +1665,7 @@ dependencies = [
  "chrono",
  "serde",
  "thiserror",
+ "toml",
  "uuid",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,3 +24,4 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
 tokio = { version = "1", features = ["rt", "macros"] }
+toml = "0.8"

--- a/crates/toku-cli/Cargo.toml
+++ b/crates/toku-cli/Cargo.toml
@@ -17,8 +17,10 @@ toku-db = { path = "../toku-db", version = "0.1.0" }
 toku-meta = { path = "../toku-meta", version = "0.1.0" }
 toku-import = { path = "../toku-import", version = "0.1.0" }
 clap = { version = "4", features = ["derive", "env"] }
+clap_complete = "4"
 anyhow = "1"
 serde.workspace = true
 serde_json.workspace = true
+toml.workspace = true
 tokio.workspace = true
 tabled = "0.17"

--- a/crates/toku-cli/src/main.rs
+++ b/crates/toku-cli/src/main.rs
@@ -1,8 +1,11 @@
 use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result};
-use clap::{Parser, Subcommand, ValueEnum};
-use toku_core::{Author, Book, BookFormat, ContributorRole, Isbn};
+use clap::{CommandFactory, Parser, Subcommand, ValueEnum};
+use clap_complete::Shell;
+use toku_core::{
+    Author, Book, BookFormat, ContributorRole, Isbn, ReadingSession, ReadingStatus, TokuConfig,
+};
 use toku_db::{BookRepository, Database};
 
 /// Toku — a private, offline-first personal book manager.
@@ -53,18 +56,73 @@ enum Commands {
         /// Filter by reading status
         #[arg(long, short)]
         status: Option<String>,
+
+        /// Filter by shelf name
+        #[arg(long)]
+        shelf: Option<String>,
+
+        /// Filter by tag name
+        #[arg(long)]
+        tag: Option<String>,
     },
 
     /// Search your library
     Search {
         /// Search query
         query: String,
+
+        /// Filter by reading status
+        #[arg(long, short)]
+        status: Option<String>,
+
+        /// Filter by shelf name
+        #[arg(long)]
+        shelf: Option<String>,
+
+        /// Filter by tag name
+        #[arg(long)]
+        tag: Option<String>,
     },
 
     /// Import books from external sources
     Import {
         #[command(subcommand)]
         source: ImportSource,
+    },
+
+    /// Show or edit configuration
+    Config {
+        /// Print the config file path
+        #[arg(long)]
+        path: bool,
+
+        /// Open the config file in your editor
+        #[arg(long)]
+        edit: bool,
+    },
+
+    /// Generate shell completions
+    Completions {
+        /// Shell to generate completions for
+        shell: Shell,
+    },
+
+    /// Manage reading status (start, finish, abandon, hold, resume)
+    Reading {
+        #[command(subcommand)]
+        action: ReadingAction,
+    },
+
+    /// Manage shelves for organizing books
+    Shelf {
+        #[command(subcommand)]
+        action: ShelfAction,
+    },
+
+    /// Manage tags for categorizing books
+    Tag {
+        #[command(subcommand)]
+        action: TagAction,
     },
 }
 
@@ -87,6 +145,99 @@ enum ImportSource {
     },
 }
 
+#[derive(Subcommand)]
+enum ReadingAction {
+    /// Start reading a book (WantToRead → Reading)
+    Start {
+        /// Book title
+        book: String,
+    },
+
+    /// Finish reading a book (Reading → Read)
+    Finish {
+        /// Book title
+        book: String,
+
+        /// Rating (0–10, displayed as 5★ with half-star increments)
+        #[arg(long, short)]
+        rating: Option<i32>,
+    },
+
+    /// Abandon a book (Reading → Abandoned)
+    Abandon {
+        /// Book title
+        book: String,
+    },
+
+    /// Put a book on hold (Reading → OnHold)
+    Hold {
+        /// Book title
+        book: String,
+    },
+
+    /// Resume reading a book (OnHold/Abandoned → Reading)
+    Resume {
+        /// Book title
+        book: String,
+    },
+}
+
+#[derive(Subcommand)]
+enum ShelfAction {
+    /// Create a new shelf
+    Create {
+        /// Shelf name
+        name: String,
+    },
+
+    /// Add books to a shelf
+    Add {
+        /// Shelf name
+        shelf: String,
+
+        /// Book titles to add
+        #[arg(required = true)]
+        books: Vec<String>,
+    },
+
+    /// Remove a book from a shelf
+    Remove {
+        /// Shelf name
+        shelf: String,
+
+        /// Book title to remove
+        book: String,
+    },
+
+    /// List all shelves
+    List,
+}
+
+#[derive(Subcommand)]
+enum TagAction {
+    /// Add a tag to books
+    Add {
+        /// Tag name
+        tag: String,
+
+        /// Book titles to tag
+        #[arg(required = true)]
+        books: Vec<String>,
+    },
+
+    /// Remove a tag from a book
+    Remove {
+        /// Tag name
+        tag: String,
+
+        /// Book title
+        book: String,
+    },
+
+    /// List all tags with book counts
+    List,
+}
+
 #[derive(Clone, ValueEnum)]
 enum OutputFormat {
     Table,
@@ -97,11 +248,22 @@ enum OutputFormat {
 fn main() -> Result<()> {
     let cli = Cli::parse();
 
-    let db_path = match &cli.data_dir {
-        Some(dir) => dir.join("toku.db"),
-        None => Database::default_db_path().context("could not determine data directory")?,
+    let data_dir = match &cli.data_dir {
+        Some(dir) => dir.clone(),
+        None => Database::default_data_dir().context("could not determine data directory")?,
     };
 
+    // Commands that don't need the database
+    match &cli.command {
+        Commands::Config { path, edit } => return cmd_config(&data_dir, *path, *edit),
+        Commands::Completions { shell } => {
+            clap_complete::generate(*shell, &mut Cli::command(), "toku", &mut std::io::stdout());
+            return Ok(());
+        }
+        _ => {}
+    }
+
+    let db_path = data_dir.join("toku.db");
     let db = Database::open(&db_path)
         .with_context(|| format!("failed to open database at {}", db_path.display()))?;
     let repo = BookRepository::new(&db);
@@ -122,10 +284,74 @@ fn main() -> Result<()> {
             &cli.format,
         ),
         Commands::Show { query } => cmd_show(&repo, &query, &cli.format),
-        Commands::List { status } => cmd_list(&repo, status.as_deref(), &cli.format),
-        Commands::Search { query } => cmd_search(&repo, &query, &cli.format),
+        Commands::List { status, shelf, tag } => cmd_list(
+            &repo,
+            status.as_deref(),
+            shelf.as_deref(),
+            tag.as_deref(),
+            &cli.format,
+        ),
+        Commands::Search {
+            query,
+            status,
+            shelf,
+            tag,
+        } => cmd_search(
+            &repo,
+            &query,
+            status.as_deref(),
+            shelf.as_deref(),
+            tag.as_deref(),
+            &cli.format,
+        ),
         Commands::Import { source } => cmd_import(&db, &repo, source, &cli.format),
+        Commands::Reading { action } => cmd_reading(&repo, action),
+        Commands::Shelf { action } => cmd_shelf(&repo, action, &cli.format),
+        Commands::Tag { action } => cmd_tag(&repo, action, &cli.format),
+        // Already handled above
+        Commands::Config { .. } | Commands::Completions { .. } => unreachable!(),
     }
+}
+
+fn cmd_config(data_dir: &Path, show_path: bool, open_edit: bool) -> Result<()> {
+    let config_path = TokuConfig::config_path(data_dir);
+
+    if show_path {
+        println!("{}", config_path.display());
+        return Ok(());
+    }
+
+    if open_edit {
+        // Ensure the config file exists with defaults
+        if !config_path.exists() {
+            TokuConfig::default()
+                .save(data_dir)
+                .context("failed to create default config")?;
+            eprintln!("Created default config at {}", config_path.display());
+        }
+
+        let editor = std::env::var("VISUAL")
+            .or_else(|_| std::env::var("EDITOR"))
+            .unwrap_or_else(|_| {
+                if cfg!(windows) {
+                    "notepad".to_string()
+                } else {
+                    "nano".to_string()
+                }
+            });
+
+        std::process::Command::new(&editor)
+            .arg(&config_path)
+            .status()
+            .with_context(|| format!("failed to open editor: {editor}"))?;
+        return Ok(());
+    }
+
+    // Default: show current config
+    let config = TokuConfig::load(data_dir).context("failed to load config")?;
+    let toml_str = toml::to_string_pretty(&config).context("failed to serialize config")?;
+    println!("{toml_str}");
+    Ok(())
 }
 
 fn cmd_add(
@@ -243,9 +469,18 @@ fn cmd_show(repo: &BookRepository, query: &str, output_format: &OutputFormat) ->
 fn cmd_list(
     repo: &BookRepository,
     status: Option<&str>,
+    shelf: Option<&str>,
+    tag: Option<&str>,
     output_format: &OutputFormat,
 ) -> Result<()> {
-    let books = repo.list_books()?;
+    let books = if let Some(shelf_name) = shelf {
+        repo.list_books_in_shelf(shelf_name)?
+    } else if let Some(tag_name) = tag {
+        repo.list_books_by_tag(tag_name)?
+    } else {
+        repo.list_books()?
+    };
+
     let filtered: Vec<Book> = if let Some(s) = status {
         let target: toku_core::ReadingStatus = s.parse().context("invalid status")?;
         books.into_iter().filter(|b| b.status == target).collect()
@@ -263,8 +498,15 @@ fn cmd_list(
     Ok(())
 }
 
-fn cmd_search(repo: &BookRepository, query: &str, output_format: &OutputFormat) -> Result<()> {
-    let books = repo.search_books(query)?;
+fn cmd_search(
+    repo: &BookRepository,
+    query: &str,
+    status: Option<&str>,
+    shelf: Option<&str>,
+    tag: Option<&str>,
+    output_format: &OutputFormat,
+) -> Result<()> {
+    let books = repo.search_books_filtered(query, status, shelf, tag)?;
     if books.is_empty() {
         eprintln!("No results for \"{query}\"");
         return Ok(());
@@ -506,6 +748,318 @@ fn cmd_import(
                 eprintln!("No books found for import ID {import_id}");
             }
 
+            Ok(())
+        }
+    }
+}
+
+/// Resolve a book title to a Book, returning a user-friendly error if not found.
+fn resolve_book(repo: &BookRepository, title: &str) -> Result<Book> {
+    if let Some(book) = repo.find_book_by_title(title)? {
+        return Ok(book);
+    }
+
+    // Fall back to substring search
+    let all = repo.list_books()?;
+    let matches: Vec<&Book> = all
+        .iter()
+        .filter(|b| b.title.to_lowercase().contains(&title.to_lowercase()))
+        .collect();
+
+    match matches.len() {
+        0 => anyhow::bail!("no book found matching \"{title}\""),
+        1 => Ok(matches[0].clone()),
+        _ => {
+            eprintln!("Multiple books match \"{title}\":");
+            for b in &matches {
+                eprintln!("  • {} ({})", b.title, b.status);
+            }
+            anyhow::bail!("be more specific or use the exact title")
+        }
+    }
+}
+
+fn cmd_reading(repo: &BookRepository, action: ReadingAction) -> Result<()> {
+    match action {
+        ReadingAction::Start { book: title } => {
+            let book = resolve_book(repo, &title)?;
+            let target = ReadingStatus::Reading;
+
+            if !book.status.can_transition_to(&target) {
+                anyhow::bail!(
+                    "cannot start: \"{}\" is currently {} (expected want-to-read, on-hold, abandoned, or read)",
+                    book.title,
+                    book.status
+                );
+            }
+
+            repo.update_book_status(&book.id, target)?;
+
+            let session = ReadingSession::new(book.id);
+            repo.create_reading_session(&session)?;
+
+            eprintln!("✓ Started reading \"{}\"", book.title);
+            Ok(())
+        }
+
+        ReadingAction::Finish {
+            book: title,
+            rating,
+        } => {
+            let book = resolve_book(repo, &title)?;
+            let target = ReadingStatus::Read;
+
+            if !book.status.can_transition_to(&target) {
+                anyhow::bail!(
+                    "cannot finish: \"{}\" is currently {} (expected reading)",
+                    book.title,
+                    book.status
+                );
+            }
+
+            if let Some(r) = rating {
+                if !(0..=10).contains(&r) {
+                    anyhow::bail!("rating must be between 0 and 10, got {r}");
+                }
+                repo.update_book_rating(&book.id, r)?;
+            }
+
+            repo.update_book_status(&book.id, target)?;
+
+            match rating {
+                Some(r) => eprintln!(
+                    "✓ Finished \"{}\" — rated {:.1}★",
+                    book.title,
+                    r as f32 / 2.0
+                ),
+                None => eprintln!("✓ Finished \"{}\"", book.title),
+            }
+            Ok(())
+        }
+
+        ReadingAction::Abandon { book: title } => {
+            let book = resolve_book(repo, &title)?;
+            let target = ReadingStatus::Abandoned;
+
+            if !book.status.can_transition_to(&target) {
+                anyhow::bail!(
+                    "cannot abandon: \"{}\" is currently {} (expected reading)",
+                    book.title,
+                    book.status
+                );
+            }
+
+            repo.update_book_status(&book.id, target)?;
+            eprintln!("✓ Abandoned \"{}\"", book.title);
+            Ok(())
+        }
+
+        ReadingAction::Hold { book: title } => {
+            let book = resolve_book(repo, &title)?;
+            let target = ReadingStatus::OnHold;
+
+            if !book.status.can_transition_to(&target) {
+                anyhow::bail!(
+                    "cannot hold: \"{}\" is currently {} (expected reading)",
+                    book.title,
+                    book.status
+                );
+            }
+
+            repo.update_book_status(&book.id, target)?;
+            eprintln!("✓ Put \"{}\" on hold", book.title);
+            Ok(())
+        }
+
+        ReadingAction::Resume { book: title } => {
+            let book = resolve_book(repo, &title)?;
+            let target = ReadingStatus::Reading;
+
+            if !book.status.can_transition_to(&target) {
+                anyhow::bail!(
+                    "cannot resume: \"{}\" is currently {} (expected on-hold or abandoned)",
+                    book.title,
+                    book.status
+                );
+            }
+
+            repo.update_book_status(&book.id, target)?;
+
+            let session = ReadingSession::new(book.id);
+            repo.create_reading_session(&session)?;
+
+            eprintln!("✓ Resumed reading \"{}\"", book.title);
+            Ok(())
+        }
+    }
+}
+
+fn cmd_shelf(
+    repo: &BookRepository,
+    action: ShelfAction,
+    output_format: &OutputFormat,
+) -> Result<()> {
+    match action {
+        ShelfAction::Create { name } => {
+            repo.create_shelf(&name)?;
+            eprintln!("✓ Created shelf \"{name}\"");
+            Ok(())
+        }
+        ShelfAction::Add { shelf, books } => {
+            for title in &books {
+                let book = resolve_book(repo, title)?;
+                repo.add_book_to_shelf(&book.id, &shelf)?;
+                eprintln!("✓ Added \"{}\" to shelf \"{shelf}\"", book.title);
+            }
+            Ok(())
+        }
+        ShelfAction::Remove { shelf, book: title } => {
+            let book = resolve_book(repo, &title)?;
+            repo.remove_book_from_shelf(&book.id, &shelf)?;
+            eprintln!("✓ Removed \"{}\" from shelf \"{shelf}\"", book.title);
+            Ok(())
+        }
+        ShelfAction::List => {
+            let shelves = repo.list_shelves()?;
+            if shelves.is_empty() {
+                eprintln!("No shelves yet. Create one with: toku shelf create <name>");
+                return Ok(());
+            }
+
+            match output_format {
+                OutputFormat::Json => {
+                    #[derive(serde::Serialize)]
+                    struct ShelfOut {
+                        name: String,
+                        books: usize,
+                    }
+                    let out: Vec<ShelfOut> = shelves
+                        .iter()
+                        .map(|s| {
+                            let count = repo
+                                .list_books_in_shelf(&s.name)
+                                .map(|b| b.len())
+                                .unwrap_or(0);
+                            ShelfOut {
+                                name: s.name.clone(),
+                                books: count,
+                            }
+                        })
+                        .collect();
+                    println!("{}", serde_json::to_string_pretty(&out)?);
+                }
+                OutputFormat::Csv => {
+                    println!("name,books");
+                    for s in &shelves {
+                        let count = repo
+                            .list_books_in_shelf(&s.name)
+                            .map(|b| b.len())
+                            .unwrap_or(0);
+                        println!("\"{}\",{}", s.name.replace('"', "\"\""), count);
+                    }
+                }
+                OutputFormat::Table => {
+                    use tabled::{Table, Tabled};
+
+                    #[derive(Tabled)]
+                    struct Row {
+                        #[tabled(rename = "Shelf")]
+                        name: String,
+                        #[tabled(rename = "Books")]
+                        books: usize,
+                    }
+
+                    let rows: Vec<Row> = shelves
+                        .iter()
+                        .map(|s| {
+                            let count = repo
+                                .list_books_in_shelf(&s.name)
+                                .map(|b| b.len())
+                                .unwrap_or(0);
+                            Row {
+                                name: s.name.clone(),
+                                books: count,
+                            }
+                        })
+                        .collect();
+
+                    println!("{}", Table::new(rows));
+                }
+            }
+            eprintln!("\n{} shelf(s)", shelves.len());
+            Ok(())
+        }
+    }
+}
+
+fn cmd_tag(repo: &BookRepository, action: TagAction, output_format: &OutputFormat) -> Result<()> {
+    match action {
+        TagAction::Add { tag, books } => {
+            for title in &books {
+                let book = resolve_book(repo, title)?;
+                repo.add_tag_to_book(&book.id, &tag)?;
+                eprintln!("✓ Tagged \"{}\" with \"{tag}\"", book.title);
+            }
+            Ok(())
+        }
+        TagAction::Remove { tag, book: title } => {
+            let book = resolve_book(repo, &title)?;
+            repo.remove_tag_from_book(&book.id, &tag)?;
+            eprintln!("✓ Removed tag \"{tag}\" from \"{}\"", book.title);
+            Ok(())
+        }
+        TagAction::List => {
+            let tags = repo.list_tags_with_counts()?;
+            if tags.is_empty() {
+                eprintln!("No tags yet. Add one with: toku tag add <tag> <book>");
+                return Ok(());
+            }
+
+            match output_format {
+                OutputFormat::Json => {
+                    #[derive(serde::Serialize)]
+                    struct TagOut {
+                        name: String,
+                        books: i64,
+                    }
+                    let out: Vec<TagOut> = tags
+                        .iter()
+                        .map(|(t, count)| TagOut {
+                            name: t.name.clone(),
+                            books: *count,
+                        })
+                        .collect();
+                    println!("{}", serde_json::to_string_pretty(&out)?);
+                }
+                OutputFormat::Csv => {
+                    println!("tag,books");
+                    for (t, count) in &tags {
+                        println!("\"{}\",{}", t.name.replace('"', "\"\""), count);
+                    }
+                }
+                OutputFormat::Table => {
+                    use tabled::{Table, Tabled};
+
+                    #[derive(Tabled)]
+                    struct Row {
+                        #[tabled(rename = "Tag")]
+                        name: String,
+                        #[tabled(rename = "Books")]
+                        books: i64,
+                    }
+
+                    let rows: Vec<Row> = tags
+                        .iter()
+                        .map(|(t, count)| Row {
+                            name: t.name.clone(),
+                            books: *count,
+                        })
+                        .collect();
+
+                    println!("{}", Table::new(rows));
+                }
+            }
+            eprintln!("\n{} tag(s)", tags.len());
             Ok(())
         }
     }

--- a/crates/toku-core/Cargo.toml
+++ b/crates/toku-core/Cargo.toml
@@ -12,3 +12,4 @@ thiserror.workspace = true
 uuid.workspace = true
 chrono.workspace = true
 serde.workspace = true
+toml.workspace = true

--- a/crates/toku-core/src/book.rs
+++ b/crates/toku-core/src/book.rs
@@ -85,6 +85,37 @@ impl std::str::FromStr for BookFormat {
     }
 }
 
+/// A reading session tracks a single reading attempt of a book.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ReadingSession {
+    pub id: Uuid,
+    pub book_id: Uuid,
+    pub started_at: DateTime<Utc>,
+    pub finished_at: Option<DateTime<Utc>>,
+    pub start_page: Option<i32>,
+    pub end_page: Option<i32>,
+    pub rating: Option<i32>,
+    pub notes: Option<String>,
+    pub created_at: DateTime<Utc>,
+}
+
+impl ReadingSession {
+    pub fn new(book_id: Uuid) -> Self {
+        let now = Utc::now();
+        Self {
+            id: Uuid::now_v7(),
+            book_id,
+            started_at: now,
+            finished_at: None,
+            start_page: None,
+            end_page: None,
+            rating: None,
+            notes: None,
+            created_at: now,
+        }
+    }
+}
+
 /// Reading lifecycle states.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum ReadingStatus {
@@ -104,6 +135,20 @@ impl ReadingStatus {
             Self::Abandoned => "abandoned",
             Self::OnHold => "on-hold",
         }
+    }
+
+    /// Returns whether a transition from this status to `target` is valid.
+    pub fn can_transition_to(&self, target: &ReadingStatus) -> bool {
+        matches!(
+            (self, target),
+            (ReadingStatus::WantToRead, ReadingStatus::Reading)
+                | (ReadingStatus::Reading, ReadingStatus::Read)
+                | (ReadingStatus::Reading, ReadingStatus::Abandoned)
+                | (ReadingStatus::Reading, ReadingStatus::OnHold)
+                | (ReadingStatus::OnHold, ReadingStatus::Reading)
+                | (ReadingStatus::Abandoned, ReadingStatus::Reading)
+                | (ReadingStatus::Read, ReadingStatus::Reading) // re-read
+        )
     }
 }
 
@@ -202,6 +247,43 @@ fn guess_sort_name(name: &str) -> String {
     format!("{}, {}", last, rest.join(" "))
 }
 
+/// A user-defined shelf for organizing books (e.g. "Favorites", "To Re-read").
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Shelf {
+    pub id: Uuid,
+    pub name: String,
+    pub created_at: DateTime<Utc>,
+}
+
+impl Shelf {
+    pub fn new(name: impl Into<String>) -> Self {
+        Self {
+            id: Uuid::now_v7(),
+            name: name.into(),
+            created_at: Utc::now(),
+        }
+    }
+}
+
+/// A user-defined tag for categorizing books (e.g. "sci-fi", "Hugo winner").
+/// Tag names are case-insensitive.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Tag {
+    pub id: Uuid,
+    pub name: String,
+    pub created_at: DateTime<Utc>,
+}
+
+impl Tag {
+    pub fn new(name: impl Into<String>) -> Self {
+        Self {
+            id: Uuid::now_v7(),
+            name: name.into(),
+            created_at: Utc::now(),
+        }
+    }
+}
+
 /// A book-to-author relationship with role and ordering.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct BookAuthor {
@@ -295,5 +377,60 @@ mod tests {
             "dnf".parse::<ReadingStatus>().unwrap(),
             ReadingStatus::Abandoned
         );
+    }
+
+    // --- State machine tests ---
+
+    #[test]
+    fn valid_transitions() {
+        let valid = [
+            (ReadingStatus::WantToRead, ReadingStatus::Reading),
+            (ReadingStatus::Reading, ReadingStatus::Read),
+            (ReadingStatus::Reading, ReadingStatus::Abandoned),
+            (ReadingStatus::Reading, ReadingStatus::OnHold),
+            (ReadingStatus::OnHold, ReadingStatus::Reading),
+            (ReadingStatus::Abandoned, ReadingStatus::Reading),
+            (ReadingStatus::Read, ReadingStatus::Reading), // re-read
+        ];
+
+        for (from, to) in &valid {
+            assert!(from.can_transition_to(to), "{from} → {to} should be valid");
+        }
+    }
+
+    #[test]
+    fn invalid_transitions() {
+        let invalid = [
+            (ReadingStatus::WantToRead, ReadingStatus::Read),
+            (ReadingStatus::WantToRead, ReadingStatus::Abandoned),
+            (ReadingStatus::WantToRead, ReadingStatus::OnHold),
+            (ReadingStatus::Read, ReadingStatus::Abandoned),
+            (ReadingStatus::Read, ReadingStatus::OnHold),
+            (ReadingStatus::Read, ReadingStatus::WantToRead),
+            (ReadingStatus::Abandoned, ReadingStatus::Read),
+            (ReadingStatus::Abandoned, ReadingStatus::OnHold),
+            (ReadingStatus::OnHold, ReadingStatus::Read),
+            (ReadingStatus::OnHold, ReadingStatus::Abandoned),
+            // Self-transitions
+            (ReadingStatus::Reading, ReadingStatus::Reading),
+            (ReadingStatus::WantToRead, ReadingStatus::WantToRead),
+        ];
+
+        for (from, to) in &invalid {
+            assert!(
+                !from.can_transition_to(to),
+                "{from} → {to} should be invalid"
+            );
+        }
+    }
+
+    #[test]
+    fn reading_session_new_defaults() {
+        let book_id = Uuid::now_v7();
+        let session = ReadingSession::new(book_id);
+        assert_eq!(session.book_id, book_id);
+        assert!(session.finished_at.is_none());
+        assert!(session.rating.is_none());
+        assert!(session.notes.is_none());
     }
 }

--- a/crates/toku-core/src/config.rs
+++ b/crates/toku-core/src/config.rs
@@ -1,0 +1,102 @@
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+
+use crate::TokuError;
+
+/// Application configuration, persisted as `config.toml` in the data directory.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(default)]
+pub struct TokuConfig {
+    /// Default output format: table, json, csv
+    pub default_format: String,
+    /// Whether to use colors (auto, always, never)
+    pub color: String,
+    /// Primary metadata source (openlibrary, google)
+    pub metadata_source: String,
+}
+
+impl Default for TokuConfig {
+    fn default() -> Self {
+        Self {
+            default_format: "table".to_string(),
+            color: "auto".to_string(),
+            metadata_source: "openlibrary".to_string(),
+        }
+    }
+}
+
+const CONFIG_FILENAME: &str = "config.toml";
+
+impl TokuConfig {
+    /// Returns the path to `config.toml` inside the given data directory.
+    pub fn config_path(data_dir: &Path) -> PathBuf {
+        data_dir.join(CONFIG_FILENAME)
+    }
+
+    /// Load configuration from `config.toml` in `data_dir`.
+    /// Returns defaults if the file does not exist.
+    pub fn load(data_dir: &Path) -> Result<Self, TokuError> {
+        let path = Self::config_path(data_dir);
+        if !path.exists() {
+            return Ok(Self::default());
+        }
+        let contents =
+            std::fs::read_to_string(&path).map_err(|e| TokuError::Config(e.to_string()))?;
+        let config: TokuConfig =
+            toml::from_str(&contents).map_err(|e| TokuError::Config(e.to_string()))?;
+        Ok(config)
+    }
+
+    /// Save configuration to `config.toml` in `data_dir`.
+    /// Creates the data directory if it does not exist.
+    pub fn save(&self, data_dir: &Path) -> Result<(), TokuError> {
+        std::fs::create_dir_all(data_dir).map_err(|e| TokuError::Config(e.to_string()))?;
+        let contents =
+            toml::to_string_pretty(self).map_err(|e| TokuError::Config(e.to_string()))?;
+        let path = Self::config_path(data_dir);
+        std::fs::write(&path, contents).map_err(|e| TokuError::Config(e.to_string()))?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_has_sensible_values() {
+        let cfg = TokuConfig::default();
+        assert_eq!(cfg.default_format, "table");
+        assert_eq!(cfg.color, "auto");
+        assert_eq!(cfg.metadata_source, "openlibrary");
+    }
+
+    #[test]
+    fn load_missing_file_returns_defaults() {
+        let dir = std::env::temp_dir().join("toku-test-config-missing");
+        // Ensure the directory doesn't have a config file
+        let _ = std::fs::remove_file(TokuConfig::config_path(&dir));
+        let cfg = TokuConfig::load(&dir).expect("load should succeed");
+        assert_eq!(cfg, TokuConfig::default());
+    }
+
+    #[test]
+    fn save_and_load_roundtrip() {
+        let dir = std::env::temp_dir().join("toku-test-config-roundtrip");
+        let _ = std::fs::remove_dir_all(&dir);
+
+        let cfg = TokuConfig {
+            default_format: "json".to_string(),
+            color: "never".to_string(),
+            metadata_source: "google".to_string(),
+        };
+        cfg.save(&dir).expect("save should succeed");
+
+        let loaded = TokuConfig::load(&dir).expect("load should succeed");
+        assert_eq!(loaded, cfg);
+
+        // Clean up
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+}

--- a/crates/toku-core/src/error.rs
+++ b/crates/toku-core/src/error.rs
@@ -11,4 +11,13 @@ pub enum TokuError {
 
     #[error("invalid ISBN: {0}")]
     InvalidIsbn(String),
+
+    #[error("configuration error: {0}")]
+    Config(String),
+
+    #[error("invalid transition: cannot move from {from} to {to}")]
+    InvalidTransition {
+        from: &'static str,
+        to: &'static str,
+    },
 }

--- a/crates/toku-core/src/lib.rs
+++ b/crates/toku-core/src/lib.rs
@@ -1,7 +1,9 @@
 mod book;
+mod config;
 mod error;
 mod isbn;
 
 pub use book::*;
+pub use config::*;
 pub use error::*;
 pub use isbn::*;

--- a/crates/toku-db/migrations/V3__reading_sessions.sql
+++ b/crates/toku-db/migrations/V3__reading_sessions.sql
@@ -1,0 +1,12 @@
+CREATE TABLE reading_sessions (
+    id TEXT PRIMARY KEY NOT NULL,
+    book_id TEXT NOT NULL REFERENCES books(id) ON DELETE CASCADE,
+    started_at TEXT NOT NULL,
+    finished_at TEXT,
+    start_page INTEGER,
+    end_page INTEGER,
+    rating INTEGER CHECK (rating IS NULL OR (rating >= 0 AND rating <= 10)),
+    notes TEXT,
+    created_at TEXT NOT NULL
+);
+CREATE INDEX idx_reading_sessions_book ON reading_sessions(book_id);

--- a/crates/toku-db/migrations/V4__shelves_tags.sql
+++ b/crates/toku-db/migrations/V4__shelves_tags.sql
@@ -1,0 +1,26 @@
+CREATE TABLE shelves (
+    id TEXT PRIMARY KEY NOT NULL,
+    name TEXT NOT NULL UNIQUE,
+    created_at TEXT NOT NULL
+);
+
+CREATE TABLE book_shelves (
+    book_id TEXT NOT NULL REFERENCES books(id) ON DELETE CASCADE,
+    shelf_id TEXT NOT NULL REFERENCES shelves(id) ON DELETE CASCADE,
+    PRIMARY KEY (book_id, shelf_id)
+);
+
+CREATE TABLE tags (
+    id TEXT PRIMARY KEY NOT NULL,
+    name TEXT NOT NULL UNIQUE COLLATE NOCASE,
+    created_at TEXT NOT NULL
+);
+
+CREATE TABLE book_tags (
+    book_id TEXT NOT NULL REFERENCES books(id) ON DELETE CASCADE,
+    tag_id TEXT NOT NULL REFERENCES tags(id) ON DELETE CASCADE,
+    PRIMARY KEY (book_id, tag_id)
+);
+
+CREATE INDEX idx_book_shelves_shelf ON book_shelves(shelf_id);
+CREATE INDEX idx_book_tags_tag ON book_tags(tag_id);

--- a/crates/toku-db/migrations/V5__fts5_authors.sql
+++ b/crates/toku-db/migrations/V5__fts5_authors.sql
@@ -1,0 +1,39 @@
+-- Add denormalized search text column for FTS5 indexing.
+-- Combines title, subtitle, description, and author names into one field.
+ALTER TABLE books ADD COLUMN search_text TEXT;
+
+-- Backfill search_text for existing books (title + subtitle + description).
+-- Author names will be added by the application when update_search_text is called.
+UPDATE books SET search_text = COALESCE(title, '')
+    || CASE WHEN subtitle IS NOT NULL THEN ' ' || subtitle ELSE '' END
+    || CASE WHEN description IS NOT NULL THEN ' ' || description ELSE '' END;
+
+-- Drop old FTS5 table and triggers.
+DROP TRIGGER IF EXISTS books_fts_insert;
+DROP TRIGGER IF EXISTS books_fts_delete;
+DROP TRIGGER IF EXISTS books_fts_update;
+DROP TABLE IF EXISTS books_fts;
+
+-- Recreate FTS5 with single search_text column.
+CREATE VIRTUAL TABLE books_fts USING fts5(
+    search_text,
+    content='books',
+    content_rowid='rowid'
+);
+
+-- Triggers to keep FTS5 in sync with books table.
+CREATE TRIGGER books_fts_insert AFTER INSERT ON books BEGIN
+    INSERT INTO books_fts(rowid, search_text) VALUES (new.rowid, new.search_text);
+END;
+
+CREATE TRIGGER books_fts_delete AFTER DELETE ON books BEGIN
+    INSERT INTO books_fts(books_fts, rowid, search_text) VALUES ('delete', old.rowid, old.search_text);
+END;
+
+CREATE TRIGGER books_fts_update AFTER UPDATE ON books BEGIN
+    INSERT INTO books_fts(books_fts, rowid, search_text) VALUES ('delete', old.rowid, old.search_text);
+    INSERT INTO books_fts(rowid, search_text) VALUES (new.rowid, new.search_text);
+END;
+
+-- Rebuild FTS5 index from existing data.
+INSERT INTO books_fts(books_fts) VALUES ('rebuild');

--- a/crates/toku-db/src/repo.rs
+++ b/crates/toku-db/src/repo.rs
@@ -1,5 +1,7 @@
 use rusqlite::params;
-use toku_core::{Author, Book, BookAuthor, ContributorRole};
+use toku_core::{
+    Author, Book, BookAuthor, ContributorRole, ReadingSession, ReadingStatus, Shelf, Tag,
+};
 use uuid::Uuid;
 
 use crate::{Database, DbError};
@@ -16,11 +18,17 @@ impl<'a> BookRepository<'a> {
 
     /// Insert a new book. Returns the book's ID.
     pub fn create_book(&self, book: &Book) -> Result<(), DbError> {
+        let search_text = build_search_text(
+            &book.title,
+            book.subtitle.as_deref(),
+            book.description.as_deref(),
+            &[],
+        );
         self.db.conn.execute(
             "INSERT INTO books (id, title, subtitle, description, page_count, pub_date,
              language, format, duration_minutes, cover_hash, work_id, status, rating,
-             created_at, updated_at)
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15)",
+             created_at, updated_at, search_text)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16)",
             params![
                 book.id.to_string(),
                 book.title,
@@ -37,6 +45,7 @@ impl<'a> BookRepository<'a> {
                 book.rating,
                 book.created_at.to_rfc3339(),
                 book.updated_at.to_rfc3339(),
+                search_text,
             ],
         )?;
         Ok(())
@@ -75,20 +84,73 @@ impl<'a> BookRepository<'a> {
         Ok(books)
     }
 
-    /// Full-text search across title, subtitle, description.
+    /// Full-text search across title, subtitle, description, and authors.
     pub fn search_books(&self, query: &str) -> Result<Vec<Book>, DbError> {
-        let mut stmt = self.db.conn.prepare(
+        self.search_books_filtered(query, None, None, None)
+    }
+
+    /// Full-text search with optional status, shelf, and tag filters.
+    pub fn search_books_filtered(
+        &self,
+        query: &str,
+        status: Option<&str>,
+        shelf: Option<&str>,
+        tag: Option<&str>,
+    ) -> Result<Vec<Book>, DbError> {
+        let mut sql = String::from(
             "SELECT b.id, b.title, b.subtitle, b.description, b.page_count, b.pub_date,
              b.language, b.format, b.duration_minutes, b.cover_hash, b.work_id, b.status,
              b.rating, b.created_at, b.updated_at
              FROM books_fts f
              JOIN books b ON b.rowid = f.rowid
-             WHERE books_fts MATCH ?1
-             ORDER BY rank",
-        )?;
+             WHERE books_fts MATCH ?1",
+        );
+
+        let mut param_index = 2u32;
+
+        if status.is_some() {
+            sql.push_str(&format!(" AND b.status = ?{param_index}"));
+            param_index += 1;
+        }
+
+        if shelf.is_some() {
+            sql.push_str(&format!(
+                " AND b.id IN (SELECT bs.book_id FROM book_shelves bs
+                 JOIN shelves s ON s.id = bs.shelf_id WHERE s.name = ?{param_index})"
+            ));
+            param_index += 1;
+        }
+
+        if tag.is_some() {
+            sql.push_str(&format!(
+                " AND b.id IN (SELECT bt.book_id FROM book_tags bt
+                 JOIN tags t ON t.id = bt.tag_id WHERE t.name = ?{param_index})"
+            ));
+            // param_index += 1; // last param
+        }
+
+        sql.push_str(" ORDER BY rank");
+
+        let mut stmt = self.db.conn.prepare(&sql)?;
+
+        // Build dynamic params
+        let mut values: Vec<Box<dyn rusqlite::types::ToSql>> = Vec::new();
+        values.push(Box::new(query.to_string()));
+        if let Some(s) = status {
+            values.push(Box::new(s.to_string()));
+        }
+        if let Some(s) = shelf {
+            values.push(Box::new(s.to_string()));
+        }
+        if let Some(t) = tag {
+            values.push(Box::new(t.to_string()));
+        }
+
+        let params_ref: Vec<&dyn rusqlite::types::ToSql> =
+            values.iter().map(|v| v.as_ref()).collect();
 
         let books = stmt
-            .query_map(params![query], |row| Ok(row_to_book(row)))?
+            .query_map(params_ref.as_slice(), |row| Ok(row_to_book(row)))?
             .filter_map(|r| r.ok())
             .filter_map(|r| r.ok())
             .collect();
@@ -103,6 +165,24 @@ impl<'a> BookRepository<'a> {
             .conn
             .execute("DELETE FROM books WHERE id = ?1", params![id.to_string()])?;
         Ok(rows > 0)
+    }
+
+    /// Recompute and store the `search_text` column for a book, including author names.
+    pub fn update_search_text(&self, book_id: &Uuid) -> Result<(), DbError> {
+        let book = self.get_book(book_id)?;
+        let authors = self.get_book_authors(book_id)?;
+        let author_names: Vec<&str> = authors.iter().map(|(a, _)| a.name.as_str()).collect();
+        let search_text = build_search_text(
+            &book.title,
+            book.subtitle.as_deref(),
+            book.description.as_deref(),
+            &author_names,
+        );
+        self.db.conn.execute(
+            "UPDATE books SET search_text = ?1 WHERE id = ?2",
+            params![search_text, book_id.to_string()],
+        )?;
+        Ok(())
     }
 
     /// Add an author and link them to a book.
@@ -128,6 +208,8 @@ impl<'a> BookRepository<'a> {
                 position,
             ],
         )?;
+
+        self.update_search_text(book_id)?;
 
         Ok(())
     }
@@ -202,6 +284,385 @@ impl<'a> BookRepository<'a> {
             Err(e) => Err(DbError::Sqlite(e)),
         }
     }
+
+    /// Find a book by exact title (case-insensitive).
+    pub fn find_book_by_title(&self, title: &str) -> Result<Option<Book>, DbError> {
+        let result = self.db.conn.query_row(
+            "SELECT id, title, subtitle, description, page_count, pub_date,
+             language, format, duration_minutes, cover_hash, work_id, status,
+             rating, created_at, updated_at
+             FROM books WHERE title = ?1 COLLATE NOCASE",
+            params![title],
+            |row| Ok(row_to_book(row)),
+        );
+
+        match result {
+            Ok(Ok(book)) => Ok(Some(book)),
+            Ok(Err(_)) => Ok(None),
+            Err(rusqlite::Error::QueryReturnedNoRows) => Ok(None),
+            Err(e) => Err(DbError::Sqlite(e)),
+        }
+    }
+
+    /// Update a book's reading status.
+    pub fn update_book_status(&self, id: &Uuid, status: ReadingStatus) -> Result<bool, DbError> {
+        let rows = self.db.conn.execute(
+            "UPDATE books SET status = ?1, updated_at = ?2 WHERE id = ?3",
+            params![
+                status.as_str(),
+                chrono::Utc::now().to_rfc3339(),
+                id.to_string(),
+            ],
+        )?;
+        Ok(rows > 0)
+    }
+
+    /// Update a book's rating.
+    pub fn update_book_rating(&self, id: &Uuid, rating: i32) -> Result<bool, DbError> {
+        let rows = self.db.conn.execute(
+            "UPDATE books SET rating = ?1, updated_at = ?2 WHERE id = ?3",
+            params![rating, chrono::Utc::now().to_rfc3339(), id.to_string(),],
+        )?;
+        Ok(rows > 0)
+    }
+
+    /// Insert a new reading session.
+    pub fn create_reading_session(&self, session: &ReadingSession) -> Result<(), DbError> {
+        self.db.conn.execute(
+            "INSERT INTO reading_sessions (id, book_id, started_at, finished_at,
+             start_page, end_page, rating, notes, created_at)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)",
+            params![
+                session.id.to_string(),
+                session.book_id.to_string(),
+                session.started_at.to_rfc3339(),
+                session.finished_at.map(|d| d.to_rfc3339()),
+                session.start_page,
+                session.end_page,
+                session.rating,
+                session.notes,
+                session.created_at.to_rfc3339(),
+            ],
+        )?;
+        Ok(())
+    }
+
+    // --- Shelf operations ---
+
+    /// Create a new shelf with the given name.
+    pub fn create_shelf(&self, name: &str) -> Result<Shelf, DbError> {
+        let shelf = Shelf::new(name);
+        self.db.conn.execute(
+            "INSERT INTO shelves (id, name, created_at) VALUES (?1, ?2, ?3)",
+            params![
+                shelf.id.to_string(),
+                shelf.name,
+                shelf.created_at.to_rfc3339(),
+            ],
+        )?;
+        Ok(shelf)
+    }
+
+    /// List all shelves ordered by name.
+    pub fn list_shelves(&self) -> Result<Vec<Shelf>, DbError> {
+        let mut stmt = self
+            .db
+            .conn
+            .prepare("SELECT id, name, created_at FROM shelves ORDER BY name COLLATE NOCASE")?;
+
+        let shelves = stmt
+            .query_map([], |row| {
+                let id_str: String = row.get(0)?;
+                let name: String = row.get(1)?;
+                let created_str: String = row.get(2)?;
+                Ok((id_str, name, created_str))
+            })?
+            .filter_map(|r| r.ok())
+            .filter_map(|(id_str, name, created_str)| {
+                Some(Shelf {
+                    id: Uuid::parse_str(&id_str).ok()?,
+                    name,
+                    created_at: chrono::DateTime::parse_from_rfc3339(&created_str)
+                        .ok()?
+                        .with_timezone(&chrono::Utc),
+                })
+            })
+            .collect();
+
+        Ok(shelves)
+    }
+
+    /// Add a book to a shelf, creating the shelf if it doesn't exist.
+    pub fn add_book_to_shelf(&self, book_id: &Uuid, shelf_name: &str) -> Result<(), DbError> {
+        self.get_book(book_id)?;
+
+        let shelf_id: String = match self.db.conn.query_row(
+            "SELECT id FROM shelves WHERE name = ?1",
+            params![shelf_name],
+            |row| row.get(0),
+        ) {
+            Ok(id) => id,
+            Err(rusqlite::Error::QueryReturnedNoRows) => {
+                let shelf = self.create_shelf(shelf_name)?;
+                shelf.id.to_string()
+            }
+            Err(e) => return Err(DbError::Sqlite(e)),
+        };
+
+        self.db.conn.execute(
+            "INSERT OR IGNORE INTO book_shelves (book_id, shelf_id) VALUES (?1, ?2)",
+            params![book_id.to_string(), shelf_id],
+        )?;
+
+        Ok(())
+    }
+
+    /// Remove a book from a shelf.
+    pub fn remove_book_from_shelf(&self, book_id: &Uuid, shelf_name: &str) -> Result<(), DbError> {
+        let rows = self.db.conn.execute(
+            "DELETE FROM book_shelves WHERE book_id = ?1
+             AND shelf_id = (SELECT id FROM shelves WHERE name = ?2)",
+            params![book_id.to_string(), shelf_name],
+        )?;
+
+        if rows == 0 {
+            return Err(DbError::NotFound(format!(
+                "book not on shelf '{shelf_name}'"
+            )));
+        }
+
+        Ok(())
+    }
+
+    /// Get all shelves a book belongs to.
+    pub fn get_book_shelves(&self, book_id: &Uuid) -> Result<Vec<Shelf>, DbError> {
+        let mut stmt = self.db.conn.prepare(
+            "SELECT s.id, s.name, s.created_at
+             FROM shelves s
+             JOIN book_shelves bs ON bs.shelf_id = s.id
+             WHERE bs.book_id = ?1
+             ORDER BY s.name COLLATE NOCASE",
+        )?;
+
+        let shelves = stmt
+            .query_map(params![book_id.to_string()], |row| {
+                let id_str: String = row.get(0)?;
+                let name: String = row.get(1)?;
+                let created_str: String = row.get(2)?;
+                Ok((id_str, name, created_str))
+            })?
+            .filter_map(|r| r.ok())
+            .filter_map(|(id_str, name, created_str)| {
+                Some(Shelf {
+                    id: Uuid::parse_str(&id_str).ok()?,
+                    name,
+                    created_at: chrono::DateTime::parse_from_rfc3339(&created_str)
+                        .ok()?
+                        .with_timezone(&chrono::Utc),
+                })
+            })
+            .collect();
+
+        Ok(shelves)
+    }
+
+    /// List all books in a shelf.
+    pub fn list_books_in_shelf(&self, shelf_name: &str) -> Result<Vec<Book>, DbError> {
+        let mut stmt = self.db.conn.prepare(
+            "SELECT b.id, b.title, b.subtitle, b.description, b.page_count, b.pub_date,
+             b.language, b.format, b.duration_minutes, b.cover_hash, b.work_id, b.status,
+             b.rating, b.created_at, b.updated_at
+             FROM books b
+             JOIN book_shelves bs ON bs.book_id = b.id
+             JOIN shelves s ON s.id = bs.shelf_id
+             WHERE s.name = ?1
+             ORDER BY b.title COLLATE NOCASE",
+        )?;
+
+        let books = stmt
+            .query_map(params![shelf_name], |row| Ok(row_to_book(row)))?
+            .filter_map(|r| r.ok())
+            .filter_map(|r| r.ok())
+            .collect();
+
+        Ok(books)
+    }
+
+    // --- Tag operations ---
+
+    /// Create a tag (UPSERT — returns existing tag if name matches case-insensitively).
+    pub fn create_tag(&self, name: &str) -> Result<Tag, DbError> {
+        match self.db.conn.query_row(
+            "SELECT id, name, created_at FROM tags WHERE name = ?1",
+            params![name],
+            |row| {
+                let id_str: String = row.get(0)?;
+                let tag_name: String = row.get(1)?;
+                let created_str: String = row.get(2)?;
+                Ok((id_str, tag_name, created_str))
+            },
+        ) {
+            Ok((id_str, tag_name, created_str)) => {
+                let tag = Tag {
+                    id: Uuid::parse_str(&id_str).map_err(|e| DbError::Io(e.to_string()))?,
+                    name: tag_name,
+                    created_at: chrono::DateTime::parse_from_rfc3339(&created_str)
+                        .map_err(|e| DbError::Io(e.to_string()))?
+                        .with_timezone(&chrono::Utc),
+                };
+                Ok(tag)
+            }
+            Err(rusqlite::Error::QueryReturnedNoRows) => {
+                let tag = Tag::new(name);
+                self.db.conn.execute(
+                    "INSERT INTO tags (id, name, created_at) VALUES (?1, ?2, ?3)",
+                    params![tag.id.to_string(), tag.name, tag.created_at.to_rfc3339(),],
+                )?;
+                Ok(tag)
+            }
+            Err(e) => Err(DbError::Sqlite(e)),
+        }
+    }
+
+    /// Add a tag to a book, creating the tag if it doesn't exist.
+    pub fn add_tag_to_book(&self, book_id: &Uuid, tag_name: &str) -> Result<(), DbError> {
+        self.get_book(book_id)?;
+        let tag = self.create_tag(tag_name)?;
+
+        self.db.conn.execute(
+            "INSERT OR IGNORE INTO book_tags (book_id, tag_id) VALUES (?1, ?2)",
+            params![book_id.to_string(), tag.id.to_string()],
+        )?;
+
+        Ok(())
+    }
+
+    /// Remove a tag from a book.
+    pub fn remove_tag_from_book(&self, book_id: &Uuid, tag_name: &str) -> Result<(), DbError> {
+        let rows = self.db.conn.execute(
+            "DELETE FROM book_tags WHERE book_id = ?1
+             AND tag_id IN (SELECT id FROM tags WHERE name = ?2)",
+            params![book_id.to_string(), tag_name],
+        )?;
+
+        if rows == 0 {
+            return Err(DbError::NotFound(format!(
+                "tag '{tag_name}' not on this book"
+            )));
+        }
+
+        Ok(())
+    }
+
+    /// Get all tags for a book.
+    pub fn get_book_tags(&self, book_id: &Uuid) -> Result<Vec<Tag>, DbError> {
+        let mut stmt = self.db.conn.prepare(
+            "SELECT t.id, t.name, t.created_at
+             FROM tags t
+             JOIN book_tags bt ON bt.tag_id = t.id
+             WHERE bt.book_id = ?1
+             ORDER BY t.name COLLATE NOCASE",
+        )?;
+
+        let tags = stmt
+            .query_map(params![book_id.to_string()], |row| {
+                let id_str: String = row.get(0)?;
+                let name: String = row.get(1)?;
+                let created_str: String = row.get(2)?;
+                Ok((id_str, name, created_str))
+            })?
+            .filter_map(|r| r.ok())
+            .filter_map(|(id_str, name, created_str)| {
+                Some(Tag {
+                    id: Uuid::parse_str(&id_str).ok()?,
+                    name,
+                    created_at: chrono::DateTime::parse_from_rfc3339(&created_str)
+                        .ok()?
+                        .with_timezone(&chrono::Utc),
+                })
+            })
+            .collect();
+
+        Ok(tags)
+    }
+
+    /// List all books with a given tag.
+    pub fn list_books_by_tag(&self, tag_name: &str) -> Result<Vec<Book>, DbError> {
+        let mut stmt = self.db.conn.prepare(
+            "SELECT b.id, b.title, b.subtitle, b.description, b.page_count, b.pub_date,
+             b.language, b.format, b.duration_minutes, b.cover_hash, b.work_id, b.status,
+             b.rating, b.created_at, b.updated_at
+             FROM books b
+             JOIN book_tags bt ON bt.book_id = b.id
+             JOIN tags t ON t.id = bt.tag_id
+             WHERE t.name = ?1
+             ORDER BY b.title COLLATE NOCASE",
+        )?;
+
+        let books = stmt
+            .query_map(params![tag_name], |row| Ok(row_to_book(row)))?
+            .filter_map(|r| r.ok())
+            .filter_map(|r| r.ok())
+            .collect();
+
+        Ok(books)
+    }
+
+    /// List all tags with book counts.
+    pub fn list_tags_with_counts(&self) -> Result<Vec<(Tag, i64)>, DbError> {
+        let mut stmt = self.db.conn.prepare(
+            "SELECT t.id, t.name, t.created_at, COUNT(bt.book_id) as book_count
+             FROM tags t
+             LEFT JOIN book_tags bt ON bt.tag_id = t.id
+             GROUP BY t.id
+             ORDER BY t.name COLLATE NOCASE",
+        )?;
+
+        let tags = stmt
+            .query_map([], |row| {
+                let id_str: String = row.get(0)?;
+                let name: String = row.get(1)?;
+                let created_str: String = row.get(2)?;
+                let count: i64 = row.get(3)?;
+                Ok((id_str, name, created_str, count))
+            })?
+            .filter_map(|r| r.ok())
+            .filter_map(|(id_str, name, created_str, count)| {
+                Some((
+                    Tag {
+                        id: Uuid::parse_str(&id_str).ok()?,
+                        name,
+                        created_at: chrono::DateTime::parse_from_rfc3339(&created_str)
+                            .ok()?
+                            .with_timezone(&chrono::Utc),
+                    },
+                    count,
+                ))
+            })
+            .collect();
+
+        Ok(tags)
+    }
+}
+
+/// Build the denormalized search_text from book fields and author names.
+fn build_search_text(
+    title: &str,
+    subtitle: Option<&str>,
+    description: Option<&str>,
+    author_names: &[&str],
+) -> String {
+    let mut parts: Vec<&str> = vec![title];
+    if let Some(s) = subtitle {
+        parts.push(s);
+    }
+    if let Some(d) = description {
+        parts.push(d);
+    }
+    for name in author_names {
+        parts.push(name);
+    }
+    parts.join(" ")
 }
 
 fn row_to_book(row: &rusqlite::Row<'_>) -> Result<Book, String> {
@@ -346,5 +807,334 @@ mod tests {
 
         let not_found = repo.find_by_isbn("9780000000000").unwrap();
         assert!(not_found.is_none());
+    }
+
+    #[test]
+    fn update_book_status() {
+        let db = test_db();
+        let repo = BookRepository::new(&db);
+
+        let book = Book::new("Dune");
+        repo.create_book(&book).unwrap();
+        assert_eq!(
+            repo.get_book(&book.id).unwrap().status,
+            ReadingStatus::WantToRead
+        );
+
+        assert!(
+            repo.update_book_status(&book.id, ReadingStatus::Reading)
+                .unwrap()
+        );
+        assert_eq!(
+            repo.get_book(&book.id).unwrap().status,
+            ReadingStatus::Reading
+        );
+
+        // Non-existent ID returns false
+        let fake_id = Uuid::now_v7();
+        assert!(
+            !repo
+                .update_book_status(&fake_id, ReadingStatus::Reading)
+                .unwrap()
+        );
+    }
+
+    #[test]
+    fn update_book_rating() {
+        let db = test_db();
+        let repo = BookRepository::new(&db);
+
+        let book = Book::new("Dune");
+        repo.create_book(&book).unwrap();
+        assert!(book.rating.is_none());
+
+        assert!(repo.update_book_rating(&book.id, 8).unwrap());
+        assert_eq!(repo.get_book(&book.id).unwrap().rating, Some(8));
+    }
+
+    #[test]
+    fn create_reading_session() {
+        let db = test_db();
+        let repo = BookRepository::new(&db);
+
+        let book = Book::new("Dune");
+        repo.create_book(&book).unwrap();
+
+        let session = toku_core::ReadingSession::new(book.id);
+        repo.create_reading_session(&session).unwrap();
+
+        // Verify it was inserted
+        let count: i64 = db
+            .conn
+            .query_row(
+                "SELECT COUNT(*) FROM reading_sessions WHERE book_id = ?1",
+                params![book.id.to_string()],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(count, 1);
+    }
+
+    #[test]
+    fn find_book_by_title_case_insensitive() {
+        let db = test_db();
+        let repo = BookRepository::new(&db);
+
+        let book = Book::new("Dune");
+        repo.create_book(&book).unwrap();
+
+        // Exact match
+        let found = repo.find_book_by_title("Dune").unwrap();
+        assert!(found.is_some());
+        assert_eq!(found.unwrap().title, "Dune");
+
+        // Case-insensitive
+        let found = repo.find_book_by_title("dune").unwrap();
+        assert!(found.is_some());
+        assert_eq!(found.unwrap().title, "Dune");
+
+        let found = repo.find_book_by_title("DUNE").unwrap();
+        assert!(found.is_some());
+
+        // No match
+        let found = repo.find_book_by_title("Neuromancer").unwrap();
+        assert!(found.is_none());
+    }
+
+    #[test]
+    fn create_and_list_shelves() {
+        let db = test_db();
+        let repo = BookRepository::new(&db);
+
+        repo.create_shelf("Favorites").unwrap();
+        repo.create_shelf("To Re-read").unwrap();
+
+        let shelves = repo.list_shelves().unwrap();
+        assert_eq!(shelves.len(), 2);
+        assert_eq!(shelves[0].name, "Favorites");
+        assert_eq!(shelves[1].name, "To Re-read");
+    }
+
+    #[test]
+    fn add_and_remove_book_from_shelf() {
+        let db = test_db();
+        let repo = BookRepository::new(&db);
+
+        let book = Book::new("Dune");
+        repo.create_book(&book).unwrap();
+
+        repo.add_book_to_shelf(&book.id, "Favorites").unwrap();
+
+        let shelves = repo.get_book_shelves(&book.id).unwrap();
+        assert_eq!(shelves.len(), 1);
+        assert_eq!(shelves[0].name, "Favorites");
+
+        let books = repo.list_books_in_shelf("Favorites").unwrap();
+        assert_eq!(books.len(), 1);
+        assert_eq!(books[0].title, "Dune");
+
+        repo.remove_book_from_shelf(&book.id, "Favorites").unwrap();
+        let shelves = repo.get_book_shelves(&book.id).unwrap();
+        assert!(shelves.is_empty());
+    }
+
+    #[test]
+    fn shelf_multiple_books() {
+        let db = test_db();
+        let repo = BookRepository::new(&db);
+
+        let b1 = Book::new("Dune");
+        let b2 = Book::new("Neuromancer");
+        repo.create_book(&b1).unwrap();
+        repo.create_book(&b2).unwrap();
+
+        repo.add_book_to_shelf(&b1.id, "Sci-Fi").unwrap();
+        repo.add_book_to_shelf(&b2.id, "Sci-Fi").unwrap();
+
+        let books = repo.list_books_in_shelf("Sci-Fi").unwrap();
+        assert_eq!(books.len(), 2);
+    }
+
+    #[test]
+    fn create_tag_upsert() {
+        let db = test_db();
+        let repo = BookRepository::new(&db);
+
+        let t1 = repo.create_tag("sci-fi").unwrap();
+        let t2 = repo.create_tag("Sci-Fi").unwrap();
+        assert_eq!(t1.id, t2.id);
+    }
+
+    #[test]
+    fn add_and_remove_tag() {
+        let db = test_db();
+        let repo = BookRepository::new(&db);
+
+        let book = Book::new("Dune");
+        repo.create_book(&book).unwrap();
+
+        repo.add_tag_to_book(&book.id, "sci-fi").unwrap();
+        repo.add_tag_to_book(&book.id, "classic").unwrap();
+
+        let tags = repo.get_book_tags(&book.id).unwrap();
+        assert_eq!(tags.len(), 2);
+
+        repo.remove_tag_from_book(&book.id, "sci-fi").unwrap();
+        let tags = repo.get_book_tags(&book.id).unwrap();
+        assert_eq!(tags.len(), 1);
+        assert_eq!(tags[0].name, "classic");
+    }
+
+    #[test]
+    fn list_books_by_tag_test() {
+        let db = test_db();
+        let repo = BookRepository::new(&db);
+
+        let b1 = Book::new("Dune");
+        let b2 = Book::new("Neuromancer");
+        let b3 = Book::new("War and Peace");
+        repo.create_book(&b1).unwrap();
+        repo.create_book(&b2).unwrap();
+        repo.create_book(&b3).unwrap();
+
+        repo.add_tag_to_book(&b1.id, "sci-fi").unwrap();
+        repo.add_tag_to_book(&b2.id, "sci-fi").unwrap();
+
+        let results = repo.list_books_by_tag("sci-fi").unwrap();
+        assert_eq!(results.len(), 2);
+    }
+
+    #[test]
+    fn list_tags_with_counts_test() {
+        let db = test_db();
+        let repo = BookRepository::new(&db);
+
+        let b1 = Book::new("Dune");
+        let b2 = Book::new("Neuromancer");
+        repo.create_book(&b1).unwrap();
+        repo.create_book(&b2).unwrap();
+
+        repo.add_tag_to_book(&b1.id, "sci-fi").unwrap();
+        repo.add_tag_to_book(&b2.id, "sci-fi").unwrap();
+        repo.add_tag_to_book(&b1.id, "classic").unwrap();
+
+        let tags = repo.list_tags_with_counts().unwrap();
+        assert_eq!(tags.len(), 2);
+        assert_eq!(tags[0].0.name, "classic");
+        assert_eq!(tags[0].1, 1);
+        assert_eq!(tags[1].0.name, "sci-fi");
+        assert_eq!(tags[1].1, 2);
+    }
+
+    #[test]
+    fn book_delete_cascades_shelf_and_tag() {
+        let db = test_db();
+        let repo = BookRepository::new(&db);
+
+        let book = Book::new("Dune");
+        repo.create_book(&book).unwrap();
+        repo.add_book_to_shelf(&book.id, "Favorites").unwrap();
+        repo.add_tag_to_book(&book.id, "sci-fi").unwrap();
+
+        repo.delete_book(&book.id).unwrap();
+
+        let books_in_shelf = repo.list_books_in_shelf("Favorites").unwrap();
+        assert!(books_in_shelf.is_empty());
+        let books_with_tag = repo.list_books_by_tag("sci-fi").unwrap();
+        assert!(books_with_tag.is_empty());
+    }
+
+    #[test]
+    fn search_by_author_name() {
+        let db = test_db();
+        let repo = BookRepository::new(&db);
+
+        let book = Book::new("Dune");
+        repo.create_book(&book).unwrap();
+
+        let author = Author::new("Frank Herbert");
+        repo.add_book_author(&author, &book.id, ContributorRole::Author, 0)
+            .unwrap();
+
+        let results = repo.search_books("Herbert").unwrap();
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].title, "Dune");
+    }
+
+    #[test]
+    fn search_filtered_by_status() {
+        let db = test_db();
+        let repo = BookRepository::new(&db);
+
+        let mut b1 = Book::new("Dune");
+        b1.description = Some("desert planet adventure".to_string());
+        repo.create_book(&b1).unwrap();
+        repo.update_book_status(&b1.id, ReadingStatus::Reading)
+            .unwrap();
+
+        let mut b2 = Book::new("Dune Messiah");
+        b2.description = Some("sequel on a desert world".to_string());
+        repo.create_book(&b2).unwrap();
+
+        // Both match "desert", but only b1 is "reading"
+        let results = repo
+            .search_books_filtered("desert", Some("reading"), None, None)
+            .unwrap();
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].title, "Dune");
+    }
+
+    #[test]
+    fn search_filtered_by_shelf() {
+        let db = test_db();
+        let repo = BookRepository::new(&db);
+
+        let mut b1 = Book::new("Dune");
+        b1.description = Some("desert planet adventure".to_string());
+        repo.create_book(&b1).unwrap();
+        repo.add_book_to_shelf(&b1.id, "Favorites").unwrap();
+
+        let mut b2 = Book::new("Dune Messiah");
+        b2.description = Some("sequel on a desert world".to_string());
+        repo.create_book(&b2).unwrap();
+
+        let results = repo
+            .search_books_filtered("desert", None, Some("Favorites"), None)
+            .unwrap();
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].title, "Dune");
+    }
+
+    #[test]
+    fn search_filtered_by_tag() {
+        let db = test_db();
+        let repo = BookRepository::new(&db);
+
+        let mut b1 = Book::new("Dune");
+        b1.description = Some("desert planet adventure".to_string());
+        repo.create_book(&b1).unwrap();
+        repo.add_tag_to_book(&b1.id, "classic").unwrap();
+
+        let mut b2 = Book::new("Dune Messiah");
+        b2.description = Some("sequel on a desert world".to_string());
+        repo.create_book(&b2).unwrap();
+
+        let results = repo
+            .search_books_filtered("desert", None, None, Some("classic"))
+            .unwrap();
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].title, "Dune");
+    }
+
+    #[test]
+    fn search_no_results() {
+        let db = test_db();
+        let repo = BookRepository::new(&db);
+
+        let book = Book::new("Dune");
+        repo.create_book(&book).unwrap();
+
+        let results = repo.search_books("xyzzyplugh").unwrap();
+        assert!(results.is_empty());
     }
 }


### PR DESCRIPTION
## Description

Add reading status management, shelves and tags, enhanced search with filters, configuration file, and shell completions.

### What's included

- **Reading status management** — `toku reading start|finish|abandon|hold|resume` with state machine validation (only valid transitions allowed), automatic date tracking, per-session ratings, and reading session history. New `reading_sessions` table (V3 migration).
- **Shelves** — `toku shelf create|add|remove|list` for user-defined book collections. Books can belong to multiple shelves. `toku list --shelf <name>` filters by shelf.
- **Tags** — `toku tag add|remove|list` with case-insensitive matching and book counts. `toku list --tag <name>` filters by tag. New `shelves`, `book_shelves`, `tags`, `book_tags` tables (V4 migration).
- **Enhanced FTS5 search** — search now includes author names (denormalized `search_text` column, V5 migration). `toku search` accepts `--status`, `--shelf`, and `--tag` filters for combined filtering.
- **Configuration file** — `config.toml` with `default_format`, `color`, and `metadata_source` settings. `toku config` shows current settings, `toku config --edit` opens in ``, `toku config --path` prints the file location.
- **Shell completions** — `toku completions bash|zsh|fish|powershell` generates shell completions via `clap_complete`.
- **52 tests** — 25 new tests across all crates (state machine, shelves, tags, filtered search, config round-trip).

## Related Issues

Closes #6, closes #7, closes #8, closes #9

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI / infrastructure
- [ ] Other (describe below)

## Crate

- [x] `toku-core` — Domain models, traits, state machine
- [x] `toku-db` — SQLite persistence, migrations, FTS5
- [ ] `toku-import` — Importers (Goodreads, Calibre, StoryGraph)
- [ ] `toku-meta` — Metadata fetching (Open Library, Google Books)
- [x] `toku-cli` — CLI binary
- [ ] `toku-export` — Exporters (CSV, JSON, Markdown, BibTeX)
- [ ] `docs/` — Documentation

## Data Integrity Checklist

- [x] No user data is sent to any server without explicit opt-in
- [x] Import operations are idempotent (re-importing the same file creates no duplicates)
- [x] User edits to metadata are never overwritten by auto-enrichment
- [x] New fields track provenance (source + timestamp)
- [x] Export round-trip is preserved (if applicable) — N/A for this PR

## Checklist

- [x] I have read [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] `cargo fmt --check` passes
- [x] `cargo clippy --workspace -- -D warnings` passes
- [x] `cargo test --workspace` passes — 52 tests, all green
- [x] I have updated documentation (if applicable) — CHANGELOG updated