### PR TITLE
feat(cli): add interactive TUI browser and import progress UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Interactive TUI library browser (`toku browse`, or just `toku` with no subcommand) with split-pane layout: scrollable book list on the left, live detail view on the right
+- Filter popup in TUI browser to narrow books by reading status, shelf, or tag
+- Ratatui-based import progress UI with live progress bar, per-row activity log, and colored status indicators
+- Structured import summary with status breakdown, sample lists of imported/skipped books, and undo instructions
+- Width-aware `toku list` table output that adapts columns to terminal width with modern rounded borders
+
+### Changed
+
+- Goodreads importer now uses observer pattern for progress reporting and wraps non-dry-run imports in a transaction for atomicity
+- Import report includes bounded sample lists (up to 20) of imported and skipped books with status counts
+
+### Fixed
+
+- Multibyte string truncation panic when book titles or descriptions contain non-ASCII characters
+- `toku list` no longer dumps the entire library after import — replaced with structured summary
 - Project README with "Why Toku?" naming rationale and CLI usage examples
 - Product roadmap covering 9 phases from MVP to moonshots
 - Architecture Decision Records: core language (ADR-001), database schema (ADR-002), CLI design (ADR-003), metadata sources (ADR-004), import architecture (ADR-005), sync strategy (ADR-006)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -29,6 +29,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -175,6 +181,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "cassowary"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df8670b8c7b9dae1793364eafadf7239c40d669904660c5960d74cfd80b46a53"
+
+[[package]]
+name = "castaway"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dec551ab6e7578819132c713a93c022a05d60159dc86e7a7050223577484c55a"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "cc"
 version = "1.2.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -282,6 +303,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
+name = "compact_str"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fd622ebbb56a5b2ccb651b32b911cdeb2a9b4b11776b2473bf26a26a286244e"
+dependencies = [
+ "castaway",
+ "cfg-if",
+ "itoa",
+ "rustversion",
+ "ryu",
+ "static_assertions",
+]
+
+[[package]]
 name = "const-oid"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -333,6 +368,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossterm"
+version = "0.28.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
+dependencies = [
+ "bitflags",
+ "crossterm_winapi",
+ "mio",
+ "parking_lot",
+ "rustix 0.38.44",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm_winapi"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "crypto-common"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -379,6 +439,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
 dependencies = [
  "cmov",
+]
+
+[[package]]
+name = "darling"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
+dependencies = [
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -451,6 +545,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "either"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 
 [[package]]
 name = "equivalent"
@@ -620,6 +720,8 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
+ "allocator-api2",
+ "equivalent",
  "foldhash 0.1.5",
 ]
 
@@ -882,6 +984,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "idna"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -915,12 +1023,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "indoc"
+version = "2.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "inout"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4250ce6452e92010fdf7268ccc5d14faa80bb12fc741938534c58f16804e03c7"
 dependencies = [
  "hybrid-array",
+]
+
+[[package]]
+name = "instability"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5eb2d60ef19920a3a9193c3e371f726ec1dafc045dac788d0fb3704272458971"
+dependencies = [
+ "darling",
+ "indoc",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -944,6 +1074,15 @@ name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itoa"
@@ -1013,6 +1152,12 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
+
+[[package]]
+name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
@@ -1024,10 +1169,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
+name = "lock_api"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
+dependencies = [
+ "scopeguard",
+]
+
+[[package]]
 name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "lru"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
+dependencies = [
+ "hashbrown 0.15.5",
+]
 
 [[package]]
 name = "lru-slab"
@@ -1067,6 +1230,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
 dependencies = [
  "libc",
+ "log",
  "wasi",
  "windows-sys 0.61.2",
 ]
@@ -1112,8 +1276,37 @@ checksum = "6978128c8b51d8f4080631ceb2302ab51e32cc6e8615f735ee2f83fd269ae3f1"
 dependencies = [
  "bytecount",
  "fnv",
- "unicode-width",
+ "unicode-width 0.2.0",
 ]
+
+[[package]]
+name = "parking_lot"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-link",
+]
+
+[[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "pbkdf2"
@@ -1320,6 +1513,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "ratatui"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eabd94c2f37801c20583fc49dd5cd6b0ba68c716787c2dd6ed18571e1e63117b"
+dependencies = [
+ "bitflags",
+ "cassowary",
+ "compact_str",
+ "crossterm",
+ "indoc",
+ "instability",
+ "itertools",
+ "lru",
+ "paste",
+ "strum",
+ "unicode-segmentation",
+ "unicode-truncate",
+ "unicode-width 0.2.0",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.5.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "redox_users"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1487,6 +1710,19 @@ checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
 name = "rustix"
+version = "0.38.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.4.15",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
@@ -1494,7 +1730,7 @@ dependencies = [
  "bitflags",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.12.1",
  "windows-sys 0.61.2",
 ]
 
@@ -1553,6 +1789,12 @@ checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
 ]
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "semver"
@@ -1673,6 +1915,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "signal-hook"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
+name = "signal-hook-mio"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b75a19a7a740b25bc7944bdee6172368f988763b744e3d4dfe753f6b4ece40cc"
+dependencies = [
+ "libc",
+ "mio",
+ "signal-hook",
+]
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
+dependencies = [
+ "errno",
+ "libc",
+]
+
+[[package]]
 name = "simd-adler32"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1725,10 +1998,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "strum"
+version = "0.26.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn",
+]
 
 [[package]]
 name = "subtle"
@@ -1800,7 +2101,7 @@ dependencies = [
  "fastrand",
  "getrandom 0.4.2",
  "once_cell",
- "rustix",
+ "rustix 1.1.4",
  "windows-sys 0.61.2",
 ]
 
@@ -1810,7 +2111,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0f8daae29995a24f65619e19d8d31dea5b389f3d853d8bf297bbf607cd0014cc"
 dependencies = [
- "unicode-width",
+ "unicode-width 0.2.0",
 ]
 
 [[package]]
@@ -1934,6 +2235,9 @@ dependencies = [
  "chrono",
  "clap",
  "clap_complete",
+ "crossterm",
+ "csv",
+ "ratatui",
  "serde",
  "serde_json",
  "tabled",
@@ -2186,10 +2490,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
-name = "unicode-width"
-version = "0.2.2"
+name = "unicode-segmentation"
+version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
+checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
+
+[[package]]
+name = "unicode-truncate"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3644627a5af5fa321c95b9b235a72fd24cd29c648c2c379431e6628655627bf"
+dependencies = [
+ "itertools",
+ "unicode-segmentation",
+ "unicode-width 0.1.14",
+]
+
+[[package]]
+name = "unicode-width"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
+
+[[package]]
+name = "unicode-width"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
 
 [[package]]
 name = "unicode-xid"
@@ -2413,6 +2740,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
 name = "winapi-util"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2420,6 +2763,12 @@ checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-core"

--- a/crates/toku-cli/Cargo.toml
+++ b/crates/toku-cli/Cargo.toml
@@ -26,3 +26,6 @@ serde_json.workspace = true
 toml.workspace = true
 tokio.workspace = true
 tabled = "0.20"
+ratatui = "0.29"
+crossterm = "0.28"
+csv = "1"

--- a/crates/toku-cli/src/import_ui.rs
+++ b/crates/toku-cli/src/import_ui.rs
@@ -1,0 +1,521 @@
+use std::io::{self, IsTerminal, Stderr};
+use std::path::Path;
+
+use anyhow::{Context, Result};
+use crossterm::{
+    execute,
+    terminal::{EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode, enable_raw_mode},
+};
+use ratatui::{
+    Frame,
+    backend::CrosstermBackend,
+    layout::{Constraint, Layout, Rect},
+    style::{Color, Modifier, Style, Stylize},
+    text::{Line, Span},
+    widgets::{Block, Borders, Gauge, Padding, Paragraph},
+};
+use toku_db::Database;
+use toku_import::{GoodreadsImportOptions, ImportEvent, ImportObserver, ImportReport, RowOutcome};
+
+use crate::OutputFormat;
+
+/// RAII guard that restores the terminal on drop, even if the import panics.
+struct TerminalGuard {
+    terminal: ratatui::Terminal<CrosstermBackend<Stderr>>,
+    active: bool,
+}
+
+impl TerminalGuard {
+    fn init() -> Result<Self> {
+        enable_raw_mode().context("failed to enable raw mode")?;
+        let mut stderr = io::stderr();
+        execute!(stderr, EnterAlternateScreen).context("failed to enter alternate screen")?;
+        let backend = CrosstermBackend::new(io::stderr());
+        let terminal =
+            ratatui::Terminal::new(backend).context("failed to create ratatui terminal")?;
+        Ok(Self {
+            terminal,
+            active: true,
+        })
+    }
+
+    fn restore(&mut self) {
+        if self.active {
+            self.active = false;
+            let _ = disable_raw_mode();
+            let _ = execute!(io::stderr(), LeaveAlternateScreen);
+        }
+    }
+}
+
+impl Drop for TerminalGuard {
+    fn drop(&mut self) {
+        self.restore();
+    }
+}
+
+// ── Progress State ──────────────────────────────────────────────────────────
+
+const ACTIVITY_LOG_SIZE: usize = 8;
+
+struct ActivityEntry {
+    title: String,
+    author: String,
+    status: String,
+    outcome: RowOutcome,
+}
+
+struct ImportProgressState {
+    current: usize,
+    total: usize,
+    imported: usize,
+    skipped: usize,
+    errors: usize,
+    recent: Vec<ActivityEntry>,
+    dry_run: bool,
+}
+
+impl ImportProgressState {
+    fn new(total: usize, dry_run: bool) -> Self {
+        Self {
+            current: 0,
+            total,
+            imported: 0,
+            skipped: 0,
+            errors: 0,
+            recent: Vec::with_capacity(ACTIVITY_LOG_SIZE),
+            dry_run,
+        }
+    }
+
+    fn update(&mut self, event: &ImportEvent) {
+        self.current = event.row;
+        match &event.outcome {
+            RowOutcome::Imported => self.imported += 1,
+            RowOutcome::Skipped => self.skipped += 1,
+            RowOutcome::Error(_) => self.errors += 1,
+        }
+        self.recent.push(ActivityEntry {
+            title: event.title.clone(),
+            author: event.author.clone(),
+            status: event.status.clone(),
+            outcome: event.outcome.clone(),
+        });
+        if self.recent.len() > ACTIVITY_LOG_SIZE {
+            self.recent.remove(0);
+        }
+    }
+
+    fn progress_ratio(&self) -> f64 {
+        if self.total == 0 {
+            1.0
+        } else {
+            self.current as f64 / self.total as f64
+        }
+    }
+
+    fn progress_pct(&self) -> u16 {
+        (self.progress_ratio() * 100.0).round().min(100.0) as u16
+    }
+}
+
+// ── Observer Implementation ─────────────────────────────────────────────────
+
+struct RatatuiImportObserver {
+    guard: TerminalGuard,
+    state: ImportProgressState,
+}
+
+impl RatatuiImportObserver {
+    fn new(total: usize, dry_run: bool) -> Result<Self> {
+        let guard = TerminalGuard::init()?;
+        let state = ImportProgressState::new(total, dry_run);
+        Ok(Self { guard, state })
+    }
+
+    fn restore(mut self) {
+        self.guard.restore();
+    }
+}
+
+impl ImportObserver for RatatuiImportObserver {
+    fn on_event(&mut self, event: &ImportEvent) -> Result<(), toku_import::ImportError> {
+        self.state.update(event);
+        self.guard
+            .terminal
+            .draw(|frame| render_import_progress(frame, &self.state))
+            .map_err(|e| toku_import::ImportError::Other(format!("render error: {e}")))?;
+        Ok(())
+    }
+}
+
+// ── Rendering ───────────────────────────────────────────────────────────────
+
+fn render_import_progress(frame: &mut Frame, state: &ImportProgressState) {
+    let area = frame.area();
+
+    // Vertical layout: header + progress bar + stats + activity log
+    let chunks = Layout::vertical([
+        Constraint::Length(3), // header
+        Constraint::Length(3), // progress bar
+        Constraint::Length(3), // stats
+        Constraint::Min(4),    // activity log
+    ])
+    .split(area);
+
+    render_header(frame, chunks[0], state);
+    render_progress_bar(frame, chunks[1], state);
+    render_stats(frame, chunks[2], state);
+    render_activity_log(frame, chunks[3], state);
+}
+
+fn render_header(frame: &mut Frame, area: Rect, state: &ImportProgressState) {
+    let title = if state.dry_run {
+        " 📚 Dry Run Preview — Goodreads Import "
+    } else {
+        " 📚 Importing from Goodreads "
+    };
+    let block = Block::default()
+        .title(title)
+        .borders(Borders::BOTTOM)
+        .border_style(Style::default().fg(Color::DarkGray));
+    frame.render_widget(block, area);
+}
+
+fn render_progress_bar(frame: &mut Frame, area: Rect, state: &ImportProgressState) {
+    let label = format!(
+        "{}/{} books  {}%",
+        state.current,
+        state.total,
+        state.progress_pct()
+    );
+    let gauge = Gauge::default()
+        .block(Block::default().padding(Padding::horizontal(2)))
+        .gauge_style(
+            Style::default()
+                .fg(Color::Cyan)
+                .bg(Color::DarkGray)
+                .add_modifier(Modifier::BOLD),
+        )
+        .ratio(state.progress_ratio())
+        .label(label);
+    frame.render_widget(gauge, area);
+}
+
+fn render_stats(frame: &mut Frame, area: Rect, state: &ImportProgressState) {
+    let imported_style = Style::default().fg(Color::Green).bold();
+    let skipped_style = Style::default().fg(Color::Yellow).bold();
+    let error_style = Style::default().fg(Color::Red).bold();
+    let label_style = Style::default().fg(Color::Gray);
+
+    let line = Line::from(vec![
+        Span::raw("    "),
+        Span::styled("✓ ", imported_style),
+        Span::styled("Imported ", label_style),
+        Span::styled(format!("{:<6}", state.imported), imported_style),
+        Span::raw("   "),
+        Span::styled("↷ ", skipped_style),
+        Span::styled("Duplicates ", label_style),
+        Span::styled(format!("{:<6}", state.skipped), skipped_style),
+        Span::raw("   "),
+        Span::styled("✗ ", error_style),
+        Span::styled("Errors ", label_style),
+        Span::styled(format!("{}", state.errors), error_style),
+    ]);
+
+    let paragraph = Paragraph::new(line).block(
+        Block::default()
+            .borders(Borders::BOTTOM)
+            .border_style(Style::default().fg(Color::DarkGray)),
+    );
+    frame.render_widget(paragraph, area);
+}
+
+fn render_activity_log(frame: &mut Frame, area: Rect, state: &ImportProgressState) {
+    let block = Block::default()
+        .title(" Recent ")
+        .borders(Borders::TOP)
+        .border_style(Style::default().fg(Color::DarkGray))
+        .padding(Padding::new(2, 2, 0, 0));
+
+    let inner = block.inner(area);
+    frame.render_widget(block, area);
+
+    if state.recent.is_empty() {
+        return;
+    }
+
+    let lines: Vec<Line> = state
+        .recent
+        .iter()
+        .map(|entry| {
+            let (icon, icon_style) = match &entry.outcome {
+                RowOutcome::Imported => ("✓ ", Style::default().fg(Color::Green)),
+                RowOutcome::Skipped => ("↷ ", Style::default().fg(Color::Yellow)),
+                RowOutcome::Error(_) => ("✗ ", Style::default().fg(Color::Red)),
+            };
+
+            let title = truncate_str(&entry.title, 40);
+            let author = if entry.author.is_empty() {
+                String::new()
+            } else {
+                format!(" — {}", truncate_str(&entry.author, 25))
+            };
+
+            let right_label = match &entry.outcome {
+                RowOutcome::Imported => entry.status.clone(),
+                RowOutcome::Skipped => "(duplicate)".to_string(),
+                RowOutcome::Error(e) => truncate_str(e, 30),
+            };
+
+            let right_style = match &entry.outcome {
+                RowOutcome::Imported => Style::default().fg(Color::DarkGray),
+                RowOutcome::Skipped => Style::default().fg(Color::Yellow),
+                RowOutcome::Error(_) => Style::default().fg(Color::Red),
+            };
+
+            Line::from(vec![
+                Span::styled(icon, icon_style),
+                Span::styled(title, Style::default().fg(Color::White)),
+                Span::styled(author, Style::default().fg(Color::Gray)),
+                Span::raw("  "),
+                Span::styled(right_label, right_style),
+            ])
+        })
+        .collect();
+
+    let paragraph = Paragraph::new(lines);
+    frame.render_widget(paragraph, inner);
+}
+
+/// Truncate a string to a maximum display width, using character boundaries.
+pub(crate) fn truncate_str(s: &str, max_chars: usize) -> String {
+    let char_count = s.chars().count();
+    if char_count <= max_chars {
+        s.to_string()
+    } else {
+        let truncated: String = s.chars().take(max_chars.saturating_sub(1)).collect();
+        format!("{truncated}…")
+    }
+}
+
+// ── Public API ──────────────────────────────────────────────────────────────
+
+/// Run a Goodreads import with a ratatui progress UI (if stderr is a TTY and
+/// format is table), or fall back to a plain summary.
+pub fn run_goodreads_import(
+    db: &Database,
+    path: &Path,
+    dry_run: bool,
+    format: &OutputFormat,
+) -> Result<()> {
+    if !path.exists() {
+        anyhow::bail!("file not found: {}", path.display());
+    }
+
+    let opts = GoodreadsImportOptions { dry_run };
+    let use_tui = matches!(format, OutputFormat::Table) && io::stderr().is_terminal();
+
+    if use_tui {
+        run_with_tui(db, path, &opts, format)
+    } else {
+        run_without_tui(db, path, &opts, format)
+    }
+}
+
+fn run_with_tui(
+    db: &Database,
+    path: &Path,
+    opts: &GoodreadsImportOptions,
+    format: &OutputFormat,
+) -> Result<()> {
+    // Pre-count by the observer (it will be counted inside import_goodreads)
+    // but we need the count to initialize the observer.
+    let total = count_csv_rows_quick(path)?;
+    let mut observer =
+        RatatuiImportObserver::new(total, opts.dry_run).context("failed to initialize TUI")?;
+
+    let result = toku_import::import_goodreads(db, path, opts, Some(&mut observer));
+
+    // Always restore terminal before printing anything
+    observer.restore();
+
+    let report = result.context("Goodreads import failed")?;
+    print_import_summary(&report, format, opts.dry_run);
+    Ok(())
+}
+
+fn run_without_tui(
+    db: &Database,
+    path: &Path,
+    opts: &GoodreadsImportOptions,
+    format: &OutputFormat,
+) -> Result<()> {
+    let report =
+        toku_import::import_goodreads(db, path, opts, None).context("Goodreads import failed")?;
+    print_import_summary(&report, format, opts.dry_run);
+    Ok(())
+}
+
+/// Quick CSV row count (using csv crate to handle embedded newlines).
+fn count_csv_rows_quick(path: &Path) -> Result<usize> {
+    let mut rdr = csv::ReaderBuilder::new()
+        .has_headers(true)
+        .flexible(true)
+        .from_path(path)
+        .context("failed to read CSV for row count")?;
+    Ok(rdr.records().count())
+}
+
+// ── Summary Printing ────────────────────────────────────────────────────────
+
+fn print_import_summary(report: &ImportReport, format: &OutputFormat, dry_run: bool) {
+    match format {
+        OutputFormat::Json => print_summary_json(report, dry_run),
+        OutputFormat::Csv => print_summary_csv(report),
+        OutputFormat::Table => print_summary_table(report, dry_run),
+    }
+}
+
+fn print_summary_table(report: &ImportReport, dry_run: bool) {
+    eprintln!();
+    if dry_run {
+        eprintln!("  📋 Dry run complete (no changes made)\n");
+    } else if report.errors == 0 {
+        eprintln!("  ✓ Goodreads import complete\n");
+    } else {
+        eprintln!("  ⚠ Goodreads import completed with errors\n");
+    }
+
+    // Main stats
+    let status_label = if dry_run { "Would import" } else { "Imported" };
+    eprintln!("    {:<14} {:>4} books", status_label, report.imported);
+    if report.skipped > 0 {
+        eprintln!(
+            "    {:<14} {:>4} (already in library)",
+            "Duplicates", report.skipped
+        );
+    }
+    if report.errors > 0 {
+        eprintln!("    {:<14} {:>4} rows", "Errors", report.errors);
+    }
+    eprintln!("    {:<14} {:>4}", "Total rows", report.total_rows);
+
+    // Status breakdown
+    if !report.status_counts.is_empty() {
+        eprintln!("\n  Status breakdown:");
+        // Sort for consistent output
+        let mut counts: Vec<_> = report.status_counts.iter().collect();
+        counts.sort_by(|a, b| b.1.cmp(a.1));
+        for (status, count) in counts {
+            let label = match status.as_str() {
+                "read" => "Read",
+                "reading" => "Currently Reading",
+                "want-to-read" => "Want to Read",
+                "abandoned" => "Abandoned",
+                "on-hold" => "On Hold",
+                other => other,
+            };
+            eprintln!("    {:<20} {:>4}", label, count);
+        }
+    }
+
+    // Skipped books sample
+    if !report.skipped_samples.is_empty() {
+        eprintln!("\n  Duplicates skipped:");
+        for s in &report.skipped_samples {
+            let author = if s.author.is_empty() {
+                String::new()
+            } else {
+                format!(" — {}", s.author)
+            };
+            eprintln!("    ↷ {}{}", truncate_str(&s.title, 50), author);
+        }
+        if report.skipped > report.skipped_samples.len() {
+            eprintln!(
+                "    ... and {} more",
+                report.skipped - report.skipped_samples.len()
+            );
+        }
+    }
+
+    // Errors
+    if !report.error_details.is_empty() {
+        eprintln!("\n  Errors:");
+        for e in &report.error_details {
+            eprintln!("    ✗ {e}");
+        }
+    }
+
+    // Import ID
+    if let Some(ref id) = report.import_id {
+        eprintln!("\n  Import ID: {id}");
+        eprintln!("  To undo:   toku import undo {id}");
+    }
+
+    eprintln!();
+}
+
+fn print_summary_json(report: &ImportReport, dry_run: bool) {
+    #[derive(serde::Serialize)]
+    struct JsonReport {
+        dry_run: bool,
+        total_rows: usize,
+        imported: usize,
+        skipped: usize,
+        errors: usize,
+        import_id: Option<String>,
+        error_details: Vec<String>,
+        skipped_books: Vec<JsonRowSummary>,
+        imported_books: Vec<JsonRowSummary>,
+        status_counts: std::collections::HashMap<String, usize>,
+    }
+    #[derive(serde::Serialize)]
+    struct JsonRowSummary {
+        title: String,
+        author: String,
+        status: String,
+    }
+
+    let out = JsonReport {
+        dry_run,
+        total_rows: report.total_rows,
+        imported: report.imported,
+        skipped: report.skipped,
+        errors: report.errors,
+        import_id: report.import_id.clone(),
+        error_details: report.error_details.clone(),
+        skipped_books: report
+            .skipped_samples
+            .iter()
+            .map(|s| JsonRowSummary {
+                title: s.title.clone(),
+                author: s.author.clone(),
+                status: s.status.clone(),
+            })
+            .collect(),
+        imported_books: report
+            .imported_samples
+            .iter()
+            .map(|s| JsonRowSummary {
+                title: s.title.clone(),
+                author: s.author.clone(),
+                status: s.status.clone(),
+            })
+            .collect(),
+        status_counts: report.status_counts.clone(),
+    };
+    println!("{}", serde_json::to_string_pretty(&out).unwrap_or_default());
+}
+
+fn print_summary_csv(report: &ImportReport) {
+    println!("total_rows,imported,skipped,errors,import_id");
+    println!(
+        "{},{},{},{},{}",
+        report.total_rows,
+        report.imported,
+        report.skipped,
+        report.errors,
+        report.import_id.as_deref().unwrap_or(""),
+    );
+}

--- a/crates/toku-cli/src/main.rs
+++ b/crates/toku-cli/src/main.rs
@@ -10,6 +10,9 @@ use toku_core::{
 };
 use toku_db::{BookRepository, Database};
 
+mod import_ui;
+mod tui;
+
 /// Toku — a private, offline-first personal book manager.
 #[derive(Parser)]
 #[command(name = "toku", version, about)]
@@ -23,11 +26,14 @@ struct Cli {
     format: OutputFormat,
 
     #[command(subcommand)]
-    command: Commands,
+    command: Option<Commands>,
 }
 
 #[derive(Subcommand)]
 enum Commands {
+    /// Interactive library browser (TUI) — default when no subcommand given
+    Browse,
+
     /// Add a book to your library
     Add {
         /// Book title (for manual entry)
@@ -345,8 +351,11 @@ fn main() -> Result<()> {
         None => Database::default_data_dir().context("could not determine data directory")?,
     };
 
+    // Resolve command (default: Browse = TUI)
+    let command = cli.command.unwrap_or(Commands::Browse);
+
     // Commands that don't need the database
-    match &cli.command {
+    match &command {
         Commands::Config { path, edit } => return cmd_config(&data_dir, *path, *edit),
         Commands::Completions { shell } => {
             clap_complete::generate(*shell, &mut Cli::command(), "toku", &mut std::io::stdout());
@@ -360,7 +369,8 @@ fn main() -> Result<()> {
         .with_context(|| format!("failed to open database at {}", db_path.display()))?;
     let repo = BookRepository::new(&db);
 
-    match cli.command {
+    match command {
+        Commands::Browse => tui::run(&repo),
         Commands::Add {
             title,
             author,
@@ -668,7 +678,21 @@ fn print_books(books: &[Book], repo: &BookRepository, output_format: &OutputForm
             }
         }
         OutputFormat::Table => {
+            use tabled::settings::Style;
             use tabled::{Table, Tabled};
+
+            // Detect terminal width (fallback: 120 columns)
+            let term_width = crossterm::terminal::size()
+                .map(|(w, _)| w as usize)
+                .unwrap_or(120);
+
+            // Width budget: 7 borders + 12 padding = 19 overhead
+            // Fixed columns: Status(7) + Fmt(5) + ★(3) + Pages(5) = 20
+            // Remaining goes to Title (60%) and Author (40%)
+            let fixed_overhead = 39;
+            let flexible = term_width.saturating_sub(fixed_overhead);
+            let title_max = (flexible * 3 / 5).max(12);
+            let author_max = flexible.saturating_sub(title_max).max(8);
 
             #[derive(Tabled)]
             struct Row {
@@ -678,9 +702,9 @@ fn print_books(books: &[Book], repo: &BookRepository, output_format: &OutputForm
                 author: String,
                 #[tabled(rename = "Status")]
                 status: String,
-                #[tabled(rename = "Format")]
+                #[tabled(rename = "Fmt")]
                 format: String,
-                #[tabled(rename = "Rating")]
+                #[tabled(rename = "★")]
                 rating: String,
                 #[tabled(rename = "Pages")]
                 pages: String,
@@ -696,26 +720,36 @@ fn print_books(books: &[Book], repo: &BookRepository, output_format: &OutputForm
                         .map(|(a, _)| a.name)
                         .collect();
 
-                    let title = if b.title.len() > 40 {
-                        format!("{}…", &b.title[..39])
-                    } else {
-                        b.title.clone()
+                    let status = match b.status {
+                        ReadingStatus::WantToRead => "Want",
+                        ReadingStatus::Reading => "Reading",
+                        ReadingStatus::Read => "Read",
+                        ReadingStatus::Abandoned => "DNF",
+                        ReadingStatus::OnHold => "On Hold",
+                    };
+
+                    let format = match b.format {
+                        BookFormat::Physical => "Print",
+                        BookFormat::Ebook => "Ebook",
+                        BookFormat::Audiobook => "Audio",
                     };
 
                     Row {
-                        title,
-                        author: authors.join(", "),
-                        status: b.status.as_str().to_string(),
-                        format: b.format.as_str().to_string(),
+                        title: import_ui::truncate_str(&b.title, title_max),
+                        author: import_ui::truncate_str(&authors.join(", "), author_max),
+                        status: status.to_string(),
+                        format: format.to_string(),
                         rating: b
                             .rating
-                            .map_or("—".to_string(), |r| format!("{:.1}★", r as f32 / 2.0)),
+                            .map_or("—".to_string(), |r| format!("{:.1}", r as f32 / 2.0)),
                         pages: b.page_count.map_or("—".to_string(), |p| p.to_string()),
                     }
                 })
                 .collect();
 
-            println!("{}", Table::new(rows));
+            let mut table = Table::new(rows);
+            table.with(Style::rounded());
+            println!("{table}");
         }
     }
     Ok(())
@@ -780,10 +814,14 @@ fn print_book_detail(
                 println!("  Cover:   ✓ ({hash})");
             }
             if let Some(desc) = &book.description {
-                let truncated = if desc.len() > 200 {
-                    format!("{}…", &desc[..200])
-                } else {
-                    desc.clone()
+                let truncated = {
+                    let char_count = desc.chars().count();
+                    if char_count > 200 {
+                        let t: String = desc.chars().take(199).collect();
+                        format!("{t}…")
+                    } else {
+                        desc.clone()
+                    }
                 };
                 println!("  Desc:    {truncated}");
             }
@@ -795,42 +833,13 @@ fn print_book_detail(
 
 fn cmd_import(
     db: &Database,
-    repo: &BookRepository,
+    _repo: &BookRepository,
     source: ImportSource,
     output_format: &OutputFormat,
 ) -> Result<()> {
     match source {
         ImportSource::Goodreads { path, dry_run } => {
-            if !path.exists() {
-                anyhow::bail!("file not found: {}", path.display());
-            }
-
-            let opts = toku_import::GoodreadsImportOptions { dry_run };
-
-            if dry_run {
-                eprintln!("Dry run — no changes will be made:\n");
-            } else {
-                eprintln!("Importing from Goodreads CSV: {}\n", path.display());
-            }
-
-            let report = toku_import::import_goodreads(db, &path, &opts)
-                .context("Goodreads import failed")?;
-
-            eprintln!("\n{report}");
-
-            if let Some(ref id) = report.import_id {
-                eprintln!("Import ID: {id}");
-                eprintln!("To undo: toku import undo {id}");
-            }
-
-            if !dry_run && report.imported > 0 {
-                eprintln!();
-                let books = repo.list_books()?;
-                print_books(&books, repo, output_format)?;
-                eprintln!("\n{} book(s) in library", books.len());
-            }
-
-            Ok(())
+            import_ui::run_goodreads_import(db, &path, dry_run, output_format)
         }
         ImportSource::Calibre {
             path,
@@ -860,13 +869,6 @@ fn cmd_import(
             if let Some(ref id) = report.import_id {
                 eprintln!("Import ID: {id}");
                 eprintln!("To undo: toku import undo {id}");
-            }
-
-            if !dry_run && report.imported > 0 {
-                eprintln!();
-                let books = repo.list_books()?;
-                print_books(&books, repo, output_format)?;
-                eprintln!("\n{} book(s) in library", books.len());
             }
 
             Ok(())

--- a/crates/toku-cli/src/tui.rs
+++ b/crates/toku-cli/src/tui.rs
@@ -1,0 +1,748 @@
+//! Interactive TUI browser for the Toku book library.
+//!
+//! Split-pane layout: left = scrollable book list, right = book details.
+//! Supports filtering by status, shelf, and tag via a popup overlay.
+
+use std::io::{self, IsTerminal};
+
+use anyhow::Result;
+use crossterm::event::{self, Event, KeyCode, KeyEventKind, KeyModifiers};
+use crossterm::terminal::{self, EnterAlternateScreen, LeaveAlternateScreen};
+use ratatui::prelude::*;
+use ratatui::widgets::*;
+use toku_core::{BookFormat, ContributorRole, ReadingStatus};
+use toku_db::BookRepository;
+
+use crate::import_ui::truncate_str;
+
+// ── Types ───────────────────────────────────────────────────────────────────
+
+#[derive(Clone)]
+enum Filter {
+    All,
+    Status(ReadingStatus),
+    Shelf(String),
+    Tag(String),
+}
+
+impl std::fmt::Display for Filter {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Filter::All => write!(f, "All Books"),
+            Filter::Status(s) => write!(f, "Status: {s}"),
+            Filter::Shelf(n) => write!(f, "Shelf: {n}"),
+            Filter::Tag(n) => write!(f, "Tag: {n}"),
+        }
+    }
+}
+
+enum Mode {
+    Normal,
+    FilterPopup,
+}
+
+struct BookDetail {
+    authors: Vec<String>,
+    isbns: Vec<String>,
+    shelves: Vec<String>,
+    tags: Vec<String>,
+}
+
+struct FilterItem {
+    label: String,
+    filter: Filter,
+    selectable: bool,
+}
+
+// ── Terminal guard (RAII) ───────────────────────────────────────────────────
+
+/// Restores the terminal on drop — protects against panics leaving the
+/// terminal in raw/alternate-screen mode.
+struct TerminalGuard;
+
+impl Drop for TerminalGuard {
+    fn drop(&mut self) {
+        let _ = terminal::disable_raw_mode();
+        let _ = crossterm::execute!(io::stdout(), LeaveAlternateScreen);
+    }
+}
+
+// ── App state ───────────────────────────────────────────────────────────────
+
+struct App<'a> {
+    repo: &'a BookRepository<'a>,
+
+    // Data
+    books: Vec<toku_core::Book>,
+    shelves: Vec<toku_core::Shelf>,
+    tags: Vec<(toku_core::Tag, i64)>,
+
+    // Active filter
+    active_filter: Filter,
+
+    // Book list state
+    list_state: ListState,
+
+    // Detail cache (loaded in event handler, read in draw)
+    detail: Option<BookDetail>,
+    detail_idx: Option<usize>,
+
+    // Filter popup
+    mode: Mode,
+    filter_items: Vec<FilterItem>,
+    filter_state: ListState,
+
+    running: bool,
+}
+
+impl<'a> App<'a> {
+    fn new(repo: &'a BookRepository<'a>) -> Result<Self> {
+        let books = repo.list_books().map_err(|e| anyhow::anyhow!("{e}"))?;
+        let shelves = repo.list_shelves().map_err(|e| anyhow::anyhow!("{e}"))?;
+        let tags = repo
+            .list_tags_with_counts()
+            .map_err(|e| anyhow::anyhow!("{e}"))?;
+
+        let mut app = Self {
+            repo,
+            books,
+            shelves,
+            tags,
+            active_filter: Filter::All,
+            list_state: ListState::default(),
+            detail: None,
+            detail_idx: None,
+            mode: Mode::Normal,
+            filter_items: Vec::new(),
+            filter_state: ListState::default(),
+            running: true,
+        };
+
+        if !app.books.is_empty() {
+            app.list_state.select(Some(0));
+            app.ensure_detail_loaded();
+        }
+
+        Ok(app)
+    }
+
+    // ── Data loading ────────────────────────────────────────────────────
+
+    fn refresh_books(&mut self) {
+        let result = match &self.active_filter {
+            Filter::All => self.repo.list_books(),
+            Filter::Status(s) => {
+                let target = *s;
+                self.repo
+                    .list_books()
+                    .map(|books| books.into_iter().filter(|b| b.status == target).collect())
+            }
+            Filter::Shelf(name) => self.repo.list_books_in_shelf(name),
+            Filter::Tag(name) => self.repo.list_books_by_tag(name),
+        };
+
+        self.books = result.unwrap_or_default();
+        self.detail = None;
+        self.detail_idx = None;
+
+        if self.books.is_empty() {
+            self.list_state.select(None);
+        } else {
+            self.list_state.select(Some(0));
+            self.ensure_detail_loaded();
+        }
+    }
+
+    fn ensure_detail_loaded(&mut self) {
+        let idx = match self.list_state.selected() {
+            Some(i) if i < self.books.len() => i,
+            _ => return,
+        };
+
+        if self.detail_idx == Some(idx) {
+            return;
+        }
+
+        // Copy the ID to release the borrow on self.books
+        let book_id = self.books[idx].id;
+
+        let authors = self
+            .repo
+            .get_book_authors(&book_id)
+            .unwrap_or_default()
+            .into_iter()
+            .map(|(a, ba)| {
+                if ba.role == ContributorRole::Author {
+                    a.name
+                } else {
+                    format!("{} ({})", a.name, ba.role)
+                }
+            })
+            .collect();
+
+        let isbns = self.repo.get_book_isbns(&book_id).unwrap_or_default();
+
+        let shelves = self
+            .repo
+            .get_book_shelves(&book_id)
+            .unwrap_or_default()
+            .into_iter()
+            .map(|s| s.name)
+            .collect();
+
+        let tags = self
+            .repo
+            .get_book_tags(&book_id)
+            .unwrap_or_default()
+            .into_iter()
+            .map(|t| t.name)
+            .collect();
+
+        self.detail = Some(BookDetail {
+            authors,
+            isbns,
+            shelves,
+            tags,
+        });
+        self.detail_idx = Some(idx);
+    }
+
+    // ── Event handling ──────────────────────────────────────────────────
+
+    fn handle_key(&mut self, key: event::KeyEvent) {
+        if key.kind != KeyEventKind::Press {
+            return;
+        }
+
+        // Ctrl+C always quits
+        if key.code == KeyCode::Char('c') && key.modifiers.contains(KeyModifiers::CONTROL) {
+            self.running = false;
+            return;
+        }
+
+        match self.mode {
+            Mode::Normal => self.handle_normal_key(key),
+            Mode::FilterPopup => self.handle_filter_key(key),
+        }
+    }
+
+    fn handle_normal_key(&mut self, key: event::KeyEvent) {
+        match key.code {
+            KeyCode::Char('q') | KeyCode::Esc => self.running = false,
+            KeyCode::Down | KeyCode::Char('j') => self.move_selection(1),
+            KeyCode::Up | KeyCode::Char('k') => self.move_selection(-1),
+            KeyCode::PageDown => {
+                let page = terminal::size()
+                    .map(|(_, h)| h.saturating_sub(6) as i32)
+                    .unwrap_or(20);
+                self.move_selection(page);
+            }
+            KeyCode::PageUp => {
+                let page = terminal::size()
+                    .map(|(_, h)| h.saturating_sub(6) as i32)
+                    .unwrap_or(20);
+                self.move_selection(-page);
+            }
+            KeyCode::Home => {
+                if !self.books.is_empty() {
+                    self.list_state.select(Some(0));
+                    self.ensure_detail_loaded();
+                }
+            }
+            KeyCode::End => {
+                if !self.books.is_empty() {
+                    self.list_state.select(Some(self.books.len() - 1));
+                    self.ensure_detail_loaded();
+                }
+            }
+            KeyCode::Char('f') => self.open_filter_popup(),
+            _ => {}
+        }
+    }
+
+    fn handle_filter_key(&mut self, key: event::KeyEvent) {
+        match key.code {
+            KeyCode::Esc | KeyCode::Char('q') => {
+                self.mode = Mode::Normal;
+            }
+            KeyCode::Down | KeyCode::Char('j') => self.move_filter_selection(1),
+            KeyCode::Up | KeyCode::Char('k') => self.move_filter_selection(-1),
+            KeyCode::Enter => {
+                if let Some(i) = self.filter_state.selected()
+                    && let Some(item) = self.filter_items.get(i)
+                    && item.selectable
+                {
+                    self.active_filter = item.filter.clone();
+                    self.refresh_books();
+                    self.mode = Mode::Normal;
+                }
+            }
+            _ => {}
+        }
+    }
+
+    fn move_selection(&mut self, delta: i32) {
+        if self.books.is_empty() {
+            return;
+        }
+        let current = self.list_state.selected().unwrap_or(0) as i32;
+        let len = self.books.len() as i32;
+        let next = (current + delta).clamp(0, len - 1) as usize;
+        self.list_state.select(Some(next));
+        self.ensure_detail_loaded();
+    }
+
+    fn move_filter_selection(&mut self, delta: i32) {
+        let len = self.filter_items.len();
+        if len == 0 {
+            return;
+        }
+
+        let current = self.filter_state.selected().unwrap_or(0) as i32;
+        let mut next = (current + delta).rem_euclid(len as i32) as usize;
+
+        // Skip non-selectable header items
+        let mut attempts = 0;
+        while !self.filter_items[next].selectable && attempts < len {
+            next = (next as i32 + delta.signum()).rem_euclid(len as i32) as usize;
+            attempts += 1;
+        }
+
+        self.filter_state.select(Some(next));
+    }
+
+    fn open_filter_popup(&mut self) {
+        let mut items = Vec::new();
+
+        items.push(FilterItem {
+            label: "  All Books".to_string(),
+            filter: Filter::All,
+            selectable: true,
+        });
+
+        // ── Status section
+        items.push(FilterItem {
+            label: "── Status ──".to_string(),
+            filter: Filter::All,
+            selectable: false,
+        });
+        for status in [
+            ReadingStatus::Reading,
+            ReadingStatus::Read,
+            ReadingStatus::WantToRead,
+            ReadingStatus::OnHold,
+            ReadingStatus::Abandoned,
+        ] {
+            let label = match status {
+                ReadingStatus::Reading => "  ◉ Reading",
+                ReadingStatus::Read => "  ✓ Read",
+                ReadingStatus::WantToRead => "  ○ Want to Read",
+                ReadingStatus::OnHold => "  ⏸ On Hold",
+                ReadingStatus::Abandoned => "  ✗ Abandoned",
+            };
+            items.push(FilterItem {
+                label: label.to_string(),
+                filter: Filter::Status(status),
+                selectable: true,
+            });
+        }
+
+        // ── Shelves section
+        if !self.shelves.is_empty() {
+            items.push(FilterItem {
+                label: "── Shelves ──".to_string(),
+                filter: Filter::All,
+                selectable: false,
+            });
+            for shelf in &self.shelves {
+                items.push(FilterItem {
+                    label: format!("  📚 {}", shelf.name),
+                    filter: Filter::Shelf(shelf.name.clone()),
+                    selectable: true,
+                });
+            }
+        }
+
+        // ── Tags section
+        if !self.tags.is_empty() {
+            items.push(FilterItem {
+                label: "── Tags ──".to_string(),
+                filter: Filter::All,
+                selectable: false,
+            });
+            for (tag, count) in &self.tags {
+                items.push(FilterItem {
+                    label: format!("  🏷 {} ({count})", tag.name),
+                    filter: Filter::Tag(tag.name.clone()),
+                    selectable: true,
+                });
+            }
+        }
+
+        self.filter_items = items;
+        self.filter_state = ListState::default();
+
+        // Select the first selectable item
+        if let Some(pos) = self.filter_items.iter().position(|i| i.selectable) {
+            self.filter_state.select(Some(pos));
+        }
+
+        self.mode = Mode::FilterPopup;
+    }
+}
+
+// ── Drawing ─────────────────────────────────────────────────────────────────
+
+fn draw(frame: &mut Frame, app: &mut App) {
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Length(1), // header bar
+            Constraint::Min(5),    // body (list + detail)
+            Constraint::Length(1), // footer / help bar
+        ])
+        .split(frame.area());
+
+    draw_header(frame, chunks[0], app);
+    draw_body(frame, chunks[1], app);
+    draw_footer(frame, chunks[2], app);
+
+    if matches!(app.mode, Mode::FilterPopup) {
+        draw_filter_popup(frame, app);
+    }
+}
+
+fn draw_header(frame: &mut Frame, area: Rect, app: &App) {
+    let title = format!(" 読 Toku ── {} ({}) ", app.active_filter, app.books.len());
+    let bar = Paragraph::new(title).style(
+        Style::default()
+            .bg(Color::DarkGray)
+            .fg(Color::White)
+            .add_modifier(Modifier::BOLD),
+    );
+    frame.render_widget(bar, area);
+}
+
+fn draw_body(frame: &mut Frame, area: Rect, app: &mut App) {
+    let chunks = Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints([Constraint::Percentage(40), Constraint::Percentage(60)])
+        .split(area);
+
+    draw_book_list(frame, chunks[0], app);
+    draw_book_detail(frame, chunks[1], app);
+}
+
+fn draw_book_list(frame: &mut Frame, area: Rect, app: &mut App) {
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_type(BorderType::Rounded)
+        .title(" Library ");
+
+    if app.books.is_empty() {
+        let msg = Paragraph::new(
+            "\n  No books found.\n\n  Import with:\n    toku import goodreads <file>\n\n  Or add manually:\n    toku add --isbn <isbn>",
+        )
+        .style(Style::default().fg(Color::DarkGray))
+        .block(block);
+        frame.render_widget(msg, area);
+        return;
+    }
+
+    let max_title = area.width.saturating_sub(7) as usize; // borders + icon + padding
+
+    let items: Vec<ListItem> = app
+        .books
+        .iter()
+        .map(|book| {
+            let (icon, icon_color) = match book.status {
+                ReadingStatus::Read => ("✓", Color::Green),
+                ReadingStatus::Reading => ("◉", Color::Yellow),
+                ReadingStatus::WantToRead => ("○", Color::DarkGray),
+                ReadingStatus::Abandoned => ("✗", Color::Red),
+                ReadingStatus::OnHold => ("⏸", Color::Magenta),
+            };
+
+            let title = truncate_str(&book.title, max_title);
+
+            ListItem::new(Line::from(vec![
+                Span::styled(format!("{icon} "), Style::default().fg(icon_color)),
+                Span::raw(title),
+            ]))
+        })
+        .collect();
+
+    let list = List::new(items)
+        .block(block)
+        .highlight_style(
+            Style::default()
+                .bg(Color::Blue)
+                .fg(Color::White)
+                .add_modifier(Modifier::BOLD),
+        )
+        .highlight_symbol("▸ ");
+
+    frame.render_stateful_widget(list, area, &mut app.list_state);
+}
+
+fn draw_book_detail(frame: &mut Frame, area: Rect, app: &App) {
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_type(BorderType::Rounded)
+        .title(" Details ");
+
+    let inner = block.inner(area);
+    frame.render_widget(block, area);
+
+    let idx = match app.list_state.selected() {
+        Some(i) if i < app.books.len() => i,
+        _ => {
+            let msg = Paragraph::new("  Select a book to view details")
+                .style(Style::default().fg(Color::DarkGray));
+            frame.render_widget(msg, inner);
+            return;
+        }
+    };
+
+    let book = &app.books[idx];
+    let detail = match &app.detail {
+        Some(d) => d,
+        None => return,
+    };
+
+    let content_width = inner.width.saturating_sub(2) as usize;
+    let label_w = 10;
+
+    let mut lines: Vec<Line> = Vec::new();
+
+    // Title
+    lines.push(Line::from(vec![
+        Span::styled("Title     ", Style::default().fg(Color::DarkGray)),
+        Span::styled(
+            book.title.clone(),
+            Style::default().add_modifier(Modifier::BOLD),
+        ),
+    ]));
+
+    if let Some(ref sub) = book.subtitle {
+        lines.push(Line::from(vec![
+            Span::raw("          "),
+            Span::styled(
+                sub.clone(),
+                Style::default()
+                    .fg(Color::DarkGray)
+                    .add_modifier(Modifier::ITALIC),
+            ),
+        ]));
+    }
+
+    // Author
+    let author_text = if detail.authors.is_empty() {
+        "—".to_string()
+    } else {
+        detail.authors.join(", ")
+    };
+    lines.push(Line::from(vec![
+        Span::styled("Author    ", Style::default().fg(Color::DarkGray)),
+        Span::raw(author_text),
+    ]));
+
+    lines.push(Line::from(""));
+
+    // Status
+    let (status_label, status_color) = match book.status {
+        ReadingStatus::Read => ("Read", Color::Green),
+        ReadingStatus::Reading => ("Reading", Color::Yellow),
+        ReadingStatus::WantToRead => ("Want to Read", Color::Blue),
+        ReadingStatus::Abandoned => ("DNF", Color::Red),
+        ReadingStatus::OnHold => ("On Hold", Color::Magenta),
+    };
+    lines.push(Line::from(vec![
+        Span::styled("Status    ", Style::default().fg(Color::DarkGray)),
+        Span::styled(status_label, Style::default().fg(status_color)),
+    ]));
+
+    // Format + pages/duration
+    let format_label = match book.format {
+        BookFormat::Physical => "Print",
+        BookFormat::Ebook => "Ebook",
+        BookFormat::Audiobook => "Audio",
+    };
+    let format_detail = match (book.page_count, book.duration_minutes) {
+        (Some(p), _) => format!("{format_label} · {p} pages"),
+        (_, Some(d)) => format!("{format_label} · {}h {}m", d / 60, d % 60),
+        _ => format_label.to_string(),
+    };
+    lines.push(Line::from(vec![
+        Span::styled("Format    ", Style::default().fg(Color::DarkGray)),
+        Span::raw(format_detail),
+    ]));
+
+    // Rating
+    if let Some(rating) = book.rating {
+        let stars = rating as f32 / 2.0;
+        let full = stars as usize;
+        let half = (stars - full as f32) >= 0.4;
+        let mut star_str = "★".repeat(full);
+        if half {
+            star_str.push('½');
+        }
+        let filled = full + usize::from(half);
+        star_str.push_str(&"☆".repeat(5usize.saturating_sub(filled)));
+
+        lines.push(Line::from(vec![
+            Span::styled("Rating    ", Style::default().fg(Color::DarkGray)),
+            Span::styled(star_str, Style::default().fg(Color::Yellow)),
+            Span::raw(format!(" ({:.1})", stars)),
+        ]));
+    }
+
+    // Pub date
+    if let Some(ref date) = book.pub_date {
+        lines.push(Line::from(vec![
+            Span::styled("Published ", Style::default().fg(Color::DarkGray)),
+            Span::raw(date.clone()),
+        ]));
+    }
+
+    // Language
+    if let Some(ref lang) = book.language {
+        lines.push(Line::from(vec![
+            Span::styled("Language  ", Style::default().fg(Color::DarkGray)),
+            Span::raw(lang.clone()),
+        ]));
+    }
+
+    // ISBNs
+    if !detail.isbns.is_empty() {
+        lines.push(Line::from(vec![
+            Span::styled("ISBN      ", Style::default().fg(Color::DarkGray)),
+            Span::raw(detail.isbns.join(", ")),
+        ]));
+    }
+
+    // Shelves & Tags
+    if !detail.shelves.is_empty() || !detail.tags.is_empty() {
+        lines.push(Line::from(""));
+    }
+
+    if !detail.shelves.is_empty() {
+        lines.push(Line::from(vec![
+            Span::styled("Shelves   ", Style::default().fg(Color::DarkGray)),
+            Span::raw(detail.shelves.join(", ")),
+        ]));
+    }
+
+    if !detail.tags.is_empty() {
+        lines.push(Line::from(vec![
+            Span::styled("Tags      ", Style::default().fg(Color::DarkGray)),
+            Span::raw(detail.tags.join(", ")),
+        ]));
+    }
+
+    // Description (word-wrapped by Paragraph)
+    if let Some(ref desc) = book.description {
+        lines.push(Line::from(""));
+        // Truncate extremely long descriptions to keep the TUI responsive
+        let max_chars = content_width.saturating_add(label_w) * 15;
+        let display_desc = truncate_str(desc, max_chars);
+        lines.push(Line::from(Span::styled(
+            display_desc,
+            Style::default().fg(Color::DarkGray),
+        )));
+    }
+
+    let paragraph = Paragraph::new(lines).wrap(Wrap { trim: true });
+    frame.render_widget(paragraph, inner);
+}
+
+fn draw_footer(frame: &mut Frame, area: Rect, app: &App) {
+    let help = match app.mode {
+        Mode::Normal => " ↑↓/jk Navigate │ PgUp/PgDn Page │ f Filter │ Home/End Jump │ q Quit ",
+        Mode::FilterPopup => " ↑↓ Select │ Enter Apply │ Esc Cancel ",
+    };
+    let bar = Paragraph::new(help)
+        .style(Style::default().fg(Color::DarkGray))
+        .alignment(Alignment::Center);
+    frame.render_widget(bar, area);
+}
+
+fn draw_filter_popup(frame: &mut Frame, app: &mut App) {
+    let area = frame.area();
+    let popup_w = 36u16.min(area.width.saturating_sub(4));
+    let popup_h = (app.filter_items.len() as u16 + 2).min(area.height.saturating_sub(4));
+    let popup = Rect::new(
+        area.width.saturating_sub(popup_w) / 2,
+        area.height.saturating_sub(popup_h) / 2,
+        popup_w,
+        popup_h,
+    );
+
+    frame.render_widget(Clear, popup);
+
+    let items: Vec<ListItem> = app
+        .filter_items
+        .iter()
+        .map(|fi| {
+            let style = if fi.selectable {
+                Style::default()
+            } else {
+                Style::default()
+                    .fg(Color::DarkGray)
+                    .add_modifier(Modifier::BOLD)
+            };
+            ListItem::new(fi.label.as_str()).style(style)
+        })
+        .collect();
+
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_type(BorderType::Rounded)
+        .title(" Filter ")
+        .title_alignment(Alignment::Center)
+        .style(Style::default().bg(Color::Black));
+
+    let list = List::new(items).block(block).highlight_style(
+        Style::default()
+            .bg(Color::Blue)
+            .fg(Color::White)
+            .add_modifier(Modifier::BOLD),
+    );
+
+    frame.render_stateful_widget(list, popup, &mut app.filter_state);
+}
+
+// ── Entry point ─────────────────────────────────────────────────────────────
+
+/// Launch the interactive TUI browser.
+pub fn run(repo: &BookRepository) -> Result<()> {
+    if !io::stdout().is_terminal() {
+        anyhow::bail!(
+            "TUI requires an interactive terminal. Use 'toku list' for non-interactive output."
+        );
+    }
+
+    terminal::enable_raw_mode()?;
+    crossterm::execute!(io::stdout(), EnterAlternateScreen)?;
+
+    // RAII guard: even if we panic, the terminal is restored
+    let _guard = TerminalGuard;
+
+    let backend = CrosstermBackend::new(io::stdout());
+    let mut terminal = Terminal::new(backend)?;
+    terminal.clear()?;
+
+    let mut app = App::new(repo)?;
+
+    while app.running {
+        terminal.draw(|frame| draw(frame, &mut app))?;
+
+        if event::poll(std::time::Duration::from_millis(50))?
+            && let Event::Key(key) = event::read()?
+        {
+            app.handle_key(key);
+        }
+    }
+
+    Ok(())
+}

--- a/crates/toku-cli/src/tui.rs
+++ b/crates/toku-cli/src/tui.rs
@@ -243,17 +243,13 @@ impl<'a> App<'a> {
                     .unwrap_or(20);
                 self.move_selection(-page);
             }
-            KeyCode::Home => {
-                if !self.books.is_empty() {
-                    self.list_state.select(Some(0));
-                    self.ensure_detail_loaded();
-                }
+            KeyCode::Home if !self.books.is_empty() => {
+                self.list_state.select(Some(0));
+                self.ensure_detail_loaded();
             }
-            KeyCode::End => {
-                if !self.books.is_empty() {
-                    self.list_state.select(Some(self.books.len() - 1));
-                    self.ensure_detail_loaded();
-                }
+            KeyCode::End if !self.books.is_empty() => {
+                self.list_state.select(Some(self.books.len() - 1));
+                self.ensure_detail_loaded();
             }
             KeyCode::Char('f') => self.open_filter_popup(),
             _ => {}

--- a/crates/toku-import/src/goodreads.rs
+++ b/crates/toku-import/src/goodreads.rs
@@ -15,6 +15,41 @@ pub struct GoodreadsImportOptions {
     pub dry_run: bool,
 }
 
+/// The outcome of processing a single row.
+#[derive(Debug, Clone)]
+pub enum RowOutcome {
+    Imported,
+    Skipped,
+    Error(String),
+}
+
+/// Progress event emitted for each row during import.
+#[derive(Debug, Clone)]
+pub struct ImportEvent {
+    pub row: usize,
+    pub total: usize,
+    pub title: String,
+    pub author: String,
+    pub status: String,
+    pub outcome: RowOutcome,
+}
+
+/// Trait for observing import progress. Implement this to receive per-row
+/// events during an import (e.g. to drive a progress bar).
+pub trait ImportObserver {
+    fn on_event(&mut self, event: &ImportEvent) -> Result<(), ImportError>;
+}
+
+/// A short summary of a skipped or imported row, kept for the final report.
+#[derive(Debug, Clone)]
+pub struct RowSummary {
+    pub title: String,
+    pub author: String,
+    pub status: String,
+}
+
+const MAX_REPORT_SAMPLES: usize = 20;
+
 /// Summary report of an import operation.
 #[derive(Debug, Default)]
 pub struct ImportReport {
@@ -24,6 +59,12 @@ pub struct ImportReport {
     pub errors: usize,
     pub error_details: Vec<String>,
     pub import_id: Option<String>,
+    /// Bounded sample of imported books (capped at 20).
+    pub imported_samples: Vec<RowSummary>,
+    /// Bounded sample of skipped (duplicate) books (capped at 20).
+    pub skipped_samples: Vec<RowSummary>,
+    /// Counts of imported books by reading status.
+    pub status_counts: HashMap<String, usize>,
 }
 
 impl std::fmt::Display for ImportReport {
@@ -46,19 +87,46 @@ impl std::fmt::Display for ImportReport {
     }
 }
 
+/// Count the number of data rows in a CSV file (excludes the header).
+fn count_csv_rows(csv_path: &Path) -> Result<usize, ImportError> {
+    let mut rdr = ReaderBuilder::new()
+        .has_headers(true)
+        .flexible(true)
+        .from_path(csv_path)?;
+    Ok(rdr.records().count())
+}
+
 /// Import books from a Goodreads CSV export.
+///
+/// If an `observer` is provided, it will be called with progress events for
+/// each row processed, enabling progress bars and live feedback.
 pub fn import_goodreads(
     db: &Database,
     csv_path: &Path,
     opts: &GoodreadsImportOptions,
+    observer: Option<&mut dyn ImportObserver>,
+) -> Result<ImportReport, ImportError> {
+    let total_rows = count_csv_rows(csv_path)?;
+    import_goodreads_inner(db, csv_path, opts, observer, total_rows)
+}
+
+fn import_goodreads_inner(
+    db: &Database,
+    csv_path: &Path,
+    opts: &GoodreadsImportOptions,
+    mut observer: Option<&mut dyn ImportObserver>,
+    total_rows: usize,
 ) -> Result<ImportReport, ImportError> {
     let repo = BookRepository::new(db);
     let mut report = ImportReport::default();
 
     let import_id = Uuid::now_v7().to_string();
 
-    // Create import log entry (unless dry run)
+    // Wrap non-dry-run imports in a transaction for atomicity
     if !opts.dry_run {
+        db.conn.execute_batch("BEGIN IMMEDIATE")?;
+
+        // Create import log entry (rows will reference this via FK)
         db.conn.execute(
             "INSERT INTO import_logs (id, source, file_path, started_at, total_rows)
              VALUES (?1, 'goodreads', ?2, ?3, 0)",
@@ -70,6 +138,57 @@ pub fn import_goodreads(
         )?;
     }
 
+    let result = import_rows(
+        db,
+        &repo,
+        csv_path,
+        opts,
+        &mut report,
+        &import_id,
+        &mut observer,
+        total_rows,
+    );
+
+    if !opts.dry_run {
+        match &result {
+            Ok(()) => {
+                // Finalize import log and commit
+                db.conn.execute(
+                    "UPDATE import_logs SET finished_at = ?1, total_rows = ?2,
+                     imported = ?3, skipped = ?4, errors = ?5 WHERE id = ?6",
+                    params![
+                        Utc::now().to_rfc3339(),
+                        report.total_rows as i64,
+                        report.imported as i64,
+                        report.skipped as i64,
+                        report.errors as i64,
+                        import_id,
+                    ],
+                )?;
+                report.import_id = Some(import_id);
+                db.conn.execute_batch("COMMIT")?;
+            }
+            Err(_) => {
+                db.conn.execute_batch("ROLLBACK").ok();
+            }
+        }
+    }
+
+    result?;
+    Ok(report)
+}
+
+#[allow(clippy::too_many_arguments)]
+fn import_rows(
+    db: &Database,
+    repo: &BookRepository,
+    csv_path: &Path,
+    opts: &GoodreadsImportOptions,
+    report: &mut ImportReport,
+    import_id: &str,
+    observer: &mut Option<&mut dyn ImportObserver>,
+    total_rows: usize,
+) -> Result<(), ImportError> {
     let mut rdr = ReaderBuilder::new()
         .has_headers(true)
         .flexible(true)
@@ -126,10 +245,20 @@ pub fn import_goodreads(
         let record = match result {
             Ok(r) => r,
             Err(e) => {
+                let err_msg = format!("Row {}: CSV parse error: {e}", report.total_rows);
                 report.errors += 1;
-                report
-                    .error_details
-                    .push(format!("Row {}: CSV parse error: {e}", report.total_rows));
+                if report.error_details.len() < MAX_REPORT_SAMPLES {
+                    report.error_details.push(err_msg);
+                }
+                emit_event(
+                    observer,
+                    report.total_rows,
+                    total_rows,
+                    "",
+                    "",
+                    "",
+                    RowOutcome::Error(format!("CSV parse error: {e}")),
+                )?;
                 continue;
             }
         };
@@ -144,33 +273,73 @@ pub fn import_goodreads(
             Some(t) => t,
             None => {
                 report.errors += 1;
-                report
-                    .error_details
-                    .push(format!("Row {}: missing title", report.total_rows));
+                if report.error_details.len() < MAX_REPORT_SAMPLES {
+                    report
+                        .error_details
+                        .push(format!("Row {}: missing title", report.total_rows));
+                }
+                emit_event(
+                    observer,
+                    report.total_rows,
+                    total_rows,
+                    "",
+                    "",
+                    "",
+                    RowOutcome::Error("missing title".to_string()),
+                )?;
                 continue;
             }
         };
 
         let gr_id = get(col_book_id);
+        let author_name = get(col_author).unwrap_or_default();
+        let status_str = get(col_exclusive)
+            .map(|s| map_shelf_to_status(&s).as_str().to_string())
+            .unwrap_or_else(|| "want-to-read".to_string());
 
         // Dedup: skip if goodreads_id already exists
         if let Some(ref id) = gr_id
             && existing_gr_ids.contains_key(id)
         {
             report.skipped += 1;
+            if report.skipped_samples.len() < MAX_REPORT_SAMPLES {
+                report.skipped_samples.push(RowSummary {
+                    title: title.clone(),
+                    author: author_name.clone(),
+                    status: status_str.clone(),
+                });
+            }
+            emit_event(
+                observer,
+                report.total_rows,
+                total_rows,
+                &title,
+                &author_name,
+                &status_str,
+                RowOutcome::Skipped,
+            )?;
             continue;
         }
 
         if opts.dry_run {
-            let author = get(col_author).unwrap_or_default();
-            let status = get(col_exclusive)
-                .map(|s| map_shelf_to_status(&s).as_str().to_string())
-                .unwrap_or_else(|| "want-to-read".to_string());
-            eprintln!(
-                "  [dry-run] Would import: \"{}\" by {} ({})",
-                title, author, status
-            );
             report.imported += 1;
+            *report.status_counts.entry(status_str.clone()).or_insert(0) += 1;
+            if report.imported_samples.len() < MAX_REPORT_SAMPLES {
+                report.imported_samples.push(RowSummary {
+                    title: title.clone(),
+                    author: author_name.clone(),
+                    status: status_str.clone(),
+                });
+            }
+            emit_event(
+                observer,
+                report.total_rows,
+                total_rows,
+                &title,
+                &author_name,
+                &status_str,
+                RowOutcome::Imported,
+            )?;
             continue;
         }
 
@@ -209,7 +378,7 @@ pub fn import_goodreads(
             book.format = map_binding_to_format(&binding);
         }
 
-        // Set goodreads_id
+        // Insert book with goodreads_id
         db.conn.execute(
             "INSERT INTO books (id, title, subtitle, description, page_count, pub_date,
              language, format, duration_minutes, cover_hash, work_id, status, rating,
@@ -254,7 +423,7 @@ pub fn import_goodreads(
         }
 
         // Author
-        if let Some(author_name) = get(col_author) {
+        if let Some(ref author_name) = get(col_author) {
             let a = Author::new(author_name.as_str());
             repo.add_book_author(&a, &book.id, ContributorRole::Author, 0)?;
         }
@@ -292,27 +461,51 @@ pub fn import_goodreads(
             existing_gr_ids.insert(id.clone(), book.id);
         }
 
+        let book_status = book.status.as_str().to_string();
         report.imported += 1;
-    }
+        *report.status_counts.entry(book_status.clone()).or_insert(0) += 1;
+        if report.imported_samples.len() < MAX_REPORT_SAMPLES {
+            report.imported_samples.push(RowSummary {
+                title: title.clone(),
+                author: author_name.clone(),
+                status: book_status.clone(),
+            });
+        }
 
-    // Finalize import log
-    if !opts.dry_run {
-        db.conn.execute(
-            "UPDATE import_logs SET finished_at = ?1, total_rows = ?2,
-             imported = ?3, skipped = ?4, errors = ?5 WHERE id = ?6",
-            params![
-                Utc::now().to_rfc3339(),
-                report.total_rows as i64,
-                report.imported as i64,
-                report.skipped as i64,
-                report.errors as i64,
-                import_id,
-            ],
+        emit_event(
+            observer,
+            report.total_rows,
+            total_rows,
+            &title,
+            &author_name,
+            &book_status,
+            RowOutcome::Imported,
         )?;
-        report.import_id = Some(import_id);
     }
 
-    Ok(report)
+    Ok(())
+}
+
+fn emit_event(
+    observer: &mut Option<&mut dyn ImportObserver>,
+    row: usize,
+    total: usize,
+    title: &str,
+    author: &str,
+    status: &str,
+    outcome: RowOutcome,
+) -> Result<(), ImportError> {
+    if let Some(obs) = observer {
+        obs.on_event(&ImportEvent {
+            row,
+            total,
+            title: title.to_string(),
+            author: author.to_string(),
+            status: status.to_string(),
+            outcome,
+        })?;
+    }
+    Ok(())
 }
 
 /// Undo an import by removing all books added by it.
@@ -392,8 +585,13 @@ mod tests {
         let csv_path = write_test_csv(tmp.path());
         let db = Database::open_in_memory().unwrap();
 
-        let report =
-            import_goodreads(&db, &csv_path, &GoodreadsImportOptions { dry_run: false }).unwrap();
+        let report = import_goodreads(
+            &db,
+            &csv_path,
+            &GoodreadsImportOptions { dry_run: false },
+            None,
+        )
+        .unwrap();
 
         assert_eq!(report.total_rows, 3);
         assert_eq!(report.imported, 3);
@@ -431,12 +629,22 @@ mod tests {
         let csv_path = write_test_csv(tmp.path());
         let db = Database::open_in_memory().unwrap();
 
-        let r1 =
-            import_goodreads(&db, &csv_path, &GoodreadsImportOptions { dry_run: false }).unwrap();
+        let r1 = import_goodreads(
+            &db,
+            &csv_path,
+            &GoodreadsImportOptions { dry_run: false },
+            None,
+        )
+        .unwrap();
         assert_eq!(r1.imported, 3);
 
-        let r2 =
-            import_goodreads(&db, &csv_path, &GoodreadsImportOptions { dry_run: false }).unwrap();
+        let r2 = import_goodreads(
+            &db,
+            &csv_path,
+            &GoodreadsImportOptions { dry_run: false },
+            None,
+        )
+        .unwrap();
         assert_eq!(r2.imported, 0);
         assert_eq!(r2.skipped, 3);
 
@@ -450,8 +658,13 @@ mod tests {
         let csv_path = write_test_csv(tmp.path());
         let db = Database::open_in_memory().unwrap();
 
-        let report =
-            import_goodreads(&db, &csv_path, &GoodreadsImportOptions { dry_run: true }).unwrap();
+        let report = import_goodreads(
+            &db,
+            &csv_path,
+            &GoodreadsImportOptions { dry_run: true },
+            None,
+        )
+        .unwrap();
         assert_eq!(report.imported, 3);
 
         let repo = BookRepository::new(&db);
@@ -464,8 +677,13 @@ mod tests {
         let csv_path = write_test_csv(tmp.path());
         let db = Database::open_in_memory().unwrap();
 
-        let report =
-            import_goodreads(&db, &csv_path, &GoodreadsImportOptions { dry_run: false }).unwrap();
+        let report = import_goodreads(
+            &db,
+            &csv_path,
+            &GoodreadsImportOptions { dry_run: false },
+            None,
+        )
+        .unwrap();
         assert_eq!(report.imported, 3);
         let import_id = report.import_id.unwrap();
 
@@ -483,7 +701,13 @@ mod tests {
         let csv_path = write_test_csv(tmp.path());
         let db = Database::open_in_memory().unwrap();
 
-        import_goodreads(&db, &csv_path, &GoodreadsImportOptions { dry_run: false }).unwrap();
+        import_goodreads(
+            &db,
+            &csv_path,
+            &GoodreadsImportOptions { dry_run: false },
+            None,
+        )
+        .unwrap();
 
         let repo = BookRepository::new(&db);
         let books = repo.list_books().unwrap();

--- a/crates/toku-import/src/lib.rs
+++ b/crates/toku-import/src/lib.rs
@@ -4,4 +4,7 @@ mod goodreads;
 
 pub use calibre::{CalibreImportOptions, import_calibre};
 pub use error::ImportError;
-pub use goodreads::{GoodreadsImportOptions, ImportReport, import_goodreads, undo_import};
+pub use goodreads::{
+    GoodreadsImportOptions, ImportEvent, ImportObserver, ImportReport, RowOutcome, RowSummary,
+    import_goodreads, undo_import,
+};


### PR DESCRIPTION
## Description

Add an interactive TUI library browser and overhauled import experience to Toku.

### What's included

- **Interactive TUI browser** — running `toku` with no subcommand (or `toku browse`) launches a full-screen ratatui interface with a split-pane layout: scrollable book list on the left, live detail view on the right. A filter popup (`f` key) lets users narrow by reading status, shelf, or tag. Keyboard-driven with vim-style navigation (`j/k`, `PgUp/PgDn`, `Home/End`).

- **Import progress UI** — `toku import goodreads` now shows a live ratatui progress bar on stderr with per-row activity log, colored outcome indicators (imported/skipped/error), and a structured summary with status breakdown and sample lists. Non-interactive terminals fall back to a plain-text summary.

- **Observer pattern for imports** — the Goodreads importer emits `ImportEvent` callbacks via an `ImportObserver` trait, enabling the TUI progress bar without coupling the import logic to any specific UI.

- **Transaction wrapping** — non-dry-run Goodreads imports are wrapped in a SQLite transaction (`BEGIN IMMEDIATE` / `COMMIT` / `ROLLBACK`) for atomicity.

- **Width-aware list output** — `toku list` dynamically sizes Title and Author columns to the terminal width with modern rounded borders and shorter status/format labels.

- **Multibyte truncation fix** — string truncation now operates on character boundaries, preventing panics on non-ASCII book titles and descriptions.

## Related Issues

None

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI / infrastructure
- [ ] Other (describe below)

## Crate

- [ ] `toku-core` — Domain models, traits, state machine
- [ ] `toku-db` — SQLite persistence, migrations, FTS5
- [x] `toku-import` — Importers (Goodreads, Calibre, StoryGraph)
- [ ] `toku-meta` — Metadata fetching (Open Library, Google Books)
- [x] `toku-cli` — CLI binary
- [ ] `toku-export` — Exporters (CSV, JSON, Markdown, BibTeX)
- [ ] `docs/` — Documentation

## Data Integrity Checklist

- [x] No user data is sent to any server without explicit opt-in
- [x] Import operations are idempotent (re-importing the same file creates no duplicates)
- [x] User edits to metadata are never overwritten by auto-enrichment
- [x] New fields track provenance (source + timestamp)
- [x] Export round-trip is preserved (if applicable)

## Checklist

- [x] I have read [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] `cargo fmt --check` passes
- [x] `cargo clippy --workspace -- -D warnings` passes
- [x] `cargo test --workspace` passes
- [ ] I have updated documentation (if applicable)