### PR TITLE
feat: full statistics engine and typed tags (mood, pace, content warnings)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Reading statistics: `toku stats` with books/pages read, average rating, reading pace, and format breakdown
 - `toku stats --year 2025` for year-filtered analytics
 - Currently reading list with progress percentages in stats output
+- Full statistics engine: rating distribution, reading streaks, monthly books finished, shortest/longest book, average days to finish, reading speed (pages/hour), top authors, and top tags
+- `toku stats --author <name>` to filter all statistics to a single author's books
+- Mood tags, pace ratings, and content warnings as typed tag categories (`toku edit --mood adventurous --pace fast --content-warning violence`)
+- `toku edit` command for updating mood tags, pace, content warnings, and rating on existing books (with `--remove-mood` and `--remove-content-warning` for removal)
+- `toku add --mood`, `--pace`, and `--content-warning` flags for setting typed tags at add time
+- `toku list --mood <tag>` and `--pace <rate>` filters with same-type OR, cross-type AND semantics
+- `toku stats --mood-trends` showing mood tag distribution per month across finished books
+- `toku show` now displays mood tags, pace rating, and content warnings in detail view (all output formats)
+- `toku tag list` now shows tag type column (general, mood, pace, content_warning)
 - Export to CSV: `toku export csv` with flat book table (title, authors, status, rating, shelves, tags)
 - Export to JSON: `toku export json` with full structured library data
 - Export to Markdown: `toku export markdown` with books grouped by reading status and star ratings

--- a/crates/toku-cli/src/main.rs
+++ b/crates/toku-cli/src/main.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
 
@@ -5,9 +6,9 @@ use anyhow::{Context, Result};
 use clap::{CommandFactory, Parser, Subcommand, ValueEnum};
 use clap_complete::Shell;
 use toku_core::{
-    Author, Book, BookFormat, ContributorRole, CurrentlyReadingInput, Isbn, ProgressType,
-    ReadingProgress, ReadingSession, ReadingStatus, TokuConfig, compute_stats,
-    parse_duration_to_minutes,
+    Author, Book, BookFormat, ContributorRole, CurrentlyReadingInput, Isbn, PaceRating,
+    ProgressType, ReadingProgress, ReadingSession, ReadingStatus, StatsInput, TagType, TokuConfig,
+    compute_stats, parse_duration_to_minutes,
 };
 use toku_db::{BookRepository, Database};
 
@@ -57,6 +58,18 @@ enum Commands {
         #[arg(long, short = 'T')]
         tag: Vec<String>,
 
+        /// Mood tag(s) to apply (repeatable)
+        #[arg(long)]
+        mood: Vec<String>,
+
+        /// Pace rating (fast, medium, slow)
+        #[arg(long)]
+        pace: Option<String>,
+
+        /// Content warning(s) to apply (repeatable)
+        #[arg(long, alias = "cw")]
+        content_warning: Vec<String>,
+
         /// Initial reading status (want-to-read, reading, read, abandoned, on-hold)
         #[arg(long)]
         status: Option<String>,
@@ -68,6 +81,36 @@ enum Commands {
         query: String,
     },
 
+    /// Edit book metadata (mood tags, pace, content warnings, rating)
+    Edit {
+        /// Book title or ID
+        query: String,
+
+        /// Mood tag(s) to add (repeatable)
+        #[arg(long)]
+        mood: Vec<String>,
+
+        /// Pace rating (fast, medium, slow)
+        #[arg(long)]
+        pace: Option<String>,
+
+        /// Content warning(s) to add (repeatable)
+        #[arg(long, alias = "cw")]
+        content_warning: Vec<String>,
+
+        /// Mood tag(s) to remove (repeatable)
+        #[arg(long)]
+        remove_mood: Vec<String>,
+
+        /// Content warning(s) to remove (repeatable)
+        #[arg(long, alias = "remove-cw")]
+        remove_content_warning: Vec<String>,
+
+        /// Set rating (0–10, displayed as 5★ with half-star increments)
+        #[arg(long, short)]
+        rating: Option<i32>,
+    },
+
     /// List books in your library
     List {
         /// Filter by reading status
@@ -77,6 +120,14 @@ enum Commands {
         /// Filter by tag name
         #[arg(long)]
         tag: Option<String>,
+
+        /// Filter by mood tag(s) (same-type OR, cross-type AND)
+        #[arg(long)]
+        mood: Vec<String>,
+
+        /// Filter by pace (fast, medium, slow)
+        #[arg(long)]
+        pace: Option<String>,
     },
 
     /// Search your library
@@ -155,6 +206,14 @@ enum Commands {
         /// Show stats for a specific year only
         #[arg(long)]
         year: Option<i32>,
+
+        /// Filter stats to a specific author (case-insensitive)
+        #[arg(long)]
+        author: Option<String>,
+
+        /// Show mood tag distribution over time
+        #[arg(long)]
+        mood_trends: bool,
     },
 }
 
@@ -411,6 +470,9 @@ fn main() -> Result<()> {
             isbn,
             book_format,
             tag,
+            mood,
+            pace,
+            content_warning,
             status,
         } => cmd_add(
             &repo,
@@ -420,13 +482,45 @@ fn main() -> Result<()> {
             isbn,
             &book_format,
             &tag,
+            &mood,
+            pace.as_deref(),
+            &content_warning,
             status.as_deref(),
             &cli.format,
         ),
         Commands::Show { query } => cmd_show(&repo, &query, &cli.format),
-        Commands::List { status, tag } => {
-            cmd_list(&repo, status.as_deref(), tag.as_deref(), &cli.format)
-        }
+        Commands::Edit {
+            query,
+            mood,
+            pace,
+            content_warning,
+            remove_mood,
+            remove_content_warning,
+            rating,
+        } => cmd_edit(
+            &repo,
+            &query,
+            &mood,
+            pace.as_deref(),
+            &content_warning,
+            &remove_mood,
+            &remove_content_warning,
+            rating,
+            &cli.format,
+        ),
+        Commands::List {
+            status,
+            tag,
+            mood,
+            pace,
+        } => cmd_list(
+            &repo,
+            status.as_deref(),
+            tag.as_deref(),
+            &mood,
+            pace.as_deref(),
+            &cli.format,
+        ),
         Commands::Search { query, status, tag } => cmd_search(
             &repo,
             &query,
@@ -440,7 +534,11 @@ fn main() -> Result<()> {
         Commands::Tag { action } => cmd_tag(&repo, action, &cli.format),
         Commands::Export { target } => cmd_export(&db, &data_dir, target),
         Commands::Bulk { action } => cmd_bulk(&repo, action),
-        Commands::Stats { year } => cmd_stats(&repo, year, &cli.format),
+        Commands::Stats {
+            year,
+            author,
+            mood_trends,
+        } => cmd_stats(&repo, year, author.as_deref(), mood_trends, &cli.format),
         // Already handled above
         Commands::Config { .. } | Commands::Completions { .. } => unreachable!(),
     }
@@ -496,6 +594,9 @@ fn cmd_add(
     isbn: Option<String>,
     book_format: &str,
     tags: &[String],
+    moods: &[String],
+    pace: Option<&str>,
+    content_warnings: &[String],
     initial_status: Option<&str>,
     output_format: &OutputFormat,
 ) -> Result<()> {
@@ -515,7 +616,15 @@ fn cmd_add(
         // Check for existing book with this ISBN
         if let Some(existing) = repo.find_by_isbn(&isbn13)? {
             // Apply tags/status to existing book instead of silently ignoring
-            apply_post_add(repo, &existing, tags, target_status)?;
+            apply_post_add(
+                repo,
+                &existing,
+                tags,
+                moods,
+                pace,
+                content_warnings,
+                target_status,
+            )?;
             print_books(&[existing], repo, output_format)?;
             eprintln!("Book already exists — applied tags/status updates");
             return Ok(());
@@ -558,7 +667,15 @@ fn cmd_add(
                     repo.add_book_author(&a, &book.id, ContributorRole::Author, i as i32)?;
                 }
 
-                apply_post_add(repo, &book, tags, target_status)?;
+                apply_post_add(
+                    repo,
+                    &book,
+                    tags,
+                    moods,
+                    pace,
+                    content_warnings,
+                    target_status,
+                )?;
                 print_books(&[book], repo, output_format)?;
                 eprintln!("✓ Added from Open Library");
             }
@@ -569,7 +686,15 @@ fn cmd_add(
                 book.format = format;
                 repo.create_book(&book)?;
                 repo.add_isbn(&isbn13, &book.id)?;
-                apply_post_add(repo, &book, tags, target_status)?;
+                apply_post_add(
+                    repo,
+                    &book,
+                    tags,
+                    moods,
+                    pace,
+                    content_warnings,
+                    target_status,
+                )?;
                 print_books(&[book], repo, output_format)?;
             }
         }
@@ -583,7 +708,15 @@ fn cmd_add(
             repo.add_book_author(&a, &book.id, ContributorRole::Author, 0)?;
         }
 
-        apply_post_add(repo, &book, tags, target_status)?;
+        apply_post_add(
+            repo,
+            &book,
+            tags,
+            moods,
+            pace,
+            content_warnings,
+            target_status,
+        )?;
         print_books(&[book], repo, output_format)?;
         eprintln!("✓ Added manually");
     } else {
@@ -593,11 +726,15 @@ fn cmd_add(
     Ok(())
 }
 
-/// Apply tags and optional status change after creating/finding a book.
+/// Apply tags, mood tags, pace, content warnings, and optional status change after creating/finding a book.
+#[allow(clippy::too_many_arguments)]
 fn apply_post_add(
     repo: &BookRepository,
     book: &Book,
     tags: &[String],
+    moods: &[String],
+    pace: Option<&str>,
+    content_warnings: &[String],
     status: Option<ReadingStatus>,
 ) -> Result<()> {
     for tag_name in tags {
@@ -606,9 +743,26 @@ fn apply_post_add(
             repo.add_tag_to_book(&book.id, trimmed)?;
         }
     }
+    for mood in moods {
+        let trimmed = mood.trim();
+        if !trimmed.is_empty() {
+            repo.add_typed_tag_to_book(&book.id, trimmed, TagType::Mood)?;
+        }
+    }
+    if let Some(pace_str) = pace {
+        let pace_rating: PaceRating = pace_str
+            .parse()
+            .map_err(|_| anyhow::anyhow!("invalid pace: {pace_str} (use fast, medium, or slow)"))?;
+        repo.set_book_pace(&book.id, pace_rating)?;
+    }
+    for cw in content_warnings {
+        let trimmed = cw.trim();
+        if !trimmed.is_empty() {
+            repo.add_typed_tag_to_book(&book.id, trimmed, TagType::ContentWarning)?;
+        }
+    }
     if let Some(target) = status {
         repo.update_book_status(&book.id, target)?;
-        // If marking as "reading", also create a reading session
         if target == ReadingStatus::Reading {
             let session = ReadingSession::new(book.id);
             repo.create_reading_session(&session)?;
@@ -634,6 +788,93 @@ fn cmd_show(repo: &BookRepository, query: &str, output_format: &OutputFormat) ->
     } else {
         print_book_detail(&books[0], repo, output_format)?;
     }
+    Ok(())
+}
+
+#[allow(clippy::too_many_arguments)]
+fn cmd_edit(
+    repo: &BookRepository,
+    query: &str,
+    moods: &[String],
+    pace: Option<&str>,
+    content_warnings: &[String],
+    remove_moods: &[String],
+    remove_content_warnings: &[String],
+    rating: Option<i32>,
+    output_format: &OutputFormat,
+) -> Result<()> {
+    let book = resolve_book(repo, query)?;
+    let mut changes = Vec::new();
+
+    // Add mood tags
+    for mood in moods {
+        let trimmed = mood.trim();
+        if !trimmed.is_empty() {
+            repo.add_typed_tag_to_book(&book.id, trimmed, TagType::Mood)?;
+            changes.push(format!("added mood \"{trimmed}\""));
+        }
+    }
+
+    // Remove mood tags
+    for mood in remove_moods {
+        let trimmed = mood.trim();
+        if !trimmed.is_empty() {
+            repo.remove_typed_tag_from_book(&book.id, trimmed, TagType::Mood)?;
+            changes.push(format!("removed mood \"{trimmed}\""));
+        }
+    }
+
+    // Set pace
+    if let Some(pace_str) = pace {
+        let pace_rating: PaceRating = pace_str
+            .parse()
+            .map_err(|_| anyhow::anyhow!("invalid pace: {pace_str} (use fast, medium, or slow)"))?;
+        repo.set_book_pace(&book.id, pace_rating)?;
+        changes.push(format!("set pace to {pace_str}"));
+    }
+
+    // Add content warnings
+    for cw in content_warnings {
+        let trimmed = cw.trim();
+        if !trimmed.is_empty() {
+            repo.add_typed_tag_to_book(&book.id, trimmed, TagType::ContentWarning)?;
+            changes.push(format!("added content warning \"{trimmed}\""));
+        }
+    }
+
+    // Remove content warnings
+    for cw in remove_content_warnings {
+        let trimmed = cw.trim();
+        if !trimmed.is_empty() {
+            repo.remove_typed_tag_from_book(&book.id, trimmed, TagType::ContentWarning)?;
+            changes.push(format!("removed content warning \"{trimmed}\""));
+        }
+    }
+
+    // Set rating
+    if let Some(r) = rating {
+        if !(0..=10).contains(&r) {
+            anyhow::bail!("rating must be between 0 and 10, got {r}");
+        }
+        repo.update_book_rating(&book.id, r)?;
+        changes.push(format!("set rating to {:.1}★", r as f32 / 2.0));
+    }
+
+    if changes.is_empty() {
+        eprintln!("No changes specified for \"{}\"", book.title);
+        eprintln!(
+            "Use --mood, --pace, --content-warning, --remove-mood, --remove-content-warning, or --rating"
+        );
+    } else {
+        // Re-fetch to show updated rating, then display
+        let updated = repo.get_book(&book.id).unwrap_or(book.clone());
+        print_book_detail(&updated, repo, output_format)?;
+        for change in &changes {
+            eprintln!("  ✓ {change}");
+        }
+        eprintln!("✓ Updated \"{}\" ({} change(s))", book.title, changes.len());
+    }
+
     Ok(())
 }
 
@@ -751,6 +992,8 @@ fn cmd_list(
     repo: &BookRepository,
     status: Option<&str>,
     tag: Option<&str>,
+    moods: &[String],
+    pace: Option<&str>,
     output_format: &OutputFormat,
 ) -> Result<()> {
     let books = if let Some(tag_name) = tag {
@@ -764,6 +1007,36 @@ fn cmd_list(
         books.into_iter().filter(|b| b.status == target).collect()
     } else {
         books
+    };
+
+    // Apply mood filter (same-type OR): keep books that have ANY of the specified moods
+    let filtered = if moods.is_empty() {
+        filtered
+    } else {
+        let mut mood_matched: Vec<Book> = Vec::new();
+        for book in filtered {
+            let book_moods = repo.get_book_tags_by_type(&book.id, TagType::Mood)?;
+            let mood_names: Vec<String> = book_moods.iter().map(|t| t.name.clone()).collect();
+            if moods.iter().any(|m| mood_names.contains(m)) {
+                mood_matched.push(book);
+            }
+        }
+        mood_matched
+    };
+
+    // Apply pace filter (AND with mood)
+    let filtered = if let Some(pace_str) = pace {
+        let mut pace_matched: Vec<Book> = Vec::new();
+        for book in filtered {
+            let book_pace = repo.get_book_tags_by_type(&book.id, TagType::Pace)?;
+            let pace_names: Vec<String> = book_pace.iter().map(|t| t.name.clone()).collect();
+            if pace_names.contains(&pace_str.to_string()) {
+                pace_matched.push(book);
+            }
+        }
+        pace_matched
+    } else {
+        filtered
     };
 
     if filtered.is_empty() {
@@ -933,9 +1206,42 @@ fn print_book_detail(
     repo: &BookRepository,
     output_format: &OutputFormat,
 ) -> Result<()> {
+    // Gather typed tags for all output formats
+    let mood_tags = repo
+        .get_book_tags_by_type(&book.id, TagType::Mood)
+        .unwrap_or_default();
+    let pace_tags = repo
+        .get_book_tags_by_type(&book.id, TagType::Pace)
+        .unwrap_or_default();
+    let cw_tags = repo
+        .get_book_tags_by_type(&book.id, TagType::ContentWarning)
+        .unwrap_or_default();
+
     match output_format {
         OutputFormat::Json => {
-            print_books(std::slice::from_ref(book), repo, output_format)?;
+            let authors: Vec<String> = repo
+                .get_book_authors(&book.id)
+                .unwrap_or_default()
+                .into_iter()
+                .map(|(a, _)| a.name)
+                .collect();
+            let general_tags = repo
+                .get_book_tags_by_type(&book.id, TagType::General)
+                .unwrap_or_default();
+            let json = serde_json::json!({
+                "id": book.id.to_string(),
+                "title": book.title,
+                "authors": authors,
+                "status": book.status.as_str(),
+                "format": book.format.as_str(),
+                "rating": book.rating,
+                "pages": book.page_count,
+                "tags": general_tags.iter().map(|t| &t.name).collect::<Vec<_>>(),
+                "moods": mood_tags.iter().map(|t| &t.name).collect::<Vec<_>>(),
+                "pace": pace_tags.first().map(|t| &t.name),
+                "content_warnings": cw_tags.iter().map(|t| &t.name).collect::<Vec<_>>(),
+            });
+            println!("{}", serde_json::to_string_pretty(&json)?);
         }
         OutputFormat::Csv => {
             print_books(std::slice::from_ref(book), repo, output_format)?;
@@ -976,6 +1282,17 @@ fn print_book_detail(
             }
             if let Some(rating) = book.rating {
                 println!("  Rating:  {:.1}★", rating as f32 / 2.0);
+            }
+            if !mood_tags.is_empty() {
+                let names: Vec<&str> = mood_tags.iter().map(|t| t.name.as_str()).collect();
+                println!("  Moods:   {}", names.join(", "));
+            }
+            if let Some(pace) = pace_tags.first() {
+                println!("  Pace:    {}", pace.name);
+            }
+            if !cw_tags.is_empty() {
+                let names: Vec<&str> = cw_tags.iter().map(|t| t.name.as_str()).collect();
+                println!("  ⚠ CW:    {}", names.join(", "));
             }
             if let Some(date) = &book.pub_date {
                 println!("  Pub:     {date}");
@@ -1430,21 +1747,28 @@ fn cmd_tag(repo: &BookRepository, action: TagAction, output_format: &OutputForma
                     #[derive(serde::Serialize)]
                     struct TagOut {
                         name: String,
+                        tag_type: String,
                         books: i64,
                     }
                     let out: Vec<TagOut> = tags
                         .iter()
                         .map(|(t, count)| TagOut {
                             name: t.name.clone(),
+                            tag_type: t.tag_type.to_string(),
                             books: *count,
                         })
                         .collect();
                     println!("{}", serde_json::to_string_pretty(&out)?);
                 }
                 OutputFormat::Csv => {
-                    println!("tag,books");
+                    println!("tag,type,books");
                     for (t, count) in &tags {
-                        println!("\"{}\",{}", t.name.replace('"', "\"\""), count);
+                        println!(
+                            "\"{}\",{},{}",
+                            t.name.replace('"', "\"\""),
+                            t.tag_type,
+                            count
+                        );
                     }
                 }
                 OutputFormat::Table => {
@@ -1454,6 +1778,8 @@ fn cmd_tag(repo: &BookRepository, action: TagAction, output_format: &OutputForma
                     struct Row {
                         #[tabled(rename = "Tag")]
                         name: String,
+                        #[tabled(rename = "Type")]
+                        tag_type: String,
                         #[tabled(rename = "Books")]
                         books: i64,
                     }
@@ -1462,6 +1788,7 @@ fn cmd_tag(repo: &BookRepository, action: TagAction, output_format: &OutputForma
                         .iter()
                         .map(|(t, count)| Row {
                             name: t.name.clone(),
+                            tag_type: t.tag_type.to_string(),
                             books: *count,
                         })
                         .collect();
@@ -1630,34 +1957,102 @@ fn cmd_bulk(repo: &BookRepository, action: BulkAction) -> Result<()> {
     }
 }
 
-fn cmd_stats(repo: &BookRepository, year: Option<i32>, output_format: &OutputFormat) -> Result<()> {
-    let books = repo.list_books()?;
-
-    let sessions = match year {
-        Some(y) => repo.list_reading_sessions_in_year(y)?,
-        None => repo.list_reading_sessions()?,
+fn cmd_stats(
+    repo: &BookRepository,
+    year: Option<i32>,
+    author: Option<&str>,
+    show_mood_trends: bool,
+    output_format: &OutputFormat,
+) -> Result<()> {
+    // Gather books — optionally filtered by author
+    let books = match author {
+        Some(name) => repo.list_books_by_author_name(name)?,
+        None => repo.list_books()?,
     };
 
+    let book_ids: Vec<String> = books.iter().map(|b| b.id.to_string()).collect();
+
+    // Gather sessions — scoped by author's books if filtered, then by year
+    let sessions = if author.is_some() {
+        match year {
+            Some(y) => repo.list_sessions_for_books_in_year(&book_ids, y)?,
+            None => repo.list_sessions_for_books(&book_ids)?,
+        }
+    } else {
+        match year {
+            Some(y) => repo.list_reading_sessions_in_year(y)?,
+            None => repo.list_reading_sessions()?,
+        }
+    };
+
+    // Currently reading details (only relevant when not author-filtered)
     let currently_reading_details = repo.get_currently_reading_details()?;
     let currently_reading_input: Vec<CurrentlyReadingInput> = currently_reading_details
         .into_iter()
+        .filter(|(book, _, _)| {
+            // When author-filtered, only include that author's books
+            author.is_none() || book_ids.contains(&book.id.to_string())
+        })
         .map(|(book, progress, authors)| {
-            let author = authors
+            let author_name = authors
                 .into_iter()
                 .map(|(a, _)| a.name)
                 .collect::<Vec<_>>()
                 .join(", ");
             CurrentlyReadingInput {
                 title: book.title,
-                author,
+                author: author_name,
                 page_count: book.page_count,
                 latest_progress: progress,
             }
         })
         .collect();
 
+    // Tag counts — scoped by author's books if filtered
+    let tag_counts = if author.is_some() {
+        repo.list_tag_counts_for_books(&book_ids)?
+    } else {
+        repo.list_tag_counts()?
+    };
+
+    // Author counts — scoped by author's books if filtered
+    let author_counts = if author.is_some() {
+        repo.list_author_book_counts_for_books(&book_ids)?
+    } else {
+        repo.list_author_book_counts()?
+    };
+
+    // Activity dates — scoped by year and/or author
+    let activity_dates = if author.is_some() {
+        repo.list_activity_dates_for_books(&book_ids)?
+    } else {
+        match year {
+            Some(y) => repo.list_activity_dates_in_year(y)?,
+            None => repo.list_activity_dates()?,
+        }
+    };
+
     let now = chrono::Utc::now();
-    let stats = compute_stats(&books, &sessions, &currently_reading_input, now);
+    let today = chrono::Local::now().date_naive();
+
+    // Mood tag data — only gathered when --mood-trends is requested
+    let mood_tag_data = if show_mood_trends {
+        repo.get_mood_tags_for_books(&book_ids)?
+    } else {
+        HashMap::new()
+    };
+
+    let stats = compute_stats(StatsInput {
+        books: &books,
+        sessions: &sessions,
+        currently_reading: &currently_reading_input,
+        tag_counts: &tag_counts,
+        author_counts: &author_counts,
+        activity_dates: &activity_dates,
+        now,
+        today,
+        mood_tag_data: &mood_tag_data,
+    });
 
     match output_format {
         OutputFormat::Json => {
@@ -1688,20 +2083,62 @@ fn cmd_stats(repo: &BookRepository, year: Option<i32>, output_format: &OutputFor
             println!("format_physical,{}", stats.format_breakdown.physical);
             println!("format_ebook,{}", stats.format_breakdown.ebook);
             println!("format_audiobook,{}", stats.format_breakdown.audiobook);
+            println!(
+                "rating_total_rated,{}",
+                stats.rating_distribution.total_rated
+            );
+            for (i, &count) in stats.rating_distribution.counts.iter().enumerate() {
+                println!("rating_{i},{count}");
+            }
+            println!("unique_authors,{}", stats.author_stats.unique_count);
+            println!(
+                "current_streak_days,{}",
+                stats.reading_streaks.current_streak_days
+            );
+            println!(
+                "longest_streak_days,{}",
+                stats.reading_streaks.longest_streak_days
+            );
+            println!(
+                "total_active_days,{}",
+                stats.reading_streaks.total_active_days
+            );
+            println!(
+                "avg_days_to_finish,{}",
+                stats
+                    .avg_days_to_finish
+                    .map_or("-".to_string(), |d| format!("{d:.1}"))
+            );
+            println!(
+                "reading_speed_pages_per_hour,{}",
+                stats
+                    .reading_speed_pages_per_hour
+                    .map_or("-".to_string(), |s| format!("{s:.1}"))
+            );
+            if let Some(ref b) = stats.shortest_book {
+                println!("shortest_book_pages,{}", b.page_count);
+            }
+            if let Some(ref b) = stats.longest_book {
+                println!("longest_book_pages,{}", b.page_count);
+            }
         }
         OutputFormat::Table => {
-            let header = match year {
-                Some(y) => format!("📊 Reading Statistics ({y})"),
-                None => "📊 Reading Statistics (All Time)".to_string(),
+            let header = match (year, author) {
+                (Some(y), Some(a)) => format!("📊 Reading Statistics ({y}) — {a}"),
+                (Some(y), None) => format!("📊 Reading Statistics ({y})"),
+                (None, Some(a)) => format!("📊 Reading Statistics (All Time) — {a}"),
+                (None, None) => "📊 Reading Statistics (All Time)".to_string(),
             };
             println!("\n{header}\n");
 
+            // --- Library overview ---
             println!("  Books read:        {:>5}", stats.books_read);
             println!("  Currently reading: {:>5}", stats.books_reading);
             println!("  Want to read:      {:>5}", stats.books_want_to_read);
             println!("  Abandoned:         {:>5}", stats.books_abandoned);
             println!();
 
+            // --- Reading metrics ---
             println!(
                 "  Pages read:        {:>5}",
                 format_number(stats.total_pages_read)
@@ -1721,6 +2158,28 @@ fn cmd_stats(repo: &BookRepository, year: Option<i32>, output_format: &OutputFor
                 format!("{:.1}", stats.pages_per_day)
             );
 
+            // --- Reading speed ---
+            if let Some(speed) = stats.reading_speed_pages_per_hour {
+                println!(
+                    "  Reading speed:     {:>5} pages/hour",
+                    format!("{speed:.1}")
+                );
+            }
+
+            // --- Time to finish ---
+            if let Some(avg) = stats.avg_days_to_finish {
+                println!("  Avg. time to finish: {avg:.1} days");
+            }
+
+            // --- Shortest / longest ---
+            if let Some(ref b) = stats.shortest_book {
+                println!("  Shortest book:     {} ({} pages)", b.title, b.page_count);
+            }
+            if let Some(ref b) = stats.longest_book {
+                println!("  Longest book:      {} ({} pages)", b.title, b.page_count);
+            }
+
+            // --- Format breakdown ---
             let total_formats = stats.format_breakdown.physical
                 + stats.format_breakdown.ebook
                 + stats.format_breakdown.audiobook;
@@ -1752,6 +2211,77 @@ fn cmd_stats(repo: &BookRepository, year: Option<i32>, output_format: &OutputFor
                 );
             }
 
+            // --- Rating distribution ---
+            if stats.rating_distribution.total_rated > 0 {
+                println!();
+                println!("  Rating distribution:");
+                for i in (0..=10).rev() {
+                    let count = stats.rating_distribution.counts[i];
+                    if count > 0 {
+                        let stars = i as f64 / 2.0;
+                        let bar = "█".repeat(count.min(40));
+                        println!("    {stars:>4.1}★ {bar} {count}");
+                    }
+                }
+            }
+
+            // --- Tag distribution ---
+            if !stats.tag_distribution.is_empty() {
+                println!();
+                println!("  Top tags:");
+                for tc in stats.tag_distribution.iter().take(10) {
+                    println!("    {:<20} {:>3}", tc.name, tc.count);
+                }
+            }
+
+            // --- Author stats ---
+            if stats.author_stats.unique_count > 0 {
+                println!();
+                println!("  Authors: {} unique", stats.author_stats.unique_count);
+                if !stats.author_stats.top_authors.is_empty() {
+                    println!("  Top authors:");
+                    for ac in &stats.author_stats.top_authors {
+                        println!("    {:<20} {:>3} books", ac.name, ac.count);
+                    }
+                }
+            }
+
+            // --- Reading streaks ---
+            let streaks = &stats.reading_streaks;
+            if streaks.total_active_days > 0 {
+                println!();
+                println!("  Reading streaks:");
+                println!("    Current:  {:>3} days", streaks.current_streak_days);
+                println!("    Longest:  {:>3} days", streaks.longest_streak_days);
+                println!("    Active days: {}", streaks.total_active_days);
+            }
+
+            // --- Monthly breakdown ---
+            if !stats.monthly_finished.is_empty() {
+                println!();
+                println!("  Books finished per month:");
+                for mf in &stats.monthly_finished {
+                    let month_name = match mf.month {
+                        1 => "Jan",
+                        2 => "Feb",
+                        3 => "Mar",
+                        4 => "Apr",
+                        5 => "May",
+                        6 => "Jun",
+                        7 => "Jul",
+                        8 => "Aug",
+                        9 => "Sep",
+                        10 => "Oct",
+                        11 => "Nov",
+                        12 => "Dec",
+                        _ => "???",
+                    };
+                    let bar = "█".repeat(mf.count.min(40));
+                    println!("    {} {:>4} {bar} {}", month_name, mf.year, mf.count);
+                }
+            }
+
+            // --- Currently reading ---
             if !stats.currently_reading.is_empty() {
                 println!();
                 println!("  Currently reading:");
@@ -1763,12 +2293,41 @@ fn cmd_stats(repo: &BookRepository, year: Option<i32>, output_format: &OutputFor
                         (Some(page), None, _) => format!(" (page {page})"),
                         _ => String::new(),
                     };
-                    let author = if cr.author.is_empty() {
+                    let author_str = if cr.author.is_empty() {
                         String::new()
                     } else {
                         format!(" — {}", cr.author)
                     };
-                    println!("    {}{author}{progress}", cr.title);
+                    println!("    {}{author_str}{progress}", cr.title);
+                }
+            }
+
+            // --- Mood trends ---
+            if !stats.mood_trends.is_empty() {
+                println!();
+                println!("  Mood trends:");
+                for trend in &stats.mood_trends {
+                    let month_name = match trend.month {
+                        1 => "Jan",
+                        2 => "Feb",
+                        3 => "Mar",
+                        4 => "Apr",
+                        5 => "May",
+                        6 => "Jun",
+                        7 => "Jul",
+                        8 => "Aug",
+                        9 => "Sep",
+                        10 => "Oct",
+                        11 => "Nov",
+                        12 => "Dec",
+                        _ => "???",
+                    };
+                    let moods: Vec<String> = trend
+                        .moods
+                        .iter()
+                        .map(|m| format!("{} ({})", m.name, m.count))
+                        .collect();
+                    println!("    {} {:>4}: {}", month_name, trend.year, moods.join(", "));
                 }
             }
 

--- a/crates/toku-core/src/book.rs
+++ b/crates/toku-core/src/book.rs
@@ -379,12 +379,90 @@ impl Shelf {
     }
 }
 
+/// Type of tag: general, mood, pace, or content warning.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum TagType {
+    General,
+    Mood,
+    Pace,
+    ContentWarning,
+}
+
+impl TagType {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::General => "general",
+            Self::Mood => "mood",
+            Self::Pace => "pace",
+            Self::ContentWarning => "content_warning",
+        }
+    }
+}
+
+impl std::fmt::Display for TagType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl std::str::FromStr for TagType {
+    type Err = crate::TokuError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.to_lowercase().as_str() {
+            "general" => Ok(Self::General),
+            "mood" => Ok(Self::Mood),
+            "pace" => Ok(Self::Pace),
+            "content_warning" | "content-warning" | "cw" => Ok(Self::ContentWarning),
+            _ => Err(crate::TokuError::InvalidTagType(s.to_string())),
+        }
+    }
+}
+
+/// Pace rating for a book: fast, medium, or slow.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum PaceRating {
+    Fast,
+    Medium,
+    Slow,
+}
+
+impl PaceRating {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Fast => "fast",
+            Self::Medium => "medium",
+            Self::Slow => "slow",
+        }
+    }
+}
+
+impl std::fmt::Display for PaceRating {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl std::str::FromStr for PaceRating {
+    type Err = crate::TokuError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.to_lowercase().as_str() {
+            "fast" => Ok(Self::Fast),
+            "medium" | "med" => Ok(Self::Medium),
+            "slow" => Ok(Self::Slow),
+            _ => Err(crate::TokuError::InvalidPaceRating(s.to_string())),
+        }
+    }
+}
+
 /// A user-defined tag for categorizing books (e.g. "sci-fi", "Hugo winner").
-/// Tag names are case-insensitive.
+/// Tag names are case-insensitive. Tags are unique by `(name, tag_type)`.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Tag {
     pub id: Uuid,
     pub name: String,
+    pub tag_type: TagType,
     pub created_at: DateTime<Utc>,
 }
 
@@ -393,6 +471,16 @@ impl Tag {
         Self {
             id: Uuid::now_v7(),
             name: name.into(),
+            tag_type: TagType::General,
+            created_at: Utc::now(),
+        }
+    }
+
+    pub fn with_type(name: impl Into<String>, tag_type: TagType) -> Self {
+        Self {
+            id: Uuid::now_v7(),
+            name: name.into(),
+            tag_type,
             created_at: Utc::now(),
         }
     }
@@ -612,5 +700,63 @@ mod tests {
     fn parse_duration_invalid() {
         assert!(parse_duration_to_minutes("abc").is_err());
         assert!(parse_duration_to_minutes("").is_err());
+    }
+
+    #[test]
+    fn tag_type_roundtrip() {
+        for tt in [
+            TagType::General,
+            TagType::Mood,
+            TagType::Pace,
+            TagType::ContentWarning,
+        ] {
+            let parsed: TagType = tt.as_str().parse().unwrap();
+            assert_eq!(parsed, tt);
+        }
+    }
+
+    #[test]
+    fn tag_type_aliases() {
+        assert_eq!(
+            "content-warning".parse::<TagType>().unwrap(),
+            TagType::ContentWarning
+        );
+        assert_eq!("cw".parse::<TagType>().unwrap(), TagType::ContentWarning);
+    }
+
+    #[test]
+    fn tag_type_invalid() {
+        assert!("unknown".parse::<TagType>().is_err());
+    }
+
+    #[test]
+    fn pace_rating_roundtrip() {
+        for pr in [PaceRating::Fast, PaceRating::Medium, PaceRating::Slow] {
+            let parsed: PaceRating = pr.as_str().parse().unwrap();
+            assert_eq!(parsed, pr);
+        }
+    }
+
+    #[test]
+    fn pace_rating_alias_med() {
+        assert_eq!("med".parse::<PaceRating>().unwrap(), PaceRating::Medium);
+    }
+
+    #[test]
+    fn pace_rating_invalid() {
+        assert!("very-fast".parse::<PaceRating>().is_err());
+    }
+
+    #[test]
+    fn tag_with_type() {
+        let tag = Tag::with_type("adventurous", TagType::Mood);
+        assert_eq!(tag.name, "adventurous");
+        assert_eq!(tag.tag_type, TagType::Mood);
+    }
+
+    #[test]
+    fn tag_new_defaults_to_general() {
+        let tag = Tag::new("sci-fi");
+        assert_eq!(tag.tag_type, TagType::General);
     }
 }

--- a/crates/toku-core/src/error.rs
+++ b/crates/toku-core/src/error.rs
@@ -15,6 +15,12 @@ pub enum TokuError {
     #[error("invalid duration format: {0}")]
     InvalidDuration(String),
 
+    #[error("invalid tag type: {0}")]
+    InvalidTagType(String),
+
+    #[error("invalid pace rating: {0} (expected fast, medium, or slow)")]
+    InvalidPaceRating(String),
+
     #[error("invalid ISBN: {0}")]
     InvalidIsbn(String),
 

--- a/crates/toku-core/src/stats.rs
+++ b/crates/toku-core/src/stats.rs
@@ -1,7 +1,59 @@
-use chrono::{DateTime, Utc};
+use std::collections::HashMap;
+
+use chrono::{DateTime, Datelike, NaiveDate, Utc};
 use serde::{Deserialize, Serialize};
 
 use crate::{Book, BookFormat, ReadingProgress, ReadingSession, ReadingStatus};
+
+// ---------------------------------------------------------------------------
+// Input types — gathered by the DB layer, consumed by pure computation
+// ---------------------------------------------------------------------------
+
+/// All inputs needed to compute reading statistics.
+/// Collected by the DB/CLI layer and passed to `compute_stats`.
+pub struct StatsInput<'a> {
+    pub books: &'a [Book],
+    pub sessions: &'a [ReadingSession],
+    pub currently_reading: &'a [CurrentlyReadingInput],
+    pub tag_counts: &'a [TagCount],
+    pub author_counts: &'a [AuthorCount],
+    /// Unique dates of reading activity (progress logs, session dates),
+    /// sorted ascending. Should be in the user's local timezone.
+    pub activity_dates: &'a [NaiveDate],
+    /// The current timestamp (injected for testability).
+    pub now: DateTime<Utc>,
+    /// Today's date in the user's local timezone (for streak calculation).
+    pub today: NaiveDate,
+    /// Mood tags per book (book_id → list of mood tag names).
+    /// Used for `--mood-trends`. Pass an empty map to skip.
+    pub mood_tag_data: &'a HashMap<String, Vec<String>>,
+}
+
+/// Input data for a currently-reading book gathered by the DB layer.
+pub struct CurrentlyReadingInput {
+    pub title: String,
+    pub author: String,
+    pub page_count: Option<i32>,
+    pub latest_progress: Option<ReadingProgress>,
+}
+
+/// Tag name with book count, provided by the DB layer.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TagCount {
+    pub name: String,
+    pub count: usize,
+}
+
+/// Author name with book count, provided by the DB layer.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AuthorCount {
+    pub name: String,
+    pub count: usize,
+}
+
+// ---------------------------------------------------------------------------
+// Output types — the computed statistics
+// ---------------------------------------------------------------------------
 
 /// Aggregated reading statistics.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -22,6 +74,20 @@ pub struct ReadingStats {
     pub pages_per_day: f64,
     pub format_breakdown: FormatBreakdown,
     pub currently_reading: Vec<CurrentlyReading>,
+    pub rating_distribution: RatingDistribution,
+    pub tag_distribution: Vec<TagCount>,
+    pub author_stats: AuthorStats,
+    pub reading_streaks: ReadingStreaks,
+    /// Average days to finish a book, or `None` if no books have been finished.
+    pub avg_days_to_finish: Option<f64>,
+    /// Weighted reading speed in pages per hour, or `None` if no session data.
+    pub reading_speed_pages_per_hour: Option<f64>,
+    /// Books finished per month. When scoped to a year, contains all 12 months.
+    pub monthly_finished: Vec<MonthlyFinished>,
+    pub shortest_book: Option<BookStat>,
+    pub longest_book: Option<BookStat>,
+    /// Mood tag distribution per month (populated only with `--mood-trends`).
+    pub mood_trends: Vec<MoodTrend>,
 }
 
 /// Count of books per physical format.
@@ -42,26 +108,66 @@ pub struct CurrentlyReading {
     pub percent: Option<f64>,
 }
 
-/// Input data for a currently-reading book gathered by the DB layer.
-pub struct CurrentlyReadingInput {
-    pub title: String,
-    pub author: String,
-    pub page_count: Option<i32>,
-    pub latest_progress: Option<ReadingProgress>,
+/// Rating distribution: count of books at each rating level 0–10.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RatingDistribution {
+    /// `counts[i]` = number of books with rating `i` (index 0–10).
+    pub counts: [usize; 11],
+    pub total_rated: usize,
 }
 
+/// Author diversity and top-author statistics.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AuthorStats {
+    pub unique_count: usize,
+    /// Top authors by book count (up to 10).
+    pub top_authors: Vec<AuthorCount>,
+}
+
+/// Reading streak information.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ReadingStreaks {
+    /// Current consecutive days with reading activity (0 if no activity today/yesterday).
+    pub current_streak_days: u32,
+    /// Longest consecutive streak ever recorded.
+    pub longest_streak_days: u32,
+    /// Total distinct days with reading activity.
+    pub total_active_days: u32,
+}
+
+/// Books finished in a calendar month.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MonthlyFinished {
+    pub year: i32,
+    pub month: u32,
+    pub count: usize,
+}
+
+/// A book with its page count, used for shortest/longest stats.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BookStat {
+    pub title: String,
+    pub page_count: i32,
+}
+
+/// Mood tag distribution for a single month.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MoodTrend {
+    pub year: i32,
+    pub month: u32,
+    pub moods: Vec<TagCount>,
+}
+
+// ---------------------------------------------------------------------------
+// Computation
+// ---------------------------------------------------------------------------
+
 /// Compute reading statistics from pure data — no database access.
-///
-/// * `books` — all books in the library (or the filtered subset).
-/// * `sessions` — reading sessions in the selected period.
-/// * `currently_reading` — details about books with status `Reading`.
-/// * `now` — the current timestamp (injected for testability).
-pub fn compute_stats(
-    books: &[Book],
-    sessions: &[ReadingSession],
-    currently_reading: &[CurrentlyReadingInput],
-    now: DateTime<Utc>,
-) -> ReadingStats {
+pub fn compute_stats(input: StatsInput<'_>) -> ReadingStats {
+    let books = input.books;
+    let sessions = input.sessions;
+    let now = input.now;
+
     let total_books = books.len();
 
     let books_read = books
@@ -89,7 +195,11 @@ pub fn compute_stats(
         .sum();
 
     // Average rating (0–10 scale)
-    let rated: Vec<i32> = books.iter().filter_map(|b| b.rating).collect();
+    let rated: Vec<i32> = books
+        .iter()
+        .filter_map(|b| b.rating)
+        .filter(|&r| (0..=10).contains(&r))
+        .collect();
     let average_rating = if rated.is_empty() {
         None
     } else {
@@ -121,7 +231,85 @@ pub fn compute_stats(
     };
 
     // Currently reading details
-    let currently_reading_list: Vec<CurrentlyReading> = currently_reading
+    let currently_reading = compute_currently_reading(input.currently_reading);
+
+    // Rating distribution
+    let rating_distribution = compute_rating_distribution(books);
+
+    // Tag distribution (already sorted by DB, take top 20)
+    let tag_distribution: Vec<TagCount> = input.tag_counts.iter().take(20).cloned().collect();
+
+    // Author stats
+    let author_stats = AuthorStats {
+        unique_count: input.author_counts.len(),
+        top_authors: input.author_counts.iter().take(10).cloned().collect(),
+    };
+
+    // Reading streaks
+    let reading_streaks = compute_streaks(input.activity_dates, input.today);
+
+    // Time to finish (average days per finished session)
+    let avg_days_to_finish = compute_avg_days_to_finish(&finished_sessions);
+
+    // Reading speed (weighted pages/hour)
+    let reading_speed_pages_per_hour = compute_reading_speed(sessions);
+
+    // Monthly finished books
+    let monthly_finished = compute_monthly_finished(&finished_sessions);
+
+    // Shortest / longest book (all books in scope with page_count > 0)
+    let books_with_pages: Vec<&Book> = books
+        .iter()
+        .filter(|b| b.page_count.is_some_and(|p| p > 0))
+        .collect();
+
+    let shortest_book = books_with_pages
+        .iter()
+        .min_by_key(|b| b.page_count.unwrap())
+        .map(|b| BookStat {
+            title: b.title.clone(),
+            page_count: b.page_count.unwrap(),
+        });
+
+    let longest_book = books_with_pages
+        .iter()
+        .max_by_key(|b| b.page_count.unwrap())
+        .map(|b| BookStat {
+            title: b.title.clone(),
+            page_count: b.page_count.unwrap(),
+        });
+
+    // Mood trends: aggregate mood tags of finished books per month
+    let mood_trends = compute_mood_trends(&finished_sessions, input.mood_tag_data);
+
+    ReadingStats {
+        total_books,
+        books_read,
+        books_reading,
+        books_want_to_read,
+        books_abandoned,
+        total_pages_read,
+        average_rating,
+        average_rating_stars,
+        books_per_month,
+        pages_per_day,
+        format_breakdown,
+        currently_reading,
+        rating_distribution,
+        tag_distribution,
+        author_stats,
+        reading_streaks,
+        avg_days_to_finish,
+        reading_speed_pages_per_hour,
+        monthly_finished,
+        shortest_book,
+        longest_book,
+        mood_trends,
+    }
+}
+
+fn compute_currently_reading(inputs: &[CurrentlyReadingInput]) -> Vec<CurrentlyReading> {
+    inputs
         .iter()
         .map(|cr| {
             let latest_page = cr.latest_progress.as_ref().map(|p| p.value);
@@ -141,22 +329,197 @@ pub fn compute_stats(
                 percent,
             }
         })
+        .collect()
+}
+
+fn compute_rating_distribution(books: &[Book]) -> RatingDistribution {
+    let mut counts = [0usize; 11];
+    let mut total_rated = 0;
+    for book in books {
+        if let Some(r) = book.rating
+            && (0..=10).contains(&r)
+        {
+            counts[r as usize] += 1;
+            total_rated += 1;
+        }
+    }
+    RatingDistribution {
+        counts,
+        total_rated,
+    }
+}
+
+/// Compute current and longest reading streaks from sorted activity dates.
+fn compute_streaks(activity_dates: &[NaiveDate], today: NaiveDate) -> ReadingStreaks {
+    if activity_dates.is_empty() {
+        return ReadingStreaks {
+            current_streak_days: 0,
+            longest_streak_days: 0,
+            total_active_days: 0,
+        };
+    }
+
+    // Deduplicate and sort (should already be sorted, but ensure)
+    let mut dates: Vec<NaiveDate> = activity_dates.to_vec();
+    dates.sort();
+    dates.dedup();
+
+    let total_active_days = dates.len() as u32;
+
+    let mut longest = 1u32;
+    let mut current = 1u32;
+
+    for window in dates.windows(2) {
+        let diff = window[1].signed_duration_since(window[0]).num_days();
+        if diff == 1 {
+            current += 1;
+            longest = longest.max(current);
+        } else {
+            current = 1;
+        }
+    }
+
+    // Determine current streak: the streak must include today or yesterday.
+    let last_date = *dates.last().unwrap();
+    let gap = today.signed_duration_since(last_date).num_days();
+    let current_streak = if gap <= 1 { current } else { 0 };
+
+    ReadingStreaks {
+        current_streak_days: current_streak,
+        longest_streak_days: longest,
+        total_active_days,
+    }
+}
+
+/// Average days to finish a book, based on completed sessions.
+fn compute_avg_days_to_finish(finished_sessions: &[&ReadingSession]) -> Option<f64> {
+    let durations: Vec<f64> = finished_sessions
+        .iter()
+        .filter_map(|s| {
+            s.finished_at.map(|fin| {
+                let days = fin.signed_duration_since(s.started_at).num_hours() as f64 / 24.0;
+                days.max(0.0)
+            })
+        })
         .collect();
 
-    ReadingStats {
-        total_books,
-        books_read,
-        books_reading,
-        books_want_to_read,
-        books_abandoned,
-        total_pages_read,
-        average_rating,
-        average_rating_stars,
-        books_per_month,
-        pages_per_day,
-        format_breakdown,
-        currently_reading: currently_reading_list,
+    if durations.is_empty() {
+        None
+    } else {
+        Some(durations.iter().sum::<f64>() / durations.len() as f64)
     }
+}
+
+/// Weighted reading speed: total pages / total hours across all valid sessions.
+/// Only includes sessions with valid page range and non-zero duration.
+fn compute_reading_speed(sessions: &[ReadingSession]) -> Option<f64> {
+    let mut total_pages: f64 = 0.0;
+    let mut total_hours: f64 = 0.0;
+
+    for s in sessions {
+        let (start_p, end_p, finished) = match (s.start_page, s.end_page, s.finished_at) {
+            (Some(sp), Some(ep), Some(fin)) if ep > sp => (sp, ep, fin),
+            _ => continue,
+        };
+
+        let hours = finished.signed_duration_since(s.started_at).num_minutes() as f64 / 60.0;
+        if hours > 0.0 {
+            total_pages += (end_p - start_p) as f64;
+            total_hours += hours;
+        }
+    }
+
+    if total_hours > 0.0 {
+        Some(total_pages / total_hours)
+    } else {
+        None
+    }
+}
+
+/// Books finished per month from completed sessions.
+fn compute_monthly_finished(finished_sessions: &[&ReadingSession]) -> Vec<MonthlyFinished> {
+    let mut counts: HashMap<(i32, u32), usize> = HashMap::new();
+
+    for s in finished_sessions {
+        if let Some(fin) = s.finished_at {
+            let key = (fin.year(), fin.month());
+            *counts.entry(key).or_default() += 1;
+        }
+    }
+
+    // If we have data, fill in all months between min and max.
+    if counts.is_empty() {
+        return Vec::new();
+    }
+
+    let min_key = *counts.keys().min().unwrap();
+    let max_key = *counts.keys().max().unwrap();
+
+    let mut result = Vec::new();
+    let mut year = min_key.0;
+    let mut month = min_key.1;
+
+    loop {
+        let count = counts.get(&(year, month)).copied().unwrap_or(0);
+        result.push(MonthlyFinished { year, month, count });
+
+        if (year, month) == max_key {
+            break;
+        }
+
+        month += 1;
+        if month > 12 {
+            month = 1;
+            year += 1;
+        }
+    }
+
+    result
+}
+
+/// Compute mood tag distribution per month from finished sessions.
+fn compute_mood_trends(
+    finished_sessions: &[&ReadingSession],
+    mood_tag_data: &HashMap<String, Vec<String>>,
+) -> Vec<MoodTrend> {
+    if mood_tag_data.is_empty() {
+        return Vec::new();
+    }
+
+    // Group finished book_ids by month
+    let mut month_moods: HashMap<(i32, u32), HashMap<String, usize>> = HashMap::new();
+
+    for s in finished_sessions {
+        if let Some(fin) = s.finished_at {
+            let key = (fin.year(), fin.month());
+            let book_id = s.book_id.to_string();
+            if let Some(moods) = mood_tag_data.get(&book_id) {
+                let month_entry = month_moods.entry(key).or_default();
+                for mood in moods {
+                    *month_entry.entry(mood.clone()).or_default() += 1;
+                }
+            }
+        }
+    }
+
+    if month_moods.is_empty() {
+        return Vec::new();
+    }
+
+    let mut result: Vec<MoodTrend> = month_moods
+        .into_iter()
+        .map(|((year, month), counts)| {
+            let mut moods: Vec<TagCount> = counts
+                .into_iter()
+                .map(|(name, count)| TagCount { name, count })
+                .collect();
+            moods.sort_by(|a, b| b.count.cmp(&a.count).then(a.name.cmp(&b.name)));
+            MoodTrend { year, month, moods }
+        })
+        .collect();
+
+    result.sort_by_key(|t| (t.year, t.month));
+    result
 }
 
 /// Compute books/month and pages/day from finished sessions.
@@ -201,7 +564,6 @@ fn compute_pace(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use chrono::TimeZone;
     use uuid::Uuid;
 
     fn make_book(title: &str, status: ReadingStatus, format: BookFormat) -> Book {
@@ -222,10 +584,26 @@ mod tests {
         session
     }
 
+    fn empty_input(now: DateTime<Utc>) -> StatsInput<'static> {
+        static EMPTY_MOODS: std::sync::LazyLock<HashMap<String, Vec<String>>> =
+            std::sync::LazyLock::new(HashMap::new);
+        StatsInput {
+            books: &[],
+            sessions: &[],
+            currently_reading: &[],
+            tag_counts: &[],
+            author_counts: &[],
+            activity_dates: &[],
+            now,
+            today: now.date_naive(),
+            mood_tag_data: &EMPTY_MOODS,
+        }
+    }
+
     #[test]
     fn empty_library_returns_zeroed_stats() {
         let now = Utc::now();
-        let stats = compute_stats(&[], &[], &[], now);
+        let stats = compute_stats(empty_input(now));
 
         assert_eq!(stats.total_books, 0);
         assert_eq!(stats.books_read, 0);
@@ -241,6 +619,16 @@ mod tests {
         assert_eq!(stats.format_breakdown.ebook, 0);
         assert_eq!(stats.format_breakdown.audiobook, 0);
         assert!(stats.currently_reading.is_empty());
+        assert_eq!(stats.rating_distribution.total_rated, 0);
+        assert!(stats.tag_distribution.is_empty());
+        assert_eq!(stats.author_stats.unique_count, 0);
+        assert_eq!(stats.reading_streaks.current_streak_days, 0);
+        assert_eq!(stats.reading_streaks.longest_streak_days, 0);
+        assert!(stats.avg_days_to_finish.is_none());
+        assert!(stats.reading_speed_pages_per_hour.is_none());
+        assert!(stats.monthly_finished.is_empty());
+        assert!(stats.shortest_book.is_none());
+        assert!(stats.longest_book.is_none());
     }
 
     #[test]
@@ -248,8 +636,13 @@ mod tests {
         let mut book1 = make_book("A", ReadingStatus::Read, BookFormat::Physical);
         book1.rating = None;
         let book2 = make_book("B", ReadingStatus::WantToRead, BookFormat::Ebook);
+        let books = [book1, book2];
 
-        let stats = compute_stats(&[book1, book2], &[], &[], Utc::now());
+        let now = Utc::now();
+        let stats = compute_stats(StatsInput {
+            books: &books,
+            ..empty_input(now)
+        });
         assert!(stats.average_rating.is_none());
         assert!(stats.average_rating_stars.is_none());
     }
@@ -261,8 +654,13 @@ mod tests {
         let mut book2 = make_book("B", ReadingStatus::Read, BookFormat::Ebook);
         book2.rating = Some(6); // 3.0★
         let book3 = make_book("C", ReadingStatus::WantToRead, BookFormat::Physical);
+        let books = [book1, book2, book3];
 
-        let stats = compute_stats(&[book1, book2, book3], &[], &[], Utc::now());
+        let now = Utc::now();
+        let stats = compute_stats(StatsInput {
+            books: &books,
+            ..empty_input(now)
+        });
         let avg = stats.average_rating.expect("should have an average");
         assert!((avg - 7.0).abs() < f64::EPSILON); // (8+6)/2 = 7.0
         let stars = stats.average_rating_stars.expect("should have stars");
@@ -279,7 +677,11 @@ mod tests {
             make_book("E", ReadingStatus::Read, BookFormat::Ebook),
         ];
 
-        let stats = compute_stats(&books, &[], &[], Utc::now());
+        let now = Utc::now();
+        let stats = compute_stats(StatsInput {
+            books: &books,
+            ..empty_input(now)
+        });
         assert_eq!(stats.format_breakdown.physical, 2);
         assert_eq!(stats.format_breakdown.ebook, 2);
         assert_eq!(stats.format_breakdown.audiobook, 1);
@@ -296,7 +698,11 @@ mod tests {
             make_book("F", ReadingStatus::Abandoned, BookFormat::Audiobook),
         ];
 
-        let stats = compute_stats(&books, &[], &[], Utc::now());
+        let now = Utc::now();
+        let stats = compute_stats(StatsInput {
+            books: &books,
+            ..empty_input(now)
+        });
         assert_eq!(stats.total_books, 6);
         assert_eq!(stats.books_read, 2);
         assert_eq!(stats.books_reading, 1);
@@ -314,8 +720,13 @@ mod tests {
         book3.page_count = Some(500); // not counted — still reading
         let book4 = make_book("D", ReadingStatus::Read, BookFormat::Physical);
         // no page count — skipped
+        let books = [book1, book2, book3, book4];
 
-        let stats = compute_stats(&[book1, book2, book3, book4], &[], &[], Utc::now());
+        let now = Utc::now();
+        let stats = compute_stats(StatsInput {
+            books: &books,
+            ..empty_input(now)
+        });
         assert_eq!(stats.total_pages_read, 500); // 300 + 200
     }
 
@@ -332,7 +743,11 @@ mod tests {
             )),
         }];
 
-        let stats = compute_stats(&[], &[], &input, Utc::now());
+        let now = Utc::now();
+        let stats = compute_stats(StatsInput {
+            currently_reading: &input,
+            ..empty_input(now)
+        });
         assert_eq!(stats.currently_reading.len(), 1);
         let cr = &stats.currently_reading[0];
         assert_eq!(cr.title, "Dune");
@@ -353,11 +768,347 @@ mod tests {
         let thirty_days_ago = now - chrono::Duration::days(30);
         let sixty_days_ago = now - chrono::Duration::days(60);
         let session = make_session(book.id, sixty_days_ago, Some(thirty_days_ago));
+        let books = [book];
+        let sessions = [session];
 
-        let stats = compute_stats(&[book], &[session], &[], now);
+        let stats = compute_stats(StatsInput {
+            books: &books,
+            sessions: &sessions,
+            ..empty_input(now)
+        });
 
         // 1 book over ~1 month
         assert!(stats.books_per_month > 0.0);
         assert!(stats.pages_per_day > 0.0);
+    }
+
+    // --- New statistics tests ---
+
+    #[test]
+    fn rating_distribution_buckets() {
+        let mut b1 = make_book("A", ReadingStatus::Read, BookFormat::Physical);
+        b1.rating = Some(8);
+        let mut b2 = make_book("B", ReadingStatus::Read, BookFormat::Physical);
+        b2.rating = Some(8);
+        let mut b3 = make_book("C", ReadingStatus::Read, BookFormat::Physical);
+        b3.rating = Some(5);
+        let mut b4 = make_book("D", ReadingStatus::Read, BookFormat::Physical);
+        b4.rating = None; // unrated
+        let books = [b1, b2, b3, b4];
+
+        let now = Utc::now();
+        let stats = compute_stats(StatsInput {
+            books: &books,
+            ..empty_input(now)
+        });
+
+        assert_eq!(stats.rating_distribution.total_rated, 3);
+        assert_eq!(stats.rating_distribution.counts[8], 2);
+        assert_eq!(stats.rating_distribution.counts[5], 1);
+        assert_eq!(stats.rating_distribution.counts[0], 0);
+    }
+
+    #[test]
+    fn rating_distribution_ignores_out_of_range() {
+        let mut b1 = make_book("A", ReadingStatus::Read, BookFormat::Physical);
+        b1.rating = Some(11); // out of range, should be ignored
+        let mut b2 = make_book("B", ReadingStatus::Read, BookFormat::Physical);
+        b2.rating = Some(-1); // out of range
+        let books = [b1, b2];
+
+        let now = Utc::now();
+        let stats = compute_stats(StatsInput {
+            books: &books,
+            ..empty_input(now)
+        });
+        assert_eq!(stats.rating_distribution.total_rated, 0);
+    }
+
+    #[test]
+    fn tag_distribution_passes_through() {
+        let tags = vec![
+            TagCount {
+                name: "sci-fi".to_string(),
+                count: 10,
+            },
+            TagCount {
+                name: "fantasy".to_string(),
+                count: 5,
+            },
+        ];
+
+        let now = Utc::now();
+        let stats = compute_stats(StatsInput {
+            tag_counts: &tags,
+            ..empty_input(now)
+        });
+        assert_eq!(stats.tag_distribution.len(), 2);
+        assert_eq!(stats.tag_distribution[0].name, "sci-fi");
+        assert_eq!(stats.tag_distribution[0].count, 10);
+    }
+
+    #[test]
+    fn tag_distribution_caps_at_20() {
+        let tags: Vec<TagCount> = (0..30)
+            .map(|i| TagCount {
+                name: format!("tag-{i}"),
+                count: 30 - i,
+            })
+            .collect();
+
+        let now = Utc::now();
+        let stats = compute_stats(StatsInput {
+            tag_counts: &tags,
+            ..empty_input(now)
+        });
+        assert_eq!(stats.tag_distribution.len(), 20);
+    }
+
+    #[test]
+    fn author_stats_from_input() {
+        let authors = vec![
+            AuthorCount {
+                name: "Frank Herbert".to_string(),
+                count: 5,
+            },
+            AuthorCount {
+                name: "Ursula K. Le Guin".to_string(),
+                count: 3,
+            },
+        ];
+
+        let now = Utc::now();
+        let stats = compute_stats(StatsInput {
+            author_counts: &authors,
+            ..empty_input(now)
+        });
+        assert_eq!(stats.author_stats.unique_count, 2);
+        assert_eq!(stats.author_stats.top_authors.len(), 2);
+        assert_eq!(stats.author_stats.top_authors[0].name, "Frank Herbert");
+    }
+
+    #[test]
+    fn streaks_consecutive_days() {
+        let today = NaiveDate::from_ymd_opt(2024, 6, 15).unwrap();
+        let dates = vec![
+            NaiveDate::from_ymd_opt(2024, 6, 10).unwrap(),
+            NaiveDate::from_ymd_opt(2024, 6, 11).unwrap(),
+            NaiveDate::from_ymd_opt(2024, 6, 12).unwrap(),
+            // gap on 13th
+            NaiveDate::from_ymd_opt(2024, 6, 14).unwrap(),
+            NaiveDate::from_ymd_opt(2024, 6, 15).unwrap(),
+        ];
+
+        let streaks = compute_streaks(&dates, today);
+        assert_eq!(streaks.current_streak_days, 2); // 14th, 15th
+        assert_eq!(streaks.longest_streak_days, 3); // 10th, 11th, 12th
+        assert_eq!(streaks.total_active_days, 5);
+    }
+
+    #[test]
+    fn streaks_no_activity() {
+        let today = NaiveDate::from_ymd_opt(2024, 6, 15).unwrap();
+        let streaks = compute_streaks(&[], today);
+        assert_eq!(streaks.current_streak_days, 0);
+        assert_eq!(streaks.longest_streak_days, 0);
+        assert_eq!(streaks.total_active_days, 0);
+    }
+
+    #[test]
+    fn streaks_yesterday_counts_as_current() {
+        let today = NaiveDate::from_ymd_opt(2024, 6, 15).unwrap();
+        let dates = vec![
+            NaiveDate::from_ymd_opt(2024, 6, 13).unwrap(),
+            NaiveDate::from_ymd_opt(2024, 6, 14).unwrap(),
+        ];
+
+        let streaks = compute_streaks(&dates, today);
+        assert_eq!(streaks.current_streak_days, 2); // yesterday still counts
+    }
+
+    #[test]
+    fn streaks_old_activity_not_current() {
+        let today = NaiveDate::from_ymd_opt(2024, 6, 15).unwrap();
+        let dates = vec![
+            NaiveDate::from_ymd_opt(2024, 6, 10).unwrap(),
+            NaiveDate::from_ymd_opt(2024, 6, 11).unwrap(),
+            NaiveDate::from_ymd_opt(2024, 6, 12).unwrap(),
+        ];
+
+        let streaks = compute_streaks(&dates, today);
+        assert_eq!(streaks.current_streak_days, 0); // gap of 3 days
+        assert_eq!(streaks.longest_streak_days, 3);
+    }
+
+    #[test]
+    fn avg_days_to_finish_computation() {
+        let now = Utc::now();
+        let s1 = make_session(
+            Uuid::now_v7(),
+            now - chrono::Duration::days(10),
+            Some(now - chrono::Duration::days(5)),
+        );
+        let s2 = make_session(
+            Uuid::now_v7(),
+            now - chrono::Duration::days(20),
+            Some(now - chrono::Duration::days(10)),
+        );
+        let refs: Vec<&ReadingSession> = vec![&s1, &s2];
+
+        let avg = compute_avg_days_to_finish(&refs).expect("should have avg");
+        // s1: 5 days, s2: 10 days => avg = 7.5
+        assert!((avg - 7.5).abs() < 0.1);
+    }
+
+    #[test]
+    fn reading_speed_weighted() {
+        let now = Utc::now();
+
+        let mut s1 = make_session(Uuid::now_v7(), now - chrono::Duration::hours(2), Some(now));
+        s1.start_page = Some(0);
+        s1.end_page = Some(60); // 60 pages in 2 hours = 30 pages/hour
+
+        let mut s2 = make_session(
+            Uuid::now_v7(),
+            now - chrono::Duration::hours(4),
+            Some(now - chrono::Duration::hours(2)),
+        );
+        s2.start_page = Some(0);
+        s2.end_page = Some(80); // 80 pages in 2 hours = 40 pages/hour
+
+        let sessions = [s1, s2];
+        // Weighted: 140 pages / 4 hours = 35 pages/hour
+        let speed = compute_reading_speed(&sessions).expect("should have speed");
+        assert!((speed - 35.0).abs() < 0.1);
+    }
+
+    #[test]
+    fn reading_speed_skips_invalid_sessions() {
+        let now = Utc::now();
+
+        // Session with no pages
+        let s1 = make_session(Uuid::now_v7(), now - chrono::Duration::hours(2), Some(now));
+
+        // Session not finished
+        let mut s2 = make_session(Uuid::now_v7(), now - chrono::Duration::hours(2), None);
+        s2.start_page = Some(0);
+        s2.end_page = Some(60);
+
+        let sessions = [s1, s2];
+        assert!(compute_reading_speed(&sessions).is_none());
+    }
+
+    #[test]
+    fn monthly_finished_fills_gaps() {
+        let base = Utc::now();
+        let mut s1 = ReadingSession::new(Uuid::now_v7());
+        s1.started_at = base - chrono::Duration::days(90);
+        s1.finished_at = Some(
+            chrono::NaiveDate::from_ymd_opt(2024, 1, 15)
+                .unwrap()
+                .and_hms_opt(12, 0, 0)
+                .unwrap()
+                .and_utc(),
+        );
+
+        let mut s2 = ReadingSession::new(Uuid::now_v7());
+        s2.started_at = base - chrono::Duration::days(60);
+        s2.finished_at = Some(
+            chrono::NaiveDate::from_ymd_opt(2024, 3, 10)
+                .unwrap()
+                .and_hms_opt(12, 0, 0)
+                .unwrap()
+                .and_utc(),
+        );
+
+        let refs: Vec<&ReadingSession> = vec![&s1, &s2];
+        let monthly = compute_monthly_finished(&refs);
+
+        assert_eq!(monthly.len(), 3); // Jan, Feb (zero-filled), Mar
+        assert_eq!(monthly[0].year, 2024);
+        assert_eq!(monthly[0].month, 1);
+        assert_eq!(monthly[0].count, 1);
+        assert_eq!(monthly[1].month, 2);
+        assert_eq!(monthly[1].count, 0); // gap month
+        assert_eq!(monthly[2].month, 3);
+        assert_eq!(monthly[2].count, 1);
+    }
+
+    #[test]
+    fn shortest_longest_book() {
+        let mut b1 = make_book("Short", ReadingStatus::Read, BookFormat::Physical);
+        b1.page_count = Some(100);
+        let mut b2 = make_book("Long", ReadingStatus::Read, BookFormat::Physical);
+        b2.page_count = Some(900);
+        let mut b3 = make_book("No pages", ReadingStatus::Read, BookFormat::Audiobook);
+        b3.page_count = None; // excluded
+        let books = [b1, b2, b3];
+
+        let now = Utc::now();
+        let stats = compute_stats(StatsInput {
+            books: &books,
+            ..empty_input(now)
+        });
+
+        let shortest = stats.shortest_book.expect("should have shortest");
+        assert_eq!(shortest.title, "Short");
+        assert_eq!(shortest.page_count, 100);
+
+        let longest = stats.longest_book.expect("should have longest");
+        assert_eq!(longest.title, "Long");
+        assert_eq!(longest.page_count, 900);
+    }
+
+    #[test]
+    fn mood_trends_empty_when_no_data() {
+        let now = Utc::now();
+        let stats = compute_stats(empty_input(now));
+        assert!(stats.mood_trends.is_empty());
+    }
+
+    #[test]
+    fn mood_trends_aggregates_by_month() {
+        let book1 = make_book("A", ReadingStatus::Read, BookFormat::Physical);
+        let book2 = make_book("B", ReadingStatus::Read, BookFormat::Ebook);
+        let books = [book1.clone(), book2.clone()];
+
+        let jan = "2024-01-15T12:00:00Z".parse::<DateTime<Utc>>().unwrap();
+        let feb = "2024-02-20T12:00:00Z".parse::<DateTime<Utc>>().unwrap();
+
+        let s1 = make_session(book1.id, jan - chrono::Duration::days(30), Some(jan));
+        let s2 = make_session(book2.id, feb - chrono::Duration::days(15), Some(feb));
+        let sessions = [s1, s2];
+
+        let mut mood_data = HashMap::new();
+        mood_data.insert(
+            book1.id.to_string(),
+            vec!["dark".to_string(), "epic".to_string()],
+        );
+        mood_data.insert(
+            book2.id.to_string(),
+            vec!["dark".to_string(), "hopeful".to_string()],
+        );
+
+        let now = "2024-03-01T00:00:00Z".parse::<DateTime<Utc>>().unwrap();
+        let stats = compute_stats(StatsInput {
+            books: &books,
+            sessions: &sessions,
+            mood_tag_data: &mood_data,
+            ..empty_input(now)
+        });
+
+        assert_eq!(stats.mood_trends.len(), 2);
+
+        // January
+        let jan_trend = &stats.mood_trends[0];
+        assert_eq!(jan_trend.year, 2024);
+        assert_eq!(jan_trend.month, 1);
+        assert_eq!(jan_trend.moods.len(), 2);
+
+        // February
+        let feb_trend = &stats.mood_trends[1];
+        assert_eq!(feb_trend.year, 2024);
+        assert_eq!(feb_trend.month, 2);
+        assert_eq!(feb_trend.moods.len(), 2);
     }
 }

--- a/crates/toku-db/migrations/V9__tag_types.sql
+++ b/crates/toku-db/migrations/V9__tag_types.sql
@@ -1,0 +1,19 @@
+-- Add tag_type column to tags table.
+-- Tags are now unique by (name, tag_type) instead of just (name).
+-- This allows the same name in different categories (e.g. "dark" as mood
+-- and "dark" as a general genre tag).
+
+CREATE TABLE tags_new (
+    id TEXT PRIMARY KEY NOT NULL,
+    name TEXT NOT NULL COLLATE NOCASE,
+    tag_type TEXT NOT NULL DEFAULT 'general',
+    created_at TEXT NOT NULL,
+    UNIQUE(name, tag_type)
+);
+
+INSERT INTO tags_new (id, name, tag_type, created_at)
+    SELECT id, name, 'general', created_at FROM tags;
+
+DROP TABLE tags;
+
+ALTER TABLE tags_new RENAME TO tags;

--- a/crates/toku-db/src/repo.rs
+++ b/crates/toku-db/src/repo.rs
@@ -1,7 +1,7 @@
 use rusqlite::params;
 use toku_core::{
-    Author, Book, BookAuthor, ContributorRole, ReadingProgress, ReadingSession, ReadingStatus,
-    Shelf, Tag,
+    Author, AuthorCount, Book, BookAuthor, ContributorRole, PaceRating, ReadingProgress,
+    ReadingSession, ReadingStatus, Shelf, Tag, TagCount, TagType,
 };
 use uuid::Uuid;
 
@@ -591,20 +591,27 @@ impl<'a> BookRepository<'a> {
 
     /// Create a tag (UPSERT — returns existing tag if name matches case-insensitively).
     pub fn create_tag(&self, name: &str) -> Result<Tag, DbError> {
+        self.create_typed_tag(name, TagType::General)
+    }
+
+    /// Create or get a tag with a specific type. Tags are unique by (name, tag_type).
+    pub fn create_typed_tag(&self, name: &str, tag_type: TagType) -> Result<Tag, DbError> {
         match self.db.conn.query_row(
-            "SELECT id, name, created_at FROM tags WHERE name = ?1",
-            params![name],
+            "SELECT id, name, tag_type, created_at FROM tags WHERE name = ?1 AND tag_type = ?2",
+            params![name, tag_type.as_str()],
             |row| {
                 let id_str: String = row.get(0)?;
                 let tag_name: String = row.get(1)?;
-                let created_str: String = row.get(2)?;
-                Ok((id_str, tag_name, created_str))
+                let type_str: String = row.get(2)?;
+                let created_str: String = row.get(3)?;
+                Ok((id_str, tag_name, type_str, created_str))
             },
         ) {
-            Ok((id_str, tag_name, created_str)) => {
+            Ok((id_str, tag_name, type_str, created_str)) => {
                 let tag = Tag {
                     id: Uuid::parse_str(&id_str).map_err(|e| DbError::Io(e.to_string()))?,
                     name: tag_name,
+                    tag_type: type_str.parse().unwrap_or(TagType::General),
                     created_at: chrono::DateTime::parse_from_rfc3339(&created_str)
                         .map_err(|e| DbError::Io(e.to_string()))?
                         .with_timezone(&chrono::Utc),
@@ -612,10 +619,15 @@ impl<'a> BookRepository<'a> {
                 Ok(tag)
             }
             Err(rusqlite::Error::QueryReturnedNoRows) => {
-                let tag = Tag::new(name);
+                let tag = Tag::with_type(name, tag_type);
                 self.db.conn.execute(
-                    "INSERT INTO tags (id, name, created_at) VALUES (?1, ?2, ?3)",
-                    params![tag.id.to_string(), tag.name, tag.created_at.to_rfc3339(),],
+                    "INSERT INTO tags (id, name, tag_type, created_at) VALUES (?1, ?2, ?3, ?4)",
+                    params![
+                        tag.id.to_string(),
+                        tag.name,
+                        tag.tag_type.as_str(),
+                        tag.created_at.to_rfc3339(),
+                    ],
                 )?;
                 Ok(tag)
             }
@@ -623,10 +635,20 @@ impl<'a> BookRepository<'a> {
         }
     }
 
-    /// Add a tag to a book, creating the tag if it doesn't exist.
+    /// Add a general tag to a book, creating the tag if it doesn't exist.
     pub fn add_tag_to_book(&self, book_id: &Uuid, tag_name: &str) -> Result<(), DbError> {
+        self.add_typed_tag_to_book(book_id, tag_name, TagType::General)
+    }
+
+    /// Add a typed tag to a book, creating the tag if it doesn't exist.
+    pub fn add_typed_tag_to_book(
+        &self,
+        book_id: &Uuid,
+        tag_name: &str,
+        tag_type: TagType,
+    ) -> Result<(), DbError> {
         self.get_book(book_id)?;
-        let tag = self.create_tag(tag_name)?;
+        let tag = self.create_typed_tag(tag_name, tag_type)?;
 
         self.db.conn.execute(
             "INSERT OR IGNORE INTO book_tags (book_id, tag_id) VALUES (?1, ?2)",
@@ -636,17 +658,42 @@ impl<'a> BookRepository<'a> {
         Ok(())
     }
 
-    /// Remove a tag from a book.
+    /// Set the pace rating for a book. Removes any existing pace tag first.
+    pub fn set_book_pace(&self, book_id: &Uuid, pace: PaceRating) -> Result<(), DbError> {
+        self.get_book(book_id)?;
+
+        // Remove existing pace tags
+        self.db.conn.execute(
+            "DELETE FROM book_tags WHERE book_id = ?1
+             AND tag_id IN (SELECT id FROM tags WHERE tag_type = 'pace')",
+            params![book_id.to_string()],
+        )?;
+
+        // Add new pace tag
+        self.add_typed_tag_to_book(book_id, pace.as_str(), TagType::Pace)
+    }
+
+    /// Remove a general tag from a book.
     pub fn remove_tag_from_book(&self, book_id: &Uuid, tag_name: &str) -> Result<(), DbError> {
+        self.remove_typed_tag_from_book(book_id, tag_name, TagType::General)
+    }
+
+    /// Remove a typed tag from a book.
+    pub fn remove_typed_tag_from_book(
+        &self,
+        book_id: &Uuid,
+        tag_name: &str,
+        tag_type: TagType,
+    ) -> Result<(), DbError> {
         let rows = self.db.conn.execute(
             "DELETE FROM book_tags WHERE book_id = ?1
-             AND tag_id IN (SELECT id FROM tags WHERE name = ?2)",
-            params![book_id.to_string(), tag_name],
+             AND tag_id IN (SELECT id FROM tags WHERE name = ?2 AND tag_type = ?3)",
+            params![book_id.to_string(), tag_name, tag_type.as_str()],
         )?;
 
         if rows == 0 {
             return Err(DbError::NotFound(format!(
-                "tag '{tag_name}' not on this book"
+                "tag '{tag_name}' ({tag_type}) not on this book"
             )));
         }
 
@@ -656,25 +703,27 @@ impl<'a> BookRepository<'a> {
     /// Get all tags for a book.
     pub fn get_book_tags(&self, book_id: &Uuid) -> Result<Vec<Tag>, DbError> {
         let mut stmt = self.db.conn.prepare(
-            "SELECT t.id, t.name, t.created_at
+            "SELECT t.id, t.name, t.tag_type, t.created_at
              FROM tags t
              JOIN book_tags bt ON bt.tag_id = t.id
              WHERE bt.book_id = ?1
-             ORDER BY t.name COLLATE NOCASE",
+             ORDER BY t.tag_type, t.name COLLATE NOCASE",
         )?;
 
         let tags = stmt
             .query_map(params![book_id.to_string()], |row| {
                 let id_str: String = row.get(0)?;
                 let name: String = row.get(1)?;
-                let created_str: String = row.get(2)?;
-                Ok((id_str, name, created_str))
+                let type_str: String = row.get(2)?;
+                let created_str: String = row.get(3)?;
+                Ok((id_str, name, type_str, created_str))
             })?
             .filter_map(|r| r.ok())
-            .filter_map(|(id_str, name, created_str)| {
+            .filter_map(|(id_str, name, type_str, created_str)| {
                 Some(Tag {
                     id: Uuid::parse_str(&id_str).ok()?,
                     name,
+                    tag_type: type_str.parse().unwrap_or(TagType::General),
                     created_at: chrono::DateTime::parse_from_rfc3339(&created_str)
                         .ok()?
                         .with_timezone(&chrono::Utc),
@@ -685,8 +734,55 @@ impl<'a> BookRepository<'a> {
         Ok(tags)
     }
 
-    /// List all books with a given tag.
+    /// Get tags of a specific type for a book.
+    pub fn get_book_tags_by_type(
+        &self,
+        book_id: &Uuid,
+        tag_type: TagType,
+    ) -> Result<Vec<Tag>, DbError> {
+        let mut stmt = self.db.conn.prepare(
+            "SELECT t.id, t.name, t.tag_type, t.created_at
+             FROM tags t
+             JOIN book_tags bt ON bt.tag_id = t.id
+             WHERE bt.book_id = ?1 AND t.tag_type = ?2
+             ORDER BY t.name COLLATE NOCASE",
+        )?;
+
+        let tags = stmt
+            .query_map(params![book_id.to_string(), tag_type.as_str()], |row| {
+                let id_str: String = row.get(0)?;
+                let name: String = row.get(1)?;
+                let type_str: String = row.get(2)?;
+                let created_str: String = row.get(3)?;
+                Ok((id_str, name, type_str, created_str))
+            })?
+            .filter_map(|r| r.ok())
+            .filter_map(|(id_str, name, type_str, created_str)| {
+                Some(Tag {
+                    id: Uuid::parse_str(&id_str).ok()?,
+                    name,
+                    tag_type: type_str.parse().unwrap_or(TagType::General),
+                    created_at: chrono::DateTime::parse_from_rfc3339(&created_str)
+                        .ok()?
+                        .with_timezone(&chrono::Utc),
+                })
+            })
+            .collect();
+
+        Ok(tags)
+    }
+
+    /// List all books with a given general tag.
     pub fn list_books_by_tag(&self, tag_name: &str) -> Result<Vec<Book>, DbError> {
+        self.list_books_by_typed_tag(tag_name, TagType::General)
+    }
+
+    /// List all books with a given typed tag.
+    pub fn list_books_by_typed_tag(
+        &self,
+        tag_name: &str,
+        tag_type: TagType,
+    ) -> Result<Vec<Book>, DbError> {
         let mut stmt = self.db.conn.prepare(
             "SELECT b.id, b.title, b.subtitle, b.description, b.page_count, b.pub_date,
              b.language, b.format, b.duration_minutes, b.cover_hash, b.work_id, b.status,
@@ -694,12 +790,14 @@ impl<'a> BookRepository<'a> {
              FROM books b
              JOIN book_tags bt ON bt.book_id = b.id
              JOIN tags t ON t.id = bt.tag_id
-             WHERE t.name = ?1
+             WHERE t.name = ?1 AND t.tag_type = ?2
              ORDER BY b.title COLLATE NOCASE",
         )?;
 
         let books = stmt
-            .query_map(params![tag_name], |row| Ok(row_to_book(row)))?
+            .query_map(params![tag_name, tag_type.as_str()], |row| {
+                Ok(row_to_book(row))
+            })?
             .filter_map(|r| r.ok())
             .filter_map(|r| r.ok())
             .collect();
@@ -710,27 +808,71 @@ impl<'a> BookRepository<'a> {
     /// List all tags with book counts.
     pub fn list_tags_with_counts(&self) -> Result<Vec<(Tag, i64)>, DbError> {
         let mut stmt = self.db.conn.prepare(
-            "SELECT t.id, t.name, t.created_at, COUNT(bt.book_id) as book_count
+            "SELECT t.id, t.name, t.tag_type, t.created_at, COUNT(bt.book_id) as book_count
              FROM tags t
              LEFT JOIN book_tags bt ON bt.tag_id = t.id
              GROUP BY t.id
-             ORDER BY t.name COLLATE NOCASE",
+             ORDER BY t.tag_type, t.name COLLATE NOCASE",
         )?;
 
         let tags = stmt
             .query_map([], |row| {
                 let id_str: String = row.get(0)?;
                 let name: String = row.get(1)?;
-                let created_str: String = row.get(2)?;
-                let count: i64 = row.get(3)?;
-                Ok((id_str, name, created_str, count))
+                let type_str: String = row.get(2)?;
+                let created_str: String = row.get(3)?;
+                let count: i64 = row.get(4)?;
+                Ok((id_str, name, type_str, created_str, count))
             })?
             .filter_map(|r| r.ok())
-            .filter_map(|(id_str, name, created_str, count)| {
+            .filter_map(|(id_str, name, type_str, created_str, count)| {
                 Some((
                     Tag {
                         id: Uuid::parse_str(&id_str).ok()?,
                         name,
+                        tag_type: type_str.parse().unwrap_or(TagType::General),
+                        created_at: chrono::DateTime::parse_from_rfc3339(&created_str)
+                            .ok()?
+                            .with_timezone(&chrono::Utc),
+                    },
+                    count,
+                ))
+            })
+            .collect();
+
+        Ok(tags)
+    }
+
+    /// List tags of a specific type with book counts.
+    pub fn list_tags_with_counts_by_type(
+        &self,
+        tag_type: TagType,
+    ) -> Result<Vec<(Tag, i64)>, DbError> {
+        let mut stmt = self.db.conn.prepare(
+            "SELECT t.id, t.name, t.tag_type, t.created_at, COUNT(bt.book_id) as book_count
+             FROM tags t
+             LEFT JOIN book_tags bt ON bt.tag_id = t.id
+             WHERE t.tag_type = ?1
+             GROUP BY t.id
+             ORDER BY t.name COLLATE NOCASE",
+        )?;
+
+        let tags = stmt
+            .query_map(params![tag_type.as_str()], |row| {
+                let id_str: String = row.get(0)?;
+                let name: String = row.get(1)?;
+                let type_str: String = row.get(2)?;
+                let created_str: String = row.get(3)?;
+                let count: i64 = row.get(4)?;
+                Ok((id_str, name, type_str, created_str, count))
+            })?
+            .filter_map(|r| r.ok())
+            .filter_map(|(id_str, name, type_str, created_str, count)| {
+                Some((
+                    Tag {
+                        id: Uuid::parse_str(&id_str).ok()?,
+                        name,
+                        tag_type: type_str.parse().unwrap_or(TagType::General),
                         created_at: chrono::DateTime::parse_from_rfc3339(&created_str)
                             .ok()?
                             .with_timezone(&chrono::Utc),
@@ -837,6 +979,379 @@ impl<'a> BookRepository<'a> {
         }
 
         Ok(results)
+    }
+
+    /// Get mood tag names for each book in a list of IDs.
+    /// Returns a map of book_id string → list of mood tag names.
+    pub fn get_mood_tags_for_books(
+        &self,
+        book_ids: &[String],
+    ) -> Result<std::collections::HashMap<String, Vec<String>>, DbError> {
+        if book_ids.is_empty() {
+            return Ok(std::collections::HashMap::new());
+        }
+
+        let placeholders: String = book_ids.iter().map(|_| "?").collect::<Vec<_>>().join(",");
+        let sql = format!(
+            "SELECT bt.book_id, t.name
+             FROM book_tags bt
+             JOIN tags t ON t.id = bt.tag_id
+             WHERE t.tag_type = 'mood' AND bt.book_id IN ({placeholders})
+             ORDER BY bt.book_id, t.name"
+        );
+
+        let mut stmt = self.db.conn.prepare(&sql)?;
+        let params: Vec<&dyn rusqlite::types::ToSql> = book_ids
+            .iter()
+            .map(|id| id as &dyn rusqlite::types::ToSql)
+            .collect();
+
+        let mut result: std::collections::HashMap<String, Vec<String>> =
+            std::collections::HashMap::new();
+
+        let rows = stmt.query_map(params.as_slice(), |row| {
+            let book_id: String = row.get(0)?;
+            let mood: String = row.get(1)?;
+            Ok((book_id, mood))
+        })?;
+
+        for row in rows.flatten() {
+            result.entry(row.0).or_default().push(row.1);
+        }
+
+        Ok(result)
+    }
+
+    /// Tag names with book counts, sorted by count descending.
+    pub fn list_tag_counts(&self) -> Result<Vec<TagCount>, DbError> {
+        let mut stmt = self.db.conn.prepare(
+            "SELECT t.name, COUNT(bt.book_id) as cnt
+             FROM tags t
+             JOIN book_tags bt ON bt.tag_id = t.id
+             GROUP BY t.name
+             ORDER BY cnt DESC, t.name COLLATE NOCASE",
+        )?;
+
+        let rows = stmt
+            .query_map([], |row| {
+                let name: String = row.get(0)?;
+                let count: i64 = row.get(1)?;
+                Ok(TagCount {
+                    name,
+                    count: count as usize,
+                })
+            })?
+            .filter_map(|r| r.ok())
+            .collect();
+
+        Ok(rows)
+    }
+
+    /// Tag counts scoped to a specific set of book IDs.
+    pub fn list_tag_counts_for_books(&self, book_ids: &[String]) -> Result<Vec<TagCount>, DbError> {
+        if book_ids.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        let placeholders: String = book_ids.iter().map(|_| "?").collect::<Vec<_>>().join(",");
+        let sql = format!(
+            "SELECT t.name, COUNT(bt.book_id) as cnt
+             FROM tags t
+             JOIN book_tags bt ON bt.tag_id = t.id
+             WHERE bt.book_id IN ({placeholders})
+             GROUP BY t.name
+             ORDER BY cnt DESC, t.name COLLATE NOCASE"
+        );
+
+        let mut stmt = self.db.conn.prepare(&sql)?;
+        let params: Vec<&dyn rusqlite::types::ToSql> = book_ids
+            .iter()
+            .map(|id| id as &dyn rusqlite::types::ToSql)
+            .collect();
+
+        let rows = stmt
+            .query_map(params.as_slice(), |row| {
+                let name: String = row.get(0)?;
+                let count: i64 = row.get(1)?;
+                Ok(TagCount {
+                    name,
+                    count: count as usize,
+                })
+            })?
+            .filter_map(|r| r.ok())
+            .collect();
+
+        Ok(rows)
+    }
+
+    /// Author names with book counts (role = author), sorted by count descending.
+    pub fn list_author_book_counts(&self) -> Result<Vec<AuthorCount>, DbError> {
+        let mut stmt = self.db.conn.prepare(
+            "SELECT a.name, COUNT(DISTINCT ba.book_id) as cnt
+             FROM authors a
+             JOIN book_authors ba ON ba.author_id = a.id
+             WHERE ba.role = 'author'
+             GROUP BY a.name
+             ORDER BY cnt DESC, a.name COLLATE NOCASE",
+        )?;
+
+        let rows = stmt
+            .query_map([], |row| {
+                let name: String = row.get(0)?;
+                let count: i64 = row.get(1)?;
+                Ok(AuthorCount {
+                    name,
+                    count: count as usize,
+                })
+            })?
+            .filter_map(|r| r.ok())
+            .collect();
+
+        Ok(rows)
+    }
+
+    /// Author book counts scoped to specific book IDs.
+    pub fn list_author_book_counts_for_books(
+        &self,
+        book_ids: &[String],
+    ) -> Result<Vec<AuthorCount>, DbError> {
+        if book_ids.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        let placeholders: String = book_ids.iter().map(|_| "?").collect::<Vec<_>>().join(",");
+        let sql = format!(
+            "SELECT a.name, COUNT(DISTINCT ba.book_id) as cnt
+             FROM authors a
+             JOIN book_authors ba ON ba.author_id = a.id
+             WHERE ba.role = 'author' AND ba.book_id IN ({placeholders})
+             GROUP BY a.name
+             ORDER BY cnt DESC, a.name COLLATE NOCASE"
+        );
+
+        let mut stmt = self.db.conn.prepare(&sql)?;
+        let params: Vec<&dyn rusqlite::types::ToSql> = book_ids
+            .iter()
+            .map(|id| id as &dyn rusqlite::types::ToSql)
+            .collect();
+
+        let rows = stmt
+            .query_map(params.as_slice(), |row| {
+                let name: String = row.get(0)?;
+                let count: i64 = row.get(1)?;
+                Ok(AuthorCount {
+                    name,
+                    count: count as usize,
+                })
+            })?
+            .filter_map(|r| r.ok())
+            .collect();
+
+        Ok(rows)
+    }
+
+    /// Unique dates of reading activity (progress logs + session start/finish dates).
+    pub fn list_activity_dates(&self) -> Result<Vec<chrono::NaiveDate>, DbError> {
+        let mut stmt = self.db.conn.prepare(
+            "SELECT DISTINCT d FROM (
+                 SELECT DATE(logged_at) AS d FROM reading_progress
+                 UNION
+                 SELECT DATE(started_at) AS d FROM reading_sessions
+                 UNION
+                 SELECT DATE(finished_at) AS d FROM reading_sessions
+                     WHERE finished_at IS NOT NULL
+             )
+             ORDER BY d",
+        )?;
+
+        let dates = stmt
+            .query_map([], |row| {
+                let date_str: String = row.get(0)?;
+                Ok(date_str)
+            })?
+            .filter_map(|r| r.ok())
+            .filter_map(|s| chrono::NaiveDate::parse_from_str(&s, "%Y-%m-%d").ok())
+            .collect();
+
+        Ok(dates)
+    }
+
+    /// Activity dates scoped to a specific year.
+    pub fn list_activity_dates_in_year(
+        &self,
+        year: i32,
+    ) -> Result<Vec<chrono::NaiveDate>, DbError> {
+        let start = format!("{year}-01-01");
+        let end = format!("{}-01-01", year + 1);
+
+        let mut stmt = self.db.conn.prepare(
+            "SELECT DISTINCT d FROM (
+                 SELECT DATE(logged_at) AS d FROM reading_progress
+                     WHERE DATE(logged_at) >= ?1 AND DATE(logged_at) < ?2
+                 UNION
+                 SELECT DATE(started_at) AS d FROM reading_sessions
+                     WHERE DATE(started_at) >= ?1 AND DATE(started_at) < ?2
+                 UNION
+                 SELECT DATE(finished_at) AS d FROM reading_sessions
+                     WHERE finished_at IS NOT NULL
+                       AND DATE(finished_at) >= ?1 AND DATE(finished_at) < ?2
+             )
+             ORDER BY d",
+        )?;
+
+        let dates = stmt
+            .query_map(params![start, end], |row| {
+                let date_str: String = row.get(0)?;
+                Ok(date_str)
+            })?
+            .filter_map(|r| r.ok())
+            .filter_map(|s| chrono::NaiveDate::parse_from_str(&s, "%Y-%m-%d").ok())
+            .collect();
+
+        Ok(dates)
+    }
+
+    /// Activity dates scoped to specific book IDs.
+    pub fn list_activity_dates_for_books(
+        &self,
+        book_ids: &[String],
+    ) -> Result<Vec<chrono::NaiveDate>, DbError> {
+        if book_ids.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        let placeholders: String = book_ids.iter().map(|_| "?").collect::<Vec<_>>().join(",");
+        let sql = format!(
+            "SELECT DISTINCT d FROM (
+                 SELECT DATE(logged_at) AS d FROM reading_progress
+                     WHERE book_id IN ({placeholders})
+                 UNION
+                 SELECT DATE(started_at) AS d FROM reading_sessions
+                     WHERE book_id IN ({placeholders})
+                 UNION
+                 SELECT DATE(finished_at) AS d FROM reading_sessions
+                     WHERE finished_at IS NOT NULL AND book_id IN ({placeholders})
+             )
+             ORDER BY d"
+        );
+
+        let mut stmt = self.db.conn.prepare(&sql)?;
+        // Each subquery uses the same placeholders, so triple the params
+        let mut all_params: Vec<&dyn rusqlite::types::ToSql> = Vec::new();
+        for _ in 0..3 {
+            for id in book_ids {
+                all_params.push(id as &dyn rusqlite::types::ToSql);
+            }
+        }
+
+        let dates = stmt
+            .query_map(all_params.as_slice(), |row| {
+                let date_str: String = row.get(0)?;
+                Ok(date_str)
+            })?
+            .filter_map(|r| r.ok())
+            .filter_map(|s| chrono::NaiveDate::parse_from_str(&s, "%Y-%m-%d").ok())
+            .collect();
+
+        Ok(dates)
+    }
+
+    /// List books by a specific author name (case-insensitive match).
+    pub fn list_books_by_author_name(&self, name: &str) -> Result<Vec<Book>, DbError> {
+        let mut stmt = self.db.conn.prepare(
+            "SELECT DISTINCT b.id, b.title, b.subtitle, b.description, b.page_count,
+                    b.pub_date, b.language, b.format, b.duration_minutes, b.cover_hash,
+                    b.work_id, b.status, b.rating, b.created_at, b.updated_at
+             FROM books b
+             JOIN book_authors ba ON ba.book_id = b.id
+             JOIN authors a ON a.id = ba.author_id
+             WHERE LOWER(a.name) = LOWER(?1)
+             ORDER BY b.title COLLATE NOCASE",
+        )?;
+
+        let books = stmt
+            .query_map(params![name], |row| Ok(row_to_book(row)))?
+            .filter_map(|r| r.ok())
+            .filter_map(|r| r.ok())
+            .collect();
+
+        Ok(books)
+    }
+
+    /// List reading sessions for specific book IDs.
+    pub fn list_sessions_for_books(
+        &self,
+        book_ids: &[String],
+    ) -> Result<Vec<ReadingSession>, DbError> {
+        if book_ids.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        let placeholders: String = book_ids.iter().map(|_| "?").collect::<Vec<_>>().join(",");
+        let sql = format!(
+            "SELECT id, book_id, started_at, finished_at, start_page, end_page,
+                    rating, notes, created_at
+             FROM reading_sessions
+             WHERE book_id IN ({placeholders})
+             ORDER BY started_at DESC"
+        );
+
+        let mut stmt = self.db.conn.prepare(&sql)?;
+        let params: Vec<&dyn rusqlite::types::ToSql> = book_ids
+            .iter()
+            .map(|id| id as &dyn rusqlite::types::ToSql)
+            .collect();
+
+        let sessions = stmt
+            .query_map(params.as_slice(), |row| Ok(row_to_reading_session(row)))?
+            .filter_map(|r| r.ok())
+            .filter_map(|r| r.ok())
+            .collect();
+
+        Ok(sessions)
+    }
+
+    /// List reading sessions for specific book IDs, filtered to a year.
+    pub fn list_sessions_for_books_in_year(
+        &self,
+        book_ids: &[String],
+        year: i32,
+    ) -> Result<Vec<ReadingSession>, DbError> {
+        if book_ids.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        let start = format!("{year}-01-01T00:00:00+00:00");
+        let end = format!("{}-01-01T00:00:00+00:00", year + 1);
+        let placeholders: String = book_ids.iter().map(|_| "?").collect::<Vec<_>>().join(",");
+        let sql = format!(
+            "SELECT id, book_id, started_at, finished_at, start_page, end_page,
+                    rating, notes, created_at
+             FROM reading_sessions
+             WHERE book_id IN ({placeholders})
+               AND finished_at IS NOT NULL
+               AND finished_at >= ?{p1}
+               AND finished_at < ?{p2}
+             ORDER BY finished_at DESC",
+            p1 = book_ids.len() + 1,
+            p2 = book_ids.len() + 2,
+        );
+
+        let mut stmt = self.db.conn.prepare(&sql)?;
+        let mut all_params: Vec<&dyn rusqlite::types::ToSql> = book_ids
+            .iter()
+            .map(|id| id as &dyn rusqlite::types::ToSql)
+            .collect();
+        all_params.push(&start as &dyn rusqlite::types::ToSql);
+        all_params.push(&end as &dyn rusqlite::types::ToSql);
+
+        let sessions = stmt
+            .query_map(all_params.as_slice(), |row| Ok(row_to_reading_session(row)))?
+            .filter_map(|r| r.ok())
+            .filter_map(|r| r.ok())
+            .collect();
+
+        Ok(sessions)
     }
 }
 


### PR DESCRIPTION
## Description

Full statistics engine and typed tags (mood, pace, content warnings) for the Toku book manager.

### What's included

**Statistics engine** (closes #41):
- 9 new stat types: rating distribution, reading streaks, monthly books finished, shortest/longest book, avg days to finish, reading speed (pages/hour), top authors, top tags
- `StatsInput` struct replacing positional args for extensibility
- `--author <name>` flag to scope all statistics to one author's books
- Pure computation functions in `toku-core` with no I/O — 54 tests

**Typed tags** (closes #42):
- `TagType` enum: General, Mood, Pace, ContentWarning with `UNIQUE(name, tag_type)` constraint
- `PaceRating` enum: Fast, Medium, Slow (single pace per book enforced)
- `toku edit` command: `--mood`, `--pace`, `--content-warning`, `--remove-mood`, `--remove-content-warning`, `--rating`
- `toku add` extended with `--mood`, `--pace`, `--content-warning` flags
- `toku list --mood <tag> --pace <rate>` filters (same-type OR, cross-type AND)
- `toku show` displays mood tags, pace, and content warnings in all output formats
- `toku tag list` shows tag type column
- `toku stats --mood-trends` shows mood distribution over time by month
- Migration V9: recreates `tags` table with `tag_type` column, preserving existing data as `general`

## Related Issues

Closes #41
Closes #42

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI / infrastructure
- [ ] Other (describe below)

## Crate

- [x] `toku-core` — Domain models, traits, state machine
- [x] `toku-db` — SQLite persistence, migrations, FTS5
- [ ] `toku-import` — Importers (Goodreads, Calibre, StoryGraph)
- [ ] `toku-meta` — Metadata fetching (Open Library, Google Books)
- [x] `toku-cli` — CLI binary
- [ ] `toku-export` — Exporters (CSV, JSON, Markdown, BibTeX)
- [ ] `docs/` — Documentation

## Data Integrity Checklist

- [x] No user data is sent to any server without explicit opt-in
- [x] Import operations are idempotent (re-importing the same file creates no duplicates)
- [x] User edits to metadata are never overwritten by auto-enrichment
- [x] New fields track provenance (source + timestamp)
- [x] Export round-trip is preserved (if applicable)

## Checklist

- [x] I have read [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] `cargo fmt --check` passes
- [x] `cargo clippy --workspace -- -D warnings` passes
- [x] `cargo test --workspace` passes
- [x] I have updated documentation (if applicable)