### PR TITLE
feat: work grouping, StoryGraph import, and smart shelves

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Work grouping: `toku work link|unlink|show|auto` to group multiple editions of the same creative work, with automatic candidate detection by normalized title and primary author
+- Duplicate merging: `toku merge <keep> <remove>` moves all reading sessions, progress, tags, authors, ISBNs, and metadata from the removed book to the kept book in a single transaction
+- StoryGraph CSV import: `toku import storygraph <file>` with mood tags, pace ratings, content warnings, quarter-star rating conversion, multi-session date parsing, contributor roles (narrator/translator), and DNF/paused status mapping
+- Smart shelves: `toku shelf create "Unread Sci-Fi" --smart --filter "status:want_to_read AND tag:sci-fi"` creates saved filter rules that auto-populate with matching books
+- Filter DSL for smart shelves supporting 11 fields (status, tag, mood, pace, rating, pages, author, format, shelf, pub_date, date_added) with comparison operators and AND/OR/parentheses
+- `toku shelf list|show|delete|add|remove` for managing both regular and smart shelves with `--format table|json|csv` output
 - Interactive TUI library browser (`toku browse`, or just `toku` with no subcommand) with split-pane layout: scrollable book list on the left, live detail view on the right
 - Tag display in TUI book detail pane with styled cyan labels
 - Filter popup in TUI browser to narrow books by reading status or tag
@@ -25,6 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Shared import types (ImportReport, ImportEvent, ImportObserver) extracted to common module for reuse across all importers
 - Goodreads importer now uses observer pattern for progress reporting and wraps non-dry-run imports in a transaction for atomicity
 - Import report includes bounded sample lists (up to 20) of imported, updated, and skipped books with status counts
 - Shelves merged into tags — all user-created groupings are now tags; `ReadingStatus` remains as the separate state machine for tracking reading progress

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2256,6 +2256,7 @@ version = "0.1.0"
 dependencies = [
  "chrono",
  "serde",
+ "serde_json",
  "thiserror",
  "toml 1.1.2+spec-1.1.0",
  "uuid",

--- a/crates/toku-cli/src/import_ui.rs
+++ b/crates/toku-cli/src/import_ui.rs
@@ -15,7 +15,10 @@ use ratatui::{
     widgets::{Block, Borders, Gauge, Padding, Paragraph},
 };
 use toku_db::Database;
-use toku_import::{GoodreadsImportOptions, ImportEvent, ImportObserver, ImportReport, RowOutcome};
+use toku_import::{
+    GoodreadsImportOptions, ImportEvent, ImportObserver, ImportReport, RowOutcome,
+    StorygraphImportOptions,
+};
 
 use crate::OutputFormat;
 
@@ -332,6 +335,39 @@ pub fn run_goodreads_import(
     } else {
         run_without_tui(db, path, &opts, format)
     }
+}
+
+/// Run a StoryGraph import with the same UI as Goodreads import.
+pub fn run_storygraph_import(
+    db: &Database,
+    path: &Path,
+    dry_run: bool,
+    format: &OutputFormat,
+) -> Result<()> {
+    if !path.exists() {
+        anyhow::bail!("file not found: {}", path.display());
+    }
+
+    let opts = StorygraphImportOptions { dry_run };
+    let use_tui = matches!(format, OutputFormat::Table) && io::stderr().is_terminal();
+
+    if use_tui {
+        let total = count_csv_rows_quick(path)?;
+        let mut observer =
+            RatatuiImportObserver::new(total, dry_run).context("failed to initialize TUI")?;
+
+        let result = toku_import::import_storygraph(db, path, &opts, Some(&mut observer));
+        observer.restore();
+
+        let report = result.context("StoryGraph import failed")?;
+        print_import_summary(&report, format, dry_run);
+    } else {
+        let report = toku_import::import_storygraph(db, path, &opts, None)
+            .context("StoryGraph import failed")?;
+        print_import_summary(&report, format, dry_run);
+    }
+
+    Ok(())
 }
 
 fn run_with_tui(

--- a/crates/toku-cli/src/main.rs
+++ b/crates/toku-cli/src/main.rs
@@ -7,8 +7,8 @@ use clap::{CommandFactory, Parser, Subcommand, ValueEnum};
 use clap_complete::Shell;
 use toku_core::{
     Author, Book, BookFormat, ContributorRole, CurrentlyReadingInput, Isbn, PaceRating,
-    ProgressType, ReadingProgress, ReadingSession, ReadingStatus, StatsInput, TagType, TokuConfig,
-    compute_stats, parse_duration_to_minutes,
+    ProgressType, ReadingProgress, ReadingSession, ReadingStatus, SmartFilter, StatsInput, TagType,
+    TokuConfig, compute_stats, parse_duration_to_minutes,
 };
 use toku_db::{BookRepository, Database};
 
@@ -215,6 +215,27 @@ enum Commands {
         #[arg(long)]
         mood_trends: bool,
     },
+
+    /// Manage work grouping (link editions of the same creative work)
+    Work {
+        #[command(subcommand)]
+        action: WorkAction,
+    },
+
+    /// Merge duplicate books (keep one, move all data from the other)
+    Merge {
+        /// Book to keep (title or ID)
+        keep: String,
+
+        /// Book to remove (title or ID) — its data is moved to the kept book
+        remove: String,
+    },
+
+    /// Manage shelves (regular and smart)
+    Shelf {
+        #[command(subcommand)]
+        action: ShelfAction,
+    },
 }
 
 #[derive(Subcommand)]
@@ -241,6 +262,16 @@ enum ImportSource {
         /// Skip importing cover images
         #[arg(long)]
         no_covers: bool,
+    },
+
+    /// Import from a StoryGraph CSV export
+    Storygraph {
+        /// Path to the StoryGraph CSV file
+        path: PathBuf,
+
+        /// Preview what would be imported without writing
+        #[arg(long)]
+        dry_run: bool,
     },
 
     /// Undo a previous import by its ID
@@ -399,6 +430,84 @@ enum BulkAction {
 }
 
 #[derive(Subcommand)]
+enum WorkAction {
+    /// Link a book to a work (creates the work if needed)
+    Link {
+        /// Book title or ID
+        book: String,
+
+        /// Work title (creates or finds an existing work)
+        #[arg(long)]
+        work: String,
+    },
+
+    /// Unlink a book from its work
+    Unlink {
+        /// Book title or ID
+        book: String,
+    },
+
+    /// Show all editions of a work
+    Show {
+        /// Work title to display
+        work: String,
+    },
+
+    /// Auto-detect potential work groups from ungrouped books
+    Auto,
+}
+
+#[derive(Subcommand)]
+enum ShelfAction {
+    /// Create a shelf (use --smart --filter for smart shelves)
+    Create {
+        /// Shelf name
+        name: String,
+
+        /// Create a smart shelf with a filter rule
+        #[arg(long)]
+        smart: bool,
+
+        /// Filter expression (required with --smart)
+        #[arg(long, requires = "smart")]
+        filter: Option<String>,
+    },
+
+    /// List all shelves
+    List,
+
+    /// Show books in a shelf (smart shelves are evaluated dynamically)
+    Show {
+        /// Shelf name
+        name: String,
+    },
+
+    /// Delete a shelf
+    Delete {
+        /// Shelf name
+        name: String,
+    },
+
+    /// Add a book to a regular shelf
+    Add {
+        /// Shelf name
+        shelf: String,
+
+        /// Book title or ID
+        book: String,
+    },
+
+    /// Remove a book from a regular shelf
+    Remove {
+        /// Shelf name
+        shelf: String,
+
+        /// Book title or ID
+        book: String,
+    },
+}
+
+#[derive(Subcommand)]
 enum ExportTarget {
     /// Export as CSV
     Csv {
@@ -539,6 +648,9 @@ fn main() -> Result<()> {
             author,
             mood_trends,
         } => cmd_stats(&repo, year, author.as_deref(), mood_trends, &cli.format),
+        Commands::Work { action } => cmd_work(&repo, action, &cli.format),
+        Commands::Merge { keep, remove } => cmd_merge(&repo, &keep, &remove, &cli.format),
+        Commands::Shelf { action } => cmd_shelf(&repo, action, &cli.format),
         // Already handled above
         Commands::Config { .. } | Commands::Completions { .. } => unreachable!(),
     }
@@ -1236,6 +1348,7 @@ fn print_book_detail(
                 "format": book.format.as_str(),
                 "rating": book.rating,
                 "pages": book.page_count,
+                "work_id": book.work_id.map(|w| w.to_string()),
                 "tags": general_tags.iter().map(|t| &t.name).collect::<Vec<_>>(),
                 "moods": mood_tags.iter().map(|t| &t.name).collect::<Vec<_>>(),
                 "pace": pace_tags.first().map(|t| &t.name),
@@ -1316,6 +1429,13 @@ fn print_book_detail(
                 println!("  Desc:    {truncated}");
             }
             println!("  ID:      {}", book.id);
+            if let Some(work_id) = &book.work_id {
+                if let Ok(work) = repo.get_work(work_id) {
+                    println!("  Work:    {} ({})", work.title, work_id);
+                } else {
+                    println!("  Work:    {work_id}");
+                }
+            }
         }
     }
     Ok(())
@@ -1362,6 +1482,9 @@ fn cmd_import(
             }
 
             Ok(())
+        }
+        ImportSource::Storygraph { path, dry_run } => {
+            import_ui::run_storygraph_import(db, &path, dry_run, output_format)
         }
         ImportSource::Undo { import_id } => {
             let count =
@@ -1957,6 +2080,194 @@ fn cmd_bulk(repo: &BookRepository, action: BulkAction) -> Result<()> {
     }
 }
 
+fn cmd_work(repo: &BookRepository, action: WorkAction, output_format: &OutputFormat) -> Result<()> {
+    match action {
+        WorkAction::Link { book, work } => {
+            let b = resolve_book(repo, &book)?;
+            // Find or create the work
+            let works = repo.find_works_by_title(&work)?;
+            let w = if let Some(existing) = works
+                .into_iter()
+                .find(|w| w.title.eq_ignore_ascii_case(&work))
+            {
+                existing
+            } else {
+                let new_work = toku_core::Work::new(&work);
+                repo.create_work(&new_work)?;
+                eprintln!("Created work \"{}\"", work);
+                new_work
+            };
+
+            // Check if the book already has a different work
+            if let Some(existing_work_id) = b.work_id {
+                if existing_work_id == w.id {
+                    eprintln!("\"{}\" is already linked to work \"{}\"", b.title, w.title);
+                    return Ok(());
+                }
+                anyhow::bail!(
+                    "\"{}\" is already linked to a different work ({}). Unlink it first with `toku work unlink`.",
+                    b.title,
+                    existing_work_id
+                );
+            }
+
+            repo.link_book_to_work(&b.id, &w.id)?;
+            eprintln!("Linked \"{}\" → work \"{}\"", b.title, w.title);
+            Ok(())
+        }
+        WorkAction::Unlink { book } => {
+            let b = resolve_book(repo, &book)?;
+            if b.work_id.is_none() {
+                eprintln!("\"{}\" is not linked to any work", b.title);
+                return Ok(());
+            }
+            repo.unlink_book_from_work(&b.id)?;
+            eprintln!("Unlinked \"{}\" from its work", b.title);
+            Ok(())
+        }
+        WorkAction::Show { work } => {
+            let works = repo.find_works_by_title(&work)?;
+            if works.is_empty() {
+                eprintln!("No work found matching \"{work}\"");
+                return Ok(());
+            }
+            for w in &works {
+                let editions = repo.get_work_editions(&w.id)?;
+                match output_format {
+                    OutputFormat::Json => {
+                        let json = serde_json::json!({
+                            "work_id": w.id.to_string(),
+                            "title": w.title,
+                            "original_language": w.original_language,
+                            "first_published": w.first_published,
+                            "editions": editions.iter().map(|b| serde_json::json!({
+                                "id": b.id.to_string(),
+                                "title": b.title,
+                                "format": b.format.as_str(),
+                                "status": b.status.as_str(),
+                            })).collect::<Vec<_>>(),
+                        });
+                        println!("{}", serde_json::to_string_pretty(&json)?);
+                    }
+                    OutputFormat::Csv => {
+                        println!("work_id,work_title,book_id,book_title,format,status");
+                        for b in &editions {
+                            println!(
+                                "{},{},{},{},{},{}",
+                                w.id, w.title, b.id, b.title, b.format, b.status
+                            );
+                        }
+                    }
+                    OutputFormat::Table => {
+                        println!("Work: {}", w.title);
+                        println!("  ID: {}", w.id);
+                        if let Some(lang) = &w.original_language {
+                            println!("  Language: {lang}");
+                        }
+                        if let Some(pub_date) = &w.first_published {
+                            println!("  First published: {pub_date}");
+                        }
+                        println!("  Editions ({}):", editions.len());
+                        for b in &editions {
+                            println!("    • {} [{}] — {}", b.title, b.format, b.status);
+                        }
+                    }
+                }
+            }
+            Ok(())
+        }
+        WorkAction::Auto => {
+            let candidates = repo.auto_group_candidates()?;
+            if candidates.is_empty() {
+                eprintln!("No potential work groups found among ungrouped books.");
+                return Ok(());
+            }
+            match output_format {
+                OutputFormat::Json => {
+                    let json: Vec<_> = candidates
+                        .iter()
+                        .map(|(key, books)| {
+                            serde_json::json!({
+                                "group_key": key,
+                                "books": books.iter().map(|b| serde_json::json!({
+                                    "id": b.id.to_string(),
+                                    "title": b.title,
+                                    "format": b.format.as_str(),
+                                })).collect::<Vec<_>>(),
+                            })
+                        })
+                        .collect();
+                    println!("{}", serde_json::to_string_pretty(&json)?);
+                }
+                OutputFormat::Csv => {
+                    println!("group_key,book_id,title,format");
+                    for (key, books) in &candidates {
+                        for b in books {
+                            println!("{},{},{},{}", key, b.id, b.title, b.format);
+                        }
+                    }
+                }
+                OutputFormat::Table => {
+                    eprintln!(
+                        "Found {} potential work group(s). Use `toku work link` to group them.\n",
+                        candidates.len()
+                    );
+                    for (key, books) in &candidates {
+                        println!("Group: {key}");
+                        for b in books {
+                            println!("  • {} [{}] ({})", b.title, b.format, b.id);
+                        }
+                        println!();
+                    }
+                }
+            }
+            Ok(())
+        }
+    }
+}
+
+fn cmd_merge(
+    repo: &BookRepository,
+    keep_query: &str,
+    remove_query: &str,
+    output_format: &OutputFormat,
+) -> Result<()> {
+    let keep = resolve_book(repo, keep_query)?;
+    let remove = resolve_book(repo, remove_query)?;
+
+    if keep.id == remove.id {
+        anyhow::bail!("Cannot merge a book with itself");
+    }
+
+    // Show comparison before merge
+    match output_format {
+        OutputFormat::Json => {
+            let json = serde_json::json!({
+                "action": "merge",
+                "keep": { "id": keep.id.to_string(), "title": keep.title },
+                "remove": { "id": remove.id.to_string(), "title": remove.title },
+            });
+            repo.merge_books(&keep.id, &remove.id)?;
+            let result = serde_json::json!({
+                "merged": json,
+                "status": "ok",
+            });
+            println!("{}", serde_json::to_string_pretty(&result)?);
+        }
+        _ => {
+            eprintln!("Merging:");
+            eprintln!("  Keep:   \"{}\" ({})", keep.title, keep.id);
+            eprintln!("  Remove: \"{}\" ({})", remove.title, remove.id);
+            repo.merge_books(&keep.id, &remove.id)?;
+            eprintln!(
+                "✓ Merged successfully. All data moved to \"{}\".",
+                keep.title
+            );
+        }
+    }
+    Ok(())
+}
+
 fn cmd_stats(
     repo: &BookRepository,
     year: Option<i32>,
@@ -2351,4 +2662,176 @@ fn format_number(n: i64) -> String {
         result.push(c);
     }
     result.chars().rev().collect()
+}
+
+fn cmd_shelf(
+    repo: &BookRepository,
+    action: ShelfAction,
+    output_format: &OutputFormat,
+) -> Result<()> {
+    match action {
+        ShelfAction::Create {
+            name,
+            smart,
+            filter,
+        } => {
+            if smart {
+                let filter_str = filter.as_deref().ok_or_else(|| {
+                    anyhow::anyhow!("--filter is required when creating a smart shelf")
+                })?;
+                let parsed = SmartFilter::parse(filter_str).map_err(|e| anyhow::anyhow!("{e}"))?;
+                repo.create_smart_shelf(&name, &parsed)
+                    .with_context(|| format!("failed to create smart shelf '{name}'"))?;
+                eprintln!("✓ Created smart shelf \"{name}\"");
+                eprintln!("  Filter: {parsed}");
+            } else {
+                if filter.is_some() {
+                    anyhow::bail!("--filter requires --smart");
+                }
+                repo.create_shelf(&name)
+                    .with_context(|| format!("failed to create shelf '{name}'"))?;
+                eprintln!("✓ Created shelf \"{name}\"");
+            }
+            Ok(())
+        }
+        ShelfAction::List => {
+            let shelves = repo.list_shelves()?;
+
+            if shelves.is_empty() {
+                eprintln!("No shelves yet. Create one with: toku shelf create <name>");
+                return Ok(());
+            }
+
+            match output_format {
+                OutputFormat::Json => {
+                    #[derive(serde::Serialize)]
+                    struct ShelfOut {
+                        name: String,
+                        is_smart: bool,
+                        #[serde(skip_serializing_if = "Option::is_none")]
+                        filter: Option<String>,
+                        book_count: usize,
+                    }
+                    let out: Vec<ShelfOut> = shelves
+                        .iter()
+                        .map(|s| {
+                            let count = repo
+                                .list_books_in_shelf(&s.name)
+                                .map(|b| b.len())
+                                .unwrap_or(0);
+                            let filter_display = s.smart_filter.as_ref().and_then(|json| {
+                                SmartFilter::from_json(json).ok().map(|f| f.to_string())
+                            });
+                            ShelfOut {
+                                name: s.name.clone(),
+                                is_smart: s.is_smart,
+                                filter: filter_display,
+                                book_count: count,
+                            }
+                        })
+                        .collect();
+                    println!("{}", serde_json::to_string_pretty(&out)?);
+                }
+                OutputFormat::Csv => {
+                    println!("name,type,filter,books");
+                    for s in &shelves {
+                        let count = repo
+                            .list_books_in_shelf(&s.name)
+                            .map(|b| b.len())
+                            .unwrap_or(0);
+                        let kind = if s.is_smart { "smart" } else { "regular" };
+                        let filter_display = s
+                            .smart_filter
+                            .as_ref()
+                            .and_then(|json| {
+                                SmartFilter::from_json(json).ok().map(|f| f.to_string())
+                            })
+                            .unwrap_or_default();
+                        println!("{},{kind},\"{filter_display}\",{count}", s.name);
+                    }
+                }
+                OutputFormat::Table => {
+                    for s in &shelves {
+                        let count = repo
+                            .list_books_in_shelf(&s.name)
+                            .map(|b| b.len())
+                            .unwrap_or(0);
+                        if s.is_smart {
+                            let filter_display = s
+                                .smart_filter
+                                .as_ref()
+                                .and_then(|json| {
+                                    SmartFilter::from_json(json).ok().map(|f| f.to_string())
+                                })
+                                .unwrap_or_else(|| "?".to_string());
+                            println!(
+                                "  📋 {} [smart: {}] ({} book{})",
+                                s.name,
+                                filter_display,
+                                count,
+                                if count == 1 { "" } else { "s" }
+                            );
+                        } else {
+                            println!(
+                                "  📚 {} ({} book{})",
+                                s.name,
+                                count,
+                                if count == 1 { "" } else { "s" }
+                            );
+                        }
+                    }
+                }
+            }
+            eprintln!("\n{} shelf/shelves", shelves.len());
+            Ok(())
+        }
+        ShelfAction::Show { name } => {
+            let shelf = repo
+                .get_shelf_by_name(&name)?
+                .ok_or_else(|| anyhow::anyhow!("shelf '{name}' not found"))?;
+
+            let books = repo.list_books_in_shelf(&name)?;
+
+            if shelf.is_smart {
+                let filter_display = shelf
+                    .smart_filter
+                    .as_ref()
+                    .and_then(|json| SmartFilter::from_json(json).ok().map(|f| f.to_string()))
+                    .unwrap_or_else(|| "?".to_string());
+                eprintln!("📋 Smart shelf: {name}");
+                eprintln!("   Filter: {filter_display}");
+            } else {
+                eprintln!("📚 Shelf: {name}");
+            }
+
+            if books.is_empty() {
+                eprintln!("   (empty)");
+            } else {
+                print_books(&books, repo, output_format)?;
+                eprintln!("\n{} book(s)", books.len());
+            }
+            Ok(())
+        }
+        ShelfAction::Delete { name } => {
+            if repo.delete_shelf(&name)? {
+                eprintln!("✓ Deleted shelf \"{name}\"");
+            } else {
+                anyhow::bail!("shelf '{name}' not found");
+            }
+            Ok(())
+        }
+        ShelfAction::Add { shelf, book } => {
+            let found = resolve_book(repo, &book)?;
+            repo.add_book_to_shelf(&found.id, &shelf)
+                .with_context(|| format!("failed to add '{}' to shelf '{shelf}'", found.title))?;
+            eprintln!("✓ Added \"{}\" to shelf \"{shelf}\"", found.title);
+            Ok(())
+        }
+        ShelfAction::Remove { shelf, book } => {
+            let found = resolve_book(repo, &book)?;
+            repo.remove_book_from_shelf(&found.id, &shelf)?;
+            eprintln!("✓ Removed \"{}\" from shelf \"{shelf}\"", found.title);
+            Ok(())
+        }
+    }
 }

--- a/crates/toku-core/Cargo.toml
+++ b/crates/toku-core/Cargo.toml
@@ -12,4 +12,5 @@ thiserror.workspace = true
 uuid.workspace = true
 chrono.workspace = true
 serde.workspace = true
+serde_json.workspace = true
 toml.workspace = true

--- a/crates/toku-core/src/book.rs
+++ b/crates/toku-core/src/book.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
 /// A book in the user's library. Each row represents an edition (Book = Edition).
-/// A nullable `work_id` is reserved for Phase 3 work-grouping.
+/// Set `work_id` to link this edition to a `Work` for grouping.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Book {
     pub id: Uuid,
@@ -17,7 +17,7 @@ pub struct Book {
     /// Duration in minutes — only meaningful for audiobooks.
     pub duration_minutes: Option<i32>,
     pub cover_hash: Option<String>,
-    /// Reserved for Phase 3 work-grouping. NULL until then.
+    /// Links this edition to a Work (for grouping editions).
     pub work_id: Option<Uuid>,
     pub status: ReadingStatus,
     pub rating: Option<i32>,
@@ -362,10 +362,13 @@ fn guess_sort_name(name: &str) -> String {
 }
 
 /// A user-defined shelf for organizing books (e.g. "Favorites", "To Re-read").
+/// Smart shelves have `is_smart = true` and a `smart_filter` that dynamically matches books.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Shelf {
     pub id: Uuid,
     pub name: String,
+    pub is_smart: bool,
+    pub smart_filter: Option<String>,
     pub created_at: DateTime<Utc>,
 }
 
@@ -374,6 +377,18 @@ impl Shelf {
         Self {
             id: Uuid::now_v7(),
             name: name.into(),
+            is_smart: false,
+            smart_filter: None,
+            created_at: Utc::now(),
+        }
+    }
+
+    pub fn new_smart(name: impl Into<String>, filter_json: String) -> Self {
+        Self {
+            id: Uuid::now_v7(),
+            name: name.into(),
+            is_smart: true,
+            smart_filter: Some(filter_json),
             created_at: Utc::now(),
         }
     }
@@ -511,6 +526,29 @@ pub struct BookSeries {
     pub position: Option<String>,
 }
 
+/// A Work groups multiple editions (Books) of the same creative work.
+/// E.g. "Dune" hardcover, paperback, and Kindle editions share one Work.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Work {
+    pub id: Uuid,
+    pub title: String,
+    pub original_language: Option<String>,
+    pub first_published: Option<String>,
+    pub created_at: DateTime<Utc>,
+}
+
+impl Work {
+    pub fn new(title: impl Into<String>) -> Self {
+        Self {
+            id: Uuid::now_v7(),
+            title: title.into(),
+            original_language: None,
+            first_published: None,
+            created_at: Utc::now(),
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -523,6 +561,14 @@ mod tests {
         assert_eq!(book.format, BookFormat::Physical);
         assert!(book.subtitle.is_none());
         assert!(book.rating.is_none());
+    }
+
+    #[test]
+    fn work_new_has_defaults() {
+        let work = Work::new("Dune");
+        assert_eq!(work.title, "Dune");
+        assert!(work.original_language.is_none());
+        assert!(work.first_published.is_none());
     }
 
     #[test]

--- a/crates/toku-core/src/error.rs
+++ b/crates/toku-core/src/error.rs
@@ -32,4 +32,13 @@ pub enum TokuError {
         from: &'static str,
         to: &'static str,
     },
+
+    #[error("work not found: {0}")]
+    WorkNotFound(String),
+
+    #[error("merge conflict: {0}")]
+    MergeConflict(String),
+
+    #[error("invalid filter: {0}")]
+    InvalidFilter(String),
 }

--- a/crates/toku-core/src/filter.rs
+++ b/crates/toku-core/src/filter.rs
@@ -1,0 +1,651 @@
+use serde::{Deserialize, Serialize};
+use std::fmt;
+
+use crate::TokuError;
+
+/// A saved smart-shelf filter that can be serialized to/from JSON.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct SmartFilter {
+    pub expression: FilterExpr,
+}
+
+/// A boolean expression tree of filter conditions.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub enum FilterExpr {
+    And(Vec<FilterExpr>),
+    Or(Vec<FilterExpr>),
+    Condition(FilterCondition),
+}
+
+/// A single filter predicate (e.g. `status:read`, `pages:>400`).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct FilterCondition {
+    pub field: FilterField,
+    pub op: FilterOp,
+    pub value: String,
+}
+
+/// Filterable fields for smart shelves.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+pub enum FilterField {
+    Status,
+    Tag,
+    Mood,
+    Pace,
+    Rating,
+    Pages,
+    Author,
+    Format,
+    Shelf,
+    PubDate,
+    DateAdded,
+}
+
+impl FilterField {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Status => "status",
+            Self::Tag => "tag",
+            Self::Mood => "mood",
+            Self::Pace => "pace",
+            Self::Rating => "rating",
+            Self::Pages => "pages",
+            Self::Author => "author",
+            Self::Format => "format",
+            Self::Shelf => "shelf",
+            Self::PubDate => "pub_date",
+            Self::DateAdded => "date_added",
+        }
+    }
+
+    fn from_str_loose(s: &str) -> Option<Self> {
+        match s.to_ascii_lowercase().as_str() {
+            "status" => Some(Self::Status),
+            "tag" => Some(Self::Tag),
+            "mood" => Some(Self::Mood),
+            "pace" => Some(Self::Pace),
+            "rating" => Some(Self::Rating),
+            "pages" | "page_count" => Some(Self::Pages),
+            "author" => Some(Self::Author),
+            "format" => Some(Self::Format),
+            "shelf" => Some(Self::Shelf),
+            "pub_date" | "published" => Some(Self::PubDate),
+            "date_added" | "added" | "created" => Some(Self::DateAdded),
+            _ => None,
+        }
+    }
+
+    fn is_numeric(&self) -> bool {
+        matches!(self, Self::Rating | Self::Pages)
+    }
+
+    fn is_date(&self) -> bool {
+        matches!(self, Self::PubDate | Self::DateAdded)
+    }
+
+    fn supports_comparison(&self) -> bool {
+        self.is_numeric() || self.is_date()
+    }
+}
+
+/// Comparison operator for filter conditions.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+pub enum FilterOp {
+    Eq,
+    Gt,
+    Gte,
+    Lt,
+    Lte,
+}
+
+impl FilterOp {
+    pub fn as_sql(&self) -> &'static str {
+        match self {
+            Self::Eq => "=",
+            Self::Gt => ">",
+            Self::Gte => ">=",
+            Self::Lt => "<",
+            Self::Lte => "<=",
+        }
+    }
+}
+
+impl fmt::Display for FilterOp {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Eq => Ok(()),
+            Self::Gt => write!(f, ">"),
+            Self::Gte => write!(f, ">="),
+            Self::Lt => write!(f, "<"),
+            Self::Lte => write!(f, "<="),
+        }
+    }
+}
+
+impl SmartFilter {
+    /// Parse a filter DSL string into a SmartFilter.
+    ///
+    /// Grammar:
+    /// ```text
+    /// filter     = or_expr
+    /// or_expr    = and_expr ("OR" and_expr)*
+    /// and_expr   = atom ("AND" atom)*
+    /// atom       = "(" or_expr ")" | condition
+    /// condition  = field ":" op? value
+    /// value      = quoted_string | unquoted_word
+    /// ```
+    pub fn parse(input: &str) -> Result<Self, TokuError> {
+        let tokens = tokenize(input)?;
+        let mut pos = 0;
+        let expr = parse_or_expr(&tokens, &mut pos)?;
+        if pos < tokens.len() {
+            return Err(TokuError::InvalidFilter(format!(
+                "unexpected token '{}' at position {pos}",
+                tokens[pos]
+            )));
+        }
+        Ok(SmartFilter { expression: expr })
+    }
+
+    /// Serialize to JSON for database storage.
+    pub fn to_json(&self) -> Result<String, TokuError> {
+        serde_json::to_string(self)
+            .map_err(|e| TokuError::InvalidFilter(format!("failed to serialize filter: {e}")))
+    }
+
+    /// Deserialize from JSON stored in the database.
+    pub fn from_json(json: &str) -> Result<Self, TokuError> {
+        serde_json::from_str(json)
+            .map_err(|e| TokuError::InvalidFilter(format!("invalid filter JSON: {e}")))
+    }
+}
+
+impl fmt::Display for SmartFilter {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.expression)
+    }
+}
+
+impl fmt::Display for FilterExpr {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            FilterExpr::Condition(c) => write!(f, "{}", c),
+            FilterExpr::And(exprs) => {
+                for (i, expr) in exprs.iter().enumerate() {
+                    if i > 0 {
+                        write!(f, " AND ")?;
+                    }
+                    let needs_parens = matches!(expr, FilterExpr::Or(_));
+                    if needs_parens {
+                        write!(f, "({})", expr)?;
+                    } else {
+                        write!(f, "{}", expr)?;
+                    }
+                }
+                Ok(())
+            }
+            FilterExpr::Or(exprs) => {
+                for (i, expr) in exprs.iter().enumerate() {
+                    if i > 0 {
+                        write!(f, " OR ")?;
+                    }
+                    write!(f, "{}", expr)?;
+                }
+                Ok(())
+            }
+        }
+    }
+}
+
+impl fmt::Display for FilterCondition {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}:{}{}", self.field.as_str(), self.op, self.value)
+    }
+}
+
+// --- Tokenizer ---
+
+fn tokenize(input: &str) -> Result<Vec<String>, TokuError> {
+    let mut tokens = Vec::new();
+    let chars: Vec<char> = input.chars().collect();
+    let mut i = 0;
+
+    while i < chars.len() {
+        // Skip whitespace
+        if chars[i].is_whitespace() {
+            i += 1;
+            continue;
+        }
+
+        // Parentheses
+        if chars[i] == '(' || chars[i] == ')' {
+            tokens.push(chars[i].to_string());
+            i += 1;
+            continue;
+        }
+
+        // Quoted string (part of a condition value, but we tokenize the whole condition)
+        // Actually, we tokenize words and special chars separately
+        // Collect a word (non-whitespace, non-paren sequence)
+        let start = i;
+        if chars[i] == '"' {
+            // Quoted string
+            i += 1;
+            while i < chars.len() && chars[i] != '"' {
+                i += 1;
+            }
+            if i >= chars.len() {
+                return Err(TokuError::InvalidFilter(
+                    "unterminated quoted string".to_string(),
+                ));
+            }
+            i += 1; // skip closing quote
+            tokens.push(chars[start..i].iter().collect());
+        } else {
+            while i < chars.len() && !chars[i].is_whitespace() && chars[i] != '(' && chars[i] != ')'
+            {
+                i += 1;
+            }
+            tokens.push(chars[start..i].iter().collect());
+        }
+    }
+
+    Ok(tokens)
+}
+
+// --- Recursive descent parser ---
+
+fn parse_or_expr(tokens: &[String], pos: &mut usize) -> Result<FilterExpr, TokuError> {
+    let mut exprs = vec![parse_and_expr(tokens, pos)?];
+
+    while *pos < tokens.len() && tokens[*pos].eq_ignore_ascii_case("OR") {
+        *pos += 1;
+        exprs.push(parse_and_expr(tokens, pos)?);
+    }
+
+    if exprs.len() == 1 {
+        Ok(exprs.remove(0))
+    } else {
+        Ok(FilterExpr::Or(exprs))
+    }
+}
+
+fn parse_and_expr(tokens: &[String], pos: &mut usize) -> Result<FilterExpr, TokuError> {
+    let mut exprs = vec![parse_atom(tokens, pos)?];
+
+    while *pos < tokens.len() && tokens[*pos].eq_ignore_ascii_case("AND") {
+        *pos += 1;
+        exprs.push(parse_atom(tokens, pos)?);
+    }
+
+    if exprs.len() == 1 {
+        Ok(exprs.remove(0))
+    } else {
+        Ok(FilterExpr::And(exprs))
+    }
+}
+
+fn parse_atom(tokens: &[String], pos: &mut usize) -> Result<FilterExpr, TokuError> {
+    if *pos >= tokens.len() {
+        return Err(TokuError::InvalidFilter(
+            "unexpected end of filter expression".to_string(),
+        ));
+    }
+
+    // Grouped expression: ( or_expr )
+    if tokens[*pos] == "(" {
+        *pos += 1;
+        let expr = parse_or_expr(tokens, pos)?;
+        if *pos >= tokens.len() || tokens[*pos] != ")" {
+            return Err(TokuError::InvalidFilter(
+                "missing closing parenthesis".to_string(),
+            ));
+        }
+        *pos += 1;
+        return Ok(expr);
+    }
+
+    // Condition: field:op?value
+    parse_condition(tokens, pos)
+}
+
+fn parse_condition(tokens: &[String], pos: &mut usize) -> Result<FilterExpr, TokuError> {
+    let token = &tokens[*pos];
+    *pos += 1;
+
+    // Find the colon separator
+    let colon_idx = token.find(':').ok_or_else(|| {
+        TokuError::InvalidFilter(format!("expected 'field:value' condition, got '{token}'"))
+    })?;
+
+    let field_str = &token[..colon_idx];
+    let rest = &token[colon_idx + 1..];
+
+    let field = FilterField::from_str_loose(field_str)
+        .ok_or_else(|| TokuError::InvalidFilter(format!("unknown filter field '{field_str}'")))?;
+
+    // Parse operator prefix from rest
+    let (op, value_str) = if let Some(v) = rest.strip_prefix(">=") {
+        (FilterOp::Gte, v)
+    } else if let Some(v) = rest.strip_prefix("<=") {
+        (FilterOp::Lte, v)
+    } else if let Some(v) = rest.strip_prefix('>') {
+        (FilterOp::Gt, v)
+    } else if let Some(v) = rest.strip_prefix('<') {
+        (FilterOp::Lt, v)
+    } else if let Some(v) = rest.strip_prefix('=') {
+        (FilterOp::Eq, v)
+    } else {
+        (FilterOp::Eq, rest)
+    };
+
+    // Value might be in the next token if this token ended at the colon or is a quoted string
+    let value = if value_str.is_empty() {
+        // Value is in the next token (e.g., filter was tokenized as "field:" "value")
+        if *pos < tokens.len()
+            && !is_keyword(&tokens[*pos])
+            && tokens[*pos] != "("
+            && tokens[*pos] != ")"
+        {
+            let v = tokens[*pos].clone();
+            *pos += 1;
+            strip_quotes(&v)
+        } else {
+            return Err(TokuError::InvalidFilter(format!(
+                "missing value for field '{field_str}'"
+            )));
+        }
+    } else {
+        strip_quotes(value_str)
+    };
+
+    if value.is_empty() {
+        return Err(TokuError::InvalidFilter(format!(
+            "empty value for field '{field_str}'"
+        )));
+    }
+
+    // Validate operator/value compatibility
+    if op != FilterOp::Eq && !field.supports_comparison() {
+        return Err(TokuError::InvalidFilter(format!(
+            "comparison operators are only supported for numeric and date fields, not '{field_str}'"
+        )));
+    }
+
+    if field.is_numeric() {
+        value.parse::<i64>().map_err(|_| {
+            TokuError::InvalidFilter(format!(
+                "field '{field_str}' requires a numeric value, got '{value}'"
+            ))
+        })?;
+    }
+
+    // Validate date format (YYYY or YYYY-MM-DD)
+    if field.is_date() {
+        validate_date_value(&value, field_str)?;
+    }
+
+    Ok(FilterExpr::Condition(FilterCondition { field, op, value }))
+}
+
+fn is_keyword(token: &str) -> bool {
+    token.eq_ignore_ascii_case("AND") || token.eq_ignore_ascii_case("OR")
+}
+
+fn strip_quotes(s: &str) -> String {
+    if s.len() >= 2 && s.starts_with('"') && s.ends_with('"') {
+        s[1..s.len() - 1].to_string()
+    } else {
+        s.to_string()
+    }
+}
+
+fn validate_date_value(value: &str, field_name: &str) -> Result<(), TokuError> {
+    // Accept YYYY or YYYY-MM-DD
+    if value.len() == 4 && value.parse::<u16>().is_ok() {
+        return Ok(());
+    }
+    if value.len() == 10 {
+        let parts: Vec<&str> = value.split('-').collect();
+        if parts.len() == 3
+            && parts[0].len() == 4
+            && parts[1].len() == 2
+            && parts[2].len() == 2
+            && parts[0].parse::<u16>().is_ok()
+            && parts[1].parse::<u8>().is_ok()
+            && parts[2].parse::<u8>().is_ok()
+        {
+            return Ok(());
+        }
+    }
+    Err(TokuError::InvalidFilter(format!(
+        "field '{field_name}' requires a date value (YYYY or YYYY-MM-DD), got '{value}'"
+    )))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_simple_status() {
+        let f = SmartFilter::parse("status:want_to_read").unwrap();
+        assert_eq!(
+            f.expression,
+            FilterExpr::Condition(FilterCondition {
+                field: FilterField::Status,
+                op: FilterOp::Eq,
+                value: "want_to_read".to_string(),
+            })
+        );
+    }
+
+    #[test]
+    fn parse_rating_comparison() {
+        let f = SmartFilter::parse("rating:>=9").unwrap();
+        assert_eq!(
+            f.expression,
+            FilterExpr::Condition(FilterCondition {
+                field: FilterField::Rating,
+                op: FilterOp::Gte,
+                value: "9".to_string(),
+            })
+        );
+    }
+
+    #[test]
+    fn parse_pages_gt() {
+        let f = SmartFilter::parse("pages:>400").unwrap();
+        assert_eq!(
+            f.expression,
+            FilterExpr::Condition(FilterCondition {
+                field: FilterField::Pages,
+                op: FilterOp::Gt,
+                value: "400".to_string(),
+            })
+        );
+    }
+
+    #[test]
+    fn parse_and_expression() {
+        let f = SmartFilter::parse("status:want_to_read AND tag:sci-fi").unwrap();
+        match &f.expression {
+            FilterExpr::And(exprs) => {
+                assert_eq!(exprs.len(), 2);
+                assert!(
+                    matches!(&exprs[0], FilterExpr::Condition(c) if c.field == FilterField::Status)
+                );
+                assert!(
+                    matches!(&exprs[1], FilterExpr::Condition(c) if c.field == FilterField::Tag)
+                );
+            }
+            _ => panic!("expected AND expression"),
+        }
+    }
+
+    #[test]
+    fn parse_or_expression() {
+        let f = SmartFilter::parse("tag:sci-fi OR tag:fantasy").unwrap();
+        match &f.expression {
+            FilterExpr::Or(exprs) => {
+                assert_eq!(exprs.len(), 2);
+            }
+            _ => panic!("expected OR expression"),
+        }
+    }
+
+    #[test]
+    fn parse_and_or_precedence() {
+        // AND binds tighter: status:read AND tag:sci-fi OR tag:fantasy
+        // = (status:read AND tag:sci-fi) OR tag:fantasy
+        let f = SmartFilter::parse("status:read AND tag:sci-fi OR tag:fantasy").unwrap();
+        match &f.expression {
+            FilterExpr::Or(exprs) => {
+                assert_eq!(exprs.len(), 2);
+                assert!(matches!(&exprs[0], FilterExpr::And(_)));
+                assert!(matches!(&exprs[1], FilterExpr::Condition(_)));
+            }
+            _ => panic!("expected OR expression with AND child"),
+        }
+    }
+
+    #[test]
+    fn parse_parenthesized_or() {
+        let f = SmartFilter::parse("status:want_to_read AND (tag:sci-fi OR tag:fantasy)").unwrap();
+        match &f.expression {
+            FilterExpr::And(exprs) => {
+                assert_eq!(exprs.len(), 2);
+                assert!(matches!(&exprs[0], FilterExpr::Condition(_)));
+                assert!(matches!(&exprs[1], FilterExpr::Or(_)));
+            }
+            _ => panic!("expected AND expression with OR child"),
+        }
+    }
+
+    #[test]
+    fn parse_complex_filter() {
+        let f = SmartFilter::parse(
+            "status:want_to_read AND pages:>300 AND (tag:sci-fi OR tag:fantasy)",
+        )
+        .unwrap();
+        match &f.expression {
+            FilterExpr::And(exprs) => assert_eq!(exprs.len(), 3),
+            _ => panic!("expected AND with 3 children"),
+        }
+    }
+
+    #[test]
+    fn parse_mood_and_pace() {
+        let f = SmartFilter::parse("mood:dark AND pace:fast").unwrap();
+        match &f.expression {
+            FilterExpr::And(exprs) => {
+                assert_eq!(exprs.len(), 2);
+                assert!(
+                    matches!(&exprs[0], FilterExpr::Condition(c) if c.field == FilterField::Mood)
+                );
+                assert!(
+                    matches!(&exprs[1], FilterExpr::Condition(c) if c.field == FilterField::Pace)
+                );
+            }
+            _ => panic!("expected AND"),
+        }
+    }
+
+    #[test]
+    fn parse_author_filter() {
+        let f = SmartFilter::parse("author:tolkien").unwrap();
+        assert!(matches!(
+            &f.expression,
+            FilterExpr::Condition(c) if c.field == FilterField::Author && c.value == "tolkien"
+        ));
+    }
+
+    #[test]
+    fn parse_date_filter() {
+        let f = SmartFilter::parse("pub_date:>=2020").unwrap();
+        assert!(matches!(
+            &f.expression,
+            FilterExpr::Condition(c)
+                if c.field == FilterField::PubDate
+                && c.op == FilterOp::Gte
+                && c.value == "2020"
+        ));
+    }
+
+    #[test]
+    fn parse_date_added_full() {
+        let f = SmartFilter::parse("date_added:>=2024-01-01").unwrap();
+        assert!(matches!(
+            &f.expression,
+            FilterExpr::Condition(c) if c.field == FilterField::DateAdded && c.value == "2024-01-01"
+        ));
+    }
+
+    #[test]
+    fn parse_field_aliases() {
+        SmartFilter::parse("published:>=2020").unwrap();
+        SmartFilter::parse("added:>=2024-01-01").unwrap();
+        SmartFilter::parse("created:>=2024-01-01").unwrap();
+        SmartFilter::parse("page_count:>100").unwrap();
+    }
+
+    #[test]
+    fn error_unknown_field() {
+        let err = SmartFilter::parse("foobar:value").unwrap_err();
+        assert!(err.to_string().contains("unknown filter field"));
+    }
+
+    #[test]
+    fn error_comparison_on_text_field() {
+        let err = SmartFilter::parse("tag:>sci-fi").unwrap_err();
+        assert!(err.to_string().contains("comparison operators"));
+    }
+
+    #[test]
+    fn error_non_numeric_rating() {
+        let err = SmartFilter::parse("rating:abc").unwrap_err();
+        assert!(err.to_string().contains("numeric value"));
+    }
+
+    #[test]
+    fn error_missing_value() {
+        let err = SmartFilter::parse("status:").unwrap_err();
+        assert!(err.to_string().contains("missing value"));
+    }
+
+    #[test]
+    fn error_missing_colon() {
+        let err = SmartFilter::parse("status").unwrap_err();
+        assert!(err.to_string().contains("field:value"));
+    }
+
+    #[test]
+    fn error_unclosed_paren() {
+        let err = SmartFilter::parse("(status:read AND tag:sci-fi").unwrap_err();
+        assert!(err.to_string().contains("parenthesis"));
+    }
+
+    #[test]
+    fn error_invalid_date() {
+        let err = SmartFilter::parse("pub_date:not-a-date").unwrap_err();
+        assert!(err.to_string().contains("date value"));
+    }
+
+    #[test]
+    fn json_round_trip() {
+        let f = SmartFilter::parse("status:read AND rating:>=8").unwrap();
+        let json = f.to_json().unwrap();
+        let f2 = SmartFilter::from_json(&json).unwrap();
+        assert_eq!(f, f2);
+    }
+
+    #[test]
+    fn display_round_trip() {
+        let input = "status:read AND (tag:sci-fi OR tag:fantasy)";
+        let f = SmartFilter::parse(input).unwrap();
+        let display = f.to_string();
+        // Re-parse the display output
+        let f2 = SmartFilter::parse(&display).unwrap();
+        assert_eq!(f, f2);
+    }
+}

--- a/crates/toku-core/src/lib.rs
+++ b/crates/toku-core/src/lib.rs
@@ -1,11 +1,13 @@
 mod book;
 mod config;
 mod error;
+pub mod filter;
 mod isbn;
 pub mod stats;
 
 pub use book::*;
 pub use config::*;
 pub use error::*;
+pub use filter::*;
 pub use isbn::*;
 pub use stats::*;

--- a/crates/toku-db/migrations/V10__works.sql
+++ b/crates/toku-db/migrations/V10__works.sql
@@ -1,0 +1,11 @@
+-- Works table: groups multiple editions (Books) of the same creative work.
+CREATE TABLE works (
+    id TEXT PRIMARY KEY NOT NULL,
+    title TEXT NOT NULL,
+    original_language TEXT,
+    first_published TEXT,
+    created_at TEXT NOT NULL
+);
+
+-- Case-insensitive search by work title.
+CREATE INDEX idx_works_title ON works(title COLLATE NOCASE);

--- a/crates/toku-db/migrations/V11__smart_shelves.sql
+++ b/crates/toku-db/migrations/V11__smart_shelves.sql
@@ -1,0 +1,2 @@
+ALTER TABLE shelves ADD COLUMN is_smart INTEGER NOT NULL DEFAULT 0 CHECK (is_smart IN (0, 1));
+ALTER TABLE shelves ADD COLUMN smart_filter TEXT;

--- a/crates/toku-db/src/error.rs
+++ b/crates/toku-db/src/error.rs
@@ -11,4 +11,7 @@ pub enum DbError {
 
     #[error("not found: {0}")]
     NotFound(String),
+
+    #[error("invalid operation: {0}")]
+    InvalidOperation(String),
 }

--- a/crates/toku-db/src/repo.rs
+++ b/crates/toku-db/src/repo.rs
@@ -1,7 +1,8 @@
-use rusqlite::params;
+use rusqlite::{OptionalExtension, params};
 use toku_core::{
-    Author, AuthorCount, Book, BookAuthor, ContributorRole, PaceRating, ReadingProgress,
-    ReadingSession, ReadingStatus, Shelf, Tag, TagCount, TagType,
+    Author, AuthorCount, Book, BookAuthor, ContributorRole, FilterCondition, FilterExpr,
+    FilterField, PaceRating, ReadingProgress, ReadingSession, ReadingStatus, Shelf, SmartFilter,
+    Tag, TagCount, TagType, Work,
 };
 use uuid::Uuid;
 
@@ -452,7 +453,7 @@ impl<'a> BookRepository<'a> {
     pub fn create_shelf(&self, name: &str) -> Result<Shelf, DbError> {
         let shelf = Shelf::new(name);
         self.db.conn.execute(
-            "INSERT INTO shelves (id, name, created_at) VALUES (?1, ?2, ?3)",
+            "INSERT INTO shelves (id, name, is_smart, smart_filter, created_at) VALUES (?1, ?2, 0, NULL, ?3)",
             params![
                 shelf.id.to_string(),
                 shelf.name,
@@ -467,20 +468,24 @@ impl<'a> BookRepository<'a> {
         let mut stmt = self
             .db
             .conn
-            .prepare("SELECT id, name, created_at FROM shelves ORDER BY name COLLATE NOCASE")?;
+            .prepare("SELECT id, name, is_smart, smart_filter, created_at FROM shelves ORDER BY name COLLATE NOCASE")?;
 
         let shelves = stmt
             .query_map([], |row| {
                 let id_str: String = row.get(0)?;
                 let name: String = row.get(1)?;
-                let created_str: String = row.get(2)?;
-                Ok((id_str, name, created_str))
+                let is_smart: bool = row.get(2)?;
+                let smart_filter: Option<String> = row.get(3)?;
+                let created_str: String = row.get(4)?;
+                Ok((id_str, name, is_smart, smart_filter, created_str))
             })?
             .filter_map(|r| r.ok())
-            .filter_map(|(id_str, name, created_str)| {
+            .filter_map(|(id_str, name, is_smart, smart_filter, created_str)| {
                 Some(Shelf {
                     id: Uuid::parse_str(&id_str).ok()?,
                     name,
+                    is_smart,
+                    smart_filter,
                     created_at: chrono::DateTime::parse_from_rfc3339(&created_str)
                         .ok()?
                         .with_timezone(&chrono::Utc),
@@ -491,21 +496,32 @@ impl<'a> BookRepository<'a> {
         Ok(shelves)
     }
 
-    /// Add a book to a shelf, creating the shelf if it doesn't exist.
+    /// Add a book to a regular shelf, creating the shelf if it doesn't exist.
+    /// Returns an error if the target shelf is a smart shelf.
     pub fn add_book_to_shelf(&self, book_id: &Uuid, shelf_name: &str) -> Result<(), DbError> {
         self.get_book(book_id)?;
 
-        let shelf_id: String = match self.db.conn.query_row(
-            "SELECT id FROM shelves WHERE name = ?1",
-            params![shelf_name],
-            |row| row.get(0),
-        ) {
-            Ok(id) => id,
-            Err(rusqlite::Error::QueryReturnedNoRows) => {
+        let row: Option<(String, bool)> = self
+            .db
+            .conn
+            .query_row(
+                "SELECT id, is_smart FROM shelves WHERE name = ?1",
+                params![shelf_name],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .optional()?;
+
+        let shelf_id = match row {
+            Some((_, true)) => {
+                return Err(DbError::InvalidOperation(format!(
+                    "cannot manually add books to smart shelf '{shelf_name}'"
+                )));
+            }
+            Some((id, false)) => id,
+            None => {
                 let shelf = self.create_shelf(shelf_name)?;
                 shelf.id.to_string()
             }
-            Err(e) => return Err(DbError::Sqlite(e)),
         };
 
         self.db.conn.execute(
@@ -536,7 +552,7 @@ impl<'a> BookRepository<'a> {
     /// Get all shelves a book belongs to.
     pub fn get_book_shelves(&self, book_id: &Uuid) -> Result<Vec<Shelf>, DbError> {
         let mut stmt = self.db.conn.prepare(
-            "SELECT s.id, s.name, s.created_at
+            "SELECT s.id, s.name, s.is_smart, s.smart_filter, s.created_at
              FROM shelves s
              JOIN book_shelves bs ON bs.shelf_id = s.id
              WHERE bs.book_id = ?1
@@ -547,14 +563,18 @@ impl<'a> BookRepository<'a> {
             .query_map(params![book_id.to_string()], |row| {
                 let id_str: String = row.get(0)?;
                 let name: String = row.get(1)?;
-                let created_str: String = row.get(2)?;
-                Ok((id_str, name, created_str))
+                let is_smart: bool = row.get(2)?;
+                let smart_filter: Option<String> = row.get(3)?;
+                let created_str: String = row.get(4)?;
+                Ok((id_str, name, is_smart, smart_filter, created_str))
             })?
             .filter_map(|r| r.ok())
-            .filter_map(|(id_str, name, created_str)| {
+            .filter_map(|(id_str, name, is_smart, smart_filter, created_str)| {
                 Some(Shelf {
                     id: Uuid::parse_str(&id_str).ok()?,
                     name,
+                    is_smart,
+                    smart_filter,
                     created_at: chrono::DateTime::parse_from_rfc3339(&created_str)
                         .ok()?
                         .with_timezone(&chrono::Utc),
@@ -565,21 +585,126 @@ impl<'a> BookRepository<'a> {
         Ok(shelves)
     }
 
-    /// List all books in a shelf.
+    /// List all books in a shelf. For smart shelves, evaluates the filter dynamically.
     pub fn list_books_in_shelf(&self, shelf_name: &str) -> Result<Vec<Book>, DbError> {
-        let mut stmt = self.db.conn.prepare(
+        // Check if this is a smart shelf
+        let row: Option<(bool, Option<String>)> = self
+            .db
+            .conn
+            .query_row(
+                "SELECT is_smart, smart_filter FROM shelves WHERE name = ?1",
+                params![shelf_name],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .optional()?;
+
+        match row {
+            Some((true, Some(filter_json))) => {
+                let filter =
+                    SmartFilter::from_json(&filter_json).map_err(|e| DbError::Io(e.to_string()))?;
+                self.evaluate_smart_filter(&filter)
+            }
+            Some((true, None)) => Ok(Vec::new()),
+            Some((false, _)) | None => {
+                // Regular shelf or not found — use book_shelves join
+                let mut stmt = self.db.conn.prepare(
+                    "SELECT b.id, b.title, b.subtitle, b.description, b.page_count, b.pub_date,
+                     b.language, b.format, b.duration_minutes, b.cover_hash, b.work_id, b.status,
+                     b.rating, b.created_at, b.updated_at
+                     FROM books b
+                     JOIN book_shelves bs ON bs.book_id = b.id
+                     JOIN shelves s ON s.id = bs.shelf_id
+                     WHERE s.name = ?1
+                     ORDER BY b.title COLLATE NOCASE",
+                )?;
+
+                let books = stmt
+                    .query_map(params![shelf_name], |row| Ok(row_to_book(row)))?
+                    .filter_map(|r| r.ok())
+                    .filter_map(|r| r.ok())
+                    .collect();
+
+                Ok(books)
+            }
+        }
+    }
+
+    /// Create a smart shelf with a filter expression.
+    pub fn create_smart_shelf(&self, name: &str, filter: &SmartFilter) -> Result<Shelf, DbError> {
+        let filter_json = filter.to_json().map_err(|e| DbError::Io(e.to_string()))?;
+        let shelf = Shelf::new_smart(name, filter_json.clone());
+        self.db.conn.execute(
+            "INSERT INTO shelves (id, name, is_smart, smart_filter, created_at) VALUES (?1, ?2, 1, ?3, ?4)",
+            params![
+                shelf.id.to_string(),
+                shelf.name,
+                filter_json,
+                shelf.created_at.to_rfc3339(),
+            ],
+        )?;
+        Ok(shelf)
+    }
+
+    /// Get a shelf by name.
+    pub fn get_shelf_by_name(&self, name: &str) -> Result<Option<Shelf>, DbError> {
+        self.db
+            .conn
+            .query_row(
+                "SELECT id, name, is_smart, smart_filter, created_at FROM shelves WHERE name = ?1 COLLATE NOCASE",
+                params![name],
+                |row| {
+                    let id_str: String = row.get(0)?;
+                    let name: String = row.get(1)?;
+                    let is_smart: bool = row.get(2)?;
+                    let smart_filter: Option<String> = row.get(3)?;
+                    let created_str: String = row.get(4)?;
+                    Ok((id_str, name, is_smart, smart_filter, created_str))
+                },
+            )
+            .optional()?
+            .and_then(|(id_str, name, is_smart, smart_filter, created_str)| {
+                Some(Shelf {
+                    id: Uuid::parse_str(&id_str).ok()?,
+                    name,
+                    is_smart,
+                    smart_filter,
+                    created_at: chrono::DateTime::parse_from_rfc3339(&created_str)
+                        .ok()?
+                        .with_timezone(&chrono::Utc),
+                })
+            })
+            .map_or_else(|| Ok(None), |s| Ok(Some(s)))
+    }
+
+    /// Delete a shelf by name.
+    pub fn delete_shelf(&self, name: &str) -> Result<bool, DbError> {
+        let rows = self
+            .db
+            .conn
+            .execute("DELETE FROM shelves WHERE name = ?1", params![name])?;
+        Ok(rows > 0)
+    }
+
+    /// Evaluate a smart filter and return matching books.
+    pub fn evaluate_smart_filter(&self, filter: &SmartFilter) -> Result<Vec<Book>, DbError> {
+        let mut params: Vec<Box<dyn rusqlite::types::ToSql>> = Vec::new();
+        let mut param_idx = 1u32;
+        let where_clause = build_filter_sql(&filter.expression, &mut params, &mut param_idx);
+
+        let sql = format!(
             "SELECT b.id, b.title, b.subtitle, b.description, b.page_count, b.pub_date,
              b.language, b.format, b.duration_minutes, b.cover_hash, b.work_id, b.status,
              b.rating, b.created_at, b.updated_at
-             FROM books b
-             JOIN book_shelves bs ON bs.book_id = b.id
-             JOIN shelves s ON s.id = bs.shelf_id
-             WHERE s.name = ?1
-             ORDER BY b.title COLLATE NOCASE",
-        )?;
+             FROM books b WHERE {where_clause}
+             ORDER BY b.title COLLATE NOCASE"
+        );
+
+        let mut stmt = self.db.conn.prepare(&sql)?;
+        let params_ref: Vec<&dyn rusqlite::types::ToSql> =
+            params.iter().map(|v| v.as_ref()).collect();
 
         let books = stmt
-            .query_map(params![shelf_name], |row| Ok(row_to_book(row)))?
+            .query_map(params_ref.as_slice(), |row| Ok(row_to_book(row)))?
             .filter_map(|r| r.ok())
             .filter_map(|r| r.ok())
             .collect();
@@ -1353,6 +1478,327 @@ impl<'a> BookRepository<'a> {
 
         Ok(sessions)
     }
+
+    // ── Work methods ──────────────────────────────────────────────────
+
+    /// Create a new work.
+    pub fn create_work(&self, work: &Work) -> Result<(), DbError> {
+        self.db.conn.execute(
+            "INSERT INTO works (id, title, original_language, first_published, created_at)
+             VALUES (?1, ?2, ?3, ?4, ?5)",
+            params![
+                work.id.to_string(),
+                work.title,
+                work.original_language,
+                work.first_published,
+                work.created_at.to_rfc3339(),
+            ],
+        )?;
+        Ok(())
+    }
+
+    /// Get a work by its UUID.
+    pub fn get_work(&self, id: &Uuid) -> Result<Work, DbError> {
+        self.db
+            .conn
+            .query_row(
+                "SELECT id, title, original_language, first_published, created_at
+                 FROM works WHERE id = ?1",
+                params![id.to_string()],
+                |row| {
+                    let id_str: String = row.get(0)?;
+                    let created_str: String = row.get(4)?;
+                    Ok((id_str, row.get(1)?, row.get(2)?, row.get(3)?, created_str))
+                },
+            )
+            .map(
+                |(id_str, title, original_language, first_published, created_str)| Work {
+                    id: Uuid::parse_str(&id_str).expect("valid UUID"),
+                    title,
+                    original_language,
+                    first_published,
+                    created_at: chrono::DateTime::parse_from_rfc3339(&created_str)
+                        .expect("valid datetime")
+                        .with_timezone(&chrono::Utc),
+                },
+            )
+            .map_err(DbError::from)
+    }
+
+    /// Find works whose title matches (case-insensitive LIKE).
+    pub fn find_works_by_title(&self, title: &str) -> Result<Vec<Work>, DbError> {
+        let mut stmt = self.db.conn.prepare(
+            "SELECT id, title, original_language, first_published, created_at
+             FROM works WHERE title LIKE ?1 COLLATE NOCASE",
+        )?;
+        let works = stmt
+            .query_map(params![format!("%{title}%")], |row| {
+                let id_str: String = row.get(0)?;
+                let created_str: String = row.get(4)?;
+                Ok((id_str, row.get(1)?, row.get(2)?, row.get(3)?, created_str))
+            })?
+            .filter_map(|r| r.ok())
+            .map(
+                |(id_str, title, original_language, first_published, created_str)| Work {
+                    id: Uuid::parse_str(&id_str).expect("valid UUID"),
+                    title,
+                    original_language,
+                    first_published,
+                    created_at: chrono::DateTime::parse_from_rfc3339(&created_str)
+                        .expect("valid datetime")
+                        .with_timezone(&chrono::Utc),
+                },
+            )
+            .collect();
+        Ok(works)
+    }
+
+    /// Link a book to a work by setting books.work_id.
+    pub fn link_book_to_work(&self, book_id: &Uuid, work_id: &Uuid) -> Result<(), DbError> {
+        let now = chrono::Utc::now().to_rfc3339();
+        self.db.conn.execute(
+            "UPDATE books SET work_id = ?1, updated_at = ?2 WHERE id = ?3",
+            params![work_id.to_string(), now, book_id.to_string()],
+        )?;
+        Ok(())
+    }
+
+    /// Unlink a book from its work (set work_id = NULL).
+    pub fn unlink_book_from_work(&self, book_id: &Uuid) -> Result<(), DbError> {
+        let now = chrono::Utc::now().to_rfc3339();
+        self.db.conn.execute(
+            "UPDATE books SET work_id = NULL, updated_at = ?1 WHERE id = ?2",
+            params![now, book_id.to_string()],
+        )?;
+        Ok(())
+    }
+
+    /// List all books belonging to a work (editions).
+    pub fn get_work_editions(&self, work_id: &Uuid) -> Result<Vec<Book>, DbError> {
+        let mut stmt = self.db.conn.prepare(
+            "SELECT id, title, subtitle, description, page_count, pub_date,
+                    language, format, duration_minutes, cover_hash, work_id,
+                    status, rating, created_at, updated_at
+             FROM books WHERE work_id = ?1",
+        )?;
+        let books = stmt
+            .query_map(params![work_id.to_string()], |row| {
+                row_to_book(row).map_err(rusqlite::Error::InvalidColumnName)
+            })?
+            .filter_map(|r| r.ok())
+            .collect();
+        Ok(books)
+    }
+
+    /// Find groups of ungrouped books that share the same title and primary
+    /// author (case-insensitive). Returns `(normalized_key, Vec<Book>)` pairs
+    /// where each group has at least 2 members.
+    pub fn auto_group_candidates(&self) -> Result<Vec<(String, Vec<Book>)>, DbError> {
+        // Build a map: normalized(title + primary_author) → Vec<Book>
+        let ungrouped = {
+            let mut stmt = self.db.conn.prepare(
+                "SELECT id, title, subtitle, description, page_count, pub_date,
+                        language, format, duration_minutes, cover_hash, work_id,
+                        status, rating, created_at, updated_at
+                 FROM books WHERE work_id IS NULL",
+            )?;
+            let books: Vec<Book> = stmt
+                .query_map([], |row| {
+                    row_to_book(row).map_err(rusqlite::Error::InvalidColumnName)
+                })?
+                .filter_map(|r| r.ok())
+                .collect();
+            books
+        };
+
+        let mut groups: std::collections::HashMap<String, Vec<Book>> =
+            std::collections::HashMap::new();
+        for book in ungrouped {
+            let authors = self.get_book_authors(&book.id)?;
+            let primary_author = authors
+                .iter()
+                .find(|(_, ba)| ba.role == ContributorRole::Author)
+                .map(|(a, _)| a.name.clone())
+                .unwrap_or_default();
+            let key = normalize_title_for_grouping(&book.title, &primary_author);
+            groups.entry(key).or_default().push(book);
+        }
+
+        let mut result: Vec<(String, Vec<Book>)> = groups
+            .into_iter()
+            .filter(|(_, books)| books.len() >= 2)
+            .collect();
+        result.sort_by(|a, b| a.0.cmp(&b.0));
+        Ok(result)
+    }
+
+    /// Merge book `removed_id` into `keep_id`. All dependent data
+    /// (sessions, progress, ISBNs, tags, authors, series, provenance,
+    /// import records, source IDs) is moved or merged, then the removed
+    /// book is deleted.
+    ///
+    /// Fields on the kept book that are NULL are filled from the removed
+    /// book. User-set provenance is never overwritten.
+    pub fn merge_books(&self, keep_id: &Uuid, removed_id: &Uuid) -> Result<(), DbError> {
+        let tx = self.db.conn.unchecked_transaction()?;
+
+        // 1. Reassign reading_sessions
+        tx.execute(
+            "UPDATE reading_sessions SET book_id = ?1 WHERE book_id = ?2",
+            params![keep_id.to_string(), removed_id.to_string()],
+        )?;
+
+        // 2. Reassign reading_progress
+        tx.execute(
+            "UPDATE reading_progress SET book_id = ?1 WHERE book_id = ?2",
+            params![keep_id.to_string(), removed_id.to_string()],
+        )?;
+
+        // 3. Move ISBNs (skip duplicates)
+        tx.execute(
+            "UPDATE OR IGNORE isbns SET book_id = ?1 WHERE book_id = ?2",
+            params![keep_id.to_string(), removed_id.to_string()],
+        )?;
+        tx.execute(
+            "DELETE FROM isbns WHERE book_id = ?1",
+            params![removed_id.to_string()],
+        )?;
+
+        // 4. Move tags (skip duplicates via OR IGNORE on composite PK)
+        tx.execute(
+            "INSERT OR IGNORE INTO book_tags (book_id, tag_id)
+             SELECT ?1, tag_id FROM book_tags WHERE book_id = ?2",
+            params![keep_id.to_string(), removed_id.to_string()],
+        )?;
+        tx.execute(
+            "DELETE FROM book_tags WHERE book_id = ?1",
+            params![removed_id.to_string()],
+        )?;
+
+        // 5. Move authors (skip duplicates via OR IGNORE)
+        tx.execute(
+            "INSERT OR IGNORE INTO book_authors (book_id, author_id, role)
+             SELECT ?1, author_id, role FROM book_authors WHERE book_id = ?2",
+            params![keep_id.to_string(), removed_id.to_string()],
+        )?;
+        tx.execute(
+            "DELETE FROM book_authors WHERE book_id = ?1",
+            params![removed_id.to_string()],
+        )?;
+
+        // 6. Move series memberships (skip duplicates)
+        tx.execute(
+            "INSERT OR IGNORE INTO book_series (book_id, series_id, position)
+             SELECT ?1, series_id, position FROM book_series WHERE book_id = ?2",
+            params![keep_id.to_string(), removed_id.to_string()],
+        )?;
+        tx.execute(
+            "DELETE FROM book_series WHERE book_id = ?1",
+            params![removed_id.to_string()],
+        )?;
+
+        // 7. Move provenance (only for fields not already tracked on keep)
+        tx.execute(
+            "INSERT OR IGNORE INTO metadata_provenance (book_id, field_name, source, source_date, is_user_override)
+             SELECT ?1, field_name, source, source_date, is_user_override
+             FROM metadata_provenance WHERE book_id = ?2",
+            params![keep_id.to_string(), removed_id.to_string()],
+        )?;
+        tx.execute(
+            "DELETE FROM metadata_provenance WHERE book_id = ?1",
+            params![removed_id.to_string()],
+        )?;
+
+        // 8. Move import records (skip duplicates)
+        tx.execute(
+            "INSERT OR IGNORE INTO import_books (import_id, book_id)
+             SELECT import_id, ?1 FROM import_books WHERE book_id = ?2",
+            params![keep_id.to_string(), removed_id.to_string()],
+        )?;
+        tx.execute(
+            "DELETE FROM import_books WHERE book_id = ?1",
+            params![removed_id.to_string()],
+        )?;
+
+        // 9. Fill NULL metadata fields on keep from removed
+        let fill_fields = [
+            "subtitle",
+            "description",
+            "page_count",
+            "pub_date",
+            "language",
+            "duration_minutes",
+            "cover_hash",
+            "rating",
+        ];
+        for field in &fill_fields {
+            let sql = format!(
+                "UPDATE books SET {f} = (SELECT {f} FROM books WHERE id = ?2),
+                 updated_at = ?3
+                 WHERE id = ?1 AND {f} IS NULL
+                 AND (SELECT {f} FROM books WHERE id = ?2) IS NOT NULL",
+                f = field
+            );
+            tx.execute(
+                &sql,
+                params![
+                    keep_id.to_string(),
+                    removed_id.to_string(),
+                    chrono::Utc::now().to_rfc3339()
+                ],
+            )?;
+        }
+
+        // 10. Merge source IDs (goodreads_id, calibre_id): copy if keep is NULL
+        tx.execute(
+            "UPDATE books SET goodreads_id = (SELECT goodreads_id FROM books WHERE id = ?2),
+             updated_at = ?3
+             WHERE id = ?1 AND goodreads_id IS NULL
+             AND (SELECT goodreads_id FROM books WHERE id = ?2) IS NOT NULL",
+            params![
+                keep_id.to_string(),
+                removed_id.to_string(),
+                chrono::Utc::now().to_rfc3339()
+            ],
+        )?;
+        tx.execute(
+            "UPDATE books SET calibre_id = (SELECT calibre_id FROM books WHERE id = ?2),
+             updated_at = ?3
+             WHERE id = ?1 AND calibre_id IS NULL
+             AND (SELECT calibre_id FROM books WHERE id = ?2) IS NOT NULL",
+            params![
+                keep_id.to_string(),
+                removed_id.to_string(),
+                chrono::Utc::now().to_rfc3339()
+            ],
+        )?;
+
+        // 11. If removed book had a work_id and keep doesn't, inherit it
+        tx.execute(
+            "UPDATE books SET work_id = (SELECT work_id FROM books WHERE id = ?2),
+             updated_at = ?3
+             WHERE id = ?1 AND work_id IS NULL
+             AND (SELECT work_id FROM books WHERE id = ?2) IS NOT NULL",
+            params![
+                keep_id.to_string(),
+                removed_id.to_string(),
+                chrono::Utc::now().to_rfc3339()
+            ],
+        )?;
+
+        // 12. Delete the removed book (ON DELETE CASCADE cleans up remaining refs)
+        tx.execute(
+            "DELETE FROM books WHERE id = ?1",
+            params![removed_id.to_string()],
+        )?;
+
+        tx.commit()?;
+
+        // 13. Recompute search_text outside the transaction
+        self.update_search_text(keep_id)?;
+
+        Ok(())
+    }
 }
 
 /// Build the denormalized search_text from book fields and author names.
@@ -1373,6 +1819,43 @@ fn build_search_text(
         parts.push(name);
     }
     parts.join(" ")
+}
+
+/// Normalize a title + author string for grouping purposes.
+/// Strips parentheticals, edition markers, extra whitespace; lowercases everything.
+fn normalize_title_for_grouping(title: &str, author: &str) -> String {
+    let mut s = title.to_lowercase();
+    // Remove content in parentheses: "(Paperback)", "(2nd Edition)", etc.
+    while let (Some(open), Some(close)) = (s.find('('), s.find(')')) {
+        if open < close {
+            s = format!("{}{}", &s[..open], &s[close + 1..]);
+        } else {
+            break;
+        }
+    }
+    // Remove common edition markers
+    for marker in &[
+        "hardcover",
+        "paperback",
+        "mass market",
+        "trade paperback",
+        "kindle edition",
+        "ebook",
+        "audiobook",
+        "audio cd",
+        "board book",
+        "library binding",
+    ] {
+        s = s.replace(marker, "");
+    }
+    // Collapse whitespace and trim
+    let s = s.split_whitespace().collect::<Vec<_>>().join(" ");
+    let author_norm = author.to_lowercase().trim().to_string();
+    if author_norm.is_empty() {
+        s
+    } else {
+        format!("{s} | {author_norm}")
+    }
 }
 
 fn row_to_book(row: &rusqlite::Row<'_>) -> Result<Book, String> {
@@ -1469,6 +1952,132 @@ fn row_to_reading_session(row: &rusqlite::Row<'_>) -> Result<ReadingSession, Str
             .map_err(|e| e.to_string())?
             .with_timezone(&chrono::Utc),
     })
+}
+
+/// Escape LIKE wildcards in a value for safe parameterized LIKE queries.
+fn escape_like_value(value: &str) -> String {
+    value
+        .replace('\\', "\\\\")
+        .replace('%', "\\%")
+        .replace('_', "\\_")
+}
+
+/// Recursively build a SQL WHERE clause from a filter expression tree.
+/// Appends parameterized values to `params` and increments `param_idx`.
+fn build_filter_sql(
+    expr: &FilterExpr,
+    params: &mut Vec<Box<dyn rusqlite::types::ToSql>>,
+    param_idx: &mut u32,
+) -> String {
+    match expr {
+        FilterExpr::And(exprs) => {
+            let clauses: Vec<String> = exprs
+                .iter()
+                .map(|e| {
+                    let clause = build_filter_sql(e, params, param_idx);
+                    if matches!(e, FilterExpr::Or(_)) {
+                        format!("({clause})")
+                    } else {
+                        clause
+                    }
+                })
+                .collect();
+            clauses.join(" AND ")
+        }
+        FilterExpr::Or(exprs) => {
+            let clauses: Vec<String> = exprs
+                .iter()
+                .map(|e| build_filter_sql(e, params, param_idx))
+                .collect();
+            clauses.join(" OR ")
+        }
+        FilterExpr::Condition(cond) => build_condition_sql(cond, params, param_idx),
+    }
+}
+
+fn build_condition_sql(
+    cond: &FilterCondition,
+    params: &mut Vec<Box<dyn rusqlite::types::ToSql>>,
+    param_idx: &mut u32,
+) -> String {
+    let idx = *param_idx;
+    *param_idx += 1;
+
+    match cond.field {
+        FilterField::Status => {
+            // Normalize underscores to hyphens (DSL accepts both)
+            let normalized = cond.value.replace('_', "-");
+            params.push(Box::new(normalized));
+            format!("b.status = ?{idx}")
+        }
+        FilterField::Rating => {
+            let val: i64 = cond.value.parse().unwrap_or(0);
+            params.push(Box::new(val));
+            format!("b.rating {} ?{idx}", cond.op.as_sql())
+        }
+        FilterField::Pages => {
+            let val: i64 = cond.value.parse().unwrap_or(0);
+            params.push(Box::new(val));
+            format!("b.page_count {} ?{idx}", cond.op.as_sql())
+        }
+        FilterField::Format => {
+            params.push(Box::new(cond.value.clone()));
+            format!("b.format = ?{idx}")
+        }
+        FilterField::PubDate => {
+            params.push(Box::new(cond.value.clone()));
+            if cond.value.len() == 4 {
+                // Year comparison: extract first 4 chars of pub_date
+                format!("SUBSTR(b.pub_date, 1, 4) {} ?{idx}", cond.op.as_sql())
+            } else {
+                format!("b.pub_date {} ?{idx}", cond.op.as_sql())
+            }
+        }
+        FilterField::DateAdded => {
+            params.push(Box::new(cond.value.clone()));
+            if cond.value.len() == 4 {
+                format!("SUBSTR(b.created_at, 1, 4) {} ?{idx}", cond.op.as_sql())
+            } else {
+                format!("SUBSTR(b.created_at, 1, 10) {} ?{idx}", cond.op.as_sql())
+            }
+        }
+        FilterField::Tag => {
+            params.push(Box::new(cond.value.clone()));
+            format!(
+                "EXISTS (SELECT 1 FROM book_tags bt JOIN tags t ON t.id = bt.tag_id \
+                 WHERE bt.book_id = b.id AND t.name = ?{idx} COLLATE NOCASE AND t.tag_type = 'general')"
+            )
+        }
+        FilterField::Mood => {
+            params.push(Box::new(cond.value.clone()));
+            format!(
+                "EXISTS (SELECT 1 FROM book_tags bt JOIN tags t ON t.id = bt.tag_id \
+                 WHERE bt.book_id = b.id AND t.name = ?{idx} COLLATE NOCASE AND t.tag_type = 'mood')"
+            )
+        }
+        FilterField::Pace => {
+            params.push(Box::new(cond.value.clone()));
+            format!(
+                "EXISTS (SELECT 1 FROM book_tags bt JOIN tags t ON t.id = bt.tag_id \
+                 WHERE bt.book_id = b.id AND t.name = ?{idx} COLLATE NOCASE AND t.tag_type = 'pace')"
+            )
+        }
+        FilterField::Author => {
+            let escaped = format!("%{}%", escape_like_value(&cond.value));
+            params.push(Box::new(escaped));
+            format!(
+                "EXISTS (SELECT 1 FROM book_authors ba JOIN authors a ON a.id = ba.author_id \
+                 WHERE ba.book_id = b.id AND a.name LIKE ?{idx} ESCAPE '\\' COLLATE NOCASE)"
+            )
+        }
+        FilterField::Shelf => {
+            params.push(Box::new(cond.value.clone()));
+            format!(
+                "EXISTS (SELECT 1 FROM book_shelves bs JOIN shelves s ON s.id = bs.shelf_id \
+                 WHERE bs.book_id = b.id AND s.name = ?{idx} COLLATE NOCASE AND s.is_smart = 0)"
+            )
+        }
+    }
 }
 
 #[cfg(test)]
@@ -1989,5 +2598,586 @@ mod tests {
         assert_eq!(log.len(), 1);
         assert_eq!(log[0].session_id, Some(session.id));
         assert_eq!(log[0].progress_type, ProgressType::Percent);
+    }
+
+    // ── Work & merge tests ────────────────────────────────────────────
+
+    #[test]
+    fn create_and_get_work() {
+        let db = test_db();
+        let repo = BookRepository::new(&db);
+
+        let work = Work::new("Dune");
+        repo.create_work(&work).unwrap();
+
+        let retrieved = repo.get_work(&work.id).unwrap();
+        assert_eq!(retrieved.title, "Dune");
+        assert!(retrieved.original_language.is_none());
+    }
+
+    #[test]
+    fn find_works_by_title_case_insensitive() {
+        let db = test_db();
+        let repo = BookRepository::new(&db);
+
+        let w1 = Work::new("Dune");
+        let w2 = Work::new("The Left Hand of Darkness");
+        repo.create_work(&w1).unwrap();
+        repo.create_work(&w2).unwrap();
+
+        let found = repo.find_works_by_title("dune").unwrap();
+        assert_eq!(found.len(), 1);
+        assert_eq!(found[0].title, "Dune");
+
+        let found = repo.find_works_by_title("DARKNESS").unwrap();
+        assert_eq!(found.len(), 1);
+    }
+
+    #[test]
+    fn link_and_unlink_book_to_work() {
+        let db = test_db();
+        let repo = BookRepository::new(&db);
+
+        let work = Work::new("Dune");
+        repo.create_work(&work).unwrap();
+
+        let book = Book::new("Dune (Paperback)");
+        repo.create_book(&book).unwrap();
+        assert!(repo.get_book(&book.id).unwrap().work_id.is_none());
+
+        repo.link_book_to_work(&book.id, &work.id).unwrap();
+        assert_eq!(repo.get_book(&book.id).unwrap().work_id, Some(work.id));
+
+        let editions = repo.get_work_editions(&work.id).unwrap();
+        assert_eq!(editions.len(), 1);
+        assert_eq!(editions[0].id, book.id);
+
+        repo.unlink_book_from_work(&book.id).unwrap();
+        assert!(repo.get_book(&book.id).unwrap().work_id.is_none());
+    }
+
+    #[test]
+    fn merge_books_moves_sessions_and_progress() {
+        let db = test_db();
+        let repo = BookRepository::new(&db);
+
+        let keep = Book::new("Dune");
+        let remove = Book::new("Dune (Paperback)");
+        repo.create_book(&keep).unwrap();
+        repo.create_book(&remove).unwrap();
+
+        // Add sessions and progress to the removed book
+        let session = ReadingSession::new(remove.id);
+        repo.create_reading_session(&session).unwrap();
+        let progress = ReadingProgress::new(remove.id, ProgressType::Page, 50);
+        repo.log_progress(&progress).unwrap();
+
+        repo.merge_books(&keep.id, &remove.id).unwrap();
+
+        // Sessions and progress moved to keep
+        let sessions = repo.list_reading_sessions().unwrap();
+        assert_eq!(sessions.len(), 1);
+        assert_eq!(sessions[0].book_id, keep.id);
+
+        let log = repo.get_reading_log(&keep.id).unwrap();
+        assert_eq!(log.len(), 1);
+
+        // Removed book is gone
+        assert!(repo.get_book(&remove.id).is_err());
+    }
+
+    #[test]
+    fn merge_books_dedupes_tags_and_authors() {
+        let db = test_db();
+        let repo = BookRepository::new(&db);
+
+        let keep = Book::new("Dune");
+        let remove = Book::new("Dune (Kindle)");
+        repo.create_book(&keep).unwrap();
+        repo.create_book(&remove).unwrap();
+
+        // Both have the same tag "sci-fi" and an exclusive tag each
+        repo.add_tag_to_book(&keep.id, "sci-fi").unwrap();
+        repo.add_tag_to_book(&keep.id, "classic").unwrap();
+        repo.add_tag_to_book(&remove.id, "sci-fi").unwrap();
+        repo.add_tag_to_book(&remove.id, "favorite").unwrap();
+
+        // Both have the same author
+        let frank = Author::new("Frank Herbert");
+        repo.add_book_author(&frank, &keep.id, ContributorRole::Author, 0)
+            .unwrap();
+        repo.add_book_author(&frank, &remove.id, ContributorRole::Author, 0)
+            .unwrap();
+
+        repo.merge_books(&keep.id, &remove.id).unwrap();
+
+        let tags = repo.get_book_tags(&keep.id).unwrap();
+        assert_eq!(tags.len(), 3); // sci-fi, classic, favorite (deduped)
+
+        let authors = repo.get_book_authors(&keep.id).unwrap();
+        assert_eq!(authors.len(), 1); // Frank Herbert (deduped)
+    }
+
+    #[test]
+    fn merge_books_fills_null_metadata() {
+        let db = test_db();
+        let repo = BookRepository::new(&db);
+
+        let keep = Book::new("Dune");
+        repo.create_book(&keep).unwrap();
+
+        let mut remove = Book::new("Dune (Paperback)");
+        remove.page_count = Some(412);
+        remove.language = Some("en".to_string());
+        remove.pub_date = Some("1965".to_string());
+        repo.create_book(&remove).unwrap();
+
+        repo.merge_books(&keep.id, &remove.id).unwrap();
+
+        let merged = repo.get_book(&keep.id).unwrap();
+        assert_eq!(merged.page_count, Some(412));
+        assert_eq!(merged.language.as_deref(), Some("en"));
+        assert_eq!(merged.pub_date.as_deref(), Some("1965"));
+    }
+
+    #[test]
+    fn merge_books_keeps_existing_metadata() {
+        let db = test_db();
+        let repo = BookRepository::new(&db);
+
+        let mut keep = Book::new("Dune");
+        keep.page_count = Some(300);
+        repo.create_book(&keep).unwrap();
+
+        let mut remove = Book::new("Dune (Paperback)");
+        remove.page_count = Some(412);
+        repo.create_book(&remove).unwrap();
+
+        repo.merge_books(&keep.id, &remove.id).unwrap();
+
+        let merged = repo.get_book(&keep.id).unwrap();
+        assert_eq!(merged.page_count, Some(300)); // keep's value preserved
+    }
+
+    #[test]
+    fn merge_books_inherits_work_id() {
+        let db = test_db();
+        let repo = BookRepository::new(&db);
+
+        let work = Work::new("Dune");
+        repo.create_work(&work).unwrap();
+
+        let keep = Book::new("Dune");
+        repo.create_book(&keep).unwrap();
+
+        let mut remove = Book::new("Dune (Paperback)");
+        remove.work_id = Some(work.id);
+        repo.create_book(&remove).unwrap();
+        // Manually set work_id since create_book already wrote it
+        repo.link_book_to_work(&remove.id, &work.id).unwrap();
+
+        repo.merge_books(&keep.id, &remove.id).unwrap();
+
+        let merged = repo.get_book(&keep.id).unwrap();
+        assert_eq!(merged.work_id, Some(work.id));
+    }
+
+    #[test]
+    fn auto_group_candidates_finds_duplicates() {
+        let db = test_db();
+        let repo = BookRepository::new(&db);
+
+        let b1 = Book::new("Dune");
+        let b2 = Book::new("dune");
+        let b3 = Book::new("Neuromancer");
+        repo.create_book(&b1).unwrap();
+        repo.create_book(&b2).unwrap();
+        repo.create_book(&b3).unwrap();
+
+        // b1 and b2 share a primary author
+        let frank = Author::new("Frank Herbert");
+        repo.add_book_author(&frank, &b1.id, ContributorRole::Author, 0)
+            .unwrap();
+        repo.add_book_author(&frank, &b2.id, ContributorRole::Author, 0)
+            .unwrap();
+        let gibson = Author::new("William Gibson");
+        repo.add_book_author(&gibson, &b3.id, ContributorRole::Author, 0)
+            .unwrap();
+
+        let candidates = repo.auto_group_candidates().unwrap();
+        assert_eq!(candidates.len(), 1);
+        assert_eq!(candidates[0].1.len(), 2);
+    }
+
+    #[test]
+    fn auto_group_excludes_already_grouped() {
+        let db = test_db();
+        let repo = BookRepository::new(&db);
+
+        let work = Work::new("Dune");
+        repo.create_work(&work).unwrap();
+
+        let b1 = Book::new("Dune");
+        let b2 = Book::new("Dune");
+        repo.create_book(&b1).unwrap();
+        repo.create_book(&b2).unwrap();
+
+        let frank = Author::new("Frank Herbert");
+        repo.add_book_author(&frank, &b1.id, ContributorRole::Author, 0)
+            .unwrap();
+        repo.add_book_author(&frank, &b2.id, ContributorRole::Author, 0)
+            .unwrap();
+
+        // Link b1 to work — now it shouldn't be a candidate
+        repo.link_book_to_work(&b1.id, &work.id).unwrap();
+
+        let candidates = repo.auto_group_candidates().unwrap();
+        assert!(candidates.is_empty()); // only 1 ungrouped book, needs >= 2
+    }
+
+    #[test]
+    fn normalize_title_strips_parentheticals() {
+        assert_eq!(
+            normalize_title_for_grouping("Dune (Paperback)", "Frank Herbert"),
+            "dune | frank herbert"
+        );
+        assert_eq!(
+            normalize_title_for_grouping("Dune (2nd Edition)", "Frank Herbert"),
+            "dune | frank herbert"
+        );
+    }
+
+    #[test]
+    fn normalize_title_strips_edition_markers() {
+        assert_eq!(
+            normalize_title_for_grouping("Dune Kindle Edition", ""),
+            "dune"
+        );
+        assert_eq!(
+            normalize_title_for_grouping("Dune Hardcover", "Frank Herbert"),
+            "dune | frank herbert"
+        );
+    }
+
+    // --- Smart shelf tests ---
+
+    #[test]
+    fn create_smart_shelf_and_list() {
+        let db = test_db();
+        let repo = BookRepository::new(&db);
+
+        let filter = SmartFilter::parse("status:read").unwrap();
+        let shelf = repo.create_smart_shelf("Finished Books", &filter).unwrap();
+
+        assert!(shelf.is_smart);
+        assert!(shelf.smart_filter.is_some());
+
+        let shelves = repo.list_shelves().unwrap();
+        let smart = shelves.iter().find(|s| s.name == "Finished Books").unwrap();
+        assert!(smart.is_smart);
+        assert!(smart.smart_filter.is_some());
+    }
+
+    #[test]
+    fn smart_shelf_evaluates_status_filter() {
+        let db = test_db();
+        let repo = BookRepository::new(&db);
+
+        let mut b1 = Book::new("Read Book");
+        b1.status = ReadingStatus::Read;
+        repo.create_book(&b1).unwrap();
+
+        let mut b2 = Book::new("Unread Book");
+        b2.status = ReadingStatus::WantToRead;
+        repo.create_book(&b2).unwrap();
+
+        let filter = SmartFilter::parse("status:read").unwrap();
+        repo.create_smart_shelf("Finished", &filter).unwrap();
+
+        let books = repo.list_books_in_shelf("Finished").unwrap();
+        assert_eq!(books.len(), 1);
+        assert_eq!(books[0].title, "Read Book");
+    }
+
+    #[test]
+    fn smart_shelf_evaluates_rating_filter() {
+        let db = test_db();
+        let repo = BookRepository::new(&db);
+
+        let mut b1 = Book::new("Great Book");
+        b1.rating = Some(9);
+        repo.create_book(&b1).unwrap();
+
+        let mut b2 = Book::new("OK Book");
+        b2.rating = Some(5);
+        repo.create_book(&b2).unwrap();
+
+        let filter = SmartFilter::parse("rating:>=8").unwrap();
+        let books = repo.evaluate_smart_filter(&filter).unwrap();
+        assert_eq!(books.len(), 1);
+        assert_eq!(books[0].title, "Great Book");
+    }
+
+    #[test]
+    fn smart_shelf_evaluates_pages_filter() {
+        let db = test_db();
+        let repo = BookRepository::new(&db);
+
+        let mut b1 = Book::new("Long Book");
+        b1.page_count = Some(500);
+        repo.create_book(&b1).unwrap();
+
+        let mut b2 = Book::new("Short Book");
+        b2.page_count = Some(100);
+        repo.create_book(&b2).unwrap();
+
+        let filter = SmartFilter::parse("pages:>300").unwrap();
+        let books = repo.evaluate_smart_filter(&filter).unwrap();
+        assert_eq!(books.len(), 1);
+        assert_eq!(books[0].title, "Long Book");
+    }
+
+    #[test]
+    fn smart_shelf_evaluates_tag_filter() {
+        let db = test_db();
+        let repo = BookRepository::new(&db);
+
+        let b1 = Book::new("Sci-Fi Book");
+        repo.create_book(&b1).unwrap();
+        repo.add_tag_to_book(&b1.id, "sci-fi").unwrap();
+
+        let b2 = Book::new("Fantasy Book");
+        repo.create_book(&b2).unwrap();
+        repo.add_tag_to_book(&b2.id, "fantasy").unwrap();
+
+        let filter = SmartFilter::parse("tag:sci-fi").unwrap();
+        let books = repo.evaluate_smart_filter(&filter).unwrap();
+        assert_eq!(books.len(), 1);
+        assert_eq!(books[0].title, "Sci-Fi Book");
+    }
+
+    #[test]
+    fn smart_shelf_evaluates_mood_filter() {
+        let db = test_db();
+        let repo = BookRepository::new(&db);
+
+        let b1 = Book::new("Dark Book");
+        repo.create_book(&b1).unwrap();
+        repo.add_typed_tag_to_book(&b1.id, "dark", TagType::Mood)
+            .unwrap();
+
+        let b2 = Book::new("Light Book");
+        repo.create_book(&b2).unwrap();
+
+        let filter = SmartFilter::parse("mood:dark").unwrap();
+        let books = repo.evaluate_smart_filter(&filter).unwrap();
+        assert_eq!(books.len(), 1);
+        assert_eq!(books[0].title, "Dark Book");
+    }
+
+    #[test]
+    fn smart_shelf_evaluates_author_filter() {
+        let db = test_db();
+        let repo = BookRepository::new(&db);
+
+        let b1 = Book::new("Dune");
+        repo.create_book(&b1).unwrap();
+        repo.add_book_author(
+            &Author::new("Frank Herbert"),
+            &b1.id,
+            ContributorRole::Author,
+            0,
+        )
+        .unwrap();
+
+        let b2 = Book::new("1984");
+        repo.create_book(&b2).unwrap();
+        repo.add_book_author(
+            &Author::new("George Orwell"),
+            &b2.id,
+            ContributorRole::Author,
+            0,
+        )
+        .unwrap();
+
+        let filter = SmartFilter::parse("author:herbert").unwrap();
+        let books = repo.evaluate_smart_filter(&filter).unwrap();
+        assert_eq!(books.len(), 1);
+        assert_eq!(books[0].title, "Dune");
+    }
+
+    #[test]
+    fn smart_shelf_evaluates_and_filter() {
+        let db = test_db();
+        let repo = BookRepository::new(&db);
+
+        let mut b1 = Book::new("Read Sci-Fi");
+        b1.status = ReadingStatus::Read;
+        repo.create_book(&b1).unwrap();
+        repo.add_tag_to_book(&b1.id, "sci-fi").unwrap();
+
+        let mut b2 = Book::new("Unread Sci-Fi");
+        b2.status = ReadingStatus::WantToRead;
+        repo.create_book(&b2).unwrap();
+        repo.add_tag_to_book(&b2.id, "sci-fi").unwrap();
+
+        let mut b3 = Book::new("Read Fantasy");
+        b3.status = ReadingStatus::Read;
+        repo.create_book(&b3).unwrap();
+        repo.add_tag_to_book(&b3.id, "fantasy").unwrap();
+
+        let filter = SmartFilter::parse("status:read AND tag:sci-fi").unwrap();
+        let books = repo.evaluate_smart_filter(&filter).unwrap();
+        assert_eq!(books.len(), 1);
+        assert_eq!(books[0].title, "Read Sci-Fi");
+    }
+
+    #[test]
+    fn smart_shelf_evaluates_or_filter() {
+        let db = test_db();
+        let repo = BookRepository::new(&db);
+
+        let b1 = Book::new("Sci-Fi Book");
+        repo.create_book(&b1).unwrap();
+        repo.add_tag_to_book(&b1.id, "sci-fi").unwrap();
+
+        let b2 = Book::new("Fantasy Book");
+        repo.create_book(&b2).unwrap();
+        repo.add_tag_to_book(&b2.id, "fantasy").unwrap();
+
+        let b3 = Book::new("Romance Book");
+        repo.create_book(&b3).unwrap();
+        repo.add_tag_to_book(&b3.id, "romance").unwrap();
+
+        let filter = SmartFilter::parse("tag:sci-fi OR tag:fantasy").unwrap();
+        let books = repo.evaluate_smart_filter(&filter).unwrap();
+        assert_eq!(books.len(), 2);
+    }
+
+    #[test]
+    fn smart_shelf_evaluates_parenthesized_filter() {
+        let db = test_db();
+        let repo = BookRepository::new(&db);
+
+        let mut b1 = Book::new("Unread Sci-Fi");
+        b1.status = ReadingStatus::WantToRead;
+        repo.create_book(&b1).unwrap();
+        repo.add_tag_to_book(&b1.id, "sci-fi").unwrap();
+
+        let mut b2 = Book::new("Unread Fantasy");
+        b2.status = ReadingStatus::WantToRead;
+        repo.create_book(&b2).unwrap();
+        repo.add_tag_to_book(&b2.id, "fantasy").unwrap();
+
+        let mut b3 = Book::new("Read Sci-Fi");
+        b3.status = ReadingStatus::Read;
+        repo.create_book(&b3).unwrap();
+        repo.add_tag_to_book(&b3.id, "sci-fi").unwrap();
+
+        let filter =
+            SmartFilter::parse("status:want_to_read AND (tag:sci-fi OR tag:fantasy)").unwrap();
+        let books = repo.evaluate_smart_filter(&filter).unwrap();
+        assert_eq!(books.len(), 2);
+    }
+
+    #[test]
+    fn smart_shelf_auto_updates() {
+        let db = test_db();
+        let repo = BookRepository::new(&db);
+
+        let filter = SmartFilter::parse("status:read").unwrap();
+        repo.create_smart_shelf("Finished", &filter).unwrap();
+
+        // Initially empty
+        let books = repo.list_books_in_shelf("Finished").unwrap();
+        assert!(books.is_empty());
+
+        // Add a read book — shelf auto-includes it
+        let mut b1 = Book::new("Newly Finished");
+        b1.status = ReadingStatus::Read;
+        repo.create_book(&b1).unwrap();
+
+        let books = repo.list_books_in_shelf("Finished").unwrap();
+        assert_eq!(books.len(), 1);
+        assert_eq!(books[0].title, "Newly Finished");
+    }
+
+    #[test]
+    fn cannot_add_book_to_smart_shelf() {
+        let db = test_db();
+        let repo = BookRepository::new(&db);
+
+        let b1 = Book::new("Test Book");
+        repo.create_book(&b1).unwrap();
+
+        let filter = SmartFilter::parse("status:read").unwrap();
+        repo.create_smart_shelf("Smart", &filter).unwrap();
+
+        let err = repo.add_book_to_shelf(&b1.id, "Smart").unwrap_err();
+        assert!(err.to_string().contains("smart shelf"));
+    }
+
+    #[test]
+    fn get_shelf_by_name_test() {
+        let db = test_db();
+        let repo = BookRepository::new(&db);
+
+        repo.create_shelf("Regular").unwrap();
+        let filter = SmartFilter::parse("rating:>=8").unwrap();
+        repo.create_smart_shelf("Top Rated", &filter).unwrap();
+
+        let regular = repo.get_shelf_by_name("Regular").unwrap().unwrap();
+        assert!(!regular.is_smart);
+
+        let smart = repo.get_shelf_by_name("Top Rated").unwrap().unwrap();
+        assert!(smart.is_smart);
+        assert!(smart.smart_filter.is_some());
+
+        let missing = repo.get_shelf_by_name("Nonexistent").unwrap();
+        assert!(missing.is_none());
+    }
+
+    #[test]
+    fn delete_shelf_test() {
+        let db = test_db();
+        let repo = BookRepository::new(&db);
+
+        repo.create_shelf("ToDelete").unwrap();
+        assert!(repo.delete_shelf("ToDelete").unwrap());
+        assert!(!repo.delete_shelf("ToDelete").unwrap());
+
+        let shelves = repo.list_shelves().unwrap();
+        assert!(shelves.iter().all(|s| s.name != "ToDelete"));
+    }
+
+    #[test]
+    fn smart_shelf_shelf_filter_excludes_smart_shelves() {
+        let db = test_db();
+        let repo = BookRepository::new(&db);
+
+        let b1 = Book::new("On Regular Shelf");
+        repo.create_book(&b1).unwrap();
+        repo.add_book_to_shelf(&b1.id, "Favorites").unwrap();
+
+        let b2 = Book::new("Not On Any Shelf");
+        repo.create_book(&b2).unwrap();
+
+        let filter = SmartFilter::parse("shelf:Favorites").unwrap();
+        let books = repo.evaluate_smart_filter(&filter).unwrap();
+        assert_eq!(books.len(), 1);
+        assert_eq!(books[0].title, "On Regular Shelf");
+    }
+
+    #[test]
+    fn smart_shelf_json_round_trip_from_db() {
+        let db = test_db();
+        let repo = BookRepository::new(&db);
+
+        let filter = SmartFilter::parse("status:read AND rating:>=8").unwrap();
+        repo.create_smart_shelf("Best Reads", &filter).unwrap();
+
+        let shelf = repo.get_shelf_by_name("Best Reads").unwrap().unwrap();
+        let stored_filter = SmartFilter::from_json(shelf.smart_filter.as_ref().unwrap()).unwrap();
+        assert_eq!(filter, stored_filter);
     }
 }

--- a/crates/toku-import/src/calibre.rs
+++ b/crates/toku-import/src/calibre.rs
@@ -8,7 +8,7 @@ use toku_db::{BookRepository, Database};
 use uuid::Uuid;
 
 use crate::ImportError;
-use crate::goodreads::ImportReport;
+use crate::common::ImportReport;
 
 /// Options for a Calibre import.
 pub struct CalibreImportOptions {

--- a/crates/toku-import/src/common.rs
+++ b/crates/toku-import/src/common.rs
@@ -1,0 +1,146 @@
+use std::collections::HashMap;
+
+use chrono::Utc;
+use rusqlite::params;
+use uuid::Uuid;
+
+use crate::ImportError;
+
+/// The outcome of processing a single row.
+#[derive(Debug, Clone)]
+pub enum RowOutcome {
+    Imported,
+    Skipped,
+    Updated,
+    Error(String),
+}
+
+/// Progress event emitted for each row during import.
+#[derive(Debug, Clone)]
+pub struct ImportEvent {
+    pub row: usize,
+    pub total: usize,
+    pub title: String,
+    pub author: String,
+    pub status: String,
+    pub outcome: RowOutcome,
+}
+
+/// Trait for observing import progress. Implement this to receive per-row
+/// events during an import (e.g. to drive a progress bar).
+pub trait ImportObserver {
+    fn on_event(&mut self, event: &ImportEvent) -> Result<(), ImportError>;
+}
+
+/// A short summary of a skipped or imported row, kept for the final report.
+#[derive(Debug, Clone)]
+pub struct RowSummary {
+    pub title: String,
+    pub author: String,
+    pub status: String,
+}
+
+pub const MAX_REPORT_SAMPLES: usize = 20;
+
+/// Summary report of an import operation.
+#[derive(Debug, Default)]
+pub struct ImportReport {
+    pub total_rows: usize,
+    pub imported: usize,
+    pub skipped: usize,
+    pub updated: usize,
+    pub errors: usize,
+    pub error_details: Vec<String>,
+    pub import_id: Option<String>,
+    /// Bounded sample of imported books (capped at 20).
+    pub imported_samples: Vec<RowSummary>,
+    /// Bounded sample of skipped (duplicate) books (capped at 20).
+    pub skipped_samples: Vec<RowSummary>,
+    /// Bounded sample of books updated with new tags (capped at 20).
+    pub updated_samples: Vec<RowSummary>,
+    /// Counts of imported books by reading status.
+    pub status_counts: HashMap<String, usize>,
+    /// Warnings about data that could not be imported (e.g. reviews skipped).
+    pub warnings: Vec<String>,
+}
+
+impl std::fmt::Display for ImportReport {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        writeln!(f, "Import summary:")?;
+        writeln!(f, "  Total rows:  {}", self.total_rows)?;
+        writeln!(f, "  Imported:    {}", self.imported)?;
+        writeln!(
+            f,
+            "  Updated:     {} (tags added to existing books)",
+            self.updated
+        )?;
+        writeln!(f, "  Skipped:     {} (already in library)", self.skipped)?;
+        writeln!(f, "  Errors:      {}", self.errors)?;
+        if !self.error_details.is_empty() {
+            writeln!(f, "  Error details:")?;
+            for (i, e) in self.error_details.iter().enumerate().take(10) {
+                writeln!(f, "    {}: {e}", i + 1)?;
+            }
+            if self.error_details.len() > 10 {
+                writeln!(f, "    ... and {} more", self.error_details.len() - 10)?;
+            }
+        }
+        if !self.warnings.is_empty() {
+            writeln!(f, "  Warnings:    {}", self.warnings.len())?;
+            for w in self.warnings.iter().take(5) {
+                writeln!(f, "    • {w}")?;
+            }
+            if self.warnings.len() > 5 {
+                writeln!(f, "    ... and {} more", self.warnings.len() - 5)?;
+            }
+        }
+        Ok(())
+    }
+}
+
+/// Emit a progress event to the observer (if present).
+pub fn emit_event(
+    observer: &mut Option<&mut dyn ImportObserver>,
+    row: usize,
+    total: usize,
+    title: &str,
+    author: &str,
+    status: &str,
+    outcome: RowOutcome,
+) -> Result<(), ImportError> {
+    if let Some(obs) = observer {
+        obs.on_event(&ImportEvent {
+            row,
+            total,
+            title: title.to_string(),
+            author: author.to_string(),
+            status: status.to_string(),
+            outcome,
+        })?;
+    }
+    Ok(())
+}
+
+/// Count the number of data rows in a CSV file (excludes the header).
+pub fn count_csv_rows(csv_path: &std::path::Path) -> Result<usize, ImportError> {
+    let mut rdr = csv::ReaderBuilder::new()
+        .has_headers(true)
+        .flexible(true)
+        .from_path(csv_path)?;
+    Ok(rdr.records().count())
+}
+
+/// Record provenance for a field on a book.
+pub fn set_provenance(
+    conn: &rusqlite::Connection,
+    book_id: &Uuid,
+    field: &str,
+    source: &str,
+) -> Result<(), ImportError> {
+    conn.execute(
+        "INSERT OR IGNORE INTO metadata_provenance (book_id, field_name, source, source_date)
+         VALUES (?1, ?2, ?3, ?4)",
+        params![book_id.to_string(), field, source, Utc::now().to_rfc3339()],
+    )?;
+    Ok(())
+}

--- a/crates/toku-import/src/goodreads.rs
+++ b/crates/toku-import/src/goodreads.rs
@@ -9,100 +9,14 @@ use toku_db::{BookRepository, Database};
 use uuid::Uuid;
 
 use crate::ImportError;
+use crate::common::{
+    ImportObserver, ImportReport, MAX_REPORT_SAMPLES, RowOutcome, RowSummary, count_csv_rows,
+    emit_event, set_provenance,
+};
 
 /// Options for a Goodreads import.
 pub struct GoodreadsImportOptions {
     pub dry_run: bool,
-}
-
-/// The outcome of processing a single row.
-#[derive(Debug, Clone)]
-pub enum RowOutcome {
-    Imported,
-    Skipped,
-    Updated,
-    Error(String),
-}
-
-/// Progress event emitted for each row during import.
-#[derive(Debug, Clone)]
-pub struct ImportEvent {
-    pub row: usize,
-    pub total: usize,
-    pub title: String,
-    pub author: String,
-    pub status: String,
-    pub outcome: RowOutcome,
-}
-
-/// Trait for observing import progress. Implement this to receive per-row
-/// events during an import (e.g. to drive a progress bar).
-pub trait ImportObserver {
-    fn on_event(&mut self, event: &ImportEvent) -> Result<(), ImportError>;
-}
-
-/// A short summary of a skipped or imported row, kept for the final report.
-#[derive(Debug, Clone)]
-pub struct RowSummary {
-    pub title: String,
-    pub author: String,
-    pub status: String,
-}
-
-const MAX_REPORT_SAMPLES: usize = 20;
-
-/// Summary report of an import operation.
-#[derive(Debug, Default)]
-pub struct ImportReport {
-    pub total_rows: usize,
-    pub imported: usize,
-    pub skipped: usize,
-    pub updated: usize,
-    pub errors: usize,
-    pub error_details: Vec<String>,
-    pub import_id: Option<String>,
-    /// Bounded sample of imported books (capped at 20).
-    pub imported_samples: Vec<RowSummary>,
-    /// Bounded sample of skipped (duplicate) books (capped at 20).
-    pub skipped_samples: Vec<RowSummary>,
-    /// Bounded sample of books updated with new tags (capped at 20).
-    pub updated_samples: Vec<RowSummary>,
-    /// Counts of imported books by reading status.
-    pub status_counts: HashMap<String, usize>,
-}
-
-impl std::fmt::Display for ImportReport {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        writeln!(f, "Import summary:")?;
-        writeln!(f, "  Total rows:  {}", self.total_rows)?;
-        writeln!(f, "  Imported:    {}", self.imported)?;
-        writeln!(
-            f,
-            "  Updated:     {} (tags added to existing books)",
-            self.updated
-        )?;
-        writeln!(f, "  Skipped:     {} (already in library)", self.skipped)?;
-        writeln!(f, "  Errors:      {}", self.errors)?;
-        if !self.error_details.is_empty() {
-            writeln!(f, "  Error details:")?;
-            for (i, e) in self.error_details.iter().enumerate().take(10) {
-                writeln!(f, "    {}: {e}", i + 1)?;
-            }
-            if self.error_details.len() > 10 {
-                writeln!(f, "    ... and {} more", self.error_details.len() - 10)?;
-            }
-        }
-        Ok(())
-    }
-}
-
-/// Count the number of data rows in a CSV file (excludes the header).
-fn count_csv_rows(csv_path: &Path) -> Result<usize, ImportError> {
-    let mut rdr = ReaderBuilder::new()
-        .has_headers(true)
-        .flexible(true)
-        .from_path(csv_path)?;
-    Ok(rdr.records().count())
 }
 
 /// Import books from a Goodreads CSV export.
@@ -545,28 +459,6 @@ fn import_rows(
     Ok(())
 }
 
-fn emit_event(
-    observer: &mut Option<&mut dyn ImportObserver>,
-    row: usize,
-    total: usize,
-    title: &str,
-    author: &str,
-    status: &str,
-    outcome: RowOutcome,
-) -> Result<(), ImportError> {
-    if let Some(obs) = observer {
-        obs.on_event(&ImportEvent {
-            row,
-            total,
-            title: title.to_string(),
-            author: author.to_string(),
-            status: status.to_string(),
-            outcome,
-        })?;
-    }
-    Ok(())
-}
-
 /// Undo an import by removing all books added by it.
 pub fn undo_import(db: &Database, import_id: &str) -> Result<usize, ImportError> {
     let count: i64 = db.conn.query_row(
@@ -625,20 +517,6 @@ fn map_binding_to_format(binding: &str) -> BookFormat {
 fn clean_isbn(raw: &str) -> String {
     raw.trim_matches(|c: char| c == '=' || c == '"' || c.is_whitespace())
         .to_string()
-}
-
-fn set_provenance(
-    conn: &rusqlite::Connection,
-    book_id: &Uuid,
-    field: &str,
-    source: &str,
-) -> Result<(), ImportError> {
-    conn.execute(
-        "INSERT OR IGNORE INTO metadata_provenance (book_id, field_name, source, source_date)
-         VALUES (?1, ?2, ?3, ?4)",
-        params![book_id.to_string(), field, source, Utc::now().to_rfc3339()],
-    )?;
-    Ok(())
 }
 
 #[cfg(test)]

--- a/crates/toku-import/src/lib.rs
+++ b/crates/toku-import/src/lib.rs
@@ -1,10 +1,11 @@
 mod calibre;
+pub mod common;
 mod error;
 mod goodreads;
+mod storygraph;
 
 pub use calibre::{CalibreImportOptions, import_calibre};
+pub use common::{ImportEvent, ImportObserver, ImportReport, RowOutcome, RowSummary};
 pub use error::ImportError;
-pub use goodreads::{
-    GoodreadsImportOptions, ImportEvent, ImportObserver, ImportReport, RowOutcome, RowSummary,
-    import_goodreads, undo_import,
-};
+pub use goodreads::{GoodreadsImportOptions, import_goodreads, undo_import};
+pub use storygraph::{StorygraphImportOptions, import_storygraph};

--- a/crates/toku-import/src/storygraph.rs
+++ b/crates/toku-import/src/storygraph.rs
@@ -1,0 +1,1197 @@
+use std::collections::HashMap;
+use std::path::Path;
+
+use chrono::Utc;
+use csv::ReaderBuilder;
+use rusqlite::params;
+use toku_core::{
+    Author, Book, BookFormat, ContributorRole, Isbn, ReadingSession, ReadingStatus, TagType,
+};
+use toku_db::{BookRepository, Database};
+use uuid::Uuid;
+
+use crate::ImportError;
+use crate::common::{
+    ImportObserver, ImportReport, MAX_REPORT_SAMPLES, RowOutcome, RowSummary, count_csv_rows,
+    emit_event, set_provenance,
+};
+
+/// Options for a StoryGraph import.
+pub struct StorygraphImportOptions {
+    pub dry_run: bool,
+}
+
+/// Import books from a StoryGraph CSV export.
+///
+/// If an `observer` is provided, it will be called with progress events for
+/// each row processed, enabling progress bars and live feedback.
+pub fn import_storygraph(
+    db: &Database,
+    csv_path: &Path,
+    opts: &StorygraphImportOptions,
+    observer: Option<&mut dyn ImportObserver>,
+) -> Result<ImportReport, ImportError> {
+    let total_rows = count_csv_rows(csv_path)?;
+    import_storygraph_inner(db, csv_path, opts, observer, total_rows)
+}
+
+fn import_storygraph_inner(
+    db: &Database,
+    csv_path: &Path,
+    opts: &StorygraphImportOptions,
+    mut observer: Option<&mut dyn ImportObserver>,
+    total_rows: usize,
+) -> Result<ImportReport, ImportError> {
+    let repo = BookRepository::new(db);
+    let mut report = ImportReport::default();
+
+    let import_id = Uuid::now_v7().to_string();
+
+    if !opts.dry_run {
+        db.conn.execute_batch("BEGIN IMMEDIATE")?;
+
+        db.conn.execute(
+            "INSERT INTO import_logs (id, source, file_path, started_at, total_rows)
+             VALUES (?1, 'storygraph', ?2, ?3, 0)",
+            params![
+                import_id,
+                csv_path.to_string_lossy().to_string(),
+                Utc::now().to_rfc3339()
+            ],
+        )?;
+    }
+
+    let result = import_rows(
+        db,
+        &repo,
+        csv_path,
+        opts,
+        &mut report,
+        &import_id,
+        &mut observer,
+        total_rows,
+    );
+
+    if !opts.dry_run {
+        match &result {
+            Ok(()) => {
+                db.conn.execute(
+                    "UPDATE import_logs SET finished_at = ?1, total_rows = ?2,
+                     imported = ?3, skipped = ?4, errors = ?5 WHERE id = ?6",
+                    params![
+                        Utc::now().to_rfc3339(),
+                        report.total_rows as i64,
+                        report.imported as i64,
+                        report.skipped as i64,
+                        report.errors as i64,
+                        import_id,
+                    ],
+                )?;
+                report.import_id = Some(import_id);
+                db.conn.execute_batch("COMMIT")?;
+            }
+            Err(_) => {
+                db.conn.execute_batch("ROLLBACK").ok();
+            }
+        }
+    }
+
+    result?;
+    Ok(report)
+}
+
+#[allow(clippy::too_many_arguments)]
+fn import_rows(
+    db: &Database,
+    repo: &BookRepository,
+    csv_path: &Path,
+    opts: &StorygraphImportOptions,
+    report: &mut ImportReport,
+    import_id: &str,
+    observer: &mut Option<&mut dyn ImportObserver>,
+    total_rows: usize,
+) -> Result<(), ImportError> {
+    let mut rdr = ReaderBuilder::new()
+        .has_headers(true)
+        .flexible(true)
+        .from_path(csv_path)?;
+
+    let headers = rdr.headers()?.clone();
+
+    // Detect: StoryGraph has Moods/Pace columns that Goodreads doesn't
+    let has_moods = headers.iter().any(|h| h == "Moods");
+    let has_pace = headers.iter().any(|h| h == "Pace");
+    if !has_moods && !has_pace {
+        return Err(ImportError::Other(
+            "CSV does not contain 'Moods' or 'Pace' columns — is this a StoryGraph export?"
+                .to_string(),
+        ));
+    }
+
+    let col = |name: &str| -> Option<usize> { headers.iter().position(|h| h == name) };
+
+    let col_title = col("Title");
+    let col_authors = col("Authors");
+    let col_contributors = col("Contributors");
+    let col_isbn_uid = col("ISBN/UID");
+    let col_format = col("Format");
+    let col_status = col("Read Status");
+    let col_date_added = col("Date Added");
+    let col_dates_read = col("Dates Read");
+    let col_moods = col("Moods");
+    let col_pace = col("Pace");
+    let col_star_rating = col("Star Rating");
+    let col_content_warnings = col("Content Warnings");
+    let col_tags = col("Tags");
+    let col_review = col("Review");
+    let col_char_plot = col("Character- or Plot-Driven?");
+    let col_strong_dev = col("Strong Character Development?");
+    let col_loveable = col("Loveable Characters?");
+    let col_diverse = col("Diverse Characters?");
+    let col_flawed = col("Flawed Characters?");
+
+    if col_title.is_none() {
+        return Err(ImportError::Other(
+            "CSV does not contain a 'Title' column".to_string(),
+        ));
+    }
+
+    // Build dedup maps: ISBN → book_id, and normalized(title|author) → book_id
+    let mut isbn_map: HashMap<String, Uuid> = HashMap::new();
+    {
+        let mut stmt = db.conn.prepare("SELECT isbn, book_id FROM isbns")?;
+        let rows = stmt.query_map([], |row| {
+            let isbn: String = row.get(0)?;
+            let id_str: String = row.get(1)?;
+            Ok((isbn, Uuid::parse_str(&id_str).unwrap_or_default()))
+        })?;
+        for row in rows.flatten() {
+            isbn_map.insert(row.0, row.1);
+        }
+    }
+
+    let mut title_author_map: HashMap<String, Uuid> = HashMap::new();
+    {
+        let mut stmt = db.conn.prepare(
+            "SELECT b.id, LOWER(TRIM(b.title)), COALESCE(LOWER(TRIM(a.name)), '')
+             FROM books b
+             LEFT JOIN book_authors ba ON ba.book_id = b.id AND ba.position = 0
+             LEFT JOIN authors a ON a.id = ba.author_id",
+        )?;
+        let rows = stmt.query_map([], |row| {
+            let id_str: String = row.get(0)?;
+            let title: String = row.get(1)?;
+            let author: String = row.get(2)?;
+            Ok((Uuid::parse_str(&id_str).unwrap_or_default(), title, author))
+        })?;
+        for row in rows.flatten() {
+            let key = format!("{}|{}", row.1, row.2);
+            title_author_map.insert(key, row.0);
+        }
+    }
+
+    for result in rdr.records() {
+        report.total_rows += 1;
+
+        let record = match result {
+            Ok(r) => r,
+            Err(e) => {
+                let err_msg = format!("Row {}: CSV parse error: {e}", report.total_rows);
+                report.errors += 1;
+                if report.error_details.len() < MAX_REPORT_SAMPLES {
+                    report.error_details.push(err_msg);
+                }
+                emit_event(
+                    observer,
+                    report.total_rows,
+                    total_rows,
+                    "",
+                    "",
+                    "",
+                    RowOutcome::Error(format!("CSV parse error: {e}")),
+                )?;
+                continue;
+            }
+        };
+
+        let get = |col: Option<usize>| -> Option<String> {
+            col.and_then(|i| record.get(i))
+                .map(|s| s.trim().to_string())
+                .filter(|s| !s.is_empty())
+        };
+
+        let title = match get(col_title) {
+            Some(t) => t,
+            None => {
+                report.errors += 1;
+                if report.error_details.len() < MAX_REPORT_SAMPLES {
+                    report
+                        .error_details
+                        .push(format!("Row {}: missing title", report.total_rows));
+                }
+                emit_event(
+                    observer,
+                    report.total_rows,
+                    total_rows,
+                    "",
+                    "",
+                    "",
+                    RowOutcome::Error("missing title".to_string()),
+                )?;
+                continue;
+            }
+        };
+
+        let authors_raw = get(col_authors).unwrap_or_default();
+        let primary_author = authors_raw
+            .split(',')
+            .next()
+            .unwrap_or("")
+            .trim()
+            .to_string();
+
+        let status = get(col_status)
+            .as_deref()
+            .map(map_storygraph_status)
+            .unwrap_or(ReadingStatus::WantToRead);
+        let status_str = status.as_str().to_string();
+
+        // Dedup: check ISBN first, then title+author
+        let isbn_uid = get(col_isbn_uid);
+        let parsed_isbn = isbn_uid.as_deref().and_then(detect_isbn);
+
+        let existing_book_id = parsed_isbn
+            .as_ref()
+            .and_then(|isbn| isbn_map.get(isbn))
+            .copied()
+            .or_else(|| {
+                let key = format!(
+                    "{}|{}",
+                    title.to_lowercase().trim(),
+                    primary_author.to_lowercase().trim()
+                );
+                title_author_map.get(&key).copied()
+            });
+
+        if let Some(existing_id) = existing_book_id {
+            // Apply typed tags to existing book (moods, pace, CW) but don't overwrite
+            if !opts.dry_run {
+                apply_typed_tags(
+                    repo,
+                    &existing_id,
+                    &get,
+                    col_moods,
+                    col_pace,
+                    col_content_warnings,
+                )?;
+                apply_general_tags(repo, &existing_id, &get, col_tags)?;
+                apply_character_tags(
+                    repo,
+                    &existing_id,
+                    &get,
+                    col_char_plot,
+                    col_strong_dev,
+                    col_loveable,
+                    col_diverse,
+                    col_flawed,
+                )?;
+            }
+
+            report.updated += 1;
+            if report.updated_samples.len() < MAX_REPORT_SAMPLES {
+                report.updated_samples.push(RowSummary {
+                    title: title.clone(),
+                    author: primary_author.clone(),
+                    status: status_str.clone(),
+                });
+            }
+            emit_event(
+                observer,
+                report.total_rows,
+                total_rows,
+                &title,
+                &primary_author,
+                &status_str,
+                RowOutcome::Updated,
+            )?;
+            continue;
+        }
+
+        if opts.dry_run {
+            report.imported += 1;
+            *report.status_counts.entry(status_str.clone()).or_insert(0) += 1;
+            if report.imported_samples.len() < MAX_REPORT_SAMPLES {
+                report.imported_samples.push(RowSummary {
+                    title: title.clone(),
+                    author: primary_author.clone(),
+                    status: status_str.clone(),
+                });
+            }
+            emit_event(
+                observer,
+                report.total_rows,
+                total_rows,
+                &title,
+                &primary_author,
+                &status_str,
+                RowOutcome::Imported,
+            )?;
+            continue;
+        }
+
+        // ── Build the book ──────────────────────────────────────────
+        let mut book = Book::new(&title);
+        book.status = status;
+
+        // Format
+        if let Some(fmt) = get(col_format) {
+            book.format = map_storygraph_format(&fmt);
+        }
+
+        // Rating: quarter-star → 0-10
+        if let Some(rating_str) = get(col_star_rating)
+            && let Ok(star) = rating_str.parse::<f64>()
+            && (1.0..=5.0).contains(&star)
+        {
+            book.rating = Some((star * 2.0).round() as i32);
+        }
+
+        // Date Added → created_at
+        if let Some(date_str) = get(col_date_added)
+            && let Some(dt) = parse_storygraph_date(&date_str)
+        {
+            book.created_at = dt.and_utc();
+            book.updated_at = dt.and_utc();
+        }
+
+        // Insert the book
+        let search_text = format!("{} {}", book.title, primary_author);
+        db.conn.execute(
+            "INSERT INTO books (id, title, subtitle, description, page_count, pub_date,
+             language, format, duration_minutes, cover_hash, work_id, status, rating,
+             created_at, updated_at, search_text)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16)",
+            params![
+                book.id.to_string(),
+                book.title,
+                book.subtitle,
+                book.description,
+                book.page_count,
+                book.pub_date,
+                book.language,
+                book.format.as_str(),
+                book.duration_minutes,
+                book.cover_hash,
+                book.work_id.map(|u| u.to_string()),
+                book.status.as_str(),
+                book.rating,
+                book.created_at.to_rfc3339(),
+                book.updated_at.to_rfc3339(),
+                search_text,
+            ],
+        )?;
+
+        // ISBN
+        if let Some(ref isbn) = parsed_isbn {
+            let _ = repo.add_isbn(isbn, &book.id);
+            isbn_map.insert(isbn.clone(), book.id);
+        }
+
+        // Authors
+        for (i, author_name) in authors_raw.split(',').enumerate() {
+            let name = author_name.trim();
+            if !name.is_empty() {
+                let a = Author::new(name);
+                repo.add_book_author(&a, &book.id, ContributorRole::Author, i as i32)?;
+            }
+        }
+
+        // Contributors (narrators etc.)
+        if let Some(contribs) = get(col_contributors) {
+            parse_contributors(&contribs, repo, &book.id)?;
+        }
+
+        // Typed tags: moods, pace, content warnings
+        apply_typed_tags(
+            repo,
+            &book.id,
+            &get,
+            col_moods,
+            col_pace,
+            col_content_warnings,
+        )?;
+
+        // General tags
+        apply_general_tags(repo, &book.id, &get, col_tags)?;
+
+        // Character/plot-driven and character questions → general tags
+        apply_character_tags(
+            repo,
+            &book.id,
+            &get,
+            col_char_plot,
+            col_strong_dev,
+            col_loveable,
+            col_diverse,
+            col_flawed,
+        )?;
+
+        // Reading sessions from Dates Read (full-precision only)
+        if let Some(dates_str) = get(col_dates_read) {
+            let sessions = parse_dates_read(&dates_str);
+            for (start, end) in &sessions {
+                let mut session = ReadingSession::new(book.id);
+                session.started_at = start.and_utc();
+                if let Some(e) = end {
+                    session.finished_at = Some(e.and_utc());
+                }
+                repo.create_reading_session(&session)?;
+            }
+        }
+
+        // Review → warn, not stored
+        if get(col_review).is_some() && report.warnings.len() < MAX_REPORT_SAMPLES {
+            report
+                .warnings
+                .push(format!("\"{}\": review skipped (no reviews table)", title));
+        }
+
+        // Track import → book
+        db.conn.execute(
+            "INSERT INTO import_books (import_id, book_id) VALUES (?1, ?2)",
+            params![import_id, book.id.to_string()],
+        )?;
+
+        // Provenance
+        set_provenance(&db.conn, &book.id, "title", "storygraph_import")?;
+        if book.rating.is_some() {
+            set_provenance(&db.conn, &book.id, "rating", "storygraph_import")?;
+        }
+
+        // Update dedup maps
+        let key = format!(
+            "{}|{}",
+            title.to_lowercase().trim(),
+            primary_author.to_lowercase().trim()
+        );
+        title_author_map.insert(key, book.id);
+
+        let book_status = book.status.as_str().to_string();
+        report.imported += 1;
+        *report.status_counts.entry(book_status.clone()).or_insert(0) += 1;
+        if report.imported_samples.len() < MAX_REPORT_SAMPLES {
+            report.imported_samples.push(RowSummary {
+                title: title.clone(),
+                author: primary_author.clone(),
+                status: book_status.clone(),
+            });
+        }
+
+        emit_event(
+            observer,
+            report.total_rows,
+            total_rows,
+            &title,
+            &primary_author,
+            &book_status,
+            RowOutcome::Imported,
+        )?;
+    }
+
+    Ok(())
+}
+
+// ── Field mapping helpers ───────────────────────────────────────────────
+
+fn map_storygraph_status(status: &str) -> ReadingStatus {
+    match status.to_lowercase().as_str() {
+        "read" => ReadingStatus::Read,
+        "currently-reading" => ReadingStatus::Reading,
+        "to-read" => ReadingStatus::WantToRead,
+        "did-not-finish" => ReadingStatus::Abandoned,
+        "paused" => ReadingStatus::OnHold,
+        _ => ReadingStatus::WantToRead,
+    }
+}
+
+fn map_storygraph_format(fmt: &str) -> BookFormat {
+    match fmt.to_lowercase().as_str() {
+        "digital" | "ebook" => BookFormat::Ebook,
+        "audio" | "audiobook" => BookFormat::Audiobook,
+        _ => BookFormat::Physical, // paperback, hardcover
+    }
+}
+
+/// Detect whether an ISBN/UID field contains a valid ISBN and return the
+/// normalized form. ASINs and unknown IDs are ignored for dedup purposes.
+fn detect_isbn(raw: &str) -> Option<String> {
+    let cleaned = raw.trim();
+    if cleaned.is_empty() {
+        return None;
+    }
+    // Try parsing as ISBN (handles both ISBN-10 and ISBN-13)
+    if let Ok(isbn) = Isbn::parse(cleaned) {
+        return Some(isbn.as_str().to_string());
+    }
+    None
+}
+
+/// Parse a StoryGraph date (YYYY/MM/DD, YYYY/MM, or YYYY).
+/// Returns a NaiveDateTime at midnight UTC for fully-specified dates only
+/// when used for session creation. For created_at, we use any precision.
+fn parse_storygraph_date(date_str: &str) -> Option<chrono::NaiveDateTime> {
+    let parts: Vec<&str> = date_str.split('/').collect();
+    match parts.len() {
+        3 => {
+            let y: i32 = parts[0].parse().ok()?;
+            let m: u32 = parts[1].parse().ok()?;
+            let d: u32 = parts[2].parse().ok()?;
+            chrono::NaiveDate::from_ymd_opt(y, m, d).map(|d| d.and_hms_opt(0, 0, 0).unwrap())
+        }
+        2 => {
+            let y: i32 = parts[0].parse().ok()?;
+            let m: u32 = parts[1].parse().ok()?;
+            chrono::NaiveDate::from_ymd_opt(y, m, 1).map(|d| d.and_hms_opt(0, 0, 0).unwrap())
+        }
+        1 => {
+            let y: i32 = parts[0].parse().ok()?;
+            chrono::NaiveDate::from_ymd_opt(y, 1, 1).map(|d| d.and_hms_opt(0, 0, 0).unwrap())
+        }
+        _ => None,
+    }
+}
+
+/// Check if a date string has full YYYY/MM/DD precision.
+fn is_full_precision(date_str: &str) -> bool {
+    date_str.split('/').count() == 3
+}
+
+/// Parse the multi-session "Dates Read" field.
+/// Returns only sessions with full-precision dates (YYYY/MM/DD).
+///
+/// Format examples:
+///   "2025/12/11-2025/12/14"
+///   "2025/07/08-2025/07/08, 2024"
+///   "2025/02/13-2025/03/15, 2024/09-2024/09"
+fn parse_dates_read(raw: &str) -> Vec<(chrono::NaiveDateTime, Option<chrono::NaiveDateTime>)> {
+    let mut sessions = Vec::new();
+    for session_str in raw.split(", ") {
+        let session_str = session_str.trim();
+        if session_str.is_empty() {
+            continue;
+        }
+        let parts: Vec<&str> = session_str.splitn(2, '-').collect();
+        match parts.len() {
+            2 => {
+                if is_full_precision(parts[0])
+                    && is_full_precision(parts[1])
+                    && let (Some(start), Some(end)) = (
+                        parse_storygraph_date(parts[0]),
+                        parse_storygraph_date(parts[1]),
+                    )
+                {
+                    sessions.push((start, Some(end)));
+                }
+            }
+            1 if is_full_precision(parts[0]) => {
+                if let Some(start) = parse_storygraph_date(parts[0]) {
+                    sessions.push((start, None));
+                }
+            }
+            _ => {}
+        }
+    }
+    sessions
+}
+
+/// Parse content warnings in "Severity: Type; Severity: Type;" format.
+fn parse_content_warnings(raw: &str) -> Vec<String> {
+    raw.split(';')
+        .filter_map(|part| {
+            let part = part.trim();
+            if part.is_empty() {
+                return None;
+            }
+            // Try to extract the type after the colon
+            if let Some((_severity, cw_type)) = part.split_once(':') {
+                let cw = cw_type.trim().to_lowercase();
+                if !cw.is_empty() {
+                    return Some(cw);
+                }
+            }
+            // If no colon, use the whole string
+            let cw = part.to_lowercase();
+            if !cw.is_empty() { Some(cw) } else { None }
+        })
+        .collect()
+}
+
+/// Parse Contributors field: "Name (Role), Name (Role)"
+fn parse_contributors(raw: &str, repo: &BookRepository, book_id: &Uuid) -> Result<(), ImportError> {
+    for entry in raw.split(',') {
+        let entry = entry.trim();
+        if entry.is_empty() {
+            continue;
+        }
+        // Try to parse "Name (Role)" pattern
+        let (name, role) = if let Some(paren_start) = entry.rfind('(') {
+            let name = entry[..paren_start].trim();
+            let role_str = entry[paren_start + 1..]
+                .trim_end_matches(')')
+                .trim()
+                .to_lowercase();
+            let role = match role_str.as_str() {
+                "narrator" => ContributorRole::Narrator,
+                "translator" => ContributorRole::Translator,
+                "illustrator" => ContributorRole::Illustrator,
+                "editor" => ContributorRole::Editor,
+                _ => ContributorRole::Author,
+            };
+            (name, role)
+        } else {
+            (entry, ContributorRole::Author)
+        };
+
+        if !name.is_empty() {
+            let a = Author::new(name);
+            // Use position 99 for contributors (after main authors)
+            repo.add_book_author(&a, book_id, role, 99)?;
+        }
+    }
+    Ok(())
+}
+
+/// Apply mood, pace, and content warning tags to a book.
+fn apply_typed_tags(
+    repo: &BookRepository,
+    book_id: &Uuid,
+    get: &dyn Fn(Option<usize>) -> Option<String>,
+    col_moods: Option<usize>,
+    col_pace: Option<usize>,
+    col_content_warnings: Option<usize>,
+) -> Result<(), ImportError> {
+    // Moods
+    if let Some(moods_str) = get(col_moods) {
+        for mood in moods_str.split(',') {
+            let mood = mood.trim().to_lowercase();
+            if !mood.is_empty() {
+                repo.add_typed_tag_to_book(book_id, &mood, TagType::Mood)?;
+            }
+        }
+    }
+
+    // Pace (single-value: only set if book doesn't already have one)
+    if let Some(pace_str) = get(col_pace) {
+        let pace = pace_str.trim().to_lowercase();
+        if !pace.is_empty() {
+            let existing = repo.get_book_tags_by_type(book_id, TagType::Pace)?;
+            if existing.is_empty() {
+                repo.add_typed_tag_to_book(book_id, &pace, TagType::Pace)?;
+            }
+        }
+    }
+
+    // Content warnings
+    if let Some(cw_str) = get(col_content_warnings) {
+        let warnings = parse_content_warnings(&cw_str);
+        for cw in &warnings {
+            repo.add_typed_tag_to_book(book_id, cw, TagType::ContentWarning)?;
+        }
+    }
+
+    Ok(())
+}
+
+/// Apply general tags (from StoryGraph's Tags column).
+fn apply_general_tags(
+    repo: &BookRepository,
+    book_id: &Uuid,
+    get: &dyn Fn(Option<usize>) -> Option<String>,
+    col_tags: Option<usize>,
+) -> Result<(), ImportError> {
+    if let Some(tags_str) = get(col_tags) {
+        for tag in tags_str.split(',') {
+            let tag = tag.trim().to_string();
+            if !tag.is_empty() {
+                repo.add_tag_to_book(book_id, &tag)?;
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Apply character-related StoryGraph questions as general tags.
+#[allow(clippy::too_many_arguments)]
+fn apply_character_tags(
+    repo: &BookRepository,
+    book_id: &Uuid,
+    get: &dyn Fn(Option<usize>) -> Option<String>,
+    col_char_plot: Option<usize>,
+    col_strong_dev: Option<usize>,
+    col_loveable: Option<usize>,
+    col_diverse: Option<usize>,
+    col_flawed: Option<usize>,
+) -> Result<(), ImportError> {
+    if let Some(val) = get(col_char_plot) {
+        let tag = match val.to_lowercase().as_str() {
+            "character" => Some("character-driven"),
+            "plot" => Some("plot-driven"),
+            "a mix" => Some("character-and-plot-driven"),
+            _ => None,
+        };
+        if let Some(tag) = tag {
+            repo.add_tag_to_book(book_id, tag)?;
+        }
+    }
+
+    let char_questions = [
+        (col_strong_dev, "strong-character-development"),
+        (col_loveable, "loveable-characters"),
+        (col_diverse, "diverse-characters"),
+        (col_flawed, "flawed-characters"),
+    ];
+
+    for (col, tag_name) in &char_questions {
+        if let Some(val) = get(*col)
+            && val.eq_ignore_ascii_case("Yes")
+        {
+            repo.add_tag_to_book(book_id, tag_name)?;
+        }
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+
+    fn write_storygraph_csv(dir: &Path, rows: &[&str]) -> std::path::PathBuf {
+        let path = dir.join("storygraph_export.csv");
+        let mut f = std::fs::File::create(&path).unwrap();
+        // Header: 23 columns
+        writeln!(
+            f,
+            "Title,Authors,Contributors,ISBN/UID,Format,Read Status,Date Added,\
+             Last Date Read,Dates Read,Read Count,Moods,Pace,\
+             Character- or Plot-Driven?,Strong Character Development?,\
+             Loveable Characters?,Diverse Characters?,Flawed Characters?,\
+             Star Rating,Review,Content Warnings,Content Warning Description,Tags,Owned?"
+        )
+        .unwrap();
+        for row in rows {
+            writeln!(f, "{row}").unwrap();
+        }
+        path
+    }
+
+    fn test_csv_basic() -> Vec<&'static str> {
+        vec![
+            // Dune: read, rated 4.5, has moods+pace, ISBN-13
+            r#"Dune,Frank Herbert,,9780441172719,paperback,read,2023/01/10,2024/03/15,"2024/03/01-2024/03/15",1,"adventurous, mysterious",fast,Plot,Yes,No,No,Yes,4.5,,,,sci-fi,Yes"#,
+            // Neuromancer: to-read, no rating, digital format
+            r#"Neuromancer,William Gibson,,9780441569595,digital,to-read,2024/02/20,,,,,,,,,,,,,,cyberpunk,No"#,
+            // Project Hail Mary: currently-reading, DNF example actually
+            r#"Project Hail Mary,Andy Weir,,9780593135204,hardcover,did-not-finish,2024/05/01,,,,dark,slow,Character,Yes,Yes,Yes,No,2.0,,,,abandoned-test,No"#,
+        ]
+    }
+
+    #[test]
+    fn import_storygraph_basic() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let csv_path = write_storygraph_csv(tmp.path(), &test_csv_basic());
+        let db = Database::open_in_memory().unwrap();
+
+        let report = import_storygraph(
+            &db,
+            &csv_path,
+            &StorygraphImportOptions { dry_run: false },
+            None,
+        )
+        .unwrap();
+
+        assert_eq!(report.total_rows, 3);
+        assert_eq!(report.imported, 3);
+        assert_eq!(report.skipped, 0);
+        assert_eq!(report.errors, 0);
+
+        let repo = BookRepository::new(&db);
+        let books = repo.list_books().unwrap();
+        assert_eq!(books.len(), 3);
+
+        // Check Dune
+        let dune = books.iter().find(|b| b.title == "Dune").unwrap();
+        assert_eq!(dune.status, ReadingStatus::Read);
+        assert_eq!(dune.rating, Some(9)); // 4.5 * 2 = 9
+        assert_eq!(dune.format, BookFormat::Physical);
+
+        // Check moods
+        let moods = repo.get_book_tags_by_type(&dune.id, TagType::Mood).unwrap();
+        assert_eq!(moods.len(), 2);
+
+        // Check pace
+        let pace = repo.get_book_tags_by_type(&dune.id, TagType::Pace).unwrap();
+        assert_eq!(pace.len(), 1);
+        assert_eq!(pace[0].name, "fast");
+
+        // Check Neuromancer is ebook
+        let neuro = books.iter().find(|b| b.title == "Neuromancer").unwrap();
+        assert_eq!(neuro.status, ReadingStatus::WantToRead);
+        assert_eq!(neuro.format, BookFormat::Ebook);
+        assert!(neuro.rating.is_none());
+
+        // Check DNF status
+        let phm = books
+            .iter()
+            .find(|b| b.title == "Project Hail Mary")
+            .unwrap();
+        assert_eq!(phm.status, ReadingStatus::Abandoned);
+        assert_eq!(phm.rating, Some(4)); // 2.0 * 2 = 4
+    }
+
+    #[test]
+    fn import_storygraph_dry_run() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let csv_path = write_storygraph_csv(tmp.path(), &test_csv_basic());
+        let db = Database::open_in_memory().unwrap();
+
+        let report = import_storygraph(
+            &db,
+            &csv_path,
+            &StorygraphImportOptions { dry_run: true },
+            None,
+        )
+        .unwrap();
+
+        assert_eq!(report.total_rows, 3);
+        assert_eq!(report.imported, 3);
+        assert!(report.import_id.is_none());
+
+        // No books should be in the database
+        let repo = BookRepository::new(&db);
+        let books = repo.list_books().unwrap();
+        assert!(books.is_empty());
+    }
+
+    #[test]
+    fn import_storygraph_idempotent_isbn() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let csv_path = write_storygraph_csv(tmp.path(), &test_csv_basic());
+        let db = Database::open_in_memory().unwrap();
+
+        // First import
+        let r1 = import_storygraph(
+            &db,
+            &csv_path,
+            &StorygraphImportOptions { dry_run: false },
+            None,
+        )
+        .unwrap();
+        assert_eq!(r1.imported, 3);
+
+        // Second import — same ISBNs should match
+        let r2 = import_storygraph(
+            &db,
+            &csv_path,
+            &StorygraphImportOptions { dry_run: false },
+            None,
+        )
+        .unwrap();
+        assert_eq!(r2.imported, 0);
+        assert_eq!(r2.updated, 3); // tags applied to existing books
+
+        // Still only 3 books
+        let repo = BookRepository::new(&db);
+        let books = repo.list_books().unwrap();
+        assert_eq!(books.len(), 3);
+    }
+
+    #[test]
+    fn import_storygraph_dedup_by_title_author() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        // First: book without ISBN
+        let csv1 = write_storygraph_csv(
+            tmp.path(),
+            &[r#"Dune,Frank Herbert,,,paperback,read,2023/01/10,,,,,,,,,,,,4.0,,,,No"#],
+        );
+        let db = Database::open_in_memory().unwrap();
+
+        import_storygraph(
+            &db,
+            &csv1,
+            &StorygraphImportOptions { dry_run: false },
+            None,
+        )
+        .unwrap();
+
+        // Second: same title+author, different file
+        let dir2 = tmp.path().join("second");
+        std::fs::create_dir_all(&dir2).unwrap();
+        let csv2 = write_storygraph_csv(
+            &dir2,
+            &[r#"Dune,Frank Herbert,,,hardcover,read,2024/01/01,,,,,,,,,,,,5.0,,,,No"#],
+        );
+
+        let r2 = import_storygraph(
+            &db,
+            &csv2,
+            &StorygraphImportOptions { dry_run: false },
+            None,
+        )
+        .unwrap();
+
+        assert_eq!(r2.imported, 0);
+        assert_eq!(r2.updated, 1);
+
+        let repo = BookRepository::new(&db);
+        let books = repo.list_books().unwrap();
+        assert_eq!(books.len(), 1); // no duplicate
+    }
+
+    #[test]
+    fn rating_conversion_quarter_star() {
+        // Test boundary cases
+        assert_eq!((1.0_f64 * 2.0).round() as i32, 2);
+        assert_eq!((1.25_f64 * 2.0).round() as i32, 3); // rounds up
+        assert_eq!((1.75_f64 * 2.0).round() as i32, 4); // rounds up
+        assert_eq!((2.5_f64 * 2.0).round() as i32, 5);
+        assert_eq!((3.75_f64 * 2.0).round() as i32, 8); // rounds up
+        assert_eq!((4.25_f64 * 2.0).round() as i32, 9); // rounds up
+        assert_eq!((4.5_f64 * 2.0).round() as i32, 9);
+        assert_eq!((4.75_f64 * 2.0).round() as i32, 10); // rounds up
+        assert_eq!((5.0_f64 * 2.0).round() as i32, 10);
+    }
+
+    #[test]
+    fn parse_dates_read_full_precision() {
+        let sessions = parse_dates_read("2025/12/11-2025/12/14");
+        assert_eq!(sessions.len(), 1);
+        assert_eq!(
+            sessions[0].0,
+            chrono::NaiveDate::from_ymd_opt(2025, 12, 11)
+                .unwrap()
+                .and_hms_opt(0, 0, 0)
+                .unwrap()
+        );
+    }
+
+    #[test]
+    fn parse_dates_read_multi_session() {
+        let sessions = parse_dates_read("2025/07/08-2025/07/08, 2025/02/13-2025/03/15");
+        assert_eq!(sessions.len(), 2);
+    }
+
+    #[test]
+    fn parse_dates_read_skips_partial() {
+        // Year-only and month-only should be skipped
+        let sessions = parse_dates_read("2025/07/08-2025/07/08, 2024");
+        assert_eq!(sessions.len(), 1); // only the full-precision one
+
+        let sessions = parse_dates_read("2024/09-2024/09");
+        assert!(sessions.is_empty());
+
+        let sessions = parse_dates_read("2024");
+        assert!(sessions.is_empty());
+    }
+
+    #[test]
+    fn parse_content_warnings_format() {
+        let cws = parse_content_warnings(
+            "Graphic: Sexual content; Moderate: Cancer; Minor: Death of parent;",
+        );
+        assert_eq!(cws.len(), 3);
+        assert_eq!(cws[0], "sexual content");
+        assert_eq!(cws[1], "cancer");
+        assert_eq!(cws[2], "death of parent");
+    }
+
+    #[test]
+    fn content_warnings_imported_as_tags() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let csv_path = write_storygraph_csv(
+            tmp.path(),
+            &[
+                r#"Test Book,Test Author,,,paperback,read,2024/01/01,,,,,,,,,,,,,Graphic: Violence; Minor: Death;,,,No"#,
+            ],
+        );
+        let db = Database::open_in_memory().unwrap();
+
+        import_storygraph(
+            &db,
+            &csv_path,
+            &StorygraphImportOptions { dry_run: false },
+            None,
+        )
+        .unwrap();
+
+        let repo = BookRepository::new(&db);
+        let books = repo.list_books().unwrap();
+        let cw_tags = repo
+            .get_book_tags_by_type(&books[0].id, TagType::ContentWarning)
+            .unwrap();
+        assert_eq!(cw_tags.len(), 2);
+        let names: Vec<&str> = cw_tags.iter().map(|t| t.name.as_str()).collect();
+        assert!(names.contains(&"violence"));
+        assert!(names.contains(&"death"));
+    }
+
+    #[test]
+    fn contributors_parsed_as_narrator() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let csv_path = write_storygraph_csv(
+            tmp.path(),
+            &[
+                r#"Test Book,Test Author,"Ray Porter (Narrator)",,audio,read,2024/01/01,,,,,,,,,,,,,,,No"#,
+            ],
+        );
+        let db = Database::open_in_memory().unwrap();
+
+        import_storygraph(
+            &db,
+            &csv_path,
+            &StorygraphImportOptions { dry_run: false },
+            None,
+        )
+        .unwrap();
+
+        let repo = BookRepository::new(&db);
+        let books = repo.list_books().unwrap();
+        let authors = repo.get_book_authors(&books[0].id).unwrap();
+        assert_eq!(authors.len(), 2); // Test Author + Ray Porter
+        let narrator = authors.iter().find(|(a, _)| a.name == "Ray Porter");
+        assert!(narrator.is_some());
+        assert_eq!(narrator.unwrap().1.role, ContributorRole::Narrator);
+    }
+
+    #[test]
+    fn reading_sessions_created_from_dates() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let csv_path = write_storygraph_csv(
+            tmp.path(),
+            &[
+                r#"Dune,Frank Herbert,,,paperback,read,2023/01/10,,"2024/03/01-2024/03/15, 2023/06/10-2023/06/20",2,,,,,,,,,,,,,No"#,
+            ],
+        );
+        let db = Database::open_in_memory().unwrap();
+
+        import_storygraph(
+            &db,
+            &csv_path,
+            &StorygraphImportOptions { dry_run: false },
+            None,
+        )
+        .unwrap();
+
+        let repo = BookRepository::new(&db);
+        let books = repo.list_books().unwrap();
+        let sessions = repo.list_reading_sessions().unwrap();
+        let book_sessions: Vec<_> = sessions
+            .iter()
+            .filter(|s| s.book_id == books[0].id)
+            .collect();
+        assert_eq!(book_sessions.len(), 2);
+    }
+
+    #[test]
+    fn detect_storygraph_csv_rejects_goodreads() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let path = tmp.path().join("goodreads.csv");
+        let mut f = std::fs::File::create(&path).unwrap();
+        writeln!(f, "Book Id,Title,Author,ISBN,My Rating,Exclusive Shelf").unwrap();
+        writeln!(f, "1,Dune,Frank Herbert,1234567890,5,read").unwrap();
+
+        let result = import_storygraph(
+            &Database::open_in_memory().unwrap(),
+            &path,
+            &StorygraphImportOptions { dry_run: false },
+            None,
+        );
+        assert!(result.is_err());
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("StoryGraph export")
+        );
+    }
+
+    #[test]
+    fn character_driven_imported_as_tag() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let csv_path = write_storygraph_csv(
+            tmp.path(),
+            &[
+                r#"Test Book,Author,,,paperback,read,2024/01/01,,,,,,Character,Yes,Yes,No,No,,,,,custom-tag,No"#,
+            ],
+        );
+        let db = Database::open_in_memory().unwrap();
+
+        import_storygraph(
+            &db,
+            &csv_path,
+            &StorygraphImportOptions { dry_run: false },
+            None,
+        )
+        .unwrap();
+
+        let repo = BookRepository::new(&db);
+        let books = repo.list_books().unwrap();
+        let tags = repo.get_book_tags(&books[0].id).unwrap();
+        let tag_names: Vec<&str> = tags.iter().map(|t| t.name.as_str()).collect();
+        assert!(tag_names.contains(&"character-driven"));
+        assert!(tag_names.contains(&"strong-character-development"));
+        assert!(tag_names.contains(&"loveable-characters"));
+        assert!(tag_names.contains(&"custom-tag"));
+    }
+
+    #[test]
+    fn review_not_stored_in_description() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let csv_path = write_storygraph_csv(
+            tmp.path(),
+            &[
+                r#"Test Book,Author,,,paperback,read,2024/01/01,,,,,,,,,,,,"<div>Great book!</div>",,,,No"#,
+            ],
+        );
+        let db = Database::open_in_memory().unwrap();
+
+        let report = import_storygraph(
+            &db,
+            &csv_path,
+            &StorygraphImportOptions { dry_run: false },
+            None,
+        )
+        .unwrap();
+
+        let repo = BookRepository::new(&db);
+        let books = repo.list_books().unwrap();
+        // Description should remain None
+        assert!(books[0].description.is_none());
+        // Warning should be recorded
+        assert_eq!(report.warnings.len(), 1);
+        assert!(report.warnings[0].contains("review skipped"));
+    }
+
+    #[test]
+    fn paused_status_maps_to_on_hold() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let csv_path = write_storygraph_csv(
+            tmp.path(),
+            &[r#"Test Book,Author,,,paperback,paused,2024/01/01,,,,,,,,,,,,,,,No"#],
+        );
+        let db = Database::open_in_memory().unwrap();
+
+        import_storygraph(
+            &db,
+            &csv_path,
+            &StorygraphImportOptions { dry_run: false },
+            None,
+        )
+        .unwrap();
+
+        let repo = BookRepository::new(&db);
+        let books = repo.list_books().unwrap();
+        assert_eq!(books[0].status, ReadingStatus::OnHold);
+    }
+}


### PR DESCRIPTION
## Description

Add work grouping, duplicate merging, StoryGraph import, and smart shelves — four features that round out Toku's library organization and import capabilities.

### What's included

- **Work grouping** (	oku work link|unlink|show|auto): Group multiple editions of the same creative work. Auto-detection finds candidates by normalized title and primary author. Works table added via V10 migration.
- **Duplicate merging** (	oku merge <keep> <remove>): Transactional merge that moves all reading sessions, progress, tags, authors, ISBNs, series, provenance, and source IDs from the removed book to the kept book. NULL metadata on the kept book is filled from the removed book.
- **StoryGraph CSV import** (	oku import storygraph <file>): Full parser for StoryGraph's 23-column export format. Preserves mood tags, pace ratings, and content warnings as typed tags. Handles quarter-star ratings, multi-session dates, contributor roles (narrator/translator), DNF and paused statuses. Dedup by ISBN first, then exact title+author.
- **Smart shelves** (	oku shelf create --smart --filter "..."): Saved filter rules that dynamically match books. Filter DSL supports 11 fields (status, tag, mood, pace, rating, pages, author, format, shelf, pub_date, date_added), comparison operators (=, >, >=, <, <=), and AND/OR/parentheses. Smart shelf contents are evaluated at query time — no stale results.
- **Shelf CLI** (	oku shelf create|list|show|delete|add|remove): Full shelf management with --format table|json|csv output. Smart shelves cannot have books manually added (enforced).
- **Import refactoring**: Shared import types (ImportReport, ImportEvent, ImportObserver) extracted to common.rs for reuse across all importers.

## Related Issues

Closes #43, Closes #44, Closes #45

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI / infrastructure
- [ ] Other (describe below)

## Crate

- [x] `toku-core` — Domain models, traits, state machine
- [x] `toku-db` — SQLite persistence, migrations, FTS5
- [x] `toku-import` — Importers (Goodreads, Calibre, StoryGraph)
- [ ] `toku-meta` — Metadata fetching (Open Library, Google Books)
- [x] `toku-cli` — CLI binary
- [ ] `toku-export` — Exporters (CSV, JSON, Markdown, BibTeX)
- [ ] `docs/` — Documentation

## Data Integrity Checklist

- [x] No user data is sent to any server without explicit opt-in
- [x] Import operations are idempotent (re-importing the same file creates no duplicates)
- [x] User edits to metadata are never overwritten by auto-enrichment
- [x] New fields track provenance (source + timestamp)
- [x] Export round-trip is preserved (if applicable)

## Checklist

- [x] I have read [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] `cargo fmt --check` passes
- [x] `cargo clippy --workspace -- -D warnings` passes
- [x] `cargo test --workspace` passes (186 tests)
- [x] I have updated documentation (if applicable)