### PR TITLE
docs: validate cover image licensing and StoryGraph export format

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,11 @@ their ever-growing libraries.
 
 [MIT](LICENSE)
 
+## Acknowledgments
+
+- Book metadata and cover images from [Open Library](https://openlibrary.org) by the
+  [Internet Archive](https://archive.org).
+
 ---
 
 _Built by [kafkade](https://github.com/kafkade)._

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -402,7 +402,7 @@ Each op:
 |--------|--------|----------|-----------|-------|------------|
 | **Goodreads** | CSV export | Title, author, ISBN, rating (1–5), date read, shelves, review, page count, Goodreads ID | 🟢 | **MVP** | `[Validation Required]` — verify current CSV column names |
 | **Calibre** | SQLite `metadata.db` + OPF | Full metadata, tags, custom columns, series, publisher, covers, file paths | 🟡 | Phase 2 | `[Validated]` — well-documented, stable schema |
-| **StoryGraph** | CSV export | Title, author, rating, moods, pace, dates, content warnings | 🟡 | Phase 3 | `[Validation Required]` — verify export availability and format |
+| **StoryGraph** | CSV export | Title, author, rating, moods, pace, dates, content warnings | 🟡 | Phase 3 | `[Validated]` — 23-column CSV, see `docs/validations/storygraph-export.md` |
 | **Manual entry** | CLI flags | User-supplied fields | 🟢 | **MVP** | N/A |
 | **ISBN list** | Plain text | ISBNs only → metadata fetch | 🟢 | **MVP** | N/A |
 | **Generic CSV** | User-mapped CSV | Flexible column mapping | 🟡 | Phase 2 | N/A |
@@ -485,12 +485,12 @@ Rejected alternatives:
 - Cover API: `https://covers.openlibrary.org/b/isbn/{isbn}-L.jpg`
 - Rate limits: generous (100 req/min stated, practically higher) `[Validation Required]`
 
-**Fallback: Google Books API** `[Validation Required]`
+**Fallback: Google Books API** `[Validated — significant restrictions]`
 
 - 1,000 requests/day free tier (no key), higher with API key.
 - Broader coverage than Open Library, especially for recent releases.
-- Terms of service: allows caching for offline use `[Validation Required]`
-- Better cover image quality in many cases.
+- Terms of service: **thumbnails cannot be cached locally** (ToS Section 5e.1 prohibits permanent copies). Metadata caching is restricted to HTTP cache header TTL. API keys cannot be embedded in open-source projects (Section 4b.1). See `docs/validations/cover-image-licensing.md`.
+- Google Books is viable only for transient text metadata enrichment (title, author, pages), not cover images.
 
 **Merge strategy**: Query Open Library first. If no result or missing fields, query Google Books. User edits always take precedence. Empty fields filled from the highest-quality available source.
 
@@ -502,11 +502,12 @@ Rejected alternatives:
 
 ### 3.4 — Cover Image Strategy
 
-- **Sources**: Open Library Covers API (primary), Google Books thumbnail (fallback), user upload via `toku cover set <book> <path>`.
+- **Sources**: Open Library Covers API (primary), user upload via `toku cover set <book> <path>`. Google Books thumbnails **cannot** be cached locally per Google's ToS — see `docs/validations/cover-image-licensing.md`.
 - **Storage**: Filesystem, content-addressed. `covers/{sha256_first_16_chars}.jpg`. Thumbnails generated on first display (200px width) and cached as `covers/thumb/{hash}.jpg`.
-- **Offline**: Covers fetched once, stored locally forever. App works without covers (text-only display in CLI).
+- **Offline**: Covers fetched once from Open Library, stored locally. App works without covers (text-only display in CLI).
 - **No cover placeholder**: Color-coded rectangle derived from genre/title hash. Visually distinct per book.
 - **Resolution**: Store original as fetched (typically 300–600px). Generate thumbnails on demand.
+- **Licensing**: Open Library on-demand caching is permitted per their API guidelines. Bulk crawling is prohibited. Courtesy attribution appreciated.
 
 ### 3.5 — Non-Goals & Red Lines
 
@@ -1333,7 +1334,7 @@ Before committing to the architecture, validate:
 2. **Mood tags, pace ratings, content warnings**
 3. **Work grouping** (link editions of the same book) + merge duplicates
 4. **Smart shelves** (saved filter rules that auto-populate)
-5. **StoryGraph import** `[Validation Required]`
+5. **StoryGraph import** `[Validated]` — see `docs/validations/storygraph-export.md`
 
 **Acceptance criteria**:
 
@@ -1430,11 +1431,11 @@ Before committing to the architecture, validate:
 |------|----------|--------|
 | Download real Goodreads CSV export, document all columns | P0 | `[Validation Required]` |
 | Test Open Library API: rate limits, non-English books, old editions | P0 | `[Validation Required]` |
-| Google Books API: ToS for open-source, quota limits | P1 | `[Validation Required]` |
-| StoryGraph: verify export availability and format | P1 | `[Validation Required]` |
+| Google Books API: ToS for open-source, quota limits | P1 | `[Validated]` — significant ToS restrictions. See `docs/validations/cover-image-licensing.md` |
+| StoryGraph: verify export availability and format | P1 | `[Validated]` — 23-column CSV export available. See `docs/validations/storygraph-export.md` |
 | Calibre `metadata.db` schema: document all useful tables | P1 | `[Validated]` — schema is stable |
 | ISBN-10 ↔ ISBN-13 conversion: verify algorithm, edge cases | P0 | `[Validated]` — well-documented standard |
-| Cover image licensing: caching Open Library covers locally | P1 | `[Validation Required]` |
+| Cover image licensing: caching Open Library covers locally | P1 | `[Validated]` — on-demand caching permitted. See `docs/validations/cover-image-licensing.md` |
 | `crates.io` name availability: "toku" | P0 | `[Validation Required]` |
 
 ### 14.4 — Architecture Decision Records

--- a/crates/toku-meta/src/openlibrary.rs
+++ b/crates/toku-meta/src/openlibrary.rs
@@ -132,6 +132,14 @@ pub async fn fetch_by_isbn(isbn: &str) -> Result<OpenLibraryBook, MetaError> {
 
 /// Download a cover image and save it content-addressed by SHA-256.
 /// Returns the hash filename (e.g., "a1b2c3d4e5f6.jpg").
+///
+/// This function is intended for user-initiated single-book enrichment only
+/// (e.g., `toku add --isbn`). Callers must NOT use this for bulk pre-fetching
+/// or crawling — Open Library's Covers API prohibits that usage and rate-limits
+/// to 100 requests per 5 minutes for ISBN-based lookups.
+///
+/// Cover images from Open Library: on-demand local caching is permitted per OL's
+/// API guidelines. See `docs/validations/cover-image-licensing.md`.
 pub async fn fetch_cover(isbn: &str, covers_dir: &Path) -> Result<Option<String>, MetaError> {
     let client = reqwest::Client::builder().user_agent(USER_AGENT).build()?;
 

--- a/docs/adr/004-metadata-sources.md
+++ b/docs/adr/004-metadata-sources.md
@@ -28,8 +28,23 @@ reliable, and compatible with open-source use.
 - Open Library is free, requires no API key, and is community-maintained.
 - Google Books has broader coverage (especially recent releases and non-English titles)
   but has rate limits.
-- Both are compatible with open-source use (no restrictive ToS for caching).
+- Open Library is compatible with open-source use for on-demand caching. Google Books
+  has significant ToS restrictions — see cover image licensing below.
 - The "user wins" rule prevents data corruption from bad metadata sources.
+
+## Cover Image Licensing — Validated (2026-05-29)
+
+See [docs/validations/cover-image-licensing.md](../validations/cover-image-licensing.md)
+for the full validation report.
+
+**Open Library covers**: On-demand local caching is permitted. Toku fetches one cover per
+user-initiated ISBN add and stores it locally. This is consistent with OL's API guidelines.
+Bulk crawling is prohibited. Courtesy attribution is appreciated but not required.
+
+**Google Books thumbnails**: Local caching is **prohibited** by the Google APIs ToS
+(Section 5e.1 — no permanent copies, no caching beyond HTTP cache headers). Google Books
+may only be used for transient text metadata enrichment, not cover images. API keys also
+cannot be embedded in open-source projects (Section 4b.1).
 
 ## Alternatives Considered
 
@@ -43,5 +58,9 @@ reliable, and compatible with open-source use.
 ## Open Validations
 
 - [ ] Open Library rate limits (stated 100 req/min — verify in practice)
-- [ ] Google Books ToS for open-source caching
-- [ ] Cover image licensing for local caching
+- [x] Google Books ToS for open-source caching — **Validated 2026-05-29**: Significant
+  restrictions apply. Permanent caching prohibited. API keys cannot be embedded in
+  open-source projects. See [cover-image-licensing.md](../validations/cover-image-licensing.md).
+- [x] Cover image licensing for local caching — **Validated 2026-05-29**: Open Library
+  on-demand caching permitted. Google Books thumbnail caching prohibited.
+  See [cover-image-licensing.md](../validations/cover-image-licensing.md).

--- a/docs/validations/cover-image-licensing.md
+++ b/docs/validations/cover-image-licensing.md
@@ -1,0 +1,185 @@
+# Validation: Cover Image Licensing for Local Caching
+
+**Status**: Validated
+**Date**: 2026-05-29
+**Issue**: [#19](https://github.com/kafkade/toku/issues/19)
+**Affects**: `toku-meta` crate, cover image pipeline, future Google Books integration
+
+## Summary
+
+| Source | Local caching (on-demand) | Bulk pre-fetching | Attribution | Cover fallback viable? |
+|--------|--------------------------|-------------------|-------------|----------------------|
+| **Open Library** | ✅ Permitted | ❌ Prohibited | Courtesy (not required) | ✅ Yes — primary source |
+| **Google Books** | ❌ Prohibited | ❌ Prohibited | Required ("Powered by Google" + links) | ❌ No — thumbnails cannot be stored locally |
+| **User-provided** | ✅ N/A (user-directed) | ✅ N/A | N/A | ✅ Yes |
+| **Calibre import** | ✅ User-directed local copy | ✅ User-directed | N/A | ✅ Yes |
+
+## Open Library Covers API
+
+### What is permitted
+
+Open Library's general API guidelines explicitly encourage caching:
+
+> "Please Do: **Cache responses whenever possible**"
+> — [openlibrary.org/developers/api](https://openlibrary.org/developers/api)
+
+Toku's use case — fetching a single cover image when a user runs `toku add --isbn` and
+storing it locally content-addressed by SHA-256 — is consistent with this guidance. This is
+user-initiated, on-demand, single-request behavior. Not crawling.
+
+Open Library explicitly prioritizes open-source and mission-aligned projects:
+
+> "We prioritize: **Open-source and mission-aligned projects**"
+> — [openlibrary.org/developers/api](https://openlibrary.org/developers/api)
+
+### What is NOT permitted
+
+The Covers API documentation draws a clear line against bulk usage:
+
+> "**Please, do not crawl our cover API.** If you do, we may decide to block your crawl."
+> — [openlibrary.org/dev/docs/api/covers](https://openlibrary.org/dev/docs/api/covers)
+>
+> "**The covers API is intended for displaying covers on public facing websites and not
+> for bulk download.**"
+> — [openlibrary.org/dev/docs/api/covers](https://openlibrary.org/dev/docs/api/covers)
+
+Rate limits apply: 100 requests per 5 minutes for ISBN-based cover lookups.
+
+### Attribution
+
+Attribution is framed as a courtesy, not a legal obligation:
+
+> "A **courtesy** link back to Open Library is **appreciated**"
+> — [openlibrary.org/dev/docs/api/covers](https://openlibrary.org/dev/docs/api/covers)
+
+### Copyright status of cover images
+
+The Internet Archive's licensing page clarifies:
+
+> "The Internet Archive does not assert any new copyright or other proprietary rights over
+> any of the material in the Open Library database."
+> — [openlibrary.org/developers/licensing](https://openlibrary.org/developers/licensing)
+
+This applies to the bibliographic database (metadata), not the cover images themselves.
+Cover images are reproductions of copyrighted book jacket artwork owned by publishers and
+designers. Open Library does not hold copyright to this artwork and cannot grant a license
+for it. However, for a personal, offline-first book manager that caches covers locally for
+the user's own private library display, this falls within established fair use patterns
+(personal use, non-commercial, non-redistributive).
+
+### Project policy for Open Library covers
+
+Based on the reviewed terms, the project adopts this policy:
+
+- ✅ **On-demand fetch**: Fetching a cover when a user adds a book by ISBN is permitted.
+- ✅ **Local caching**: Storing the fetched cover on the user's local filesystem is permitted.
+- ✅ **Offline display**: Displaying a locally cached cover without network is permitted.
+- ❌ **Bulk crawling**: Programmatically fetching covers for many books without user action
+  is not permitted. Any batch enrichment must be rate-limited and user-initiated.
+- ❌ **Redistribution**: Redistributing cached cover images (e.g., bundling them in an app
+  binary, serving them from a CDN) is not permitted.
+- 🔄 **Courtesy attribution**: Include "Cover images from Open Library" in the README and
+  About screen. Not legally required but good community citizenship.
+
+## Google Books API
+
+### Thumbnails CANNOT be cached locally
+
+The Google APIs Terms of Service (Section 5e.1) explicitly prohibit permanent local storage:
+
+> "you will not [...] **Scrape, build databases, or otherwise create permanent copies of
+> such content, or keep cached copies longer than permitted by the cache header**"
+> — [developers.google.com/terms](https://developers.google.com/terms) (Section 5e.1)
+
+This prohibition is unambiguous and applies to all content returned by the API, including
+book thumbnail images. Toku's offline-first architecture requires permanent local storage
+of covers — this directly conflicts with the ToS.
+
+### Metadata caching is also restricted
+
+The same Section 5e.1 restriction applies to all API content, not just thumbnails. This
+means:
+
+- Caching raw Google Books API responses is limited to the duration specified by HTTP
+  `Cache-Control` headers.
+- Building a local database of Google Books metadata (title, author, etc.) may violate
+  the "build databases" clause.
+- Using Google Books for one-time field enrichment (fetch → merge into user's record →
+  discard raw response) is likely the safest approach.
+
+### API keys cannot be embedded in open-source projects
+
+> "**Developer credentials may not be embedded in open source projects.**"
+> — [developers.google.com/terms](https://developers.google.com/terms) (Section 4b.1)
+
+This means Toku cannot ship with a bundled Google Books API key. Users would need to
+supply their own key.
+
+### Attribution requirements are heavy
+
+The Google Books Branding Guidelines require:
+
+- "Powered by Google" logo adjacent to any book results
+- Prominent links to Google Books pages on every book result
+- No result reordering or alteration
+
+These requirements conflict with Toku's design principles (no external branding, offline
+functionality, user data ownership).
+
+### Project policy for Google Books
+
+Based on the reviewed terms, the project adopts this policy:
+
+- ❌ **Thumbnail caching**: Google Books thumbnails must NOT be downloaded and stored locally.
+- ⚠️ **Metadata enrichment**: Google Books may be used for transient metadata enrichment
+  (fetch once, extract fields, discard raw response). Raw API responses must not be cached
+  beyond HTTP cache headers.
+- ❌ **Bundled API key**: No Google Books API key may be shipped in the source code. Users
+  must provide their own.
+- ⚠️ **Deferred**: Given these restrictions, Google Books as a metadata fallback is deferred
+  until the implications are fully evaluated. Open Library is sufficient as the primary and
+  sole metadata source for the foreseeable future.
+
+## Impact on Architecture
+
+### Current state (no changes needed)
+
+The existing `fetch_cover` function in `toku-meta/src/openlibrary.rs` fetches covers
+on-demand when a user adds a book by ISBN. This is consistent with Open Library's terms:
+
+1. User initiates `toku add --isbn <isbn>`
+2. One HTTP request to `covers.openlibrary.org/b/isbn/{isbn}-L.jpg`
+3. Image stored locally at `covers/{sha256_hash}.jpg`
+4. No bulk fetching, no crawling, no redistribution
+
+### Future Google Books integration
+
+When Google Books is implemented as a metadata fallback:
+
+- Use it for **text metadata only** (title, author, page count, description)
+- Do **NOT** download or cache thumbnails from Google Books
+- Do **NOT** cache raw API responses beyond HTTP cache headers
+- Require users to supply their own API key via config
+- If a book has no Open Library cover, leave the cover field empty rather than
+  caching a Google Books thumbnail
+
+### Calibre import covers
+
+Calibre import copies cover images from the user's local Calibre library directory.
+This is user-directed copying from a user-provided local source and is outside the scope
+of API provider terms. No licensing concern.
+
+## Sources Reviewed
+
+| Source | URL |
+|--------|-----|
+| Open Library API Guidelines | <https://openlibrary.org/developers/api> |
+| Open Library Covers API | <https://openlibrary.org/dev/docs/api/covers> |
+| Open Library Licensing | <https://openlibrary.org/developers/licensing> |
+| Google APIs Terms of Service | <https://developers.google.com/terms> |
+| Google Books API Terms | <https://developers.google.com/books/terms> |
+| Google Books Branding Guidelines | <https://developers.google.com/books/branding> |
+
+> **Disclaimer**: This document reflects a good-faith review of publicly available provider
+> terms as of May 2026. It is not legal advice. Terms may change; verify current terms
+> before implementing new integrations.

--- a/docs/validations/storygraph-export.md
+++ b/docs/validations/storygraph-export.md
@@ -1,0 +1,259 @@
+# Validation: StoryGraph Export Availability and Format
+
+**Status**: Validated
+**Date**: 2026-05-29
+**Issue**: [#17](https://github.com/kafkade/toku/issues/17)
+**Affects**: `toku-import` crate (Phase 3 StoryGraph importer)
+
+## Summary
+
+StoryGraph offers a **free, built-in CSV export** of the user's entire library. The export
+produces a 23-column comma-separated UTF-8 file with rich reading-experience data that
+Goodreads has no equivalent for (moods, pace, character questions, content warnings,
+quarter-star ratings, full re-read date ranges, and native DNF status). There is **no
+public API** — CSV export is the only viable data access method.
+
+**Verdict**: ✅ StoryGraph export is available and well-structured. An importer is feasible.
+
+## Export Location and Process
+
+1. Log in to `app.thestorygraph.com`
+2. Click avatar → Profile
+3. Scroll to "Export your data" → click export
+4. Download the CSV file (direct download or emailed)
+
+> **Note**: The exported file may be named `goodreads_library_export_<username>.csv` — a
+> legacy naming artifact from StoryGraph's origins. Detect StoryGraph exports by the
+> presence of StoryGraph-specific columns (`Moods`, `Pace`, `Character- or Plot-Driven?`).
+
+## File Format
+
+| Property | Value |
+|----------|-------|
+| Delimiter | Comma (`,`) |
+| Encoding | UTF-8 (with optional BOM — use `utf-8-sig` decoding) |
+| Line endings | Mixed (`\r\n` and `\n` both observed) |
+| Header row | Yes — row 1 contains column names |
+| Quote character | Double-quote (`"`) |
+| Escaped quotes | `""` (RFC 4180 standard) |
+| ISBN wrapping | Clean — no `=""` Excel-style wrapping (unlike Goodreads) |
+| Null representation | Empty string `""` |
+
+## Complete Column Reference (23 Columns)
+
+### Book metadata
+
+| # | Column Name | Type | Empty Rate | Notes |
+|---|-------------|------|------------|-------|
+| 1 | `Title` | String | 0% | Clean title — no series info embedded (unlike Goodreads) |
+| 2 | `Authors` | String | 0% | First Last format. Multiple authors comma-separated |
+| 3 | `Contributors` | String | ~95% | Narrators, translators with role: `"Name (Role)"` |
+| 4 | `ISBN/UID` | String | ~20% | Mixed: ISBN-13, ISBN-10, ASIN, or empty |
+| 5 | `Format` | Enum | ~2% | `"digital"`, `"paperback"`, `"hardcover"`, `"audio"` |
+| 23 | `Owned?` | Enum | 0% | `"Yes"` or `"No"` |
+
+**Not exported** (must be enriched via Open Library or other sources):
+
+- Page count
+- Publisher
+- Publication year
+- Cover image URL
+- Series name and number
+
+### Reading tracking
+
+| # | Column Name | Type | Empty Rate | Notes |
+|---|-------------|------|------------|-------|
+| 6 | `Read Status` | Enum | 0% | `"read"`, `"to-read"`, `"currently-reading"`, `"did-not-finish"` |
+| 7 | `Date Added` | Date | 0% | `YYYY/MM/DD` format |
+| 8 | `Last Date Read` | Date | ~40% | Variable precision: `YYYY/MM/DD`, `YYYY/MM`, or `YYYY` |
+| 9 | `Dates Read` | Complex | ~40% | Multi-session field (see parsing spec below) |
+| 10 | `Read Count` | Integer | 0% | `0` for unread books |
+
+### Rating
+
+| # | Column Name | Type | Empty Rate | Notes |
+|---|-------------|------|------------|-------|
+| 18 | `Star Rating` | Decimal | ~35% | Quarter-star: 1.0 to 5.0 in 0.25 increments. Empty = unrated |
+
+### Moods, pace, and reading experience
+
+| # | Column Name | Type | Empty Rate | Values |
+|---|-------------|------|------------|--------|
+| 11 | `Moods` | Comma-separated | ~50% | 13 canonical values (see list below) |
+| 12 | `Pace` | Enum | ~50% | `"slow"`, `"medium"`, `"fast"` |
+| 13 | `Character- or Plot-Driven?` | Enum | ~55% | `"Character"`, `"Plot"`, `"A mix"` |
+| 14 | `Strong Character Development?` | Ternary | ~55% | `"Yes"`, `"No"`, `"It's complicated"` |
+| 15 | `Loveable Characters?` | Ternary | ~55% | `"Yes"`, `"No"`, `"It's complicated"` |
+| 16 | `Diverse Characters?` | Ternary | ~60% | `"Yes"`, `"No"`, `"It's complicated"` |
+| 17 | `Flawed Characters?` | Ternary | ~60% | `"Yes"`, `"No"`, `"It's complicated"` |
+
+### Content warnings, reviews, tags
+
+| # | Column Name | Type | Empty Rate | Notes |
+|---|-------------|------|------------|-------|
+| 19 | `Review` | HTML string | ~75% | Contains `<div>`, `<br>`, `<spoiler>` tags |
+| 20 | `Content Warnings` | Structured | ~99% | `"Severity: Type; Severity: Type;"` |
+| 21 | `Content Warning Description` | String | ~99% | Free-text user notes |
+| 22 | `Tags` | Comma-separated | ~99% | User-defined, case-inconsistent |
+
+## Parsing Specifications
+
+### Dates Read (complex multi-session field)
+
+This field encodes one or more reading sessions with variable date precision:
+
+```text
+Single month:          "2024/09"
+Full date range:       "2025/12/11-2025/12/14"
+Same-day read:         "2025/07/08-2025/07/08"
+Multiple sessions:     "2025/07/08-2025/07/08, 2024"
+Complex multi-session: "2025/02/13-2025/03/15, 2024/09-2024/09"
+```
+
+**Parsing algorithm**:
+
+1. Split on `", "` to get individual sessions
+2. Split each session on `"-"` to get start and end dates
+3. Parse each date segment with variable precision:
+   - `YYYY/MM/DD` → full date
+   - `YYYY/MM` → first of month
+   - `YYYY` → first of year
+
+### Moods taxonomy (13 canonical values)
+
+```text
+adventurous, challenging, dark, emotional, funny, hopeful,
+inspiring, lighthearted, mysterious, reflective, relaxing, sad, tense
+```
+
+Parse by splitting on `","` and trimming whitespace. Normalize to lowercase.
+
+### Content Warnings format
+
+```text
+"Graphic: Sexual content; Moderate: Cancer; Minor: Death of parent;"
+```
+
+Severity levels: `Graphic`, `Moderate`, `Minor`. Parse by splitting on `";"`, then
+splitting each part on `":"`.
+
+### Star Rating conversion
+
+StoryGraph uses quarter-star increments (0.25) on a 1–5 scale.
+Toku uses a 0–10 integer scale.
+
+Conversion: `toku_rating = round(storygraph_star * 2)`
+
+| StoryGraph | Toku | Display |
+|------------|------|---------|
+| 1.0 | 2 | ★☆☆☆☆ |
+| 2.5 | 5 | ★★½☆☆ |
+| 3.75 | 8 | ★★★¾☆ |
+| 4.5 | 9 | ★★★★½ |
+| 5.0 | 10 | ★★★★★ |
+
+### ISBN/UID field detection
+
+The `ISBN/UID` column contains mixed identifier types:
+
+| Pattern | Type | Action |
+|---------|------|--------|
+| 13 digits | ISBN-13 | Store as `isbn13` identifier |
+| 10 chars matching `[0-9Xx]{10}` | ISBN-10 | Store as `isbn10`, convert to ISBN-13 |
+| Starts with `B0` + 8 alphanumeric | ASIN | Store as `asin` identifier |
+| Empty | No identifier | Match by title + author |
+
+### Read Status mapping
+
+| StoryGraph | Toku `ReadingStatus` |
+|------------|---------------------|
+| `read` | `Read` |
+| `to-read` | `WantToRead` |
+| `currently-reading` | `Reading` |
+| `did-not-finish` | `Abandoned` |
+| `paused` (rare) | `Reading` (treat as on-hold/reading) |
+
+### Format mapping
+
+| StoryGraph | Toku `BookFormat` |
+|------------|-------------------|
+| `paperback` | `Physical` |
+| `hardcover` | `Physical` |
+| `digital` | `Ebook` |
+| `audio` | `Audiobook` |
+
+## Import Fidelity Assessment
+
+### High fidelity (direct mapping)
+
+- ✅ Title, Authors → `books.title`, `book_contributors`
+- ✅ Read Status → `ReadingStatus` (native DNF support maps to `Abandoned`)
+- ✅ Star Rating → `books.rating` (quarter-star → 0-10 integer, lossless)
+- ✅ Date Added → `books.created_at`
+- ✅ Dates Read → `reading_sessions` (start/end per session, re-reads preserved)
+- ✅ Read Count → validates against number of `reading_sessions`
+- ✅ Moods → `tags` with `tag_type = 'mood'` (requires #42)
+- ✅ Pace → `tags` with `tag_type = 'pace'` (requires #42)
+- ✅ Format → `BookFormat` (direct mapping)
+- ✅ ISBN/UID → `identifiers` table (ISBN-13, ISBN-10, or ASIN)
+- ✅ Tags → `tags` with `tag_type = 'general'`
+- ✅ Review → `reviews.text` (strip HTML, preserve `<spoiler>` as markdown)
+
+### Medium fidelity (enrichment needed)
+
+- ⚠️ Page count — not exported, must enrich via Open Library ISBN lookup
+- ⚠️ Series — not in export, must enrich externally
+- ⚠️ Publisher, publication year — not exported
+- ⚠️ Cover images — not exported, fetch via Open Library
+
+### StoryGraph-specific data (extended mapping)
+
+These fields are unique to StoryGraph and have no Goodreads equivalent:
+
+- 🆕 Character- or Plot-Driven? → `custom_fields` or new tag type
+- 🆕 Strong/Loveable/Diverse/Flawed Characters → `custom_fields` or tag type
+- 🆕 Content Warnings → `tags` with `tag_type = 'content_warning'` (requires #42)
+- 🆕 Content Warning Description → linked note or `custom_fields`
+- 🆕 Contributors (narrators) → `book_contributors` with `role = 'narrator'`
+- 🆕 Owned? → `custom_fields` or future `owned` column
+
+## Known Quirks
+
+1. **No series data in titles** — Unlike Goodreads which embeds `"(Series, #N)"` in titles,
+   StoryGraph exports clean titles. Series must be enriched externally.
+
+2. **Variable date precision** — Dates can be year-only, month/year, or full dates. Parser
+   must handle all three gracefully.
+
+3. **HTML in reviews** — Reviews contain `<div>`, `<br>`, `&nbsp;`, and custom `<spoiler>`
+   tags. Strip HTML on import, convert `<spoiler>` to markdown spoiler syntax.
+
+4. **Mixed ISBN/UID field** — Single column for ISBN-13, ISBN-10, ASIN, and unknown IDs.
+   Requires detection heuristic.
+
+5. **Author comma ambiguity** — Multi-author entries use commas as separators, same as the
+   CSV delimiter. Standard CSV quoting handles this, but the importer must split the
+   `Authors` field on `","` after CSV parsing.
+
+6. **Tags are rarely used** — ~99% empty. Deduplicate case-insensitively when present.
+
+7. **`paused` status** — Rare but observed. Map to `Reading` (or `OnHold` if supported).
+
+8. **Legacy filename** — Export may be named `goodreads_library_export_*.csv`. Detect
+   StoryGraph by presence of `Moods` or `Pace` columns in the header row.
+
+## No Public API
+
+There is no public StoryGraph API. CSV export is the only viable data access method.
+Web scraping would violate the project's non-goals (Section 3.5: "No scraping").
+
+## Sources
+
+Research verified against multiple independent implementations:
+
+- Real 338-book export analysis (field frequency, value distributions)
+- TypeScript parser: `nperez0111/bookhive` (`src/utils/csv.ts`)
+- Python parser: `beforetheshoes/theseedbed` (`storygraph_parser.py`, 96 tests)
+- Python cleaner: `Runekeon/book_tracking_stuff` (`story_graph_export_cleaner.py`)
+- JS parser: `mmsge/read2listen` (`src/utils/storygraph.js`)


### PR DESCRIPTION
## Description

Validates two open research questions that block the StoryGraph importer and cover image pipeline: cover image licensing for local caching (#19) and StoryGraph export format (#17).

### What's included

- **Cover image licensing validation** (new: docs/validations/cover-image-licensing.md): Reviews Open Library and Google Books Terms of Service for local cover caching. Open Library on-demand caching is permitted; Google Books thumbnails **cannot** be cached locally (ToS §5e.1 prohibits permanent copies). Google Books is now scoped to transient text metadata enrichment only.
- **StoryGraph export format validation** (new: docs/validations/storygraph-export.md): Documents the full 23-column CSV format including parsing specs for variable-precision dates, quarter-star ratings (0.25 increments → Toku 0–10 conversion), 13 canonical moods, HTML reviews with `<spoiler>` tags, and mixed ISBN/ASIN identifier detection.
- **ADR-004 updated**: Adds a "Cover Image Licensing" section, corrects the prior claim that Google Books has "no restrictive ToS", marks two open validations complete.
- **ROADMAP updated**: Marks StoryGraph and cover licensing as `[Validated]` across the import matrix, cover image strategy, and due diligence backlog. Removes Google Books as a cover fallback source.
- **Anti-crawling guardrail**: Doc comment added to `fetch_cover` in `openlibrary.rs` documenting Open Library rate limits and permitted usage patterns.
- **Acknowledgments**: Adds Open Library courtesy attribution to `README.md`.

## Related Issues

Closes #19
Closes #17

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI / infrastructure
- [ ] Other (describe below)

## Crate

<!-- Which crate(s) does this touch? -->

- [ ] `toku-core` — Domain models, traits, state machine
- [ ] `toku-db` — SQLite persistence, migrations, FTS5
- [ ] `toku-import` — Importers (Goodreads, Calibre, StoryGraph)
- [x] `toku-meta` — Metadata fetching (Open Library, Google Books)
- [ ] `toku-cli` — CLI binary
- [ ] `toku-export` — Exporters (CSV, JSON, Markdown, BibTeX)
- [x] `docs/` — Documentation

## Data Integrity Checklist

<!-- Toku is a local-first tool — user data ownership is non-negotiable -->

- [x] No user data is sent to any server without explicit opt-in
- [x] Import operations are idempotent (re-importing the same file creates no duplicates)
- [x] User edits to metadata are never overwritten by auto-enrichment
- [x] New fields track provenance (source + timestamp)
- [x] Export round-trip is preserved (if applicable)

> Documentation-only PR — no data path modifications.

## Checklist

- [x] I have read [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] `cargo fmt --check` passes
- [x] `cargo clippy --workspace -- -D warnings` passes
- [x] `cargo test --workspace` passes
- [x] I have updated documentation (if applicable)