### PR TITLE
docs: validate Goodreads CSV, Open Library API, and Google Books terms

### DIFF
--- a/.github/.markdownlint.json
+++ b/.github/.markdownlint.json
@@ -1,6 +1,7 @@
 {
   "default": true,
   "MD013": false,
+  "MD024": { "siblings_only": true },
   "MD033": false,
   "MD041": false,
   "MD060": false

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2317,6 +2317,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.11.0",
+ "tempfile",
  "thiserror",
  "tokio",
  "toku-core",

--- a/crates/toku-import/src/goodreads.rs
+++ b/crates/toku-import/src/goodreads.rs
@@ -792,4 +792,87 @@ mod tests {
         assert_eq!(r2.skipped, 1); // PHM has no shelves
         assert_eq!(r2.imported, 0);
     }
+
+    #[test]
+    fn import_fixture_file_all_edge_cases() {
+        let fixture = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("tests/fixtures/goodreads/export.csv");
+        assert!(fixture.exists(), "fixture file missing: {fixture:?}");
+
+        let db = Database::open_in_memory().unwrap();
+        let report = import_goodreads(
+            &db,
+            &fixture,
+            &GoodreadsImportOptions { dry_run: false },
+            None,
+        )
+        .unwrap();
+
+        assert_eq!(report.total_rows, 8);
+        assert_eq!(report.imported, 8);
+        assert_eq!(report.errors, 0);
+
+        let repo = BookRepository::new(&db);
+        let books = repo.list_books().unwrap();
+        assert_eq!(books.len(), 8);
+
+        // Comma in title: Good Omens
+        let good_omens = books
+            .iter()
+            .find(|b| b.title.starts_with("Good Omens"))
+            .unwrap();
+        assert_eq!(good_omens.status, ReadingStatus::Read);
+        assert_eq!(good_omens.rating, Some(10));
+        // Multiple authors
+        let go_authors = repo.get_book_authors(&good_omens.id).unwrap();
+        assert_eq!(go_authors.len(), 2);
+        assert_eq!(go_authors[0].0.name, "Neil Gaiman");
+        assert_eq!(go_authors[1].0.name, "Terry Pratchett");
+
+        // No ISBN: Untitled Manuscript
+        let untitled = books
+            .iter()
+            .find(|b| b.title == "Untitled Manuscript")
+            .unwrap();
+        assert_eq!(untitled.status, ReadingStatus::WantToRead);
+        assert_eq!(untitled.rating, None); // 0 → unrated
+        assert_eq!(untitled.page_count, None);
+        let untitled_isbns = repo.get_book_isbns(&untitled.id).unwrap();
+        assert!(untitled_isbns.is_empty());
+
+        // Negative year (BCE): The Art of War
+        let art_of_war = books.iter().find(|b| b.title == "The Art of War").unwrap();
+        assert_eq!(art_of_war.pub_date.as_deref(), Some("-500"));
+        assert_eq!(art_of_war.format, BookFormat::Audiobook);
+        // 3 authors total (Sun Tzu + 2 additional)
+        let aow_authors = repo.get_book_authors(&art_of_war.id).unwrap();
+        assert_eq!(aow_authors.len(), 3);
+
+        // Non-ASCII: Gödel's Proof
+        let godel = books.iter().find(|b| b.title.contains("del")).unwrap();
+        assert!(godel.title.contains('ö'));
+        assert_eq!(godel.rating, Some(8)); // 4 * 2
+
+        // Non-standard exclusive shelf: favorites → tag
+        let myor = books
+            .iter()
+            .find(|b| b.title.starts_with("My Year"))
+            .unwrap();
+        assert_eq!(myor.status, ReadingStatus::WantToRead);
+        assert_eq!(myor.format, BookFormat::Ebook);
+        let myor_tags = repo.get_book_tags(&myor.id).unwrap();
+        let myor_tag_names: Vec<&str> = myor_tags.iter().map(|t| t.name.as_str()).collect();
+        assert!(myor_tag_names.contains(&"favorites"));
+
+        // Idempotent re-import
+        let r2 = import_goodreads(
+            &db,
+            &fixture,
+            &GoodreadsImportOptions { dry_run: false },
+            None,
+        )
+        .unwrap();
+        assert_eq!(r2.imported, 0);
+        assert_eq!(repo.list_books().unwrap().len(), 8);
+    }
 }

--- a/crates/toku-import/tests/fixtures/goodreads/README.md
+++ b/crates/toku-import/tests/fixtures/goodreads/README.md
@@ -1,0 +1,47 @@
+# Goodreads CSV Export — Test Fixture
+
+Sample Goodreads CSV export for testing `toku import goodreads`.
+
+Exported via **My Books → Import/Export** on Goodreads.
+
+## Column Reference
+
+| Column | Type | Notes |
+|---|---|---|
+| `Book Id` | integer | Goodreads book ID, used for dedup on re-import |
+| `Title` | string | May contain commas (field is then double-quoted) |
+| `Author` | string | Primary author, first-last format |
+| `Author l-f` | string | Primary author, last-first format (unused by importer) |
+| `Additional Authors` | string | Comma-separated additional authors |
+| `ISBN` | string | Wrapped as `="0441172717"` to prevent Excel number coercion |
+| `ISBN13` | string | Wrapped as `="9780441172719"` — same quoting |
+| `My Rating` | 0–5 | 0 means unrated; Toku converts to 0–10 scale |
+| `Average Rating` | float | Community average (unused by importer) |
+| `Publisher` | string | Publisher name (unused by importer) |
+| `Binding` | string | Maps to BookFormat: `Kindle Edition`→Ebook, `Audiobook`→Audiobook, else Physical |
+| `Number of Pages` | integer | May be empty |
+| `Year Published` | integer | Edition year; fallback if Original Publication Year missing |
+| `Original Publication Year` | integer | Preferred pub date; may be negative (BCE) |
+| `Date Read` | `YYYY/MM/DD` | May be empty if unread |
+| `Date Added` | `YYYY/MM/DD` | When user added book to Goodreads |
+| `Bookshelves` | string | Comma-separated shelf names → imported as tags |
+| `Bookshelves with positions` | string | Same shelves with `(#N)` position suffix (unused) |
+| `Exclusive Shelf` | string | `read`, `currently-reading`, `to-read`, or custom |
+| `My Review` | string | Free text; may contain escaped quotes (`""`) |
+| `Spoiler` | string | Spoiler flag (unused) |
+| `Private Notes` | string | Private notes (unused) |
+| `Read Count` | integer | Times read (unused) |
+| `Owned Copies` | integer | Owned copies (unused) |
+
+## Edge Cases Covered in `export.csv`
+
+| Row | Book | Edge Case |
+|---|---|---|
+| 1 | Dune | Standard read book, ISBN-10 + ISBN-13, rating 5, tags, review text |
+| 2 | Neuromancer | `to-read` status, Kindle Edition → Ebook format, no Date Read |
+| 3 | Project Hail Mary | `currently-reading`, rating 0 (unrated), no shelves/tags |
+| 4 | Good Omens | **Comma in title** (quoted field), **multiple authors**, escaped quotes in review (`""`), high read count |
+| 5 | Untitled Manuscript | **No ISBN**, no publisher, no pages, no binding — minimal data |
+| 6 | The Art of War | **Negative publication year** (BCE), **3 authors** (2 additional), Audiobook format |
+| 7 | Gödel's Proof | **Non-ASCII characters** in title (umlaut, apostrophe), no ISBN-13 |
+| 8 | My Year of Rest... | **Non-standard exclusive shelf** (`favorites`) → becomes tag, Kindle format |

--- a/crates/toku-import/tests/fixtures/goodreads/export.csv
+++ b/crates/toku-import/tests/fixtures/goodreads/export.csv
@@ -1,0 +1,9 @@
+Book Id,Title,Author,Author l-f,Additional Authors,ISBN,ISBN13,My Rating,Average Rating,Publisher,Binding,Number of Pages,Year Published,Original Publication Year,Date Read,Date Added,Bookshelves,Bookshelves with positions,Exclusive Shelf,My Review,Spoiler,Private Notes,Read Count,Owned Copies
+3,Dune,Frank Herbert,"Herbert, Frank",,="0441172717",="9780441172719",5,4.25,Ace,Paperback,896,2005,1965,2024/03/15,2023/01/10,"sci-fi, classics","sci-fi (#1), classics (#2)",read,"Amazing book about desert planets",,,1,1
+6,Neuromancer,William Gibson,"Gibson, William",,="0441569595",="9780441569595",4,3.89,Ace,Kindle Edition,271,2000,1984,,2024/02/20,cyberpunk,,to-read,,,,0,0
+100,Project Hail Mary,Andy Weir,"Weir, Andy",,="0593135202",="9780593135204",0,4.52,Ballantine Books,Hardcover,496,2021,2021,2024/06/01,2024/05/01,,,currently-reading,,,,0,0
+42,"Good Omens: The Nice and Accurate Prophecies of Agnes Nutter, Witch",Neil Gaiman,"Gaiman, Neil",Terry Pratchett,="0060853980",="9780060853983",5,4.25,William Morrow,Paperback,400,2006,1990,2023/12/25,2022/06/15,"humor, fantasy, fiction","humor (#1), fantasy (#2), fiction (#3)",read,"Brilliant collaboration — ""pure joy"" from start to finish!",,,2,1
+999,Untitled Manuscript,Unknown Author,"Author, Unknown",,,,0,0.00,,,,,,2024/01/01,,,to-read,,,,0,0
+55,The Art of War,Sun Tzu,"Tzu, Sun","Thomas Cleary, Samuel B. Griffith",="1590302257",="9781590302255",3,3.97,Shambhala,Audiobook,68,2005,-500,,2024/03/01,philosophy,"philosophy (#1)",read,,,,1,0
+77,Gödel's Proof,Ernest Nagel,"Nagel, Ernest",James R. Newman,,,4,4.18,NYU Press,Hardcover,129,2001,1958,2024/04/10,2024/01/15,math,"math (#1)",read,"Excellent overview of Gödel's incompleteness theorems",,,1,1
+200,My Year of Rest and Relaxation,Ottessa Moshfegh,"Moshfegh, Ottessa",,="0525522131",="9780525522133",2,3.59,Penguin Press,Kindle Edition,304,2018,2018,2024/08/01,2024/07/01,,,favorites,,,,1,0

--- a/crates/toku-meta/Cargo.toml
+++ b/crates/toku-meta/Cargo.toml
@@ -15,3 +15,6 @@ serde_json.workspace = true
 reqwest.workspace = true
 tokio.workspace = true
 sha2 = "0.11"
+
+[dev-dependencies]
+tempfile = "3"

--- a/crates/toku-meta/tests/openlibrary_validation.rs
+++ b/crates/toku-meta/tests/openlibrary_validation.rs
@@ -1,0 +1,332 @@
+//! Integration tests for Open Library API validation (issue #15).
+//!
+//! All tests are `#[ignore]` because they hit real network endpoints.
+//! Run with: `cargo test -p toku-meta -- --ignored`
+
+use std::time::Instant;
+use toku_meta::{fetch_by_isbn, fetch_cover, search_books};
+
+// ── ISBN lookups ────────────────────────────────────────────────────────
+
+#[tokio::test]
+#[ignore]
+async fn isbn_english_bestseller_dune() {
+    let start = Instant::now();
+    let book = fetch_by_isbn("9780441172719").await.unwrap();
+    let elapsed = start.elapsed();
+
+    println!("  Title:       {}", book.title);
+    println!("  Authors:     {:?}", book.authors);
+    println!("  Pages:       {:?}", book.page_count);
+    println!("  Pub date:    {:?}", book.pub_date);
+    println!("  Language:    {:?}", book.language);
+    println!("  Publishers:  {:?}", book.publishers);
+    println!("  ISBN-13:     {:?}", book.isbn_13);
+    println!("  ISBN-10:     {:?}", book.isbn_10);
+    println!("  OL ID:       {:?}", book.openlibrary_id);
+    println!("  Cover ID:    {:?}", book.cover_id);
+    println!("  Response:    {elapsed:?}");
+
+    assert!(book.title.contains("Dune"));
+    assert!(!book.authors.is_empty());
+    assert!(book.page_count.is_some());
+}
+
+#[tokio::test]
+#[ignore]
+async fn isbn_english_bestseller_harry_potter() {
+    let start = Instant::now();
+    let book = fetch_by_isbn("9780590353427").await.unwrap();
+    let elapsed = start.elapsed();
+
+    println!("  Title:       {}", book.title);
+    println!("  Authors:     {:?}", book.authors);
+    println!("  Pages:       {:?}", book.page_count);
+    println!("  Cover ID:    {:?}", book.cover_id);
+    println!("  Response:    {elapsed:?}");
+
+    assert!(book.title.contains("Harry Potter"));
+    // Known gap: some OL editions lack author links at the edition level.
+    // The work-level record has authors, but the edition may not.
+    if book.authors.is_empty() {
+        println!("  ⚠ AUTHORS MISSING — edition lacks author references");
+    }
+}
+
+#[tokio::test]
+#[ignore]
+async fn isbn_non_english_spanish() {
+    // Cien años de soledad — Spanish edition
+    let start = Instant::now();
+    let book = fetch_by_isbn("9788497592208").await.unwrap();
+    let elapsed = start.elapsed();
+
+    println!("  Title:       {}", book.title);
+    println!("  Authors:     {:?}", book.authors);
+    println!("  Language:    {:?}", book.language);
+    println!("  Pages:       {:?}", book.page_count);
+    println!("  Response:    {elapsed:?}");
+
+    assert!(!book.title.is_empty());
+    // Known gap: some OL editions have no author links (e.g., mass-market reprints).
+    // The work record has authors, but the edition may not reference them.
+    if book.authors.is_empty() {
+        println!("  ⚠ AUTHORS MISSING — edition lacks author references");
+    }
+}
+
+#[tokio::test]
+#[ignore]
+async fn isbn_non_english_japanese() {
+    // Norwegian Wood (ノルウェイの森) — Japanese edition
+    let start = Instant::now();
+    let result = fetch_by_isbn("9784062749688").await;
+    let elapsed = start.elapsed();
+
+    match result {
+        Ok(book) => {
+            println!("  Title:       {}", book.title);
+            println!("  Language:    {:?}", book.language);
+            println!("  Response:    {elapsed:?}");
+        }
+        Err(e) => {
+            println!("  NOT FOUND:   {e}");
+            println!("  Response:    {elapsed:?}");
+            println!("  (Japanese editions have poor coverage)");
+        }
+    }
+}
+
+#[tokio::test]
+#[ignore]
+async fn isbn_old_edition_pre_1970_mockingbird() {
+    // To Kill a Mockingbird (1960, HarperCollins reprint)
+    let start = Instant::now();
+    let book = fetch_by_isbn("9780061120084").await.unwrap();
+    let elapsed = start.elapsed();
+
+    println!("  Title:       {}", book.title);
+    println!("  Authors:     {:?}", book.authors);
+    println!("  Pub date:    {:?}", book.pub_date);
+    println!("  Pages:       {:?}", book.page_count);
+    println!("  Response:    {elapsed:?}");
+
+    assert!(book.title.contains("Mockingbird"));
+}
+
+#[tokio::test]
+#[ignore]
+async fn isbn_old_edition_pre_1970_1984() {
+    // 1984 by George Orwell (Signet Classic)
+    let start = Instant::now();
+    let book = fetch_by_isbn("9780451524935").await.unwrap();
+    let elapsed = start.elapsed();
+
+    println!("  Title:       {}", book.title);
+    println!("  Authors:     {:?}", book.authors);
+    println!("  Pub date:    {:?}", book.pub_date);
+    println!("  Response:    {elapsed:?}");
+
+    // Known gap: Signet Classic edition returns title "Nineteen Eighty-Four"
+    // and has no author links at the edition level.
+    if book.authors.is_empty() {
+        println!("  ⚠ AUTHORS MISSING — edition lacks author references");
+    }
+}
+
+#[tokio::test]
+#[ignore]
+async fn isbn_self_published_the_martian() {
+    // The Martian — originally self-published (Crown edition)
+    let start = Instant::now();
+    let book = fetch_by_isbn("9780553418026").await.unwrap();
+    let elapsed = start.elapsed();
+
+    println!("  Title:       {}", book.title);
+    println!("  Authors:     {:?}", book.authors);
+    println!("  Pub date:    {:?}", book.pub_date);
+    println!("  Pages:       {:?}", book.page_count);
+    println!("  Response:    {elapsed:?}");
+
+    assert!(book.title.contains("Martian"));
+}
+
+#[tokio::test]
+#[ignore]
+async fn isbn_not_found() {
+    // Bogus ISBN that should not exist
+    let start = Instant::now();
+    let result = fetch_by_isbn("9799999999999").await;
+    let elapsed = start.elapsed();
+
+    println!("  Result:      {result:?}");
+    println!("  Response:    {elapsed:?}");
+
+    assert!(result.is_err());
+}
+
+#[tokio::test]
+#[ignore]
+async fn isbn_no_pages_no_description() {
+    // Some editions lack page count or description — test a niche edition
+    // The Tao Te Ching — ancient text with many editions, some sparse
+    let start = Instant::now();
+    let book = fetch_by_isbn("9780679724346").await.unwrap();
+    let elapsed = start.elapsed();
+
+    println!("  Title:       {}", book.title);
+    println!("  Pages:       {:?}", book.page_count);
+    println!(
+        "  Description: {:?}",
+        book.description.as_ref().map(|d| &d[..d.len().min(80)])
+    );
+    println!("  Response:    {elapsed:?}");
+}
+
+// ── Search queries ──────────────────────────────────────────────────────
+
+#[tokio::test]
+#[ignore]
+async fn search_by_title() {
+    let start = Instant::now();
+    let results = search_books("Dune Frank Herbert", 5).await.unwrap();
+    let elapsed = start.elapsed();
+
+    println!("  Results:     {}", results.len());
+    for r in &results {
+        println!(
+            "    - {} by {:?} (editions: {}, isbn: {:?})",
+            r.title, r.authors, r.edition_count, r.isbn
+        );
+    }
+    println!("  Response:    {elapsed:?}");
+
+    assert!(!results.is_empty());
+    assert!(results.iter().any(|r| r.title.contains("Dune")));
+}
+
+#[tokio::test]
+#[ignore]
+async fn search_by_author_only() {
+    let start = Instant::now();
+    let results = search_books("author:Ursula K. Le Guin", 10).await.unwrap();
+    let elapsed = start.elapsed();
+
+    println!("  Results:     {}", results.len());
+    for r in &results {
+        println!("    - {} ({:?})", r.title, r.first_publish_year);
+    }
+    println!("  Response:    {elapsed:?}");
+
+    assert!(!results.is_empty());
+}
+
+#[tokio::test]
+#[ignore]
+async fn search_non_english_title() {
+    let start = Instant::now();
+    let results = search_books("Cien años de soledad", 5).await.unwrap();
+    let elapsed = start.elapsed();
+
+    println!("  Results:     {}", results.len());
+    for r in &results {
+        println!(
+            "    - {} by {:?} (languages: {:?})",
+            r.title, r.authors, r.languages
+        );
+    }
+    println!("  Response:    {elapsed:?}");
+
+    assert!(!results.is_empty());
+}
+
+// ── Cover image API ─────────────────────────────────────────────────────
+
+#[tokio::test]
+#[ignore]
+async fn cover_available_dune() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let start = Instant::now();
+    let result = fetch_cover("9780441172719", tmp.path()).await.unwrap();
+    let elapsed = start.elapsed();
+
+    println!("  Cover hash:  {result:?}");
+    println!("  Response:    {elapsed:?}");
+
+    assert!(result.is_some(), "Dune should have a cover");
+    let hash = result.unwrap();
+    let cover_path = tmp.path().join(format!("{hash}.jpg"));
+    let size = std::fs::metadata(&cover_path).unwrap().len();
+    println!("  File size:   {size} bytes");
+    assert!(
+        size > 5_000,
+        "Cover should be a real image, not placeholder"
+    );
+}
+
+#[tokio::test]
+#[ignore]
+async fn cover_not_available() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let start = Instant::now();
+    // Use the bogus ISBN
+    let result = fetch_cover("9799999999999", tmp.path()).await.unwrap();
+    let elapsed = start.elapsed();
+
+    println!("  Cover hash:  {result:?}");
+    println!("  Response:    {elapsed:?}");
+
+    assert!(result.is_none(), "Bogus ISBN should have no cover");
+}
+
+#[tokio::test]
+#[ignore]
+async fn cover_quality_harry_potter() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let start = Instant::now();
+    let result = fetch_cover("9780590353427", tmp.path()).await.unwrap();
+    let elapsed = start.elapsed();
+
+    println!("  Cover hash:  {result:?}");
+    println!("  Response:    {elapsed:?}");
+
+    if let Some(hash) = result {
+        let cover_path = tmp.path().join(format!("{hash}.jpg"));
+        let size = std::fs::metadata(&cover_path).unwrap().len();
+        println!("  File size:   {size} bytes (L-size)");
+        // L-size covers should be reasonably large
+        assert!(size > 10_000, "L-size cover should be high quality");
+    } else {
+        println!("  (No cover available)");
+    }
+}
+
+// ── Response time benchmark ─────────────────────────────────────────────
+
+#[tokio::test]
+#[ignore]
+async fn response_time_isbn_batch() {
+    let isbns = [
+        ("Dune", "9780441172719"),
+        ("1984", "9780451524935"),
+        ("Mockingbird", "9780061120084"),
+        ("Harry Potter", "9780590353427"),
+        ("The Martian", "9780553418026"),
+    ];
+
+    let mut times = Vec::new();
+    for (label, isbn) in &isbns {
+        let start = Instant::now();
+        let result = fetch_by_isbn(isbn).await;
+        let elapsed = start.elapsed();
+        let status = if result.is_ok() { "OK" } else { "ERR" };
+        println!("  {label:20} {status:3}  {elapsed:?}");
+        times.push(elapsed.as_millis());
+    }
+
+    let avg = times.iter().sum::<u128>() / times.len() as u128;
+    let max = times.iter().max().unwrap();
+    let min = times.iter().min().unwrap();
+    println!("\n  Avg: {avg}ms  Min: {min}ms  Max: {max}ms");
+    println!("  (5 sequential requests, no parallelism)");
+}

--- a/docs/adr/004-metadata-sources.md
+++ b/docs/adr/004-metadata-sources.md
@@ -20,8 +20,8 @@ reliable, and compatible with open-source use.
   Google Books. Fill empty fields only — never overwrite existing data.
 - **User edits always win**: Once a user modifies a field, auto-enrichment marks it as
   `user_override` and will not overwrite it.
-- **Caching**: API responses cached locally for 30 days to reduce API calls and enable
-  offline re-enrichment.
+- **Caching**: Open Library API responses cached locally (permitted by OL guidelines).
+  Google Books responses must NOT be cached beyond HTTP cache headers (ToS Section 5e.1).
 
 ## Rationale
 
@@ -46,6 +46,27 @@ Bulk crawling is prohibited. Courtesy attribution is appreciated but not require
 may only be used for transient text metadata enrichment, not cover images. API keys also
 cannot be embedded in open-source projects (Section 4b.1).
 
+## Google Books API — Validated (2026-05-30)
+
+See [docs/validations/google-books-api.md](../validations/google-books-api.md)
+for the full validation report.
+
+**Key findings**:
+
+- **Metadata caching**: Permanent copies of API responses are prohibited by the Google
+  APIs ToS (Section 5e.1). Toku may only use Google Books for transient enrichment —
+  fetch metadata, merge into user's record, discard raw response.
+- **API key**: Cannot be embedded in open-source projects (Section 4b.1). Users must
+  provide their own key via `config.toml`.
+- **Free quota**: 1,000 requests/day per API key. Adequate for personal use but requires
+  each user to create a Google Cloud project and generate a key.
+- **Cover images**: Local caching prohibited. Open Library remains the only cover source.
+- **Attribution**: "Powered by Google" branding required when displaying search results.
+  For individual enriched fields, showing provenance ("via Google Books") is sufficient.
+- **Recommendation**: Defer Google Books integration. Open Library is sufficient as the
+  sole metadata source for the MVP. Google Books adds user friction (API key setup) with
+  significant ToS restrictions for limited coverage gains.
+
 ## Alternatives Considered
 
 | Source | Rejected Because |
@@ -57,10 +78,15 @@ cannot be embedded in open-source projects (Section 4b.1).
 
 ## Open Validations
 
-- [ ] Open Library rate limits (stated 100 req/min — verify in practice)
+- [x] Open Library rate limits — **Validated 2026-05-30**: 100 req/5 min, adequate for
+  personal use. Response times ~2.9s avg for ISBN lookups. Some editions lack author data.
+  See [openlibrary-api.md](../validations/openlibrary-api.md).
 - [x] Google Books ToS for open-source caching — **Validated 2026-05-29**: Significant
   restrictions apply. Permanent caching prohibited. API keys cannot be embedded in
   open-source projects. See [cover-image-licensing.md](../validations/cover-image-licensing.md).
+- [x] Google Books API terms for open-source use — **Validated 2026-05-30**: Transient
+  enrichment only, user-provided API key required, no cover caching. Deferred for MVP.
+  See [google-books-api.md](../validations/google-books-api.md).
 - [x] Cover image licensing for local caching — **Validated 2026-05-29**: Open Library
   on-demand caching permitted. Google Books thumbnail caching prohibited.
   See [cover-image-licensing.md](../validations/cover-image-licensing.md).

--- a/docs/validations/google-books-api.md
+++ b/docs/validations/google-books-api.md
@@ -1,0 +1,193 @@
+# Validation: Google Books API Terms for Open-Source Use
+
+**Status**: Validated
+**Date**: 2026-05-30
+**Issue**: [#16](https://github.com/kafkade/toku/issues/16)
+**Affects**: `toku-meta` crate, metadata fallback strategy (ADR-004)
+
+## Summary
+
+| Question | Answer |
+|---|---|
+| Can an open-source app cache metadata locally? | ⚠️ Only transiently — permanent copies prohibited (Section 5e.1) |
+| Free tier quota? | 1,000 req/day per API key (default); no reliable unauthenticated access |
+| API key in binary? | ❌ Prohibited — "Developer credentials may not be embedded in open source projects" (Section 4b.1) |
+| Cover image caching? | ❌ Prohibited — thumbnails cannot be stored locally (Section 5e.1) |
+| Suitable as fallback metadata source? | ⚠️ Yes, with significant restrictions — transient enrichment only |
+
+## Detailed Findings
+
+### 1. Metadata Caching — Permanent Copies Prohibited
+
+The Google APIs ToS Section 5e.1 states:
+
+> "you will not [...] **Scrape, build databases, or otherwise create permanent
+> copies of such content, or keep cached copies longer than permitted by the
+> cache header**"
+
+This applies to ALL content returned by the API, including text metadata
+(title, author, page count, description). Toku's architecture stores book
+metadata permanently in a local SQLite database, which directly conflicts
+with the "no permanent copies" clause.
+
+**Interpretation for Toku**: Using Google Books for one-time field
+enrichment — fetch metadata, merge fields into the user's record (which
+becomes user-owned data), then discard the raw API response — is the
+safest approach. Once a field is saved as part of the user's library entry
+with provenance tracked as `google_books`, it is arguably user-curated data
+rather than a cached API response. However, this interpretation has not been
+tested legally.
+
+### 2. Free Tier Quota — 1,000 Requests/Day per API Key
+
+| Access Type | Quota | Notes |
+|---|---|---|
+| With API key (free tier) | 1,000 req/day | Resets at midnight Pacific Time |
+| Without API key | Undocumented, very low | Throttled or blocked; not reliable |
+| Paid (billing enabled) | Up to 10,000 req/day | Requires Google Cloud billing account |
+
+The 1,000 req/day free quota is adequate for a personal book manager.
+Even heavy use (adding 10 books/day with fallback lookups) would stay well
+under the limit.
+
+**Key concern**: Unauthenticated access (no API key) is unreliable and
+officially discouraged. Every user needs their own API key to use
+Google Books as a fallback source.
+
+### 3. API Key Embedding — Prohibited in Open Source
+
+Google APIs ToS Section 4b.1:
+
+> "**Developer credentials** (such as passwords, keys, and client IDs) are
+> intended to be used by you and identify your API Client. [...] **Developer
+> credentials may not be embedded in open source projects.**"
+
+This is unambiguous. Toku cannot ship with a bundled Google Books API key.
+
+**Mitigation**: Users must provide their own API key via configuration:
+
+```toml
+# config.toml
+[metadata.google_books]
+api_key = "AIza..."
+```
+
+This adds friction to the Google Books fallback feature. Users must:
+
+1. Create a Google Cloud project
+2. Enable the Books API
+3. Generate an API key
+4. Add it to their Toku config
+
+### 4. Cover Image Caching — Prohibited
+
+As documented in
+[cover-image-licensing.md](cover-image-licensing.md), Section 5e.1
+prohibits permanent local storage of thumbnails. Google Books cannot be
+used for cover images in Toku's offline-first architecture.
+
+### 5. Fees Clause — Cannot Charge Users
+
+The Google Books API-specific ToS (separate from the general Google APIs
+ToS) states:
+
+> "You may not charge users any fee for the use of your application,
+> unless you have entered into a separate agreement with Google or
+> obtained Google's written permission."
+
+Since Toku is free and open-source (MIT license), this is not an issue.
+However, it would become relevant if Toku ever offered a paid tier that
+used Google Books data.
+
+### 6. Attribution Requirements
+
+The Google Books branding guidelines require:
+
+- "Powered by Google" logo adjacent to book results sourced from Google
+- Prominent links to Google Books pages for each result
+- No reordering or alteration of results
+
+These requirements conflict with Toku's design principles (no external
+branding, offline display of enriched data, user data ownership).
+
+**Mitigation**: Attribution could be shown in `toku show` output when a
+field's provenance is `google_books` (e.g., "Description via Google
+Books"). The branding requirements apply primarily to search results
+displayed in a web UI, not to individual enriched metadata fields in a CLI.
+
+### 7. Content Removal
+
+> "You must remove from your site or application any content provided
+> through the Books API that is alleged to infringe the rights of third
+> parties"
+
+For a personal, offline-first app where the user owns their data, this is
+low risk but worth noting. If Google requests content removal, the user's
+local data would need a mechanism to mark and optionally remove
+Google-sourced fields.
+
+## Impact on Architecture (ADR-004)
+
+### Recommended approach: Transient enrichment only
+
+```text
+
+1. Query Open Library (primary) → fetch metadata
+2. If fields missing, query Google Books (fallback)
+3. Merge non-empty fields into user's book record
+4. Track provenance: field_name → "google_books"
+5. DISCARD raw Google Books API response (do not cache)
+6. User's record is now user-owned data
+```
+
+### What changes from current ADR-004
+
+| ADR-004 statement | Update needed |
+|---|---|
+| "Caching: API responses cached locally for 30 days" | ❌ Cannot cache Google Books responses beyond HTTP cache headers |
+| "Google Books as fallback" | ✅ Viable for text metadata, with user-provided API key |
+| "Cover images: Google Books thumbnails as fallback" | ❌ Cannot cache thumbnails locally |
+
+### Configuration design
+
+```toml
+[metadata]
+# Primary source — always used, no key needed
+primary = "openlibrary"
+
+[metadata.google_books]
+# Optional fallback — requires user-provided API key
+enabled = false
+api_key = ""  # User must supply their own
+```
+
+## Recommendation
+
+Google Books remains viable as a **metadata-only fallback** with these
+constraints:
+
+1. **User must provide their own API key** — cannot be bundled
+2. **Transient enrichment only** — fetch, merge fields, discard response
+3. **No cover images** — Open Library or user-provided only
+4. **Provenance tracking** — mark Google-sourced fields for potential removal
+5. **Attribution** — show "via Google Books" in CLI when displaying
+   Google-sourced fields
+
+Given the friction (API key setup) and restrictions (no caching, no covers,
+attribution), Google Books as a fallback should be **deferred** until Open
+Library's coverage gaps cause real user pain. Open Library is sufficient as
+the sole metadata source for the MVP.
+
+## Sources Reviewed
+
+| Source | URL |
+|---|---|
+| Google APIs Terms of Service | <https://developers.google.com/terms> |
+| Google Books API Terms | <https://developers.google.com/books/terms> |
+| Google Books API Documentation | <https://developers.google.com/books/docs/v1/using> |
+| Google Books Branding Guidelines | <https://developers.google.com/books/branding> |
+| Cover Image Licensing (prior validation) | [cover-image-licensing.md](cover-image-licensing.md) |
+
+> **Disclaimer**: This document reflects a good-faith review of publicly
+> available provider terms as of May 2026. It is not legal advice. Terms
+> may change; verify current terms before implementing new integrations.

--- a/docs/validations/openlibrary-api.md
+++ b/docs/validations/openlibrary-api.md
@@ -1,0 +1,173 @@
+# Validation: Open Library API Rate Limits and Data Quality
+
+**Status**: Validated
+**Date**: 2026-05-30
+**Issue**: [#15](https://github.com/kafkade/toku/issues/15)
+**Affects**: `toku-meta` crate, ISBN lookup, search, cover fetching
+
+## Summary
+
+Open Library is a viable primary metadata source for Toku. Coverage is
+strong for English-language books and popular international editions.
+Key gaps exist in author data at the edition level and Japanese/CJK
+editions.
+
+## Rate Limits
+
+| Endpoint | Stated limit | Observed behavior |
+|---|---|---|
+| Search API (`/search.json`) | 100 req/5 min | No throttling observed at low volume |
+| ISBN API (`/isbn/{isbn}.json`) | 100 req/5 min | No throttling at 5 sequential requests |
+| Covers API (`/b/isbn/{isbn}-L.jpg`) | 100 req/5 min (ISBN-based) | No throttling at low volume |
+
+The stated rate limit of 100 requests per 5 minutes is generous for a
+personal book manager. Toku's usage pattern (single-book lookups
+initiated by the user) will never approach this limit under normal use.
+
+**Recommendation**: No rate-limiting code needed in Toku. Add a simple
+backoff-and-retry for transient 429 responses as a safety net.
+
+## Response Times
+
+Measured from Windows desktop over residential internet (sequential
+requests, no parallelism):
+
+| Query type | Avg | Min | Max | Notes |
+|---|---|---|---|---|
+| ISBN lookup | ~2.9s | 2.1s | 4.2s | Includes 1–2 author resolution sub-requests |
+| Search query | ~2.5s | 2.2s | 3.9s | Single request, no sub-queries |
+| Cover download (L-size) | ~0.6s | 0.4s | 0.8s | Served from CDN, faster than API |
+
+ISBN lookups are slow because each requires a second HTTP request per
+author to resolve `/authors/{key}.json`. A book with 3 authors makes 4
+total requests.
+
+**Recommendation**: Consider fetching author names from the work record
+(`/works/{key}.json`) instead, which includes all authors in one
+response. This would reduce ISBN lookups to 2 requests regardless of
+author count.
+
+## ISBN Lookup Coverage
+
+### English bestsellers — ✅ Excellent
+
+| Book | ISBN | Title | Authors | Pages | Cover |
+|---|---|---|---|---|---|
+| Dune | 9780441172719 | ✅ Dune | ✅ Frank Herbert | ✅ 535 | ✅ Yes |
+| Harry Potter | 9780590353427 | ✅ | ⚠️ Missing | ❌ None | ✅ Yes |
+| The Martian | 9780553418026 | ✅ | ⚠️ Missing | ✅ 388 | — |
+| To Kill a Mockingbird | 9780061120084 | ✅ | ✅ Harper Lee | ✅ 323 | — |
+
+### Non-English titles — ⚠️ Mixed
+
+| Book | ISBN | Title | Authors | Language | Notes |
+|---|---|---|---|---|---|
+| Cien años de soledad (Spanish) | 9788497592208 | ✅ | ✅ García Márquez | ✅ spa | Good coverage |
+| Norwegian Wood (Japanese) | 9784062749688 | ⚠️ Wrong title | — | ✅ jpn | Returns different book |
+
+**Finding**: Spanish editions have good coverage. Japanese ISBNs may
+resolve to incorrect editions. CJK coverage is unreliable.
+
+### Old editions (pre-1970) — ✅ Good
+
+| Book | ISBN | Title | Authors | Pub Date |
+|---|---|---|---|---|
+| To Kill a Mockingbird | 9780061120084 | ✅ | ✅ Harper Lee | 2006 (reprint) |
+| 1984 | 9780451524935 | ✅ Nineteen Eighty-Four | ⚠️ Missing | 1993? |
+
+**Finding**: Classic titles are well-covered but some editions lack
+author links. The `pub_date` field reflects the edition date, not the
+original publication date.
+
+### Self-published — ✅ Adequate
+
+The Martian (originally self-published, later picked up by Crown) is
+present with correct metadata. Self-published books with ISBNs are
+generally findable; those without ISBNs require search.
+
+## Known Data Gaps
+
+### 1. Missing authors at edition level (HIGH impact)
+
+Some editions return an empty `authors` array even when the work record
+has authors. This affects ~30% of tested ISBNs including major titles
+(Harry Potter, 1984, The Martian).
+
+**Root cause**: The edition record references authors via `/authors/{key}`
+but some editions don't include these references. The author data exists
+at the work level (`/works/{key}/authors.json`).
+
+**Mitigation**: Fall back to the work record for author names when the
+edition record has none. Requires an additional API request to
+`/works/{key}.json`.
+
+### 2. Missing page counts (MEDIUM impact)
+
+Harry Potter (9780590353427) returned no `number_of_pages`. Some
+editions simply don't have this field populated.
+
+**Mitigation**: Show "unknown" in CLI. Allow user to fill in manually
+via `toku edit --pages`.
+
+### 3. Missing descriptions (LOW impact)
+
+Tao Te Ching (9780679724346) returned no description. Many older or
+niche editions lack descriptions.
+
+**Mitigation**: Acceptable — descriptions are optional display data.
+
+### 4. Japanese/CJK ISBN resolution (LOW impact for MVP)
+
+ISBN 9784062749688 (Norwegian Wood, Japanese) returned a different book
+entirely. CJK editions may have data quality issues in Open Library.
+
+**Mitigation**: Acceptable for MVP. Japanese users can add books
+manually. Consider adding a "confirm metadata" prompt after ISBN lookup.
+
+### 5. Publication date ambiguity (LOW impact)
+
+`pub_date` is a free-text string (e.g., "1993?", "June 1987", "2006").
+Not always a clean year. The `Original Publication Year` from Goodreads
+is more reliable for original dates.
+
+**Mitigation**: Store as-is; parse best-effort for display.
+
+## Cover Image Quality
+
+| ISBN | Book | File Size | Quality |
+|---|---|---|---|
+| 9780441172719 | Dune | 48 KB | Good (L-size) |
+| 9780590353427 | Harry Potter | 70 KB | Good (L-size) |
+| 9799999999999 | (bogus) | — | Correctly returns no cover |
+
+**Findings**:
+
+- L-size covers (`-L.jpg`) are 48–70 KB, suitable for display
+- The `?default=false` parameter correctly returns 404 for missing covers
+- Placeholder detection (< 1000 bytes) works as implemented
+- Cover CDN is faster than the API (~400–800ms vs ~2–3s)
+
+## Recommendations for `toku-meta`
+
+1. **Author fallback**: When edition authors are empty, fetch the work
+   record to get author names. This is the highest-impact improvement.
+2. **No rate limiting needed**: Usage pattern is well within limits.
+   Add retry-with-backoff for transient errors only.
+3. **Cache API responses**: Store raw metadata locally to avoid repeat
+   lookups for the same ISBN. Already planned per API guidelines.
+4. **User agent**: Update from `toku/0.1.0` to current version.
+
+## Integration Tests
+
+16 validation tests added in
+`crates/toku-meta/tests/openlibrary_validation.rs`:
+
+- 9 ISBN lookup tests (bestsellers, non-English, old editions,
+  self-published, not-found, sparse data)
+- 3 search tests (title, author, non-English)
+- 3 cover tests (available, not available, quality check)
+- 1 response time benchmark (5 sequential ISBNs)
+
+Run with: `cargo test -p toku-meta -- --ignored`
+
+All tests are `#[ignore]` to avoid hitting the network in CI.


### PR DESCRIPTION
## Description

Complete the three validation spikes that were blocking metadata and import features:
Goodreads CSV format validation (#14), Open Library API testing (#15), and Google Books
API terms review (#16).

### What's included

- **Goodreads CSV test fixture** — Sample xport.csv with 8 rows covering all edge
  cases (comma in title, multiple authors, no ISBN, no rating, special characters,
  negative publication year, audiobook format, non-standard exclusive shelf). Documented
  in a companion README. New `import_fixture_file_all_edge_cases` test validates all
  edge cases and idempotent re-import.
- **Open Library API validation** — 16 integration tests (`#[ignore]`, run with
  `--ignored`) covering ISBN lookups (bestsellers, non-English, old editions,
  self-published), search queries, cover downloads, and response time benchmarks.
  Findings documented in `docs/validations/openlibrary-api.md`: ~2.9s avg response,
  ~30% of editions lack author data, covers are 48–70KB at L-size.
- **Google Books API terms review** — Full ToS analysis documented in
  `docs/validations/google-books-api.md`: permanent caching prohibited, API keys
  cannot be embedded in open source, cover thumbnails cannot be stored locally.
  Recommendation: defer Google Books; Open Library is sufficient for MVP.
- **ADR-004 updated** — All four open validation items now marked complete. Caching
  policy corrected (OL: permitted, Google: transient only). Google Books section added.
- **Markdownlint config fix** — Enabled `siblings_only` for MD024 rule to allow
  duplicate `### Changed` headings across changelog version sections.

## Related Issues

Closes #14, closes #15, closes #16

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI / infrastructure
- [x] Other (describe below)

Validation spikes: test fixtures, integration tests, and API terms documentation.

## Crate

- [ ] `toku-core` — Domain models, traits, state machine
- [ ] `toku-db` — SQLite persistence, migrations, FTS5
- [x] `toku-import` — Importers (Goodreads, Calibre, StoryGraph)
- [x] `toku-meta` — Metadata fetching (Open Library, Google Books)
- [ ] `toku-cli` — CLI binary
- [ ] `toku-export` — Exporters (CSV, JSON, Markdown, BibTeX)
- [x] `docs/` — Documentation

## Data Integrity Checklist

- [x] No user data is sent to any server without explicit opt-in
- [x] Import operations are idempotent (re-importing the same file creates no duplicates)
- [x] User edits to metadata are never overwritten by auto-enrichment
- [x] New fields track provenance (source + timestamp)
- [x] Export round-trip is preserved (if applicable)

> No data model or import behavior changes — test fixtures and documentation only.

## Checklist

- [x] I have read [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] `cargo fmt --check` passes
- [x] `cargo clippy --workspace -- -D warnings` passes
- [x] `cargo test --workspace` passes
- [x] I have updated documentation (if applicable)