### PR TITLE
feat: add reading statistics and export system (CSV, JSON, Markdown, backup)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,5 +50,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Calibre library import: `toku import calibre <path>` with books, authors, series, tags, covers, and ISBNs
 - Calibre import supports `--dry-run` and `--no-covers` flags
 - Calibre HTML descriptions automatically stripped to plain text
+- Reading statistics: `toku stats` with books/pages read, average rating, reading pace, and format breakdown
+- `toku stats --year 2025` for year-filtered analytics
+- Currently reading list with progress percentages in stats output
+- Export to CSV: `toku export csv` with flat book table (title, authors, status, rating, shelves, tags)
+- Export to JSON: `toku export json` with full structured library data
+- Export to Markdown: `toku export markdown` with books grouped by reading status and star ratings
+- Canonical backup: `toku export backup --output toku-backup.zip` with library data + cover images in a self-contained ZIP
 
 [Unreleased]: https://github.com/kafkade/toku/compare/v0.1.0...HEAD

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,23 @@
 version = 4
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
+name = "aes"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -77,6 +94,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+dependencies = [
+ "derive_arbitrary",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -133,10 +159,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "175812e0be2bccb6abe50bb8d566126198344f707e304f45c648fd8f2cc0365e"
 
 [[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
 name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+
+[[package]]
+name = "bzip2"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49ecfb22d906f800d4fe833b6282cf4dc1c298f5057ca0b5445e5c209735ca47"
+dependencies = [
+ "bzip2-sys",
+]
+
+[[package]]
+name = "bzip2-sys"
+version = "0.1.13+1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "225bff33b2141874fe80d71e07d6eec4f85c5c216453dd96388240f96e1acc14"
+dependencies = [
+ "cc",
+ "pkg-config",
+]
 
 [[package]]
 name = "cc"
@@ -145,6 +196,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d16d90359e986641506914ba71350897565610e87ce0ad9e6f28569db3dd5c6d"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -170,6 +223,16 @@ dependencies = [
  "num-traits",
  "serde",
  "windows-link",
+]
+
+[[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common",
+ "inout",
 ]
 
 [[package]]
@@ -228,6 +291,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
+name = "constant_time_eq"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6"
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -241,6 +310,36 @@ checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "crc"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5eb8a2a1cd12ab0d987a5d5e825195d372001a4094a0376319d5a0ad71c1ba0d"
+dependencies = [
+ "crc-catalog",
+]
+
+[[package]]
+name = "crc-catalog"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "217698eaf96b4a3f0bc4f3662aaa55bdf913cd54d7204591faa790070c6d0853"
+
+[[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crypto-common"
@@ -274,6 +373,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "deflate64"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac6b926516df9c60bfa16e107b21086399f8285a44ca9711344b9e553c5146e2"
+
+[[package]]
 name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -284,6 +389,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -291,6 +407,7 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
  "crypto-common",
+ "subtle",
 ]
 
 [[package]]
@@ -364,6 +481,16 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "fnv"
@@ -504,6 +631,15 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
+]
 
 [[package]]
 name = "http"
@@ -749,6 +885,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "inout"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -775,6 +920,16 @@ name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "jobserver"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+dependencies = [
+ "getrandom 0.3.4",
+ "libc",
+]
 
 [[package]]
 name = "js-sys"
@@ -845,10 +1000,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
+name = "lzma-rs"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "297e814c836ae64db86b36cf2a557ba54368d03f6afcd7d947c266692f71115e"
+dependencies = [
+ "byteorder",
+ "crc",
+]
+
+[[package]]
+name = "lzma-sys"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fda04ab3764e6cde78b9974eec4f779acaba7c4e84b36eca3cf77c581b85d27"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+]
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
+]
 
 [[package]]
 name = "mio"
@@ -903,6 +1089,16 @@ dependencies = [
  "bytecount",
  "fnv",
  "unicode-width",
+]
+
+[[package]]
+name = "pbkdf2"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
+dependencies = [
+ "digest",
+ "hmac",
 ]
 
 [[package]]
@@ -1388,6 +1584,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1403,6 +1610,12 @@ name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "simd-adler32"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
 name = "siphasher"
@@ -1645,6 +1858,7 @@ name = "toku-cli"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "chrono",
  "clap",
  "clap_complete",
  "serde",
@@ -1653,6 +1867,7 @@ dependencies = [
  "tokio",
  "toku-core",
  "toku-db",
+ "toku-export",
  "toku-import",
  "toku-meta",
  "toml",
@@ -1683,6 +1898,22 @@ dependencies = [
  "thiserror",
  "toku-core",
  "uuid",
+]
+
+[[package]]
+name = "toku-export"
+version = "0.1.0"
+dependencies = [
+ "chrono",
+ "csv",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "thiserror",
+ "toku-core",
+ "toku-db",
+ "uuid",
+ "zip",
 ]
 
 [[package]]
@@ -2397,6 +2628,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
+name = "xz2"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "388c44dc09d76f1536602ead6d325eb532f5c122f17782bd57fb47baeeb767e2"
+dependencies = [
+ "lzma-sys",
+]
+
+[[package]]
 name = "yoke"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2465,6 +2705,20 @@ name = "zeroize"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "zerotrie"
@@ -2500,7 +2754,77 @@ dependencies = [
 ]
 
 [[package]]
+name = "zip"
+version = "2.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fabe6324e908f85a1c52063ce7aa26b68dcb7eb6dbc83a2d148403c9bc3eba50"
+dependencies = [
+ "aes",
+ "arbitrary",
+ "bzip2",
+ "constant_time_eq",
+ "crc32fast",
+ "crossbeam-utils",
+ "deflate64",
+ "displaydoc",
+ "flate2",
+ "getrandom 0.3.4",
+ "hmac",
+ "indexmap",
+ "lzma-rs",
+ "memchr",
+ "pbkdf2",
+ "sha1",
+ "thiserror",
+ "time",
+ "xz2",
+ "zeroize",
+ "zopfli",
+ "zstd",
+]
+
+[[package]]
 name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zopfli"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f05cd8797d63865425ff89b5c4a48804f35ba0ce8d125800027ad6017d2b5249"
+dependencies = [
+ "bumpalo",
+ "crc32fast",
+ "log",
+ "simd-adler32",
+]
+
+[[package]]
+name = "zstd"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "7.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
+dependencies = [
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.16+zstd.1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
+dependencies = [
+ "cc",
+ "pkg-config",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
     "crates/toku-db",
     "crates/toku-meta",
     "crates/toku-import",
+    "crates/toku-export",
     "crates/toku-cli",
 ]
 

--- a/crates/toku-cli/Cargo.toml
+++ b/crates/toku-cli/Cargo.toml
@@ -16,9 +16,11 @@ toku-core = { path = "../toku-core", version = "0.1.0" }
 toku-db = { path = "../toku-db", version = "0.1.0" }
 toku-meta = { path = "../toku-meta", version = "0.1.0" }
 toku-import = { path = "../toku-import", version = "0.1.0" }
+toku-export = { path = "../toku-export", version = "0.1.0" }
 clap = { version = "4", features = ["derive", "env"] }
 clap_complete = "4"
 anyhow = "1"
+chrono.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 toml.workspace = true

--- a/crates/toku-cli/src/main.rs
+++ b/crates/toku-cli/src/main.rs
@@ -1494,22 +1494,29 @@ fn cmd_stats(repo: &BookRepository, year: Option<i32>, output_format: &OutputFor
                 + stats.format_breakdown.audiobook;
 
             if total_formats > 0 {
+                let pct_physical = (stats.format_breakdown.physical * 100)
+                    .checked_div(total_formats)
+                    .unwrap_or(0);
+                let pct_ebook = (stats.format_breakdown.ebook * 100)
+                    .checked_div(total_formats)
+                    .unwrap_or(0);
+                let pct_audiobook = (stats.format_breakdown.audiobook * 100)
+                    .checked_div(total_formats)
+                    .unwrap_or(0);
+
                 println!();
                 println!("  Format breakdown:");
                 println!(
-                    "    Physical:  {:>3} ({}%)",
+                    "    Physical:  {:>3} ({pct_physical}%)",
                     stats.format_breakdown.physical,
-                    stats.format_breakdown.physical * 100 / total_formats
                 );
                 println!(
-                    "    Ebook:     {:>3} ({}%)",
+                    "    Ebook:     {:>3} ({pct_ebook}%)",
                     stats.format_breakdown.ebook,
-                    stats.format_breakdown.ebook * 100 / total_formats
                 );
                 println!(
-                    "    Audiobook: {:>3} ({}%)",
+                    "    Audiobook: {:>3} ({pct_audiobook}%)",
                     stats.format_breakdown.audiobook,
-                    stats.format_breakdown.audiobook * 100 / total_formats
                 );
             }
 

--- a/crates/toku-cli/src/main.rs
+++ b/crates/toku-cli/src/main.rs
@@ -4,8 +4,9 @@ use anyhow::{Context, Result};
 use clap::{CommandFactory, Parser, Subcommand, ValueEnum};
 use clap_complete::Shell;
 use toku_core::{
-    Author, Book, BookFormat, ContributorRole, Isbn, ProgressType, ReadingProgress, ReadingSession,
-    ReadingStatus, TokuConfig, parse_duration_to_minutes,
+    Author, Book, BookFormat, ContributorRole, CurrentlyReadingInput, Isbn, ProgressType,
+    ReadingProgress, ReadingSession, ReadingStatus, TokuConfig, compute_stats,
+    parse_duration_to_minutes,
 };
 use toku_db::{BookRepository, Database};
 
@@ -124,6 +125,19 @@ enum Commands {
     Tag {
         #[command(subcommand)]
         action: TagAction,
+    },
+
+    /// Export your library (csv, json, markdown, backup)
+    Export {
+        #[command(subcommand)]
+        target: ExportTarget,
+    },
+
+    /// Show reading statistics
+    Stats {
+        /// Show stats for a specific year only
+        #[arg(long)]
+        year: Option<i32>,
     },
 }
 
@@ -285,6 +299,37 @@ enum TagAction {
     List,
 }
 
+#[derive(Subcommand)]
+enum ExportTarget {
+    /// Export as CSV
+    Csv {
+        /// Output file path (stdout if omitted)
+        #[arg(long, short)]
+        output: Option<PathBuf>,
+    },
+
+    /// Export as JSON
+    Json {
+        /// Output file path (stdout if omitted)
+        #[arg(long, short)]
+        output: Option<PathBuf>,
+    },
+
+    /// Export as Markdown
+    Markdown {
+        /// Output file path (stdout if omitted)
+        #[arg(long, short)]
+        output: Option<PathBuf>,
+    },
+
+    /// Create a canonical backup (ZIP archive with library data and covers)
+    Backup {
+        /// Output file path (required)
+        #[arg(long, short)]
+        output: PathBuf,
+    },
+}
+
 #[derive(Clone, ValueEnum)]
 enum OutputFormat {
     Table,
@@ -355,6 +400,8 @@ fn main() -> Result<()> {
         Commands::Reading { action } => cmd_reading(&repo, action, &cli.format),
         Commands::Shelf { action } => cmd_shelf(&repo, action, &cli.format),
         Commands::Tag { action } => cmd_tag(&repo, action, &cli.format),
+        Commands::Export { target } => cmd_export(&db, &data_dir, target),
+        Commands::Stats { year } => cmd_stats(&repo, year, &cli.format),
         // Already handled above
         Commands::Config { .. } | Commands::Completions { .. } => unreachable!(),
     }
@@ -839,6 +886,50 @@ fn cmd_import(
     }
 }
 
+fn cmd_export(db: &Database, data_dir: &Path, target: ExportTarget) -> Result<()> {
+    match target {
+        ExportTarget::Csv { output } => {
+            if let Some(path) = output {
+                let file = std::fs::File::create(&path)
+                    .with_context(|| format!("failed to create {}", path.display()))?;
+                toku_export::export_csv(db, file).context("CSV export failed")?;
+                eprintln!("✓ Exported CSV to {}", path.display());
+            } else {
+                toku_export::export_csv(db, std::io::stdout()).context("CSV export failed")?;
+            }
+            Ok(())
+        }
+        ExportTarget::Json { output } => {
+            if let Some(path) = output {
+                let file = std::fs::File::create(&path)
+                    .with_context(|| format!("failed to create {}", path.display()))?;
+                toku_export::export_json(db, file).context("JSON export failed")?;
+                eprintln!("✓ Exported JSON to {}", path.display());
+            } else {
+                toku_export::export_json(db, std::io::stdout()).context("JSON export failed")?;
+            }
+            Ok(())
+        }
+        ExportTarget::Markdown { output } => {
+            if let Some(path) = output {
+                let file = std::fs::File::create(&path)
+                    .with_context(|| format!("failed to create {}", path.display()))?;
+                toku_export::export_markdown(db, file).context("Markdown export failed")?;
+                eprintln!("✓ Exported Markdown to {}", path.display());
+            } else {
+                toku_export::export_markdown(db, std::io::stdout())
+                    .context("Markdown export failed")?;
+            }
+            Ok(())
+        }
+        ExportTarget::Backup { output } => {
+            toku_export::export_backup(db, data_dir, &output).context("backup export failed")?;
+            eprintln!("✓ Backup saved to {}", output.display());
+            Ok(())
+        }
+    }
+}
+
 /// Resolve a book title to a Book, returning a user-friendly error if not found.
 fn resolve_book(repo: &BookRepository, title: &str) -> Result<Book> {
     if let Some(book) = repo.find_book_by_title(title)? {
@@ -1305,4 +1396,161 @@ fn cmd_tag(repo: &BookRepository, action: TagAction, output_format: &OutputForma
             Ok(())
         }
     }
+}
+
+fn cmd_stats(repo: &BookRepository, year: Option<i32>, output_format: &OutputFormat) -> Result<()> {
+    let books = repo.list_books()?;
+
+    let sessions = match year {
+        Some(y) => repo.list_reading_sessions_in_year(y)?,
+        None => repo.list_reading_sessions()?,
+    };
+
+    let currently_reading_details = repo.get_currently_reading_details()?;
+    let currently_reading_input: Vec<CurrentlyReadingInput> = currently_reading_details
+        .into_iter()
+        .map(|(book, progress, authors)| {
+            let author = authors
+                .into_iter()
+                .map(|(a, _)| a.name)
+                .collect::<Vec<_>>()
+                .join(", ");
+            CurrentlyReadingInput {
+                title: book.title,
+                author,
+                page_count: book.page_count,
+                latest_progress: progress,
+            }
+        })
+        .collect();
+
+    let now = chrono::Utc::now();
+    let stats = compute_stats(&books, &sessions, &currently_reading_input, now);
+
+    match output_format {
+        OutputFormat::Json => {
+            println!("{}", serde_json::to_string_pretty(&stats)?);
+        }
+        OutputFormat::Csv => {
+            println!("metric,value");
+            println!("total_books,{}", stats.total_books);
+            println!("books_read,{}", stats.books_read);
+            println!("books_reading,{}", stats.books_reading);
+            println!("books_want_to_read,{}", stats.books_want_to_read);
+            println!("books_abandoned,{}", stats.books_abandoned);
+            println!("total_pages_read,{}", stats.total_pages_read);
+            println!(
+                "average_rating,{}",
+                stats
+                    .average_rating
+                    .map_or("-".to_string(), |r| format!("{r:.1}"))
+            );
+            println!(
+                "average_rating_stars,{}",
+                stats
+                    .average_rating_stars
+                    .map_or("-".to_string(), |r| format!("{r:.1}"))
+            );
+            println!("books_per_month,{:.1}", stats.books_per_month);
+            println!("pages_per_day,{:.1}", stats.pages_per_day);
+            println!("format_physical,{}", stats.format_breakdown.physical);
+            println!("format_ebook,{}", stats.format_breakdown.ebook);
+            println!("format_audiobook,{}", stats.format_breakdown.audiobook);
+        }
+        OutputFormat::Table => {
+            let header = match year {
+                Some(y) => format!("📊 Reading Statistics ({y})"),
+                None => "📊 Reading Statistics (All Time)".to_string(),
+            };
+            println!("\n{header}\n");
+
+            println!("  Books read:        {:>5}", stats.books_read);
+            println!("  Currently reading: {:>5}", stats.books_reading);
+            println!("  Want to read:      {:>5}", stats.books_want_to_read);
+            println!("  Abandoned:         {:>5}", stats.books_abandoned);
+            println!();
+
+            println!(
+                "  Pages read:        {:>5}",
+                format_number(stats.total_pages_read)
+            );
+            println!(
+                "  Average rating:    {:>5}",
+                stats
+                    .average_rating_stars
+                    .map_or("—".to_string(), |r| format!("{r:.1}★"))
+            );
+            println!(
+                "  Reading pace:      {:>5} books/month",
+                format!("{:.1}", stats.books_per_month)
+            );
+            println!(
+                "                     {:>5} pages/day",
+                format!("{:.1}", stats.pages_per_day)
+            );
+
+            let total_formats = stats.format_breakdown.physical
+                + stats.format_breakdown.ebook
+                + stats.format_breakdown.audiobook;
+
+            if total_formats > 0 {
+                println!();
+                println!("  Format breakdown:");
+                println!(
+                    "    Physical:  {:>3} ({}%)",
+                    stats.format_breakdown.physical,
+                    stats.format_breakdown.physical * 100 / total_formats
+                );
+                println!(
+                    "    Ebook:     {:>3} ({}%)",
+                    stats.format_breakdown.ebook,
+                    stats.format_breakdown.ebook * 100 / total_formats
+                );
+                println!(
+                    "    Audiobook: {:>3} ({}%)",
+                    stats.format_breakdown.audiobook,
+                    stats.format_breakdown.audiobook * 100 / total_formats
+                );
+            }
+
+            if !stats.currently_reading.is_empty() {
+                println!();
+                println!("  Currently reading:");
+                for cr in &stats.currently_reading {
+                    let progress = match (cr.latest_page, cr.total_pages, cr.percent) {
+                        (Some(page), Some(total), Some(pct)) => {
+                            format!(" (page {page}/{total}, {pct:.0}%)")
+                        }
+                        (Some(page), None, _) => format!(" (page {page})"),
+                        _ => String::new(),
+                    };
+                    let author = if cr.author.is_empty() {
+                        String::new()
+                    } else {
+                        format!(" — {}", cr.author)
+                    };
+                    println!("    {}{author}{progress}", cr.title);
+                }
+            }
+
+            println!();
+        }
+    }
+
+    Ok(())
+}
+
+fn format_number(n: i64) -> String {
+    if n < 1_000 {
+        return n.to_string();
+    }
+    let s = n.to_string();
+    let mut result = String::new();
+    for (i, c) in s.chars().rev().enumerate() {
+        if i > 0 && i % 3 == 0 {
+            result.push(',');
+        }
+        result.push(c);
+    }
+    result.chars().rev().collect()
 }

--- a/crates/toku-core/src/lib.rs
+++ b/crates/toku-core/src/lib.rs
@@ -2,8 +2,10 @@ mod book;
 mod config;
 mod error;
 mod isbn;
+pub mod stats;
 
 pub use book::*;
 pub use config::*;
 pub use error::*;
 pub use isbn::*;
+pub use stats::*;

--- a/crates/toku-core/src/stats.rs
+++ b/crates/toku-core/src/stats.rs
@@ -1,0 +1,363 @@
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+use crate::{Book, BookFormat, ReadingProgress, ReadingSession, ReadingStatus};
+
+/// Aggregated reading statistics.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ReadingStats {
+    pub total_books: usize,
+    pub books_read: usize,
+    pub books_reading: usize,
+    pub books_want_to_read: usize,
+    pub books_abandoned: usize,
+    pub total_pages_read: i64,
+    /// Average rating on the 0–10 scale, or `None` if no books are rated.
+    pub average_rating: Option<f64>,
+    /// Average rating on a 0–5 star scale, or `None` if no books are rated.
+    pub average_rating_stars: Option<f64>,
+    /// Books finished per month in the selected period.
+    pub books_per_month: f64,
+    /// Pages read per day in the selected period.
+    pub pages_per_day: f64,
+    pub format_breakdown: FormatBreakdown,
+    pub currently_reading: Vec<CurrentlyReading>,
+}
+
+/// Count of books per physical format.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FormatBreakdown {
+    pub physical: usize,
+    pub ebook: usize,
+    pub audiobook: usize,
+}
+
+/// A book the user is currently reading, with progress info.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CurrentlyReading {
+    pub title: String,
+    pub author: String,
+    pub latest_page: Option<i32>,
+    pub total_pages: Option<i32>,
+    pub percent: Option<f64>,
+}
+
+/// Input data for a currently-reading book gathered by the DB layer.
+pub struct CurrentlyReadingInput {
+    pub title: String,
+    pub author: String,
+    pub page_count: Option<i32>,
+    pub latest_progress: Option<ReadingProgress>,
+}
+
+/// Compute reading statistics from pure data — no database access.
+///
+/// * `books` — all books in the library (or the filtered subset).
+/// * `sessions` — reading sessions in the selected period.
+/// * `currently_reading` — details about books with status `Reading`.
+/// * `now` — the current timestamp (injected for testability).
+pub fn compute_stats(
+    books: &[Book],
+    sessions: &[ReadingSession],
+    currently_reading: &[CurrentlyReadingInput],
+    now: DateTime<Utc>,
+) -> ReadingStats {
+    let total_books = books.len();
+
+    let books_read = books
+        .iter()
+        .filter(|b| b.status == ReadingStatus::Read)
+        .count();
+    let books_reading = books
+        .iter()
+        .filter(|b| b.status == ReadingStatus::Reading)
+        .count();
+    let books_want_to_read = books
+        .iter()
+        .filter(|b| b.status == ReadingStatus::WantToRead)
+        .count();
+    let books_abandoned = books
+        .iter()
+        .filter(|b| b.status == ReadingStatus::Abandoned)
+        .count();
+
+    // Total pages read: sum page_count of all "Read" books that have one.
+    let total_pages_read: i64 = books
+        .iter()
+        .filter(|b| b.status == ReadingStatus::Read)
+        .filter_map(|b| b.page_count.map(|p| p as i64))
+        .sum();
+
+    // Average rating (0–10 scale)
+    let rated: Vec<i32> = books.iter().filter_map(|b| b.rating).collect();
+    let average_rating = if rated.is_empty() {
+        None
+    } else {
+        Some(rated.iter().map(|&r| r as f64).sum::<f64>() / rated.len() as f64)
+    };
+    let average_rating_stars = average_rating.map(|r| r / 2.0);
+
+    // Reading pace: based on finished sessions in the period.
+    let finished_sessions: Vec<&ReadingSession> = sessions
+        .iter()
+        .filter(|s| s.finished_at.is_some())
+        .collect();
+    let (books_per_month, pages_per_day) = compute_pace(&finished_sessions, books, now);
+
+    // Format breakdown
+    let format_breakdown = FormatBreakdown {
+        physical: books
+            .iter()
+            .filter(|b| b.format == BookFormat::Physical)
+            .count(),
+        ebook: books
+            .iter()
+            .filter(|b| b.format == BookFormat::Ebook)
+            .count(),
+        audiobook: books
+            .iter()
+            .filter(|b| b.format == BookFormat::Audiobook)
+            .count(),
+    };
+
+    // Currently reading details
+    let currently_reading_list: Vec<CurrentlyReading> = currently_reading
+        .iter()
+        .map(|cr| {
+            let latest_page = cr.latest_progress.as_ref().map(|p| p.value);
+
+            let percent = match (latest_page, cr.page_count) {
+                (Some(page), Some(total)) if total > 0 => {
+                    Some((page as f64 / total as f64 * 100.0).min(100.0))
+                }
+                _ => None,
+            };
+
+            CurrentlyReading {
+                title: cr.title.clone(),
+                author: cr.author.clone(),
+                latest_page,
+                total_pages: cr.page_count,
+                percent,
+            }
+        })
+        .collect();
+
+    ReadingStats {
+        total_books,
+        books_read,
+        books_reading,
+        books_want_to_read,
+        books_abandoned,
+        total_pages_read,
+        average_rating,
+        average_rating_stars,
+        books_per_month,
+        pages_per_day,
+        format_breakdown,
+        currently_reading: currently_reading_list,
+    }
+}
+
+/// Compute books/month and pages/day from finished sessions.
+fn compute_pace(
+    finished_sessions: &[&ReadingSession],
+    books: &[Book],
+    now: DateTime<Utc>,
+) -> (f64, f64) {
+    if finished_sessions.is_empty() {
+        return (0.0, 0.0);
+    }
+
+    // Find the date range spanned by finished sessions.
+    let earliest = finished_sessions.iter().filter_map(|s| s.finished_at).min();
+    let latest = finished_sessions.iter().filter_map(|s| s.finished_at).max();
+
+    let (span_months, span_days) = match (earliest, latest) {
+        (Some(first), Some(_last)) => {
+            let duration = now.signed_duration_since(first);
+            let days = duration.num_days().max(1) as f64;
+            let months = (days / 30.44).max(1.0); // average days/month
+            (months, days)
+        }
+        _ => return (0.0, 0.0),
+    };
+
+    let finished_count = finished_sessions.len() as f64;
+    let books_per_month = finished_count / span_months;
+
+    // Pages/day: sum pages of books finished in the period.
+    let finished_book_ids: Vec<_> = finished_sessions.iter().map(|s| s.book_id).collect();
+    let pages: i64 = books
+        .iter()
+        .filter(|b| finished_book_ids.contains(&b.id))
+        .filter_map(|b| b.page_count.map(|p| p as i64))
+        .sum();
+    let pages_per_day = pages as f64 / span_days;
+
+    (books_per_month, pages_per_day)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::TimeZone;
+    use uuid::Uuid;
+
+    fn make_book(title: &str, status: ReadingStatus, format: BookFormat) -> Book {
+        let mut book = Book::new(title);
+        book.status = status;
+        book.format = format;
+        book
+    }
+
+    fn make_session(
+        book_id: Uuid,
+        started: DateTime<Utc>,
+        finished: Option<DateTime<Utc>>,
+    ) -> ReadingSession {
+        let mut session = ReadingSession::new(book_id);
+        session.started_at = started;
+        session.finished_at = finished;
+        session
+    }
+
+    #[test]
+    fn empty_library_returns_zeroed_stats() {
+        let now = Utc::now();
+        let stats = compute_stats(&[], &[], &[], now);
+
+        assert_eq!(stats.total_books, 0);
+        assert_eq!(stats.books_read, 0);
+        assert_eq!(stats.books_reading, 0);
+        assert_eq!(stats.books_want_to_read, 0);
+        assert_eq!(stats.books_abandoned, 0);
+        assert_eq!(stats.total_pages_read, 0);
+        assert!(stats.average_rating.is_none());
+        assert!(stats.average_rating_stars.is_none());
+        assert_eq!(stats.books_per_month, 0.0);
+        assert_eq!(stats.pages_per_day, 0.0);
+        assert_eq!(stats.format_breakdown.physical, 0);
+        assert_eq!(stats.format_breakdown.ebook, 0);
+        assert_eq!(stats.format_breakdown.audiobook, 0);
+        assert!(stats.currently_reading.is_empty());
+    }
+
+    #[test]
+    fn average_rating_handles_no_rated_books() {
+        let mut book1 = make_book("A", ReadingStatus::Read, BookFormat::Physical);
+        book1.rating = None;
+        let book2 = make_book("B", ReadingStatus::WantToRead, BookFormat::Ebook);
+
+        let stats = compute_stats(&[book1, book2], &[], &[], Utc::now());
+        assert!(stats.average_rating.is_none());
+        assert!(stats.average_rating_stars.is_none());
+    }
+
+    #[test]
+    fn average_rating_computation() {
+        let mut book1 = make_book("A", ReadingStatus::Read, BookFormat::Physical);
+        book1.rating = Some(8); // 4.0★
+        let mut book2 = make_book("B", ReadingStatus::Read, BookFormat::Ebook);
+        book2.rating = Some(6); // 3.0★
+        let book3 = make_book("C", ReadingStatus::WantToRead, BookFormat::Physical);
+
+        let stats = compute_stats(&[book1, book2, book3], &[], &[], Utc::now());
+        let avg = stats.average_rating.expect("should have an average");
+        assert!((avg - 7.0).abs() < f64::EPSILON); // (8+6)/2 = 7.0
+        let stars = stats.average_rating_stars.expect("should have stars");
+        assert!((stars - 3.5).abs() < f64::EPSILON); // 7.0 / 2 = 3.5
+    }
+
+    #[test]
+    fn format_breakdown_counts() {
+        let books = vec![
+            make_book("A", ReadingStatus::Read, BookFormat::Physical),
+            make_book("B", ReadingStatus::Read, BookFormat::Physical),
+            make_book("C", ReadingStatus::Reading, BookFormat::Ebook),
+            make_book("D", ReadingStatus::WantToRead, BookFormat::Audiobook),
+            make_book("E", ReadingStatus::Read, BookFormat::Ebook),
+        ];
+
+        let stats = compute_stats(&books, &[], &[], Utc::now());
+        assert_eq!(stats.format_breakdown.physical, 2);
+        assert_eq!(stats.format_breakdown.ebook, 2);
+        assert_eq!(stats.format_breakdown.audiobook, 1);
+    }
+
+    #[test]
+    fn status_counts() {
+        let books = vec![
+            make_book("A", ReadingStatus::Read, BookFormat::Physical),
+            make_book("B", ReadingStatus::Read, BookFormat::Ebook),
+            make_book("C", ReadingStatus::Reading, BookFormat::Physical),
+            make_book("D", ReadingStatus::WantToRead, BookFormat::Physical),
+            make_book("E", ReadingStatus::WantToRead, BookFormat::Ebook),
+            make_book("F", ReadingStatus::Abandoned, BookFormat::Audiobook),
+        ];
+
+        let stats = compute_stats(&books, &[], &[], Utc::now());
+        assert_eq!(stats.total_books, 6);
+        assert_eq!(stats.books_read, 2);
+        assert_eq!(stats.books_reading, 1);
+        assert_eq!(stats.books_want_to_read, 2);
+        assert_eq!(stats.books_abandoned, 1);
+    }
+
+    #[test]
+    fn total_pages_read_sums_read_books() {
+        let mut book1 = make_book("A", ReadingStatus::Read, BookFormat::Physical);
+        book1.page_count = Some(300);
+        let mut book2 = make_book("B", ReadingStatus::Read, BookFormat::Ebook);
+        book2.page_count = Some(200);
+        let mut book3 = make_book("C", ReadingStatus::Reading, BookFormat::Physical);
+        book3.page_count = Some(500); // not counted — still reading
+        let book4 = make_book("D", ReadingStatus::Read, BookFormat::Physical);
+        // no page count — skipped
+
+        let stats = compute_stats(&[book1, book2, book3, book4], &[], &[], Utc::now());
+        assert_eq!(stats.total_pages_read, 500); // 300 + 200
+    }
+
+    #[test]
+    fn currently_reading_with_progress() {
+        let input = vec![CurrentlyReadingInput {
+            title: "Dune".to_string(),
+            author: "Frank Herbert".to_string(),
+            page_count: Some(544),
+            latest_progress: Some(ReadingProgress::new(
+                Uuid::now_v7(),
+                crate::ProgressType::Page,
+                145,
+            )),
+        }];
+
+        let stats = compute_stats(&[], &[], &input, Utc::now());
+        assert_eq!(stats.currently_reading.len(), 1);
+        let cr = &stats.currently_reading[0];
+        assert_eq!(cr.title, "Dune");
+        assert_eq!(cr.author, "Frank Herbert");
+        assert_eq!(cr.latest_page, Some(145));
+        assert_eq!(cr.total_pages, Some(544));
+        let pct = cr.percent.expect("should have percent");
+        assert!((pct - 26.654).abs() < 0.1);
+    }
+
+    #[test]
+    fn reading_pace_computation() {
+        let mut book = make_book("A", ReadingStatus::Read, BookFormat::Physical);
+        book.page_count = Some(300);
+
+        // Session finished 30 days ago
+        let now = Utc::now();
+        let thirty_days_ago = now - chrono::Duration::days(30);
+        let sixty_days_ago = now - chrono::Duration::days(60);
+        let session = make_session(book.id, sixty_days_ago, Some(thirty_days_ago));
+
+        let stats = compute_stats(&[book], &[session], &[], now);
+
+        // 1 book over ~1 month
+        assert!(stats.books_per_month > 0.0);
+        assert!(stats.pages_per_day > 0.0);
+    }
+}

--- a/crates/toku-db/src/repo.rs
+++ b/crates/toku-db/src/repo.rs
@@ -265,6 +265,21 @@ impl<'a> BookRepository<'a> {
         Ok(())
     }
 
+    /// Get all ISBNs for a book.
+    pub fn get_book_isbns(&self, book_id: &Uuid) -> Result<Vec<String>, DbError> {
+        let mut stmt = self
+            .db
+            .conn
+            .prepare("SELECT isbn FROM isbns WHERE book_id = ?1 ORDER BY isbn")?;
+
+        let isbns = stmt
+            .query_map(params![book_id.to_string()], |row| row.get(0))?
+            .filter_map(|r| r.ok())
+            .collect();
+
+        Ok(isbns)
+    }
+
     /// Find a book by ISBN.
     pub fn find_by_isbn(&self, isbn: &str) -> Result<Option<Book>, DbError> {
         let result = self.db.conn.query_row(
@@ -726,6 +741,102 @@ impl<'a> BookRepository<'a> {
             .collect();
 
         Ok(tags)
+    }
+
+    // --- Stats operations ---
+
+    /// List all reading sessions.
+    pub fn list_reading_sessions(&self) -> Result<Vec<ReadingSession>, DbError> {
+        let mut stmt = self.db.conn.prepare(
+            "SELECT id, book_id, started_at, finished_at, start_page, end_page,
+             rating, notes, created_at
+             FROM reading_sessions
+             ORDER BY started_at DESC",
+        )?;
+
+        let sessions = stmt
+            .query_map([], |row| Ok(row_to_reading_session(row)))?
+            .filter_map(|r| r.ok())
+            .filter_map(|r| r.ok())
+            .collect();
+
+        Ok(sessions)
+    }
+
+    /// List reading sessions finished in a given year.
+    pub fn list_reading_sessions_in_year(&self, year: i32) -> Result<Vec<ReadingSession>, DbError> {
+        let start = format!("{year}-01-01T00:00:00+00:00");
+        let end = format!("{}-01-01T00:00:00+00:00", year + 1);
+
+        let mut stmt = self.db.conn.prepare(
+            "SELECT id, book_id, started_at, finished_at, start_page, end_page,
+             rating, notes, created_at
+             FROM reading_sessions
+             WHERE finished_at IS NOT NULL
+               AND finished_at >= ?1
+               AND finished_at < ?2
+             ORDER BY finished_at DESC",
+        )?;
+
+        let sessions = stmt
+            .query_map(params![start, end], |row| Ok(row_to_reading_session(row)))?
+            .filter_map(|r| r.ok())
+            .filter_map(|r| r.ok())
+            .collect();
+
+        Ok(sessions)
+    }
+
+    /// Count books grouped by reading status.
+    pub fn count_books_by_status(
+        &self,
+    ) -> Result<std::collections::HashMap<String, usize>, DbError> {
+        let mut stmt = self
+            .db
+            .conn
+            .prepare("SELECT status, COUNT(*) FROM books GROUP BY status")?;
+
+        let mut map = std::collections::HashMap::new();
+        let rows = stmt.query_map([], |row| {
+            let status: String = row.get(0)?;
+            let count: i64 = row.get(1)?;
+            Ok((status, count as usize))
+        })?;
+
+        for row in rows.flatten() {
+            map.insert(row.0, row.1);
+        }
+
+        Ok(map)
+    }
+
+    /// Get books with status=Reading, their latest progress, and authors.
+    #[allow(clippy::type_complexity)]
+    pub fn get_currently_reading_details(
+        &self,
+    ) -> Result<Vec<(Book, Option<ReadingProgress>, Vec<(Author, BookAuthor)>)>, DbError> {
+        let mut stmt = self.db.conn.prepare(
+            "SELECT id, title, subtitle, description, page_count, pub_date,
+             language, format, duration_minutes, cover_hash, work_id, status,
+             rating, created_at, updated_at
+             FROM books WHERE status = 'reading'
+             ORDER BY updated_at DESC",
+        )?;
+
+        let books: Vec<Book> = stmt
+            .query_map([], |row| Ok(row_to_book(row)))?
+            .filter_map(|r| r.ok())
+            .filter_map(|r| r.ok())
+            .collect();
+
+        let mut results = Vec::new();
+        for book in books {
+            let progress = self.get_latest_progress(&book.id)?;
+            let authors = self.get_book_authors(&book.id)?;
+            results.push((book, progress, authors));
+        }
+
+        Ok(results)
     }
 }
 

--- a/crates/toku-export/Cargo.toml
+++ b/crates/toku-export/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "toku-export"
+description = "Export implementations for Toku: CSV, JSON, Markdown, canonical backup"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[dependencies]
+toku-core = { path = "../toku-core", version = "0.1.0" }
+toku-db = { path = "../toku-db", version = "0.1.0" }
+thiserror.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+chrono.workspace = true
+uuid.workspace = true
+csv = "1"
+zip = "2"
+
+[dev-dependencies]
+tempfile = "3"

--- a/crates/toku-export/src/backup.rs
+++ b/crates/toku-export/src/backup.rs
@@ -1,0 +1,142 @@
+use std::fs;
+use std::io::Write;
+use std::path::Path;
+
+use zip::write::SimpleFileOptions;
+
+use toku_db::Database;
+
+use crate::{ExportError, build_library_export};
+
+/// Create a canonical backup ZIP containing manifest.json, library.json, and cover images.
+pub fn export_backup(
+    db: &Database,
+    data_dir: &Path,
+    output_path: &Path,
+) -> Result<(), ExportError> {
+    let export = build_library_export(db)?;
+
+    let file = fs::File::create(output_path)?;
+    let mut zip = zip::ZipWriter::new(file);
+    let options = SimpleFileOptions::default().compression_method(zip::CompressionMethod::Deflated);
+
+    // Write manifest.json
+    let manifest = serde_json::json!({
+        "version": export.version,
+        "exported_at": export.exported_at,
+        "book_count": export.book_count,
+    });
+    zip.start_file("manifest.json", options)?;
+    zip.write_all(serde_json::to_string_pretty(&manifest)?.as_bytes())?;
+
+    // Write library.json
+    zip.start_file("library.json", options)?;
+    zip.write_all(serde_json::to_string_pretty(&export)?.as_bytes())?;
+
+    // Copy cover images
+    let covers_dir = data_dir.join("covers");
+    if covers_dir.is_dir() {
+        for book in &export.books {
+            if let Some(hash) = &book.cover_hash {
+                let cover_path = covers_dir.join(format!("{hash}.jpg"));
+                if cover_path.exists() {
+                    let cover_data = fs::read(&cover_path)?;
+                    zip.start_file(format!("covers/{hash}.jpg"), options)?;
+                    zip.write_all(&cover_data)?;
+                }
+            }
+        }
+    }
+
+    zip.finish()?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Read;
+    use toku_core::{Book, BookFormat, ReadingStatus};
+    use toku_db::BookRepository;
+
+    #[test]
+    fn backup_contains_manifest_and_library() {
+        let db = Database::open_in_memory().unwrap();
+        let repo = BookRepository::new(&db);
+
+        let mut book = Book::new("Dune");
+        book.status = ReadingStatus::Read;
+        book.format = BookFormat::Physical;
+        repo.create_book(&book).unwrap();
+
+        let tmp = tempfile::TempDir::new().unwrap();
+        let data_dir = tmp.path().join("data");
+        fs::create_dir_all(&data_dir).unwrap();
+        let output = tmp.path().join("backup.zip");
+
+        export_backup(&db, &data_dir, &output).unwrap();
+
+        let file = fs::File::open(&output).unwrap();
+        let mut archive = zip::ZipArchive::new(file).unwrap();
+
+        let mut names: Vec<String> = (0..archive.len())
+            .map(|i| archive.by_index(i).unwrap().name().to_string())
+            .collect();
+        names.sort();
+
+        assert!(names.contains(&"manifest.json".to_string()));
+        assert!(names.contains(&"library.json".to_string()));
+
+        // Verify manifest parses
+        {
+            let mut manifest_file = archive.by_name("manifest.json").unwrap();
+            let mut manifest_str = String::new();
+            manifest_file.read_to_string(&mut manifest_str).unwrap();
+            let manifest: serde_json::Value = serde_json::from_str(&manifest_str).unwrap();
+            assert_eq!(manifest["version"], "1");
+            assert_eq!(manifest["book_count"], 1);
+        }
+
+        // Verify library.json round-trips
+        {
+            let mut lib_file = archive.by_name("library.json").unwrap();
+            let mut lib_str = String::new();
+            lib_file.read_to_string(&mut lib_str).unwrap();
+            let parsed: crate::LibraryExport = serde_json::from_str(&lib_str).unwrap();
+            assert_eq!(parsed.books.len(), 1);
+            assert_eq!(parsed.books[0].title, "Dune");
+        }
+    }
+
+    #[test]
+    fn backup_includes_cover_files() {
+        let db = Database::open_in_memory().unwrap();
+        let repo = BookRepository::new(&db);
+
+        let mut book = Book::new("Dune");
+        book.status = ReadingStatus::Read;
+        book.format = BookFormat::Physical;
+        book.cover_hash = Some("abc123def456".to_string());
+        repo.create_book(&book).unwrap();
+
+        let tmp = tempfile::TempDir::new().unwrap();
+        let data_dir = tmp.path().join("data");
+        let covers_dir = data_dir.join("covers");
+        fs::create_dir_all(&covers_dir).unwrap();
+
+        // Write a fake cover image
+        let cover_content = b"fake-jpeg-data";
+        fs::write(covers_dir.join("abc123def456.jpg"), cover_content).unwrap();
+
+        let output = tmp.path().join("backup.zip");
+        export_backup(&db, &data_dir, &output).unwrap();
+
+        let file = fs::File::open(&output).unwrap();
+        let mut archive = zip::ZipArchive::new(file).unwrap();
+
+        let mut cover_file = archive.by_name("covers/abc123def456.jpg").unwrap();
+        let mut cover_data = Vec::new();
+        cover_file.read_to_end(&mut cover_data).unwrap();
+        assert_eq!(cover_data, cover_content);
+    }
+}

--- a/crates/toku-export/src/csv_export.rs
+++ b/crates/toku-export/src/csv_export.rs
@@ -1,0 +1,143 @@
+use std::io::Write;
+
+use toku_db::Database;
+
+use crate::{ExportError, build_library_export};
+
+/// Export books as a flat CSV.
+///
+/// Columns: title, authors, status, format, rating, pages, pub_date, shelves, tags, isbn
+pub fn export_csv(db: &Database, writer: impl Write) -> Result<(), ExportError> {
+    let export = build_library_export(db)?;
+
+    let mut wtr = csv::Writer::from_writer(writer);
+
+    wtr.write_record([
+        "title", "authors", "status", "format", "rating", "pages", "pub_date", "shelves", "tags",
+        "isbn",
+    ])?;
+
+    for book in &export.books {
+        let authors = book
+            .authors
+            .iter()
+            .map(|a| a.name.as_str())
+            .collect::<Vec<_>>()
+            .join("; ");
+
+        let shelves = book.shelves.join("; ");
+        let tags = book.tags.join("; ");
+
+        let isbn = book
+            .isbn_13
+            .as_deref()
+            .or(book.isbn_10.as_deref())
+            .unwrap_or("");
+
+        wtr.write_record([
+            &book.title,
+            &authors,
+            &book.status,
+            &book.format,
+            &book.rating.map_or(String::new(), |r| r.to_string()),
+            &book.page_count.map_or(String::new(), |p| p.to_string()),
+            book.pub_date.as_deref().unwrap_or(""),
+            &shelves,
+            &tags,
+            isbn,
+        ])?;
+    }
+
+    wtr.flush()?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use toku_core::{Author, Book, BookFormat, ContributorRole, ReadingStatus};
+    use toku_db::BookRepository;
+
+    fn setup_db() -> Database {
+        let db = Database::open_in_memory().unwrap();
+        let repo = BookRepository::new(&db);
+
+        let mut book = Book::new("Dune");
+        book.page_count = Some(544);
+        book.pub_date = Some("1965".to_string());
+        book.status = ReadingStatus::Read;
+        book.rating = Some(9);
+        book.format = BookFormat::Physical;
+        repo.create_book(&book).unwrap();
+
+        let author = Author::new("Frank Herbert");
+        repo.add_book_author(&author, &book.id, ContributorRole::Author, 0)
+            .unwrap();
+
+        repo.add_isbn("9780441013593", &book.id).unwrap();
+
+        let mut book2 = Book::new("Neuromancer");
+        book2.status = ReadingStatus::WantToRead;
+        book2.format = BookFormat::Ebook;
+        repo.create_book(&book2).unwrap();
+
+        let author2 = Author::new("William Gibson");
+        repo.add_book_author(&author2, &book2.id, ContributorRole::Author, 0)
+            .unwrap();
+
+        db
+    }
+
+    #[test]
+    fn csv_has_correct_columns() {
+        let db = setup_db();
+        let mut buf = Vec::new();
+        export_csv(&db, &mut buf).unwrap();
+
+        let output = String::from_utf8(buf).unwrap();
+        let mut rdr = csv::Reader::from_reader(output.as_bytes());
+        let headers = rdr.headers().unwrap();
+        assert_eq!(
+            headers,
+            &csv::StringRecord::from(vec![
+                "title", "authors", "status", "format", "rating", "pages", "pub_date", "shelves",
+                "tags", "isbn"
+            ])
+        );
+    }
+
+    #[test]
+    fn csv_contains_books() {
+        let db = setup_db();
+        let mut buf = Vec::new();
+        export_csv(&db, &mut buf).unwrap();
+
+        let output = String::from_utf8(buf).unwrap();
+        let mut rdr = csv::Reader::from_reader(output.as_bytes());
+        let records: Vec<csv::StringRecord> = rdr.records().filter_map(|r| r.ok()).collect();
+        assert_eq!(records.len(), 2);
+
+        // Books are ordered by title; Dune comes first
+        assert_eq!(&records[0][0], "Dune");
+        assert_eq!(&records[0][1], "Frank Herbert");
+        assert_eq!(&records[0][2], "read");
+        assert_eq!(&records[0][9], "9780441013593");
+
+        assert_eq!(&records[1][0], "Neuromancer");
+        assert_eq!(&records[1][1], "William Gibson");
+    }
+
+    #[test]
+    fn csv_produces_valid_csv() {
+        let db = setup_db();
+        let mut buf = Vec::new();
+        export_csv(&db, &mut buf).unwrap();
+
+        let output = String::from_utf8(buf).unwrap();
+        let mut rdr = csv::Reader::from_reader(output.as_bytes());
+        // All records should parse without error
+        for result in rdr.records() {
+            result.unwrap();
+        }
+    }
+}

--- a/crates/toku-export/src/error.rs
+++ b/crates/toku-export/src/error.rs
@@ -1,0 +1,20 @@
+#[derive(Debug, thiserror::Error)]
+pub enum ExportError {
+    #[error("database error: {0}")]
+    Database(#[from] toku_db::DbError),
+
+    #[error("I/O error: {0}")]
+    Io(#[from] std::io::Error),
+
+    #[error("CSV error: {0}")]
+    Csv(#[from] csv::Error),
+
+    #[error("JSON error: {0}")]
+    Json(#[from] serde_json::Error),
+
+    #[error("ZIP error: {0}")]
+    Zip(#[from] zip::result::ZipError),
+
+    #[error("export error: {0}")]
+    Other(String),
+}

--- a/crates/toku-export/src/json_export.rs
+++ b/crates/toku-export/src/json_export.rs
@@ -1,0 +1,81 @@
+use std::io::Write;
+
+use toku_db::Database;
+
+use crate::{ExportError, build_library_export};
+
+/// Export the full library as pretty-printed JSON.
+pub fn export_json(db: &Database, writer: impl Write) -> Result<(), ExportError> {
+    let export = build_library_export(db)?;
+    serde_json::to_writer_pretty(writer, &export)?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::LibraryExport;
+    use toku_core::{Author, Book, BookFormat, ContributorRole, ReadingStatus};
+    use toku_db::BookRepository;
+
+    fn setup_db() -> Database {
+        let db = Database::open_in_memory().unwrap();
+        let repo = BookRepository::new(&db);
+
+        let mut book = Book::new("Dune");
+        book.page_count = Some(544);
+        book.pub_date = Some("1965".to_string());
+        book.status = ReadingStatus::Read;
+        book.rating = Some(8);
+        book.format = BookFormat::Physical;
+        repo.create_book(&book).unwrap();
+
+        let author = Author::new("Frank Herbert");
+        repo.add_book_author(&author, &book.id, ContributorRole::Author, 0)
+            .unwrap();
+
+        repo.add_isbn("9780441013593", &book.id).unwrap();
+
+        repo.add_book_to_shelf(&book.id, "Favorites").unwrap();
+        repo.add_tag_to_book(&book.id, "sci-fi").unwrap();
+
+        db
+    }
+
+    #[test]
+    fn json_round_trips() {
+        let db = setup_db();
+        let mut buf = Vec::new();
+        export_json(&db, &mut buf).unwrap();
+
+        let output = String::from_utf8(buf).unwrap();
+        let parsed: LibraryExport = serde_json::from_str(&output).unwrap();
+
+        assert_eq!(parsed.version, "1");
+        assert_eq!(parsed.book_count, 1);
+        assert_eq!(parsed.books.len(), 1);
+
+        let book = &parsed.books[0];
+        assert_eq!(book.title, "Dune");
+        assert_eq!(book.status, "read");
+        assert_eq!(book.rating, Some(8));
+        assert_eq!(book.page_count, Some(544));
+        assert_eq!(book.isbn_13.as_deref(), Some("9780441013593"));
+        assert_eq!(book.authors.len(), 1);
+        assert_eq!(book.authors[0].name, "Frank Herbert");
+        assert_eq!(book.authors[0].role, "author");
+        assert_eq!(book.shelves, vec!["Favorites"]);
+        assert_eq!(book.tags, vec!["sci-fi"]);
+    }
+
+    #[test]
+    fn json_empty_library() {
+        let db = Database::open_in_memory().unwrap();
+        let mut buf = Vec::new();
+        export_json(&db, &mut buf).unwrap();
+
+        let parsed: LibraryExport = serde_json::from_slice(&buf).unwrap();
+        assert_eq!(parsed.book_count, 0);
+        assert!(parsed.books.is_empty());
+    }
+}

--- a/crates/toku-export/src/lib.rs
+++ b/crates/toku-export/src/lib.rs
@@ -1,0 +1,116 @@
+mod backup;
+mod csv_export;
+mod error;
+mod json_export;
+mod markdown_export;
+
+pub use backup::export_backup;
+pub use csv_export::export_csv;
+pub use error::ExportError;
+pub use json_export::export_json;
+pub use markdown_export::export_markdown;
+
+use serde::{Deserialize, Serialize};
+
+/// Full library export with metadata envelope.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct LibraryExport {
+    pub version: String,
+    pub exported_at: String,
+    pub book_count: usize,
+    pub books: Vec<BookExport>,
+}
+
+/// A single book with all related data flattened for export.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct BookExport {
+    pub id: String,
+    pub title: String,
+    pub subtitle: Option<String>,
+    pub description: Option<String>,
+    pub authors: Vec<AuthorExport>,
+    pub isbn_13: Option<String>,
+    pub isbn_10: Option<String>,
+    pub page_count: Option<i32>,
+    pub pub_date: Option<String>,
+    pub language: Option<String>,
+    pub format: String,
+    pub status: String,
+    pub rating: Option<i32>,
+    pub shelves: Vec<String>,
+    pub tags: Vec<String>,
+    pub cover_hash: Option<String>,
+    pub created_at: String,
+    pub updated_at: String,
+}
+
+/// An author/contributor entry for export.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct AuthorExport {
+    pub name: String,
+    pub role: String,
+}
+
+use toku_db::{BookRepository, Database};
+
+/// Build a full `LibraryExport` from the database.
+pub fn build_library_export(db: &Database) -> Result<LibraryExport, ExportError> {
+    let repo = BookRepository::new(db);
+    let books = repo.list_books()?;
+
+    let mut book_exports = Vec::with_capacity(books.len());
+    for book in &books {
+        let authors_raw = repo.get_book_authors(&book.id)?;
+        let authors: Vec<AuthorExport> = authors_raw
+            .into_iter()
+            .map(|(a, ba)| AuthorExport {
+                name: a.name,
+                role: ba.role.as_str().to_string(),
+            })
+            .collect();
+
+        let shelves: Vec<String> = repo
+            .get_book_shelves(&book.id)?
+            .into_iter()
+            .map(|s| s.name)
+            .collect();
+
+        let tags: Vec<String> = repo
+            .get_book_tags(&book.id)?
+            .into_iter()
+            .map(|t| t.name)
+            .collect();
+
+        let isbns = repo.get_book_isbns(&book.id)?;
+        let isbn_13 = isbns.iter().find(|i| i.len() == 13).cloned();
+        let isbn_10 = isbns.iter().find(|i| i.len() == 10).cloned();
+
+        book_exports.push(BookExport {
+            id: book.id.to_string(),
+            title: book.title.clone(),
+            subtitle: book.subtitle.clone(),
+            description: book.description.clone(),
+            authors,
+            isbn_13,
+            isbn_10,
+            page_count: book.page_count,
+            pub_date: book.pub_date.clone(),
+            language: book.language.clone(),
+            format: book.format.as_str().to_string(),
+            status: book.status.as_str().to_string(),
+            rating: book.rating,
+            shelves,
+            tags,
+            cover_hash: book.cover_hash.clone(),
+            created_at: book.created_at.to_rfc3339(),
+            updated_at: book.updated_at.to_rfc3339(),
+        });
+    }
+
+    Ok(LibraryExport {
+        version: "1".to_string(),
+        exported_at: chrono::Utc::now().to_rfc3339(),
+        book_count: book_exports.len(),
+        books: book_exports,
+    })
+}

--- a/crates/toku-export/src/markdown_export.rs
+++ b/crates/toku-export/src/markdown_export.rs
@@ -1,0 +1,187 @@
+use std::io::Write;
+
+use toku_db::Database;
+
+use crate::{BookExport, ExportError, build_library_export};
+
+/// Export the library as a readable Markdown document grouped by reading status.
+pub fn export_markdown(db: &Database, writer: impl Write) -> Result<(), ExportError> {
+    let export = build_library_export(db)?;
+    write_markdown(&export.books, writer)
+}
+
+fn write_markdown(books: &[BookExport], mut writer: impl Write) -> Result<(), ExportError> {
+    writeln!(writer, "# My Library")?;
+
+    let sections: &[(&str, &str)] = &[
+        ("reading", "Currently Reading"),
+        ("read", "Read"),
+        ("want-to-read", "Want to Read"),
+        ("on-hold", "On Hold"),
+        ("abandoned", "Abandoned"),
+    ];
+
+    for (status_key, heading) in sections {
+        let matching: Vec<&BookExport> = books.iter().filter(|b| b.status == *status_key).collect();
+
+        if matching.is_empty() {
+            continue;
+        }
+
+        writeln!(writer)?;
+        writeln!(writer, "## {heading}")?;
+
+        for book in &matching {
+            let author_str = if book.authors.is_empty() {
+                String::new()
+            } else {
+                let names: Vec<&str> = book.authors.iter().map(|a| a.name.as_str()).collect();
+                format!(" by {}", names.join(", "))
+            };
+
+            let mut suffix = String::new();
+
+            if *status_key == "reading"
+                && let Some(pages) = book.page_count
+            {
+                suffix = format!(" ({pages} pages)");
+            }
+
+            if *status_key == "read"
+                && let Some(rating) = book.rating
+            {
+                let stars = rating_to_stars(rating);
+                let display = rating as f32 / 2.0;
+                suffix = format!(" {stars} ({display:.1})");
+            }
+
+            writeln!(writer, "- **{}**{author_str}{suffix}", book.title)?;
+        }
+    }
+
+    Ok(())
+}
+
+/// Convert a 0–10 integer rating to a star display (e.g. 8 → ★★★★).
+fn rating_to_stars(rating: i32) -> String {
+    let full = rating / 2;
+    let half = rating % 2;
+    let mut s = String::new();
+    for _ in 0..full {
+        s.push('★');
+    }
+    if half > 0 {
+        s.push('½');
+    }
+    s
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use toku_core::{Author, Book, BookFormat, ContributorRole, ReadingStatus};
+    use toku_db::BookRepository;
+
+    fn setup_db() -> Database {
+        let db = Database::open_in_memory().unwrap();
+        let repo = BookRepository::new(&db);
+
+        let mut book1 = Book::new("Dune");
+        book1.status = ReadingStatus::Reading;
+        book1.page_count = Some(544);
+        book1.format = BookFormat::Physical;
+        repo.create_book(&book1).unwrap();
+        let a1 = Author::new("Frank Herbert");
+        repo.add_book_author(&a1, &book1.id, ContributorRole::Author, 0)
+            .unwrap();
+
+        let mut book2 = Book::new("Neuromancer");
+        book2.status = ReadingStatus::Read;
+        book2.rating = Some(8);
+        book2.format = BookFormat::Physical;
+        repo.create_book(&book2).unwrap();
+        let a2 = Author::new("William Gibson");
+        repo.add_book_author(&a2, &book2.id, ContributorRole::Author, 0)
+            .unwrap();
+
+        let mut book3 = Book::new("Snow Crash");
+        book3.status = ReadingStatus::Read;
+        book3.rating = Some(10);
+        book3.format = BookFormat::Ebook;
+        repo.create_book(&book3).unwrap();
+        let a3 = Author::new("Neal Stephenson");
+        repo.add_book_author(&a3, &book3.id, ContributorRole::Author, 0)
+            .unwrap();
+
+        let mut book4 = Book::new("The Left Hand of Darkness");
+        book4.status = ReadingStatus::WantToRead;
+        book4.format = BookFormat::Physical;
+        repo.create_book(&book4).unwrap();
+        let a4 = Author::new("Ursula K. Le Guin");
+        repo.add_book_author(&a4, &book4.id, ContributorRole::Author, 0)
+            .unwrap();
+
+        db
+    }
+
+    #[test]
+    fn markdown_has_headings() {
+        let db = setup_db();
+        let mut buf = Vec::new();
+        export_markdown(&db, &mut buf).unwrap();
+        let output = String::from_utf8(buf).unwrap();
+
+        assert!(output.contains("# My Library"));
+        assert!(output.contains("## Currently Reading"));
+        assert!(output.contains("## Read"));
+        assert!(output.contains("## Want to Read"));
+    }
+
+    #[test]
+    fn markdown_contains_books() {
+        let db = setup_db();
+        let mut buf = Vec::new();
+        export_markdown(&db, &mut buf).unwrap();
+        let output = String::from_utf8(buf).unwrap();
+
+        assert!(output.contains("**Dune**"));
+        assert!(output.contains("Frank Herbert"));
+        assert!(output.contains("**Neuromancer**"));
+        assert!(output.contains("**The Left Hand of Darkness**"));
+    }
+
+    #[test]
+    fn markdown_shows_ratings_for_read() {
+        let db = setup_db();
+        let mut buf = Vec::new();
+        export_markdown(&db, &mut buf).unwrap();
+        let output = String::from_utf8(buf).unwrap();
+
+        // Neuromancer rating=8 → 4.0 stars
+        assert!(output.contains("★★★★ (4.0)"));
+        // Snow Crash rating=10 → 5.0 stars
+        assert!(output.contains("★★★★★ (5.0)"));
+    }
+
+    #[test]
+    fn markdown_omits_empty_sections() {
+        let db = Database::open_in_memory().unwrap();
+        let repo = BookRepository::new(&db);
+
+        let mut book = Book::new("Test Book");
+        book.status = ReadingStatus::Read;
+        book.rating = Some(6);
+        book.format = BookFormat::Physical;
+        repo.create_book(&book).unwrap();
+
+        let mut buf = Vec::new();
+        export_markdown(&db, &mut buf).unwrap();
+        let output = String::from_utf8(buf).unwrap();
+
+        assert!(output.contains("## Read"));
+        assert!(!output.contains("## Currently Reading"));
+        assert!(!output.contains("## Want to Read"));
+        assert!(!output.contains("## On Hold"));
+        assert!(!output.contains("## Abandoned"));
+    }
+}


### PR DESCRIPTION
## Description

Add reading statistics dashboard and full export system (CSV, JSON, Markdown, canonical backup).

### What's included

- **Reading statistics** (`toku-core/src/stats.rs`) — pure computation module: books/pages read, average rating (0–10 and 5-star display), reading pace (books/month, pages/day), format breakdown (physical/ebook/audiobook with percentages), and currently-reading list with progress. All stats computed locally from user data — no server needed.
- **`toku stats`** — CLI command with `--year` filter. Table output shows formatted analytics with emoji headers; JSON output serializes the full `ReadingStats` struct; CSV outputs metric/value pairs.
- **`toku-export` crate** — new workspace member with 4 export formats:
  - **CSV** — flat table: title, authors, status, format, rating, pages, shelves, tags, ISBN
  - **JSON** — full structured `LibraryExport` with books, authors, and metadata
  - **Markdown** — readable document grouped by reading status with star ratings
  - **Canonical backup** — self-contained ZIP with `manifest.json`, `library.json`, and `covers/` directory for round-trip backup/migration
- All export commands support `--output <file>` (or stdout for csv/json/markdown). Backup requires `--output`.
- **92 tests** — 19 new (8 stats computation + 11 export format tests)

## Related Issues

Closes #12, closes #13

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI / infrastructure
- [ ] Other (describe below)

## Crate

- [x] `toku-core` — Domain models, traits, state machine
- [x] `toku-db` — SQLite persistence, migrations, FTS5
- [ ] `toku-import` — Importers (Goodreads, Calibre, StoryGraph)
- [ ] `toku-meta` — Metadata fetching (Open Library, Google Books)
- [x] `toku-cli` — CLI binary
- [x] `toku-export` — Exporters (CSV, JSON, Markdown, BibTeX)
- [ ] `docs/` — Documentation

## Data Integrity Checklist

- [x] No user data is sent to any server without explicit opt-in — all stats and exports computed locally
- [x] Import operations are idempotent (re-importing the same file creates no duplicates)
- [x] User edits to metadata are never overwritten by auto-enrichment
- [x] New fields track provenance (source + timestamp)
- [x] Export round-trip is preserved (if applicable) — canonical backup ZIP is designed for round-trip restore

## Checklist

- [x] I have read [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] `cargo fmt --check` passes
- [x] `cargo clippy --workspace -- -D warnings` passes
- [x] `cargo test --workspace` passes — 92 tests, all green
- [x] I have updated documentation (if applicable) — CHANGELOG updated