### PR TITLE
feat: TUI browser, bulk ops, shelf-to-tag merge, and Goodreads tag import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,15 +10,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Interactive TUI library browser (`toku browse`, or just `toku` with no subcommand) with split-pane layout: scrollable book list on the left, live detail view on the right
-- Filter popup in TUI browser to narrow books by reading status, shelf, or tag
+- Tag display in TUI book detail pane with styled cyan labels
+- Filter popup in TUI browser to narrow books by reading status or tag
 - Ratatui-based import progress UI with live progress bar, per-row activity log, and colored status indicators
-- Structured import summary with status breakdown, sample lists of imported/skipped books, and undo instructions
+- Structured import summary with status breakdown, sample lists of imported/skipped/updated books, and undo instructions
 - Width-aware `toku list` table output that adapts columns to terminal width with modern rounded borders
+- Open Library search: `toku search --online <query>` searches the Open Library API and displays results with ISBNs for easy adding
+- Bulk operations: `toku bulk tag|status|delete` for applying tags, changing status, or deleting multiple books at once, with `--dry-run` and filter flags (`--status`, `--tag`)
+- `toku add --tag <tag>` (`-T`) flag to apply tags when adding a book
+- `toku add --status <status>` flag to set reading status when adding a book (creates a reading session automatically for `--status reading`)
+- Goodreads import now converts the `Bookshelves` CSV column into tags, preserving user shelf organization
+- Goodreads re-import updates tags on existing books instead of silently skipping them (shown as `Updated` in progress UI)
+- Non-standard Goodreads exclusive shelves (e.g., custom shelves like "favorites") are preserved as tags to avoid data loss
 
 ### Changed
 
 - Goodreads importer now uses observer pattern for progress reporting and wraps non-dry-run imports in a transaction for atomicity
-- Import report includes bounded sample lists (up to 20) of imported and skipped books with status counts
+- Import report includes bounded sample lists (up to 20) of imported, updated, and skipped books with status counts
+- Shelves merged into tags — all user-created groupings are now tags; `ReadingStatus` remains as the separate state machine for tracking reading progress
+- Removed `toku shelf` command — use `toku tag` instead (existing shelf data migrated to tags via DB migration V8)
+- Removed `--shelf` filter from `toku list` and `toku search` — use `--tag` instead
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -11,14 +11,17 @@ on your machine.
 
 ```sh
 toku add --isbn 9780441013593          # Add a book by ISBN
+toku add --title "Dune" -T sci-fi      # Add with tags
 toku import goodreads ~/export.csv     # Import your Goodreads library
 toku reading start "Dune" --page 1     # Start tracking progress
 toku reading update "Dune" --page 145  # Log where you are
 toku reading finish "Dune" --rating 5  # Done — rate it
 toku stats --year 2025                 # See your reading stats
+toku browse                            # Interactive TUI browser
 ```
 
-> **Status**: Early development. Not yet usable.
+> **Status**: Early development — functional CLI with import, tracking, search,
+> TUI browser, and export. Usable for personal reading management.
 
 ---
 
@@ -53,17 +56,17 @@ their ever-growing libraries.
   interfaces are planned for later — built on the same core library.
 - **Open source.** MIT licensed. Contributions welcome.
 
-## Features (Planned)
+## Features
 
-- 📖 Add books manually, by ISBN, or by search
+- 📖 Add books manually, by ISBN, or by Open Library search
 - 📊 Reading progress tracking (pages, percentage, chapters, audiobook time)
-- 🏷️ Shelves, tags, mood tags, and smart filters
-- 📈 Reading statistics and analytics (pace, streaks, genre distribution, yearly wrap-up)
-- 📥 Import from Goodreads CSV, Calibre, StoryGraph
-- 📤 Export to CSV, JSON, Markdown, BibTeX
-- 🔍 Full-text search across your entire library
-- 🎯 Reading goals and challenges
-- 🎧 Audiobook support (narrator, duration, time-based progress)
+- 🏷️ Tags for organizing your library (imported Goodreads shelves become tags)
+- 📈 Reading statistics and analytics (pace, format breakdown, yearly filtering)
+- 📥 Import from Goodreads CSV and Calibre (with dry-run, dedup, and tag preservation)
+- 📤 Export to CSV, JSON, Markdown, and canonical backup (ZIP)
+- 🔍 Full-text search across your entire library (titles, authors, descriptions)
+- 🖥️ Interactive TUI browser with split-pane layout, filters, and live detail view
+- 🔄 Bulk operations for tagging, status changes, and deletions across filtered sets
 
 ## Tech Stack
 

--- a/crates/toku-cli/src/import_ui.rs
+++ b/crates/toku-cli/src/import_ui.rs
@@ -69,6 +69,7 @@ struct ImportProgressState {
     current: usize,
     total: usize,
     imported: usize,
+    updated: usize,
     skipped: usize,
     errors: usize,
     recent: Vec<ActivityEntry>,
@@ -81,6 +82,7 @@ impl ImportProgressState {
             current: 0,
             total,
             imported: 0,
+            updated: 0,
             skipped: 0,
             errors: 0,
             recent: Vec::with_capacity(ACTIVITY_LOG_SIZE),
@@ -92,6 +94,7 @@ impl ImportProgressState {
         self.current = event.row;
         match &event.outcome {
             RowOutcome::Imported => self.imported += 1,
+            RowOutcome::Updated => self.updated += 1,
             RowOutcome::Skipped => self.skipped += 1,
             RowOutcome::Error(_) => self.errors += 1,
         }
@@ -204,6 +207,7 @@ fn render_progress_bar(frame: &mut Frame, area: Rect, state: &ImportProgressStat
 
 fn render_stats(frame: &mut Frame, area: Rect, state: &ImportProgressState) {
     let imported_style = Style::default().fg(Color::Green).bold();
+    let updated_style = Style::default().fg(Color::Cyan).bold();
     let skipped_style = Style::default().fg(Color::Yellow).bold();
     let error_style = Style::default().fg(Color::Red).bold();
     let label_style = Style::default().fg(Color::Gray);
@@ -213,6 +217,10 @@ fn render_stats(frame: &mut Frame, area: Rect, state: &ImportProgressState) {
         Span::styled("✓ ", imported_style),
         Span::styled("Imported ", label_style),
         Span::styled(format!("{:<6}", state.imported), imported_style),
+        Span::raw("   "),
+        Span::styled("⟳ ", updated_style),
+        Span::styled("Updated ", label_style),
+        Span::styled(format!("{:<6}", state.updated), updated_style),
         Span::raw("   "),
         Span::styled("↷ ", skipped_style),
         Span::styled("Duplicates ", label_style),
@@ -251,6 +259,7 @@ fn render_activity_log(frame: &mut Frame, area: Rect, state: &ImportProgressStat
         .map(|entry| {
             let (icon, icon_style) = match &entry.outcome {
                 RowOutcome::Imported => ("✓ ", Style::default().fg(Color::Green)),
+                RowOutcome::Updated => ("⟳ ", Style::default().fg(Color::Cyan)),
                 RowOutcome::Skipped => ("↷ ", Style::default().fg(Color::Yellow)),
                 RowOutcome::Error(_) => ("✗ ", Style::default().fg(Color::Red)),
             };
@@ -264,12 +273,14 @@ fn render_activity_log(frame: &mut Frame, area: Rect, state: &ImportProgressStat
 
             let right_label = match &entry.outcome {
                 RowOutcome::Imported => entry.status.clone(),
+                RowOutcome::Updated => "(tags updated)".to_string(),
                 RowOutcome::Skipped => "(duplicate)".to_string(),
                 RowOutcome::Error(e) => truncate_str(e, 30),
             };
 
             let right_style = match &entry.outcome {
                 RowOutcome::Imported => Style::default().fg(Color::DarkGray),
+                RowOutcome::Updated => Style::default().fg(Color::Cyan),
                 RowOutcome::Skipped => Style::default().fg(Color::Yellow),
                 RowOutcome::Error(_) => Style::default().fg(Color::Red),
             };
@@ -390,6 +401,13 @@ fn print_summary_table(report: &ImportReport, dry_run: bool) {
     // Main stats
     let status_label = if dry_run { "Would import" } else { "Imported" };
     eprintln!("    {:<14} {:>4} books", status_label, report.imported);
+    if report.updated > 0 {
+        let update_label = if dry_run { "Would update" } else { "Updated" };
+        eprintln!(
+            "    {:<14} {:>4} (tags added to existing books)",
+            update_label, report.updated
+        );
+    }
     if report.skipped > 0 {
         eprintln!(
             "    {:<14} {:>4} (already in library)",
@@ -417,6 +435,25 @@ fn print_summary_table(report: &ImportReport, dry_run: bool) {
                 other => other,
             };
             eprintln!("    {:<20} {:>4}", label, count);
+        }
+    }
+
+    // Updated books sample
+    if !report.updated_samples.is_empty() {
+        eprintln!("\n  Tags updated on existing books:");
+        for s in &report.updated_samples {
+            let author = if s.author.is_empty() {
+                String::new()
+            } else {
+                format!(" — {}", s.author)
+            };
+            eprintln!("    ⟳ {}{}", truncate_str(&s.title, 50), author);
+        }
+        if report.updated > report.updated_samples.len() {
+            eprintln!(
+                "    ... and {} more",
+                report.updated - report.updated_samples.len()
+            );
         }
     }
 
@@ -462,10 +499,12 @@ fn print_summary_json(report: &ImportReport, dry_run: bool) {
         dry_run: bool,
         total_rows: usize,
         imported: usize,
+        updated: usize,
         skipped: usize,
         errors: usize,
         import_id: Option<String>,
         error_details: Vec<String>,
+        updated_books: Vec<JsonRowSummary>,
         skipped_books: Vec<JsonRowSummary>,
         imported_books: Vec<JsonRowSummary>,
         status_counts: std::collections::HashMap<String, usize>,
@@ -481,10 +520,20 @@ fn print_summary_json(report: &ImportReport, dry_run: bool) {
         dry_run,
         total_rows: report.total_rows,
         imported: report.imported,
+        updated: report.updated,
         skipped: report.skipped,
         errors: report.errors,
         import_id: report.import_id.clone(),
         error_details: report.error_details.clone(),
+        updated_books: report
+            .updated_samples
+            .iter()
+            .map(|s| JsonRowSummary {
+                title: s.title.clone(),
+                author: s.author.clone(),
+                status: s.status.clone(),
+            })
+            .collect(),
         skipped_books: report
             .skipped_samples
             .iter()
@@ -509,11 +558,12 @@ fn print_summary_json(report: &ImportReport, dry_run: bool) {
 }
 
 fn print_summary_csv(report: &ImportReport) {
-    println!("total_rows,imported,skipped,errors,import_id");
+    println!("total_rows,imported,updated,skipped,errors,import_id");
     println!(
-        "{},{},{},{},{}",
+        "{},{},{},{},{},{}",
         report.total_rows,
         report.imported,
+        report.updated,
         report.skipped,
         report.errors,
         report.import_id.as_deref().unwrap_or(""),

--- a/crates/toku-cli/src/main.rs
+++ b/crates/toku-cli/src/main.rs
@@ -1,4 +1,5 @@
 use std::path::{Path, PathBuf};
+use std::str::FromStr;
 
 use anyhow::{Context, Result};
 use clap::{CommandFactory, Parser, Subcommand, ValueEnum};
@@ -51,6 +52,14 @@ enum Commands {
         /// Book format
         #[arg(long, default_value = "physical")]
         book_format: String,
+
+        /// Tag(s) to apply (repeatable)
+        #[arg(long, short = 'T')]
+        tag: Vec<String>,
+
+        /// Initial reading status (want-to-read, reading, read, abandoned, on-hold)
+        #[arg(long)]
+        status: Option<String>,
     },
 
     /// Show details of a book
@@ -64,10 +73,6 @@ enum Commands {
         /// Filter by reading status
         #[arg(long, short)]
         status: Option<String>,
-
-        /// Filter by shelf name
-        #[arg(long)]
-        shelf: Option<String>,
 
         /// Filter by tag name
         #[arg(long)]
@@ -83,10 +88,6 @@ enum Commands {
         #[arg(long, short)]
         status: Option<String>,
 
-        /// Filter by shelf name
-        #[arg(long)]
-        shelf: Option<String>,
-
         /// Filter by tag name
         #[arg(long)]
         tag: Option<String>,
@@ -96,6 +97,16 @@ enum Commands {
     Import {
         #[command(subcommand)]
         source: ImportSource,
+    },
+
+    /// Search Open Library for books online
+    Lookup {
+        /// Search query (title, author, or keywords)
+        query: String,
+
+        /// Maximum number of results to show
+        #[arg(long, default_value = "10")]
+        limit: usize,
     },
 
     /// Show or edit configuration
@@ -121,12 +132,6 @@ enum Commands {
         action: ReadingAction,
     },
 
-    /// Manage shelves for organizing books
-    Shelf {
-        #[command(subcommand)]
-        action: ShelfAction,
-    },
-
     /// Manage tags for categorizing books
     Tag {
         #[command(subcommand)]
@@ -137,6 +142,12 @@ enum Commands {
     Export {
         #[command(subcommand)]
         target: ExportTarget,
+    },
+
+    /// Bulk operations on multiple books
+    Bulk {
+        #[command(subcommand)]
+        action: BulkAction,
     },
 
     /// Show reading statistics
@@ -250,37 +261,6 @@ enum ReadingAction {
 }
 
 #[derive(Subcommand)]
-enum ShelfAction {
-    /// Create a new shelf
-    Create {
-        /// Shelf name
-        name: String,
-    },
-
-    /// Add books to a shelf
-    Add {
-        /// Shelf name
-        shelf: String,
-
-        /// Book titles to add
-        #[arg(required = true)]
-        books: Vec<String>,
-    },
-
-    /// Remove a book from a shelf
-    Remove {
-        /// Shelf name
-        shelf: String,
-
-        /// Book title to remove
-        book: String,
-    },
-
-    /// List all shelves
-    List,
-}
-
-#[derive(Subcommand)]
 enum TagAction {
     /// Add a tag to books
     Add {
@@ -303,6 +283,60 @@ enum TagAction {
 
     /// List all tags with book counts
     List,
+}
+
+#[derive(Subcommand)]
+enum BulkAction {
+    /// Add a tag to all books matching a filter
+    Tag {
+        /// Tag name to apply
+        tag: String,
+
+        /// Filter by reading status
+        #[arg(long, short)]
+        status: Option<String>,
+
+        /// Filter by existing tag
+        #[arg(long)]
+        existing_tag: Option<String>,
+
+        /// Preview changes without applying
+        #[arg(long)]
+        dry_run: bool,
+    },
+
+    /// Change reading status for all books matching a filter
+    Status {
+        /// New reading status (want-to-read, reading, read, abandoned, on-hold)
+        new_status: String,
+
+        /// Filter by current reading status
+        #[arg(long, short)]
+        status: Option<String>,
+
+        /// Filter by tag
+        #[arg(long)]
+        tag: Option<String>,
+
+        /// Preview changes without applying
+        #[arg(long)]
+        dry_run: bool,
+    },
+
+    /// Delete all books matching a filter
+    Delete {
+        /// Filter by reading status
+        #[arg(long, short)]
+        status: Option<String>,
+
+        /// Filter by tag
+        #[arg(long)]
+        tag: Option<String>,
+
+        /// Preview what would be deleted without actually deleting
+        #[arg(long)]
+        dry_run: bool,
+    },
 }
 
 #[derive(Subcommand)]
@@ -376,6 +410,8 @@ fn main() -> Result<()> {
             author,
             isbn,
             book_format,
+            tag,
+            status,
         } => cmd_add(
             &repo,
             &db_path,
@@ -383,34 +419,27 @@ fn main() -> Result<()> {
             author,
             isbn,
             &book_format,
+            &tag,
+            status.as_deref(),
             &cli.format,
         ),
         Commands::Show { query } => cmd_show(&repo, &query, &cli.format),
-        Commands::List { status, shelf, tag } => cmd_list(
-            &repo,
-            status.as_deref(),
-            shelf.as_deref(),
-            tag.as_deref(),
-            &cli.format,
-        ),
-        Commands::Search {
-            query,
-            status,
-            shelf,
-            tag,
-        } => cmd_search(
+        Commands::List { status, tag } => {
+            cmd_list(&repo, status.as_deref(), tag.as_deref(), &cli.format)
+        }
+        Commands::Search { query, status, tag } => cmd_search(
             &repo,
             &query,
             status.as_deref(),
-            shelf.as_deref(),
             tag.as_deref(),
             &cli.format,
         ),
         Commands::Import { source } => cmd_import(&db, &repo, source, &cli.format),
+        Commands::Lookup { query, limit } => cmd_lookup(&query, limit, &cli.format),
         Commands::Reading { action } => cmd_reading(&repo, action, &cli.format),
-        Commands::Shelf { action } => cmd_shelf(&repo, action, &cli.format),
         Commands::Tag { action } => cmd_tag(&repo, action, &cli.format),
         Commands::Export { target } => cmd_export(&db, &data_dir, target),
+        Commands::Bulk { action } => cmd_bulk(&repo, action),
         Commands::Stats { year } => cmd_stats(&repo, year, &cli.format),
         // Already handled above
         Commands::Config { .. } | Commands::Completions { .. } => unreachable!(),
@@ -458,6 +487,7 @@ fn cmd_config(data_dir: &Path, show_path: bool, open_edit: bool) -> Result<()> {
     Ok(())
 }
 
+#[allow(clippy::too_many_arguments)]
 fn cmd_add(
     repo: &BookRepository,
     db_path: &Path,
@@ -465,11 +495,18 @@ fn cmd_add(
     author: Option<String>,
     isbn: Option<String>,
     book_format: &str,
+    tags: &[String],
+    initial_status: Option<&str>,
     output_format: &OutputFormat,
 ) -> Result<()> {
     let format: BookFormat = book_format
         .parse()
         .with_context(|| format!("invalid format: {book_format}"))?;
+
+    // Parse status early to fail fast before creating the book
+    let target_status = initial_status
+        .map(|s| ReadingStatus::from_str(s).map_err(|_| anyhow::anyhow!("invalid status: {s}")))
+        .transpose()?;
 
     if let Some(isbn_str) = &isbn {
         let validated = Isbn::parse(isbn_str).context("invalid ISBN")?;
@@ -477,7 +514,10 @@ fn cmd_add(
 
         // Check for existing book with this ISBN
         if let Some(existing) = repo.find_by_isbn(&isbn13)? {
-            eprintln!("Book already exists: {} ({})", existing.title, existing.id);
+            // Apply tags/status to existing book instead of silently ignoring
+            apply_post_add(repo, &existing, tags, target_status)?;
+            print_books(&[existing], repo, output_format)?;
+            eprintln!("Book already exists — applied tags/status updates");
             return Ok(());
         }
 
@@ -518,6 +558,7 @@ fn cmd_add(
                     repo.add_book_author(&a, &book.id, ContributorRole::Author, i as i32)?;
                 }
 
+                apply_post_add(repo, &book, tags, target_status)?;
                 print_books(&[book], repo, output_format)?;
                 eprintln!("✓ Added from Open Library");
             }
@@ -528,6 +569,7 @@ fn cmd_add(
                 book.format = format;
                 repo.create_book(&book)?;
                 repo.add_isbn(&isbn13, &book.id)?;
+                apply_post_add(repo, &book, tags, target_status)?;
                 print_books(&[book], repo, output_format)?;
             }
         }
@@ -541,12 +583,37 @@ fn cmd_add(
             repo.add_book_author(&a, &book.id, ContributorRole::Author, 0)?;
         }
 
+        apply_post_add(repo, &book, tags, target_status)?;
         print_books(&[book], repo, output_format)?;
         eprintln!("✓ Added manually");
     } else {
         anyhow::bail!("provide --isbn or --title to add a book");
     }
 
+    Ok(())
+}
+
+/// Apply tags and optional status change after creating/finding a book.
+fn apply_post_add(
+    repo: &BookRepository,
+    book: &Book,
+    tags: &[String],
+    status: Option<ReadingStatus>,
+) -> Result<()> {
+    for tag_name in tags {
+        let trimmed = tag_name.trim();
+        if !trimmed.is_empty() {
+            repo.add_tag_to_book(&book.id, trimmed)?;
+        }
+    }
+    if let Some(target) = status {
+        repo.update_book_status(&book.id, target)?;
+        // If marking as "reading", also create a reading session
+        if target == ReadingStatus::Reading {
+            let session = ReadingSession::new(book.id);
+            repo.create_reading_session(&session)?;
+        }
+    }
     Ok(())
 }
 
@@ -570,16 +637,123 @@ fn cmd_show(repo: &BookRepository, query: &str, output_format: &OutputFormat) ->
     Ok(())
 }
 
+fn cmd_lookup(query: &str, limit: usize, output_format: &OutputFormat) -> Result<()> {
+    eprintln!("Searching Open Library for \"{query}\"...\n");
+
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()?;
+
+    let results = rt
+        .block_on(toku_meta::search_books(query, limit))
+        .context("Open Library search failed")?;
+
+    if results.is_empty() {
+        eprintln!("No results found.");
+        return Ok(());
+    }
+
+    match output_format {
+        OutputFormat::Json => {
+            let json_results: Vec<serde_json::Value> = results
+                .iter()
+                .map(|r| {
+                    serde_json::json!({
+                        "title": r.title,
+                        "authors": r.authors,
+                        "year": r.first_publish_year,
+                        "isbn": r.isbn,
+                        "pages": r.page_count,
+                        "editions": r.edition_count,
+                        "languages": r.languages,
+                        "openlibrary_key": r.openlibrary_key,
+                    })
+                })
+                .collect();
+            println!("{}", serde_json::to_string_pretty(&json_results)?);
+        }
+        OutputFormat::Csv => {
+            let mut wtr = csv::Writer::from_writer(std::io::stdout());
+            wtr.write_record(["Title", "Author", "Year", "ISBN", "Pages", "Editions"])?;
+            for r in &results {
+                wtr.write_record([
+                    &r.title,
+                    &r.authors.join(", "),
+                    &r.first_publish_year
+                        .map_or("—".to_string(), |y| y.to_string()),
+                    r.isbn.as_deref().unwrap_or("—"),
+                    &r.page_count.map_or("—".to_string(), |p| p.to_string()),
+                    &r.edition_count.to_string(),
+                ])?;
+            }
+            wtr.flush()?;
+        }
+        OutputFormat::Table => {
+            use tabled::settings::Style;
+            use tabled::{Table, Tabled};
+
+            let term_width = crossterm::terminal::size()
+                .map(|(w, _)| w as usize)
+                .unwrap_or(120);
+
+            // #(3) + Title + Author + Year(4) + ISBN(13) + Pages(5) + Editions(4)
+            let fixed_overhead = 50;
+            let flexible = term_width.saturating_sub(fixed_overhead);
+            let title_max = (flexible * 3 / 5).max(15);
+            let author_max = flexible.saturating_sub(title_max).max(10);
+
+            #[derive(Tabled)]
+            struct Row {
+                #[tabled(rename = "#")]
+                idx: String,
+                #[tabled(rename = "Title")]
+                title: String,
+                #[tabled(rename = "Author")]
+                author: String,
+                #[tabled(rename = "Year")]
+                year: String,
+                #[tabled(rename = "ISBN")]
+                isbn: String,
+                #[tabled(rename = "Pages")]
+                pages: String,
+                #[tabled(rename = "Ed.")]
+                editions: String,
+            }
+
+            let rows: Vec<Row> = results
+                .iter()
+                .enumerate()
+                .map(|(i, r)| Row {
+                    idx: format!("{}", i + 1),
+                    title: import_ui::truncate_str(&r.title, title_max),
+                    author: import_ui::truncate_str(&r.authors.join(", "), author_max),
+                    year: r
+                        .first_publish_year
+                        .map_or("—".to_string(), |y| y.to_string()),
+                    isbn: r.isbn.clone().unwrap_or_else(|| "—".to_string()),
+                    pages: r.page_count.map_or("—".to_string(), |p| p.to_string()),
+                    editions: r.edition_count.to_string(),
+                })
+                .collect();
+
+            let mut table = Table::new(rows);
+            table.with(Style::rounded());
+            println!("{table}");
+
+            eprintln!("\nTo add a book: toku add --isbn <ISBN>",);
+        }
+    }
+
+    Ok(())
+}
+
 fn cmd_list(
     repo: &BookRepository,
     status: Option<&str>,
-    shelf: Option<&str>,
     tag: Option<&str>,
     output_format: &OutputFormat,
 ) -> Result<()> {
-    let books = if let Some(shelf_name) = shelf {
-        repo.list_books_in_shelf(shelf_name)?
-    } else if let Some(tag_name) = tag {
+    let books = if let Some(tag_name) = tag {
         repo.list_books_by_tag(tag_name)?
     } else {
         repo.list_books()?
@@ -606,11 +780,10 @@ fn cmd_search(
     repo: &BookRepository,
     query: &str,
     status: Option<&str>,
-    shelf: Option<&str>,
     tag: Option<&str>,
     output_format: &OutputFormat,
 ) -> Result<()> {
-    let books = repo.search_books_filtered(query, status, shelf, tag)?;
+    let books = repo.search_books_filtered(query, status, None, tag)?;
     if books.is_empty() {
         eprintln!("No results for \"{query}\"");
         return Ok(());
@@ -1229,104 +1402,6 @@ fn cmd_reading(
     }
 }
 
-fn cmd_shelf(
-    repo: &BookRepository,
-    action: ShelfAction,
-    output_format: &OutputFormat,
-) -> Result<()> {
-    match action {
-        ShelfAction::Create { name } => {
-            repo.create_shelf(&name)?;
-            eprintln!("✓ Created shelf \"{name}\"");
-            Ok(())
-        }
-        ShelfAction::Add { shelf, books } => {
-            for title in &books {
-                let book = resolve_book(repo, title)?;
-                repo.add_book_to_shelf(&book.id, &shelf)?;
-                eprintln!("✓ Added \"{}\" to shelf \"{shelf}\"", book.title);
-            }
-            Ok(())
-        }
-        ShelfAction::Remove { shelf, book: title } => {
-            let book = resolve_book(repo, &title)?;
-            repo.remove_book_from_shelf(&book.id, &shelf)?;
-            eprintln!("✓ Removed \"{}\" from shelf \"{shelf}\"", book.title);
-            Ok(())
-        }
-        ShelfAction::List => {
-            let shelves = repo.list_shelves()?;
-            if shelves.is_empty() {
-                eprintln!("No shelves yet. Create one with: toku shelf create <name>");
-                return Ok(());
-            }
-
-            match output_format {
-                OutputFormat::Json => {
-                    #[derive(serde::Serialize)]
-                    struct ShelfOut {
-                        name: String,
-                        books: usize,
-                    }
-                    let out: Vec<ShelfOut> = shelves
-                        .iter()
-                        .map(|s| {
-                            let count = repo
-                                .list_books_in_shelf(&s.name)
-                                .map(|b| b.len())
-                                .unwrap_or(0);
-                            ShelfOut {
-                                name: s.name.clone(),
-                                books: count,
-                            }
-                        })
-                        .collect();
-                    println!("{}", serde_json::to_string_pretty(&out)?);
-                }
-                OutputFormat::Csv => {
-                    println!("name,books");
-                    for s in &shelves {
-                        let count = repo
-                            .list_books_in_shelf(&s.name)
-                            .map(|b| b.len())
-                            .unwrap_or(0);
-                        println!("\"{}\",{}", s.name.replace('"', "\"\""), count);
-                    }
-                }
-                OutputFormat::Table => {
-                    use tabled::{Table, Tabled};
-
-                    #[derive(Tabled)]
-                    struct Row {
-                        #[tabled(rename = "Shelf")]
-                        name: String,
-                        #[tabled(rename = "Books")]
-                        books: usize,
-                    }
-
-                    let rows: Vec<Row> = shelves
-                        .iter()
-                        .map(|s| {
-                            let count = repo
-                                .list_books_in_shelf(&s.name)
-                                .map(|b| b.len())
-                                .unwrap_or(0);
-                            Row {
-                                name: s.name.clone(),
-                                books: count,
-                            }
-                        })
-                        .collect();
-
-                    println!("{}", Table::new(rows));
-                }
-            }
-            eprintln!("\n{} shelf(s)", shelves.len());
-            Ok(())
-        }
-    }
-}
-
 fn cmd_tag(repo: &BookRepository, action: TagAction, output_format: &OutputFormat) -> Result<()> {
     match action {
         TagAction::Add { tag, books } => {
@@ -1395,6 +1470,161 @@ fn cmd_tag(repo: &BookRepository, action: TagAction, output_format: &OutputForma
                 }
             }
             eprintln!("\n{} tag(s)", tags.len());
+            Ok(())
+        }
+    }
+}
+
+fn resolve_bulk_books(
+    repo: &BookRepository,
+    status: Option<&str>,
+    tag: Option<&str>,
+) -> Result<Vec<Book>> {
+    let status_filter = status
+        .map(|s| ReadingStatus::from_str(s).map_err(|_| anyhow::anyhow!("invalid status: {s}")))
+        .transpose()?;
+
+    let books = if let Some(tag_name) = tag {
+        repo.list_books_by_tag(tag_name)?
+    } else {
+        repo.list_books()?
+    };
+
+    let filtered: Vec<Book> = if let Some(st) = status_filter {
+        books.into_iter().filter(|b| b.status == st).collect()
+    } else {
+        books
+    };
+
+    Ok(filtered)
+}
+
+fn cmd_bulk(repo: &BookRepository, action: BulkAction) -> Result<()> {
+    match action {
+        BulkAction::Tag {
+            tag,
+            status,
+            existing_tag,
+            dry_run,
+        } => {
+            let books = resolve_bulk_books(repo, status.as_deref(), existing_tag.as_deref())?;
+
+            if books.is_empty() {
+                eprintln!("No books match the given filter.");
+                return Ok(());
+            }
+
+            let verb = if dry_run { "Would tag" } else { "Tagging" };
+            eprintln!("{verb} {} book(s) with \"{tag}\":\n", books.len());
+
+            for book in &books {
+                if dry_run {
+                    eprintln!("  [dry-run] \"{}\"", book.title);
+                } else {
+                    repo.add_tag_to_book(&book.id, &tag)?;
+                    eprintln!("  ✓ \"{}\"", book.title);
+                }
+            }
+
+            eprintln!(
+                "\n{} {} book(s).",
+                if dry_run { "Would tag" } else { "Tagged" },
+                books.len()
+            );
+            Ok(())
+        }
+        BulkAction::Status {
+            new_status,
+            status,
+            tag,
+            dry_run,
+        } => {
+            let target_status = ReadingStatus::from_str(&new_status)
+                .map_err(|_| anyhow::anyhow!("invalid status: {new_status}"))?;
+
+            let books = resolve_bulk_books(repo, status.as_deref(), tag.as_deref())?;
+
+            if books.is_empty() {
+                eprintln!("No books match the given filter.");
+                return Ok(());
+            }
+
+            let verb = if dry_run { "Would update" } else { "Updating" };
+            eprintln!(
+                "{verb} {} book(s) to status \"{}\":\n",
+                books.len(),
+                target_status.as_str()
+            );
+
+            let mut updated = 0;
+            let mut skipped = 0;
+            for book in &books {
+                if book.status == target_status {
+                    skipped += 1;
+                    continue;
+                }
+                if dry_run {
+                    eprintln!(
+                        "  [dry-run] \"{}\" ({} → {})",
+                        book.title,
+                        book.status.as_str(),
+                        target_status.as_str()
+                    );
+                } else {
+                    repo.update_book_status(&book.id, target_status)?;
+                    eprintln!(
+                        "  ✓ \"{}\" ({} → {})",
+                        book.title,
+                        book.status.as_str(),
+                        target_status.as_str()
+                    );
+                }
+                updated += 1;
+            }
+
+            let past = if dry_run { "Would update" } else { "Updated" };
+            eprintln!(
+                "\n{past} {updated} book(s), skipped {skipped} (already {}).",
+                target_status.as_str()
+            );
+            Ok(())
+        }
+        BulkAction::Delete {
+            status,
+            tag,
+            dry_run,
+        } => {
+            let books = resolve_bulk_books(repo, status.as_deref(), tag.as_deref())?;
+
+            if books.is_empty() {
+                eprintln!("No books match the given filter.");
+                return Ok(());
+            }
+
+            if !dry_run && status.is_none() && tag.is_none() {
+                anyhow::bail!(
+                    "Refusing to delete all books without a filter. \
+                     Use --status or --tag to narrow the scope."
+                );
+            }
+
+            let verb = if dry_run { "Would delete" } else { "Deleting" };
+            eprintln!("{verb} {} book(s):\n", books.len());
+
+            for book in &books {
+                if dry_run {
+                    eprintln!("  [dry-run] \"{}\"", book.title);
+                } else {
+                    repo.delete_book(&book.id)?;
+                    eprintln!("  ✗ \"{}\"", book.title);
+                }
+            }
+
+            eprintln!(
+                "\n{} {} book(s).",
+                if dry_run { "Would delete" } else { "Deleted" },
+                books.len()
+            );
             Ok(())
         }
     }

--- a/crates/toku-cli/src/tui.rs
+++ b/crates/toku-cli/src/tui.rs
@@ -1,7 +1,7 @@
 //! Interactive TUI browser for the Toku book library.
 //!
 //! Split-pane layout: left = scrollable book list, right = book details.
-//! Supports filtering by status, shelf, and tag via a popup overlay.
+//! Supports filtering by status and tag via a popup overlay.
 
 use std::io::{self, IsTerminal};
 
@@ -21,7 +21,6 @@ use crate::import_ui::truncate_str;
 enum Filter {
     All,
     Status(ReadingStatus),
-    Shelf(String),
     Tag(String),
 }
 
@@ -30,7 +29,6 @@ impl std::fmt::Display for Filter {
         match self {
             Filter::All => write!(f, "All Books"),
             Filter::Status(s) => write!(f, "Status: {s}"),
-            Filter::Shelf(n) => write!(f, "Shelf: {n}"),
             Filter::Tag(n) => write!(f, "Tag: {n}"),
         }
     }
@@ -44,7 +42,6 @@ enum Mode {
 struct BookDetail {
     authors: Vec<String>,
     isbns: Vec<String>,
-    shelves: Vec<String>,
     tags: Vec<String>,
 }
 
@@ -74,7 +71,6 @@ struct App<'a> {
 
     // Data
     books: Vec<toku_core::Book>,
-    shelves: Vec<toku_core::Shelf>,
     tags: Vec<(toku_core::Tag, i64)>,
 
     // Active filter
@@ -98,7 +94,6 @@ struct App<'a> {
 impl<'a> App<'a> {
     fn new(repo: &'a BookRepository<'a>) -> Result<Self> {
         let books = repo.list_books().map_err(|e| anyhow::anyhow!("{e}"))?;
-        let shelves = repo.list_shelves().map_err(|e| anyhow::anyhow!("{e}"))?;
         let tags = repo
             .list_tags_with_counts()
             .map_err(|e| anyhow::anyhow!("{e}"))?;
@@ -106,7 +101,6 @@ impl<'a> App<'a> {
         let mut app = Self {
             repo,
             books,
-            shelves,
             tags,
             active_filter: Filter::All,
             list_state: ListState::default(),
@@ -137,7 +131,6 @@ impl<'a> App<'a> {
                     .list_books()
                     .map(|books| books.into_iter().filter(|b| b.status == target).collect())
             }
-            Filter::Shelf(name) => self.repo.list_books_in_shelf(name),
             Filter::Tag(name) => self.repo.list_books_by_tag(name),
         };
 
@@ -182,14 +175,6 @@ impl<'a> App<'a> {
 
         let isbns = self.repo.get_book_isbns(&book_id).unwrap_or_default();
 
-        let shelves = self
-            .repo
-            .get_book_shelves(&book_id)
-            .unwrap_or_default()
-            .into_iter()
-            .map(|s| s.name)
-            .collect();
-
         let tags = self
             .repo
             .get_book_tags(&book_id)
@@ -201,7 +186,6 @@ impl<'a> App<'a> {
         self.detail = Some(BookDetail {
             authors,
             isbns,
-            shelves,
             tags,
         });
         self.detail_idx = Some(idx);
@@ -341,22 +325,6 @@ impl<'a> App<'a> {
                 filter: Filter::Status(status),
                 selectable: true,
             });
-        }
-
-        // ── Shelves section
-        if !self.shelves.is_empty() {
-            items.push(FilterItem {
-                label: "── Shelves ──".to_string(),
-                filter: Filter::All,
-                selectable: false,
-            });
-            for shelf in &self.shelves {
-                items.push(FilterItem {
-                    label: format!("  📚 {}", shelf.name),
-                    filter: Filter::Shelf(shelf.name.clone()),
-                    selectable: true,
-                });
-            }
         }
 
         // ── Tags section
@@ -617,23 +585,35 @@ fn draw_book_detail(frame: &mut Frame, area: Rect, app: &App) {
         ]));
     }
 
-    // Shelves & Tags
-    if !detail.shelves.is_empty() || !detail.tags.is_empty() {
-        lines.push(Line::from(""));
-    }
-
-    if !detail.shelves.is_empty() {
-        lines.push(Line::from(vec![
-            Span::styled("Shelves   ", Style::default().fg(Color::DarkGray)),
-            Span::raw(detail.shelves.join(", ")),
-        ]));
-    }
-
+    // Tags
     if !detail.tags.is_empty() {
-        lines.push(Line::from(vec![
-            Span::styled("Tags      ", Style::default().fg(Color::DarkGray)),
-            Span::raw(detail.tags.join(", ")),
-        ]));
+        lines.push(Line::from(""));
+        let tag_spans: Vec<Span> = detail
+            .tags
+            .iter()
+            .enumerate()
+            .flat_map(|(i, t)| {
+                let mut spans = Vec::new();
+                if i > 0 {
+                    spans.push(Span::raw(" "));
+                }
+                spans.push(Span::styled(
+                    format!(" {t} "),
+                    Style::default()
+                        .fg(Color::Cyan)
+                        .add_modifier(Modifier::BOLD),
+                ));
+                spans
+            })
+            .collect();
+        lines.push(Line::from(
+            std::iter::once(Span::styled(
+                "Tags      ",
+                Style::default().fg(Color::DarkGray),
+            ))
+            .chain(tag_spans)
+            .collect::<Vec<_>>(),
+        ));
     }
 
     // Description (word-wrapped by Paragraph)

--- a/crates/toku-db/migrations/V8__migrate_shelves_to_tags.sql
+++ b/crates/toku-db/migrations/V8__migrate_shelves_to_tags.sql
@@ -1,0 +1,11 @@
+-- Migrate shelf memberships into tags.
+-- For each shelf, create a tag with the same name (if not already present),
+-- then copy book_shelves rows into book_tags.
+
+INSERT OR IGNORE INTO tags (id, name, created_at)
+SELECT id, name, created_at FROM shelves;
+
+INSERT OR IGNORE INTO book_tags (book_id, tag_id)
+SELECT bs.book_id, s.id
+FROM book_shelves bs
+JOIN shelves s ON s.id = bs.shelf_id;

--- a/crates/toku-import/src/goodreads.rs
+++ b/crates/toku-import/src/goodreads.rs
@@ -20,6 +20,7 @@ pub struct GoodreadsImportOptions {
 pub enum RowOutcome {
     Imported,
     Skipped,
+    Updated,
     Error(String),
 }
 
@@ -56,6 +57,7 @@ pub struct ImportReport {
     pub total_rows: usize,
     pub imported: usize,
     pub skipped: usize,
+    pub updated: usize,
     pub errors: usize,
     pub error_details: Vec<String>,
     pub import_id: Option<String>,
@@ -63,6 +65,8 @@ pub struct ImportReport {
     pub imported_samples: Vec<RowSummary>,
     /// Bounded sample of skipped (duplicate) books (capped at 20).
     pub skipped_samples: Vec<RowSummary>,
+    /// Bounded sample of books updated with new tags (capped at 20).
+    pub updated_samples: Vec<RowSummary>,
     /// Counts of imported books by reading status.
     pub status_counts: HashMap<String, usize>,
 }
@@ -72,6 +76,11 @@ impl std::fmt::Display for ImportReport {
         writeln!(f, "Import summary:")?;
         writeln!(f, "  Total rows:  {}", self.total_rows)?;
         writeln!(f, "  Imported:    {}", self.imported)?;
+        writeln!(
+            f,
+            "  Updated:     {} (tags added to existing books)",
+            self.updated
+        )?;
         writeln!(f, "  Skipped:     {} (already in library)", self.skipped)?;
         writeln!(f, "  Errors:      {}", self.errors)?;
         if !self.error_details.is_empty() {
@@ -212,7 +221,7 @@ fn import_rows(
     let col_orig_year = col("Original Publication Year");
     let _col_date_read = col("Date Read");
     let _col_date_added = col("Date Added");
-    let _col_shelves = col("Bookshelves");
+    let col_shelves = col("Bookshelves");
     let col_exclusive = col("Exclusive Shelf");
     let _col_review = col("My Review");
     let _col_read_count = col("Read Count");
@@ -293,31 +302,76 @@ fn import_rows(
 
         let gr_id = get(col_book_id);
         let author_name = get(col_author).unwrap_or_default();
-        let status_str = get(col_exclusive)
-            .map(|s| map_shelf_to_status(&s).as_str().to_string())
+        let exclusive_shelf = get(col_exclusive);
+        let status_str = exclusive_shelf
+            .as_ref()
+            .map(|s| map_shelf_to_status(s).as_str().to_string())
             .unwrap_or_else(|| "want-to-read".to_string());
 
-        // Dedup: skip if goodreads_id already exists
-        if let Some(ref id) = gr_id
-            && existing_gr_ids.contains_key(id)
+        // Collect tags from the Bookshelves column
+        let mut row_tags: Vec<String> = get(col_shelves)
+            .map(|s| parse_shelves_as_tags(&s))
+            .unwrap_or_default();
+
+        // Non-standard exclusive shelves also become tags to avoid data loss
+        if let Some(ref shelf) = exclusive_shelf
+            && !is_standard_exclusive_shelf(shelf)
+            && !shelf.is_empty()
         {
-            report.skipped += 1;
-            if report.skipped_samples.len() < MAX_REPORT_SAMPLES {
-                report.skipped_samples.push(RowSummary {
-                    title: title.clone(),
-                    author: author_name.clone(),
-                    status: status_str.clone(),
-                });
+            let shelf_tag = shelf.trim().to_string();
+            if !row_tags.iter().any(|t| t.eq_ignore_ascii_case(&shelf_tag)) {
+                row_tags.push(shelf_tag);
             }
-            emit_event(
-                observer,
-                report.total_rows,
-                total_rows,
-                &title,
-                &author_name,
-                &status_str,
-                RowOutcome::Skipped,
-            )?;
+        }
+
+        // Dedup: if goodreads_id already exists, apply tags and continue
+        if let Some(ref id) = gr_id
+            && let Some(&existing_book_id) = existing_gr_ids.get(id)
+        {
+            if row_tags.is_empty() {
+                // No tags to apply — pure skip
+                report.skipped += 1;
+                if report.skipped_samples.len() < MAX_REPORT_SAMPLES {
+                    report.skipped_samples.push(RowSummary {
+                        title: title.clone(),
+                        author: author_name.clone(),
+                        status: status_str.clone(),
+                    });
+                }
+                emit_event(
+                    observer,
+                    report.total_rows,
+                    total_rows,
+                    &title,
+                    &author_name,
+                    &status_str,
+                    RowOutcome::Skipped,
+                )?;
+            } else {
+                // Apply tags to existing book
+                if !opts.dry_run {
+                    for tag_name in &row_tags {
+                        repo.add_tag_to_book(&existing_book_id, tag_name)?;
+                    }
+                }
+                report.updated += 1;
+                if report.updated_samples.len() < MAX_REPORT_SAMPLES {
+                    report.updated_samples.push(RowSummary {
+                        title: title.clone(),
+                        author: author_name.clone(),
+                        status: status_str.clone(),
+                    });
+                }
+                emit_event(
+                    observer,
+                    report.total_rows,
+                    total_rows,
+                    &title,
+                    &author_name,
+                    &status_str,
+                    RowOutcome::Updated,
+                )?;
+            }
             continue;
         }
 
@@ -439,6 +493,11 @@ fn import_rows(
             }
         }
 
+        // Tags from Bookshelves column (and non-standard exclusive shelves)
+        for tag_name in &row_tags {
+            repo.add_tag_to_book(&book.id, tag_name)?;
+        }
+
         // Track import → book relationship
         db.conn.execute(
             "INSERT INTO import_books (import_id, book_id) VALUES (?1, ?2)",
@@ -536,6 +595,24 @@ fn map_shelf_to_status(shelf: &str) -> ReadingStatus {
     }
 }
 
+/// Returns true if this exclusive shelf is a standard Goodreads status shelf.
+fn is_standard_exclusive_shelf(shelf: &str) -> bool {
+    matches!(
+        shelf.to_lowercase().as_str(),
+        "read" | "currently-reading" | "to-read"
+    )
+}
+
+/// Parse the comma-separated `Bookshelves` column into trimmed tag names.
+/// Filters out empty entries.
+fn parse_shelves_as_tags(shelves_raw: &str) -> Vec<String> {
+    shelves_raw
+        .split(',')
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+        .collect()
+}
+
 fn map_binding_to_format(binding: &str) -> BookFormat {
     match binding.to_lowercase().as_str() {
         "kindle edition" | "ebook" => BookFormat::Ebook,
@@ -621,6 +698,20 @@ mod tests {
             .find(|b| b.title == "Project Hail Mary")
             .unwrap();
         assert_eq!(phm.status, ReadingStatus::Reading);
+
+        // Verify tags from Bookshelves column
+        let dune_tags = repo.get_book_tags(&dune.id).unwrap();
+        let dune_tag_names: Vec<&str> = dune_tags.iter().map(|t| t.name.as_str()).collect();
+        assert!(dune_tag_names.contains(&"sci-fi"));
+        assert!(dune_tag_names.contains(&"classics"));
+
+        let neuro_tags = repo.get_book_tags(&neuro.id).unwrap();
+        let neuro_tag_names: Vec<&str> = neuro_tags.iter().map(|t| t.name.as_str()).collect();
+        assert!(neuro_tag_names.contains(&"cyberpunk"));
+
+        // Project Hail Mary has no shelves → no tags
+        let phm_tags = repo.get_book_tags(&phm.id).unwrap();
+        assert!(phm_tags.is_empty());
     }
 
     #[test]
@@ -646,7 +737,10 @@ mod tests {
         )
         .unwrap();
         assert_eq!(r2.imported, 0);
-        assert_eq!(r2.skipped, 3);
+        // Dune has shelves "sci-fi, classics", Neuromancer has "cyberpunk" → updated
+        // Project Hail Mary has no shelves → skipped
+        assert_eq!(r2.updated, 2);
+        assert_eq!(r2.skipped, 1);
 
         let repo = BookRepository::new(&db);
         assert_eq!(repo.list_books().unwrap().len(), 3);
@@ -722,5 +816,102 @@ mod tests {
         assert_eq!(clean_isbn(r#"="0441172717""#), "0441172717");
         assert_eq!(clean_isbn(r#"="9780441172719""#), "9780441172719");
         assert_eq!(clean_isbn("  9780441172719  "), "9780441172719");
+    }
+
+    #[test]
+    fn import_goodreads_reimport_updates_tags() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let csv_path = write_test_csv(tmp.path());
+        let db = Database::open_in_memory().unwrap();
+
+        // First import
+        import_goodreads(
+            &db,
+            &csv_path,
+            &GoodreadsImportOptions { dry_run: false },
+            None,
+        )
+        .unwrap();
+
+        let repo = BookRepository::new(&db);
+        let books = repo.list_books().unwrap();
+        let dune = books.iter().find(|b| b.title == "Dune").unwrap();
+        let tags_before = repo.get_book_tags(&dune.id).unwrap();
+        assert_eq!(tags_before.len(), 2); // sci-fi, classics
+
+        // Re-import — tags should still be there (idempotent)
+        let r2 = import_goodreads(
+            &db,
+            &csv_path,
+            &GoodreadsImportOptions { dry_run: false },
+            None,
+        )
+        .unwrap();
+        assert_eq!(r2.updated, 2); // Dune + Neuromancer have shelves
+        assert_eq!(r2.skipped, 1); // Project Hail Mary has none
+
+        // Tags unchanged (idempotent)
+        let tags_after = repo.get_book_tags(&dune.id).unwrap();
+        assert_eq!(tags_after.len(), 2);
+    }
+
+    #[test]
+    fn import_goodreads_nonstandard_exclusive_shelf_becomes_tag() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let csv_path = tmp.path().join("custom_shelf.csv");
+        let mut f = std::fs::File::create(&csv_path).unwrap();
+        writeln!(f, "Book Id,Title,Author,Author l-f,Additional Authors,ISBN,ISBN13,My Rating,Average Rating,Publisher,Binding,Number of Pages,Year Published,Original Publication Year,Date Read,Date Added,Bookshelves,Bookshelves with positions,Exclusive Shelf,My Review,Spoiler,Private Notes,Read Count,Owned Copies").unwrap();
+        // Custom exclusive shelf "favorites" — not a standard status
+        writeln!(f, r#"42,The Hobbit,J.R.R. Tolkien,"Tolkien, J.R.R.",,="0547928229",="9780547928227",5,4.28,HMH,Paperback,300,2012,1937,,2024/01/01,"fantasy","fantasy (#1)",favorites,,,,1,0"#).unwrap();
+
+        let db = Database::open_in_memory().unwrap();
+        let report = import_goodreads(
+            &db,
+            &csv_path,
+            &GoodreadsImportOptions { dry_run: false },
+            None,
+        )
+        .unwrap();
+        assert_eq!(report.imported, 1);
+
+        let repo = BookRepository::new(&db);
+        let books = repo.list_books().unwrap();
+        let hobbit = books.iter().find(|b| b.title == "The Hobbit").unwrap();
+        // Maps to WantToRead as default for unknown exclusive shelf
+        assert_eq!(hobbit.status, ReadingStatus::WantToRead);
+
+        let tags = repo.get_book_tags(&hobbit.id).unwrap();
+        let tag_names: Vec<&str> = tags.iter().map(|t| t.name.as_str()).collect();
+        // "fantasy" from Bookshelves + "favorites" from non-standard exclusive shelf
+        assert!(tag_names.contains(&"fantasy"));
+        assert!(tag_names.contains(&"favorites"));
+    }
+
+    #[test]
+    fn import_goodreads_dry_run_duplicate_with_shelves() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let csv_path = write_test_csv(tmp.path());
+        let db = Database::open_in_memory().unwrap();
+
+        // First real import
+        import_goodreads(
+            &db,
+            &csv_path,
+            &GoodreadsImportOptions { dry_run: false },
+            None,
+        )
+        .unwrap();
+
+        // Dry-run re-import
+        let r2 = import_goodreads(
+            &db,
+            &csv_path,
+            &GoodreadsImportOptions { dry_run: true },
+            None,
+        )
+        .unwrap();
+        assert_eq!(r2.updated, 2); // Would update Dune + Neuromancer
+        assert_eq!(r2.skipped, 1); // PHM has no shelves
+        assert_eq!(r2.imported, 0);
     }
 }

--- a/crates/toku-meta/src/lib.rs
+++ b/crates/toku-meta/src/lib.rs
@@ -2,4 +2,4 @@ mod error;
 mod openlibrary;
 
 pub use error::MetaError;
-pub use openlibrary::{OpenLibraryBook, fetch_by_isbn, fetch_cover};
+pub use openlibrary::{OpenLibraryBook, SearchResult, fetch_by_isbn, fetch_cover, search_books};

--- a/crates/toku-meta/src/openlibrary.rs
+++ b/crates/toku-meta/src/openlibrary.rs
@@ -24,6 +24,64 @@ pub struct OpenLibraryBook {
     pub cover_id: Option<i64>,
 }
 
+/// A single result from an Open Library search.
+#[derive(Debug, Clone)]
+pub struct SearchResult {
+    pub title: String,
+    pub authors: Vec<String>,
+    pub first_publish_year: Option<i32>,
+    pub edition_count: i32,
+    pub isbn: Option<String>,
+    pub page_count: Option<i32>,
+    pub openlibrary_key: String,
+    pub languages: Vec<String>,
+}
+
+/// Search Open Library by free-text query. Returns up to `limit` results.
+pub async fn search_books(query: &str, limit: usize) -> Result<Vec<SearchResult>, MetaError> {
+    let client = reqwest::Client::builder().user_agent(USER_AGENT).build()?;
+
+    let resp = client
+        .get("https://openlibrary.org/search.json")
+        .query(&[
+            ("q", query),
+            ("limit", &limit.to_string()),
+            ("fields", "title,author_name,first_publish_year,isbn,edition_count,key,number_of_pages_median,language"),
+        ])
+        .send()
+        .await?
+        .error_for_status()?;
+    let raw: RawSearchResponse = resp.json().await?;
+
+    let results = raw
+        .docs
+        .into_iter()
+        .map(|doc| {
+            // Pick the first ISBN-13 if available, else first ISBN-10
+            let isbn = doc.isbn.as_ref().and_then(|isbns| {
+                isbns
+                    .iter()
+                    .find(|i| i.len() == 13)
+                    .or(isbns.first())
+                    .cloned()
+            });
+
+            SearchResult {
+                title: doc.title,
+                authors: doc.author_name.unwrap_or_default(),
+                first_publish_year: doc.first_publish_year,
+                edition_count: doc.edition_count.unwrap_or(0),
+                isbn,
+                page_count: doc.number_of_pages_median,
+                openlibrary_key: doc.key,
+                languages: doc.language.unwrap_or_default(),
+            }
+        })
+        .collect();
+
+    Ok(results)
+}
+
 /// Fetch book metadata from Open Library by ISBN.
 pub async fn fetch_by_isbn(isbn: &str) -> Result<OpenLibraryBook, MetaError> {
     let client = reqwest::Client::builder().user_agent(USER_AGENT).build()?;
@@ -116,6 +174,23 @@ async fn fetch_author_name(client: &reqwest::Client, key: &str) -> Result<String
 }
 
 // --- Raw API response structs ---
+
+#[derive(Deserialize)]
+struct RawSearchResponse {
+    docs: Vec<RawSearchDoc>,
+}
+
+#[derive(Deserialize)]
+struct RawSearchDoc {
+    title: String,
+    author_name: Option<Vec<String>>,
+    first_publish_year: Option<i32>,
+    edition_count: Option<i32>,
+    isbn: Option<Vec<String>>,
+    key: String,
+    number_of_pages_median: Option<i32>,
+    language: Option<Vec<String>>,
+}
 
 #[derive(Deserialize)]
 struct RawEdition {

--- a/docs/adr/003-cli-design.md
+++ b/docs/adr/003-cli-design.md
@@ -25,18 +25,24 @@ well-documented. It is a first-class product, not a debug tool.
 ## Command Hierarchy
 
 ```sh
-toku add [--isbn <isbn> | --title <title> --author <author>]
+toku                                            # Launch TUI browser (default)
+toku browse                                     # Launch TUI browser (explicit)
+toku add [--isbn <isbn> | --title <title> --author <author>] [-T <tag>...] [--status <status>]
 toku show <book>
-toku list [--status <status>] [--shelf <shelf>] [--sort <field>]
-toku search <query>
+toku list [--status <status>] [--tag <tag>] [--sort <field>]
+toku search <query> [--status <status>] [--tag <tag>] [--online]
 toku reading start|update|finish|abandon <book> [--page N] [--rating N]
 toku import goodreads|calibre|storygraph <path> [--dry-run]
 toku export csv|json|backup [--output <path>]
 toku stats [--year <year>]
-toku shelf create|add|remove|list <shelf> [<books>...]
 toku tag add|remove|list <tag> [<books>...]
+toku bulk tag|status|delete [--status <s>] [--tag <t>] [--dry-run]
 toku config [--edit]
 ```
+
+> **Note**: Shelves were merged into tags (see migration V8). Use `toku tag`
+> for all user-defined book groupings. `ReadingStatus` remains a separate
+> per-book state machine.
 
 ## Rationale
 

--- a/docs/adr/005-import-architecture.md
+++ b/docs/adr/005-import-architecture.md
@@ -17,8 +17,8 @@ Every importer implements a common `ImportEngine` trait with these capabilities:
 
 1. **Dry-run mode**: `--dry-run` shows what would happen without writing to the database.
 2. **Idempotent re-import**: Each imported record stores a source identifier (e.g.,
-   `goodreads_id`, `calibre_id`). Re-importing the same file skips existing entries and
-   updates changed fields (respecting user edits).
+   `goodreads_id`, `calibre_id`). Re-importing the same file updates tags on existing
+   entries and imports new ones (respecting user edits).
 3. **Match confidence levels**:
    - Exact: ISBN match → auto-merge
    - High: Title + Author exact match → auto-merge with summary
@@ -30,7 +30,11 @@ Every importer implements a common `ImportEngine` trait with these capabilities:
 6. **Provenance tracking**: Every imported field records `(source, timestamp)`. User
    edits clear provenance and set `user_override`.
 7. **Rollback**: `toku import undo <import-id>` removes books added by that import.
+   Note: tags applied to pre-existing books during re-import are not rolled back.
 8. **Import log**: `import_logs` table records every operation.
+9. **Shelf-to-tag conversion**: Goodreads `Bookshelves` column values are imported as
+   tags. Non-standard exclusive shelves are also preserved as tags. Standard exclusive
+   shelves (`read`, `to-read`, `currently-reading`) map to `ReadingStatus`.
 
 ### Import priority
 


### PR DESCRIPTION
## Description

Adds several major features to Toku's CLI and import pipeline, and simplifies the data model by merging shelves into tags.

### What's included

- **Interactive TUI browser** — 	oku browse (or just 	oku) launches a split-pane ratatui interface with a scrollable book list, live detail view, and filter popup (by status or tag)
- **Goodreads shelf-to-tag import** — the Bookshelves CSV column is now parsed into tags on import; re-importing updates tags on existing books instead of silently skipping; non-standard exclusive shelves (e.g., "favorites") are preserved as tags
- **Shelf → tag merge** — removed the 	oku shelf command and --shelf filters; all user-created groupings are now tags; DB migration V8 copies existing shelf data to tags; ReadingStatus remains as the separate per-book state machine
- **Open Library search** — 	oku lookup <query> searches the Open Library API and displays results with ISBNs for easy 	oku add --isbn
- **Bulk operations** — 	oku bulk tag|status|delete with --dry-run, --status, and --tag filter flags; bulk delete requires at least one filter for safety
- **Enhanced 	oku add** — new --tag (-T, repeatable) and --status flags; applies tags/status to existing ISBN matches instead of silently ignoring
- **Tag display in TUI** — book detail pane shows tags with bold cyan styling
- **Import progress UI** — RowOutcome::Updated variant with cyan ⟳ indicator in the ratatui progress bar and activity log

## Related Issues

<!-- No linked issues -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [x] Documentation update
- [x] Refactoring (no functional changes)
- [ ] CI / infrastructure
- [ ] Other (describe below)

## Crate

- [ ] `toku-core` — Domain models, traits, state machine
- [x] `toku-db` — SQLite persistence, migrations, FTS5
- [x] `toku-import` — Importers (Goodreads, Calibre, StoryGraph)
- [x] `toku-meta` — Metadata fetching (Open Library, Google Books)
- [x] `toku-cli` — CLI binary
- [ ] `toku-export` — Exporters (CSV, JSON, Markdown, BibTeX)
- [x] `docs/` — Documentation

## Data Integrity Checklist

- [x] No user data is sent to any server without explicit opt-in
- [x] Import operations are idempotent (re-importing the same file creates no duplicates)
- [x] User edits to metadata are never overwritten by auto-enrichment
- [x] New fields track provenance (source + timestamp)
- [x] Export round-trip is preserved (if applicable)

## Checklist

- [x] I have read [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] `cargo fmt --check` passes
- [x] `cargo clippy --workspace -- -D warnings` passes
- [x] `cargo test --workspace` passes
- [x] I have updated documentation (if applicable)