### PR TITLE
feat(web): add statistics dashboard and import wizard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Web statistics dashboard (`toku serve`): reading stats, rating histogram, monthly pace chart, format breakdown donut, top authors and tags — all rendered as server-side SVG with dark mode support
+- Yearly wrap-up pages at `/stats/wrap/{year}` summarizing a single year's reading
+- JSON statistics API at `/api/stats` for programmatic access
+- Web import wizard with step-by-step flow: upload CSV or enter Calibre path → dry-run preview → live progress via SSE → results summary
+- Real-time import progress streaming with Server-Sent Events and automatic reconnect replay
+- Support for Goodreads, StoryGraph, and Calibre imports through the web interface
+
 ## [0.2.1] - 2026-05-30
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -123,6 +123,59 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "axum"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
+dependencies = [
+ "axum-core",
+ "bytes",
+ "form_urlencoded",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "multer",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde_core",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -572,6 +625,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 
 [[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -662,6 +724,12 @@ name = "futures-core"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-sink"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
 
 [[package]]
 name = "futures-task"
@@ -829,6 +897,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
 name = "hybrid-array"
 version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -850,6 +924,7 @@ dependencies = [
  "http",
  "http-body",
  "httparse",
+ "httpdate",
  "itoa",
  "pin-project-lite",
  "smallvec",
@@ -1233,10 +1308,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "matchit"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
+
+[[package]]
+name = "maud"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df518b75016b4289cdddffa1b01f2122f4a49802c93191f3133f6dc2472ebcaa"
+dependencies = [
+ "itoa",
+ "maud_macros",
+]
+
+[[package]]
+name = "maud_macros"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa453238ec218da0af6b11fc5978d3b5c3a45ed97b722391a2a11f3306274e18"
+dependencies = [
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "miniz_oxide"
@@ -1258,6 +1367,23 @@ dependencies = [
  "log",
  "wasi",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "multer"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83e87776546dc87511aa5ee218730c92b666d7264ab6ed41f9d215af9cd5224b"
+dependencies = [
+ "bytes",
+ "encoding_rs",
+ "futures-util",
+ "http",
+ "httparse",
+ "memchr",
+ "mime",
+ "spin",
+ "version_check",
 ]
 
 [[package]]
@@ -1399,6 +1525,29 @@ checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
  "syn",
+]
+
+[[package]]
+name = "proc-macro-error"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
+dependencies = [
+ "proc-macro-error-attr",
+ "proc-macro2",
+ "quote",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "version_check",
 ]
 
 [[package]]
@@ -1871,6 +2020,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_path_to_error"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457"
+dependencies = [
+ "itoa",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
 name = "serde_spanned"
 version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2003,6 +2163,12 @@ dependencies = [
  "libc",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 
 [[package]]
 name = "sqlite-wasm-rs"
@@ -2253,6 +2419,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-stream"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
+ "tokio-util",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "toku-cli"
 version = "0.2.1"
 dependencies = [
@@ -2272,6 +2463,7 @@ dependencies = [
  "toku-export",
  "toku-import",
  "toku-meta",
+ "toku-web",
  "toml 1.1.2+spec-1.1.0",
 ]
 
@@ -2358,6 +2550,24 @@ dependencies = [
  "thiserror",
  "tokio",
  "toku-core",
+]
+
+[[package]]
+name = "toku-web"
+version = "0.2.1"
+dependencies = [
+ "axum",
+ "chrono",
+ "maud",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "tokio",
+ "tokio-stream",
+ "toku-core",
+ "toku-db",
+ "toku-import",
+ "uuid",
 ]
 
 [[package]]
@@ -2453,6 +2663,7 @@ dependencies = [
  "tokio",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -2491,6 +2702,7 @@ version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
+ "log",
  "pin-project-lite",
  "tracing-core",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ members = [
     "crates/toku-export",
     "crates/toku-cli",
     "crates/toku-ffi",
+    "crates/toku-web",
 ]
 
 [workspace.package]
@@ -23,6 +24,7 @@ toku-db = { path = "crates/toku-db", version = "0.2.1" }
 toku-meta = { path = "crates/toku-meta", version = "0.2.1" }
 toku-import = { path = "crates/toku-import", version = "0.2.1" }
 toku-export = { path = "crates/toku-export", version = "0.2.1" }
+toku-web = { path = "crates/toku-web", version = "0.2.1" }
 thiserror = "2"
 uuid = { version = "1", features = ["v7", "serde"] }
 chrono = { version = "0.4", default-features = false, features = ["std", "clock", "serde"] }

--- a/crates/toku-cli/Cargo.toml
+++ b/crates/toku-cli/Cargo.toml
@@ -17,6 +17,7 @@ toku-db.workspace = true
 toku-meta.workspace = true
 toku-import.workspace = true
 toku-export.workspace = true
+toku-web.workspace = true
 clap = { version = "4", features = ["derive", "env"] }
 clap_complete = "4"
 anyhow = "1"

--- a/crates/toku-cli/src/main.rs
+++ b/crates/toku-cli/src/main.rs
@@ -216,6 +216,17 @@ enum Commands {
         mood_trends: bool,
     },
 
+    /// Start the web dashboard server
+    Serve {
+        /// Port to listen on
+        #[arg(long, short, default_value = "3000")]
+        port: u16,
+
+        /// Host to bind (use 127.0.0.1 for local-only access)
+        #[arg(long, default_value = "127.0.0.1")]
+        host: String,
+    },
+
     /// Manage work grouping (link editions of the same creative work)
     Work {
         #[command(subcommand)]
@@ -563,6 +574,18 @@ fn main() -> Result<()> {
             clap_complete::generate(*shell, &mut Cli::command(), "toku", &mut std::io::stdout());
             return Ok(());
         }
+        Commands::Serve { port, host } => {
+            let db_path = data_dir.join("toku.db");
+            let rt = tokio::runtime::Builder::new_multi_thread()
+                .enable_all()
+                .build()
+                .context("failed to build tokio runtime")?;
+            return rt.block_on(async {
+                toku_web::serve(db_path, host, *port)
+                    .await
+                    .map_err(|e| anyhow::anyhow!("{e}"))
+            });
+        }
         _ => {}
     }
 
@@ -652,7 +675,9 @@ fn main() -> Result<()> {
         Commands::Merge { keep, remove } => cmd_merge(&repo, &keep, &remove, &cli.format),
         Commands::Shelf { action } => cmd_shelf(&repo, action, &cli.format),
         // Already handled above
-        Commands::Config { .. } | Commands::Completions { .. } => unreachable!(),
+        Commands::Config { .. } | Commands::Completions { .. } | Commands::Serve { .. } => {
+            unreachable!()
+        }
     }
 }
 

--- a/crates/toku-db/src/database.rs
+++ b/crates/toku-db/src/database.rs
@@ -28,6 +28,17 @@ impl Database {
         Ok(Self { conn })
     }
 
+    /// Open the database without running migrations.
+    ///
+    /// Use this for request-time reads after migrations have already run
+    /// at startup via [`Database::open`].
+    pub fn open_no_migrate(path: &Path) -> Result<Self, DbError> {
+        let conn = Connection::open(path)?;
+        conn.pragma_update(None, "journal_mode", "WAL")?;
+        conn.pragma_update(None, "foreign_keys", "ON")?;
+        Ok(Self { conn })
+    }
+
     /// Open an in-memory database (for testing).
     pub fn open_in_memory() -> Result<Self, DbError> {
         let mut conn = Connection::open_in_memory()?;

--- a/crates/toku-import/src/common.rs
+++ b/crates/toku-import/src/common.rs
@@ -7,7 +7,7 @@ use uuid::Uuid;
 use crate::ImportError;
 
 /// The outcome of processing a single row.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize)]
 pub enum RowOutcome {
     Imported,
     Skipped,
@@ -16,7 +16,7 @@ pub enum RowOutcome {
 }
 
 /// Progress event emitted for each row during import.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize)]
 pub struct ImportEvent {
     pub row: usize,
     pub total: usize,
@@ -33,7 +33,7 @@ pub trait ImportObserver {
 }
 
 /// A short summary of a skipped or imported row, kept for the final report.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize)]
 pub struct RowSummary {
     pub title: String,
     pub author: String,
@@ -43,7 +43,7 @@ pub struct RowSummary {
 pub const MAX_REPORT_SAMPLES: usize = 20;
 
 /// Summary report of an import operation.
-#[derive(Debug, Default)]
+#[derive(Debug, Clone, Default, serde::Serialize)]
 pub struct ImportReport {
     pub total_rows: usize,
     pub imported: usize,

--- a/crates/toku-web/Cargo.toml
+++ b/crates/toku-web/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "toku-web"
+description = "Web dashboard for Toku personal book manager"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[dependencies]
+toku-core.workspace = true
+toku-db.workspace = true
+toku-import.workspace = true
+thiserror.workspace = true
+chrono.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+uuid.workspace = true
+axum = { version = "0.8", features = ["multipart"] }
+maud = "0.26"
+tokio = { workspace = true, features = ["rt-multi-thread", "net", "sync"] }
+tokio-stream = { version = "0.1", features = ["sync"] }

--- a/crates/toku-web/src/charts.rs
+++ b/crates/toku-web/src/charts.rs
@@ -1,0 +1,397 @@
+//! SVG chart generation for the statistics dashboard.
+//!
+//! All charts use CSS custom properties for theming so they automatically
+//! adapt to light/dark mode. Output is raw SVG markup for embedding via
+//! `maud::PreEscaped`.
+
+use std::fmt::Write;
+
+use toku_core::{AuthorCount, FormatBreakdown, MonthlyFinished, RatingDistribution, TagCount};
+
+/// HTML-escape user-supplied text for safe embedding in SVG.
+fn esc(s: &str) -> String {
+    s.replace('&', "&amp;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
+        .replace('"', "&quot;")
+        .replace('\'', "&#x27;")
+}
+
+const MONTH_NAMES: [&str; 12] = [
+    "Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec",
+];
+
+// ── Rating histogram ────────────────────────────────────────────────
+
+/// Vertical bar chart showing count of books at each rating level (0–10,
+/// displayed as 0–5 stars).
+pub fn rating_histogram(dist: &RatingDistribution) -> String {
+    if dist.total_rated == 0 {
+        return empty_state("No rated books yet");
+    }
+
+    let width = 460;
+    let height = 220;
+    let ml = 32;
+    let mr = 12;
+    let mt = 24;
+    let mb = 36;
+    let chart_w = width - ml - mr;
+    let chart_h = height - mt - mb;
+    let bar_count = 11usize;
+    let gap = 6;
+    let bar_w = (chart_w - gap * (bar_count - 1)) / bar_count;
+    let max_val = dist.counts.iter().copied().max().unwrap_or(1).max(1);
+
+    let mut s = String::with_capacity(2048);
+    write!(
+        s,
+        r#"<svg viewBox="0 0 {width} {height}" class="chart" role="img" aria-label="Rating distribution">"#
+    )
+    .unwrap();
+    write!(s, "<title>Rating Distribution</title>").unwrap();
+
+    // Baseline
+    write!(
+        s,
+        r#"<line x1="{ml}" y1="{}" x2="{}" y2="{}" class="chart-axis"/>"#,
+        mt + chart_h,
+        ml + chart_w,
+        mt + chart_h
+    )
+    .unwrap();
+
+    for (i, &count) in dist.counts.iter().enumerate() {
+        let x = ml + i * (bar_w + gap);
+        let bar_h = (count * chart_h).checked_div(max_val).unwrap_or(0);
+        let y = mt + chart_h - bar_h;
+
+        // Bar
+        write!(
+            s,
+            r#"<rect class="chart-bar" x="{x}" y="{y}" width="{bar_w}" height="{bar_h}" rx="3">"#
+        )
+        .unwrap();
+        write!(s, "<title>{count} book(s) rated {i}/10</title>").unwrap();
+        s.push_str("</rect>");
+
+        // Value above bar
+        if count > 0 {
+            let tx = x + bar_w / 2;
+            let ty = y.saturating_sub(5);
+            write!(
+                s,
+                r#"<text class="chart-value" x="{tx}" y="{ty}" text-anchor="middle">{count}</text>"#
+            )
+            .unwrap();
+        }
+
+        // X-axis label (show as star rating)
+        let tx = x + bar_w / 2;
+        let ty = mt + chart_h + 18;
+        let label = if i % 2 == 0 {
+            format!("{}", i / 2)
+        } else {
+            format!("{}.5", i / 2)
+        };
+        write!(
+            s,
+            r#"<text class="chart-label" x="{tx}" y="{ty}" text-anchor="middle">{label}</text>"#
+        )
+        .unwrap();
+    }
+
+    // X-axis title
+    write!(
+        s,
+        r#"<text class="chart-axis-title" x="{}" y="{}" text-anchor="middle">★ Rating</text>"#,
+        ml + chart_w / 2,
+        height - 2
+    )
+    .unwrap();
+
+    s.push_str("</svg>");
+    s
+}
+
+// ── Monthly reading pace ────────────────────────────────────────────
+
+/// Vertical bar chart showing books finished per month.
+pub fn monthly_pace(months: &[MonthlyFinished]) -> String {
+    if months.is_empty() {
+        return empty_state("No finished books yet");
+    }
+
+    let bar_count = months.len();
+    let gap = 4usize;
+    let bar_w = 30usize.min(600 / bar_count.max(1));
+    let ml = 32;
+    let mr = 12;
+    let mt = 24;
+    let mb = 36;
+    let chart_w = bar_count * (bar_w + gap) - gap;
+    let width = ml + chart_w + mr;
+    let chart_h = 160usize;
+    let height = mt + chart_h + mb;
+    let max_val = months.iter().map(|m| m.count).max().unwrap_or(1).max(1);
+
+    let mut s = String::with_capacity(2048);
+    write!(
+        s,
+        r#"<svg viewBox="0 0 {width} {height}" class="chart" role="img" aria-label="Monthly reading pace">"#
+    )
+    .unwrap();
+    write!(s, "<title>Monthly Reading Pace</title>").unwrap();
+
+    // Baseline
+    write!(
+        s,
+        r#"<line x1="{ml}" y1="{}" x2="{}" y2="{}" class="chart-axis"/>"#,
+        mt + chart_h,
+        ml + chart_w,
+        mt + chart_h
+    )
+    .unwrap();
+
+    for (i, m) in months.iter().enumerate() {
+        let x = ml + i * (bar_w + gap);
+        let bar_h = (m.count * chart_h).checked_div(max_val).unwrap_or(0);
+        let y = mt + chart_h - bar_h;
+        let month_name = MONTH_NAMES
+            .get(m.month.saturating_sub(1) as usize)
+            .unwrap_or(&"?");
+
+        write!(
+            s,
+            r#"<rect class="chart-bar" x="{x}" y="{y}" width="{bar_w}" height="{bar_h}" rx="3">"#
+        )
+        .unwrap();
+        write!(
+            s,
+            "<title>{month_name} {}: {} book(s)</title>",
+            m.year, m.count
+        )
+        .unwrap();
+        s.push_str("</rect>");
+
+        if m.count > 0 {
+            let tx = x + bar_w / 2;
+            let ty = y.saturating_sub(5);
+            write!(
+                s,
+                r#"<text class="chart-value" x="{tx}" y="{ty}" text-anchor="middle">{}</text>"#,
+                m.count
+            )
+            .unwrap();
+        }
+
+        // X-axis label — show month (and year if it changes)
+        let tx = x + bar_w / 2;
+        let ty = mt + chart_h + 16;
+        let show_year = i == 0
+            || months
+                .get(i.wrapping_sub(1))
+                .is_some_and(|p| p.year != m.year);
+        let label = if show_year {
+            format!("{month_name} '{}", m.year % 100)
+        } else {
+            (*month_name).to_string()
+        };
+        write!(
+            s,
+            r#"<text class="chart-label" x="{tx}" y="{ty}" text-anchor="middle">{label}</text>"#
+        )
+        .unwrap();
+    }
+
+    s.push_str("</svg>");
+    s
+}
+
+// ── Format breakdown donut ──────────────────────────────────────────
+
+const FORMAT_COLORS: [&str; 3] = ["var(--chart-1)", "var(--chart-2)", "var(--chart-3)"];
+
+/// Donut chart showing physical / ebook / audiobook breakdown.
+pub fn format_donut(breakdown: &FormatBreakdown) -> String {
+    let segments = [
+        ("Physical", breakdown.physical),
+        ("Ebook", breakdown.ebook),
+        ("Audiobook", breakdown.audiobook),
+    ];
+    let total: usize = segments.iter().map(|(_, c)| c).sum();
+
+    if total == 0 {
+        return empty_state("No books in library");
+    }
+
+    let size = 240;
+    let cx = size / 2;
+    let cy = 100;
+    let r = 70usize;
+    let stroke_w = 28;
+    let circumference = 2.0 * std::f64::consts::PI * r as f64;
+
+    let mut s = String::with_capacity(1024);
+    write!(
+        s,
+        r#"<svg viewBox="0 0 {size} 240" class="chart" role="img" aria-label="Format breakdown">"#
+    )
+    .unwrap();
+    write!(s, "<title>Format Breakdown</title>").unwrap();
+
+    let mut offset = 0.0f64;
+    for (i, &(label, count)) in segments.iter().enumerate() {
+        if count == 0 {
+            continue;
+        }
+        let frac = count as f64 / total as f64;
+        let dash = frac * circumference;
+        let gap = circumference - dash;
+        let color = FORMAT_COLORS[i];
+
+        write!(
+            s,
+            r#"<circle cx="{cx}" cy="{cy}" r="{r}" fill="none" stroke="{color}" stroke-width="{stroke_w}" stroke-dasharray="{dash:.1} {gap:.1}" stroke-dashoffset="{offset:.1}" transform="rotate(-90 {cx} {cy})">"#
+        ).unwrap();
+        write!(s, "<title>{label}: {count} ({:.0}%)</title>", frac * 100.0).unwrap();
+        s.push_str("</circle>");
+        offset -= dash;
+    }
+
+    // Center label
+    write!(
+        s,
+        r#"<text x="{cx}" y="{}" text-anchor="middle" class="chart-center-value">{total}</text>"#,
+        cy - 4
+    )
+    .unwrap();
+    write!(
+        s,
+        r#"<text x="{cx}" y="{}" text-anchor="middle" class="chart-center-label">books</text>"#,
+        cy + 14
+    )
+    .unwrap();
+
+    // Legend
+    let legend_y = cy + r + 36;
+    let mut lx = 10usize;
+    for (i, &(label, count)) in segments.iter().enumerate() {
+        if count == 0 {
+            continue;
+        }
+        let color = FORMAT_COLORS[i];
+        write!(
+            s,
+            r#"<rect x="{lx}" y="{}" width="12" height="12" rx="2" fill="{color}"/>"#,
+            legend_y - 10
+        )
+        .unwrap();
+        write!(
+            s,
+            r#"<text x="{}" y="{legend_y}" class="chart-legend">{label} ({count})</text>"#,
+            lx + 16
+        )
+        .unwrap();
+        lx += 16 + label.len() * 7 + format!(" ({count})").len() * 7 + 12;
+    }
+
+    s.push_str("</svg>");
+    s
+}
+
+// ── Horizontal bar chart (tags, authors) ────────────────────────────
+
+/// Horizontal bar chart for tag distribution (top N items).
+pub fn tag_bar_chart(tags: &[TagCount], max_items: usize) -> String {
+    let items: Vec<(&str, usize)> = tags
+        .iter()
+        .take(max_items)
+        .map(|t| (t.name.as_str(), t.count))
+        .collect();
+    horizontal_bars(&items, "Tag distribution")
+}
+
+/// Horizontal bar chart for top authors.
+pub fn author_bar_chart(authors: &[AuthorCount], max_items: usize) -> String {
+    let items: Vec<(&str, usize)> = authors
+        .iter()
+        .take(max_items)
+        .map(|a| (a.name.as_str(), a.count))
+        .collect();
+    horizontal_bars(&items, "Top authors")
+}
+
+fn horizontal_bars(items: &[(&str, usize)], title: &str) -> String {
+    if items.is_empty() {
+        return empty_state(&format!("No {title} data"));
+    }
+
+    let max_label_len = items.iter().map(|(l, _)| l.len()).max().unwrap_or(0);
+    let label_w = (max_label_len * 7 + 12).min(140);
+    let bar_area = 260;
+    let value_w = 40;
+    let width = label_w + bar_area + value_w;
+    let row_h = 28usize;
+    let gap = 4usize;
+    let mt = 8;
+    let height = mt + items.len() * (row_h + gap);
+    let max_val = items.iter().map(|(_, v)| *v).max().unwrap_or(1).max(1);
+
+    let mut s = String::with_capacity(2048);
+    write!(
+        s,
+        r#"<svg viewBox="0 0 {width} {height}" class="chart" role="img" aria-label="{title}">"#
+    )
+    .unwrap();
+    write!(s, "<title>{title}</title>").unwrap();
+
+    for (i, &(label, count)) in items.iter().enumerate() {
+        let y = mt + i * (row_h + gap);
+        let bar_w = (count * bar_area).checked_div(max_val).unwrap_or(0);
+
+        // Label (right-aligned)
+        let truncated = if label.len() > 18 {
+            format!("{}…", &label[..17])
+        } else {
+            label.to_string()
+        };
+        write!(
+            s,
+            r#"<text class="chart-h-label" x="{}" y="{}" text-anchor="end" dominant-baseline="middle">{}</text>"#,
+            label_w - 4,
+            y + row_h / 2,
+            esc(&truncated)
+        )
+        .unwrap();
+
+        // Bar
+        write!(
+            s,
+            r#"<rect class="chart-bar" x="{label_w}" y="{y}" width="{bar_w}" height="{row_h}" rx="3">"#
+        )
+        .unwrap();
+        write!(s, "<title>{}: {count}</title>", esc(label)).unwrap();
+        s.push_str("</rect>");
+
+        // Value
+        write!(
+            s,
+            r#"<text class="chart-h-value" x="{}" y="{}" dominant-baseline="middle">{count}</text>"#,
+            label_w + bar_w + 6,
+            y + row_h / 2
+        )
+        .unwrap();
+    }
+
+    s.push_str("</svg>");
+    s
+}
+
+// ── Empty state ─────────────────────────────────────────────────────
+
+fn empty_state(message: &str) -> String {
+    format!(
+        r#"<svg viewBox="0 0 300 80" class="chart chart-empty" role="img" aria-label="{message}"><text x="150" y="45" text-anchor="middle" class="chart-empty-text">{message}</text></svg>"#
+    )
+}

--- a/crates/toku-web/src/error.rs
+++ b/crates/toku-web/src/error.rs
@@ -1,0 +1,25 @@
+use axum::http::StatusCode;
+use axum::response::{IntoResponse, Response};
+
+#[derive(Debug, thiserror::Error)]
+pub enum WebError {
+    #[error("database error: {0}")]
+    Database(#[from] toku_db::DbError),
+
+    #[error("import error: {0}")]
+    Import(#[from] toku_import::ImportError),
+
+    #[error("internal error: {0}")]
+    Internal(String),
+}
+
+impl IntoResponse for WebError {
+    fn into_response(self) -> Response {
+        let status = match &self {
+            WebError::Database(_) => StatusCode::INTERNAL_SERVER_ERROR,
+            WebError::Import(_) => StatusCode::INTERNAL_SERVER_ERROR,
+            WebError::Internal(_) => StatusCode::INTERNAL_SERVER_ERROR,
+        };
+        (status, self.to_string()).into_response()
+    }
+}

--- a/crates/toku-web/src/handlers.rs
+++ b/crates/toku-web/src/handlers.rs
@@ -1,0 +1,145 @@
+//! Axum route handlers for the statistics dashboard.
+
+use std::collections::HashMap;
+
+use axum::extract::{Path, Query, State};
+use axum::response::{Html, Redirect};
+use chrono::Datelike;
+use toku_core::{CurrentlyReadingInput, StatsInput, compute_stats};
+use toku_db::{BookRepository, Database};
+
+use crate::AppState;
+use crate::error::WebError;
+use crate::views;
+
+/// `GET /` → redirect to `/stats`.
+pub async fn root() -> Redirect {
+    Redirect::permanent("/stats")
+}
+
+#[derive(serde::Deserialize)]
+pub struct StatsQuery {
+    pub year: Option<i32>,
+}
+
+/// `GET /stats` — main statistics dashboard.
+pub async fn stats_dashboard(
+    State(state): State<AppState>,
+    Query(query): Query<StatsQuery>,
+) -> Result<Html<String>, WebError> {
+    let db_path = state.db_path.clone();
+    let year = query.year;
+
+    let (stats, available_years) =
+        tokio::task::spawn_blocking(move || gather_stats(&db_path, year))
+            .await
+            .map_err(|e| WebError::Internal(e.to_string()))??;
+
+    Ok(Html(
+        views::dashboard(&stats, year, &available_years).into_string(),
+    ))
+}
+
+/// `GET /stats/wrap/:year` — yearly wrap-up.
+pub async fn yearly_wrap(
+    State(state): State<AppState>,
+    Path(year): Path<i32>,
+) -> Result<Html<String>, WebError> {
+    let db_path = state.db_path.clone();
+
+    let (stats, _) = tokio::task::spawn_blocking(move || gather_stats(&db_path, Some(year)))
+        .await
+        .map_err(|e| WebError::Internal(e.to_string()))??;
+
+    Ok(Html(views::yearly_wrap(&stats, year).into_string()))
+}
+
+/// `GET /api/stats` — JSON statistics endpoint.
+pub async fn stats_json(
+    State(state): State<AppState>,
+    Query(query): Query<StatsQuery>,
+) -> Result<axum::Json<toku_core::ReadingStats>, WebError> {
+    let db_path = state.db_path.clone();
+    let year = query.year;
+
+    let (stats, _) = tokio::task::spawn_blocking(move || gather_stats(&db_path, year))
+        .await
+        .map_err(|e| WebError::Internal(e.to_string()))??;
+
+    Ok(axum::Json(stats))
+}
+
+// ── Data gathering ──────────────────────────────────────────────────
+
+/// Gather stats from the database — runs on a blocking thread.
+///
+/// Returns `(ReadingStats, available_years)`.
+fn gather_stats(
+    db_path: &std::path::Path,
+    year: Option<i32>,
+) -> Result<(toku_core::ReadingStats, Vec<i32>), WebError> {
+    let db = Database::open_no_migrate(db_path)?;
+    let repo = BookRepository::new(&db);
+
+    let books = repo.list_books()?;
+    let book_ids: Vec<String> = books.iter().map(|b| b.id.to_string()).collect();
+
+    let sessions = match year {
+        Some(y) => repo.list_reading_sessions_in_year(y)?,
+        None => repo.list_reading_sessions()?,
+    };
+
+    let currently_reading_details = repo.get_currently_reading_details()?;
+    let currently_reading_input: Vec<CurrentlyReadingInput> = currently_reading_details
+        .into_iter()
+        .map(|(book, progress, authors)| {
+            let author_name = authors
+                .into_iter()
+                .map(|(a, _)| a.name)
+                .collect::<Vec<_>>()
+                .join(", ");
+            CurrentlyReadingInput {
+                title: book.title,
+                author: author_name,
+                page_count: book.page_count,
+                latest_progress: progress,
+            }
+        })
+        .collect();
+
+    let tag_counts = repo.list_tag_counts()?;
+    let author_counts = repo.list_author_book_counts()?;
+
+    let activity_dates = match year {
+        Some(y) => repo.list_activity_dates_in_year(y)?,
+        None => repo.list_activity_dates()?,
+    };
+
+    let now = chrono::Utc::now();
+    let today = chrono::Local::now().date_naive();
+
+    let mood_tag_data: HashMap<String, Vec<String>> = repo.get_mood_tags_for_books(&book_ids)?;
+
+    let stats = compute_stats(StatsInput {
+        books: &books,
+        sessions: &sessions,
+        currently_reading: &currently_reading_input,
+        tag_counts: &tag_counts,
+        author_counts: &author_counts,
+        activity_dates: &activity_dates,
+        now,
+        today,
+        mood_tag_data: &mood_tag_data,
+    });
+
+    // Derive available years from all sessions
+    let all_sessions = repo.list_reading_sessions()?;
+    let mut years: Vec<i32> = all_sessions
+        .iter()
+        .filter_map(|s| s.finished_at.map(|f| f.date_naive().year()))
+        .collect();
+    years.sort();
+    years.dedup();
+
+    Ok((stats, years))
+}

--- a/crates/toku-web/src/import_handlers.rs
+++ b/crates/toku-web/src/import_handlers.rs
@@ -1,0 +1,594 @@
+//! Axum route handlers for the import wizard.
+
+use std::collections::HashMap;
+use std::io::Write;
+use std::path::PathBuf;
+use std::sync::{Arc, Mutex};
+
+use axum::extract::{Multipart, Path, State};
+use axum::response::sse::{Event, KeepAlive};
+use axum::response::{Html, Redirect, Sse};
+use tokio::sync::broadcast;
+use tokio_stream::StreamExt;
+use toku_import::{ImportEvent, ImportObserver, ImportReport, RowOutcome};
+
+use crate::AppState;
+use crate::error::WebError;
+use crate::import_views;
+
+// ── Types ───────────────────────────────────────────────────────────
+
+/// Which import source this session is using.
+#[derive(Debug, Clone)]
+pub enum ImportSourceKind {
+    Goodreads,
+    Calibre { import_covers: bool },
+    StoryGraph,
+}
+
+/// Current status of an import session.
+#[derive(Debug, Clone)]
+pub enum ImportSessionStatus {
+    Preview,
+    Running,
+    Complete,
+    Failed(String),
+}
+
+/// An in-progress or completed import session.
+pub struct ImportSession {
+    pub id: String,
+    pub source: ImportSourceKind,
+    pub file_path: PathBuf,
+    pub status: ImportSessionStatus,
+    pub dry_run_report: Option<ImportReport>,
+    pub final_report: Option<ImportReport>,
+    pub progress_tx: Option<broadcast::Sender<ProgressEvent>>,
+    /// Snapshot of latest progress (for SSE replay on reconnect).
+    pub latest_progress: Option<ProgressEvent>,
+}
+
+/// A progress event sent over SSE.
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct ProgressEvent {
+    pub event_type: String, // "progress", "complete", "error"
+    pub row: usize,
+    pub total: usize,
+    pub title: String,
+    pub imported: usize,
+    pub skipped: usize,
+    pub updated: usize,
+    pub errors: usize,
+}
+
+/// Import session storage type.
+pub type ImportSessions = Arc<Mutex<HashMap<String, ImportSession>>>;
+
+// ── Observer ────────────────────────────────────────────────────────
+
+/// Implements `ImportObserver` by sending events through a broadcast channel.
+struct WebImportObserver {
+    tx: broadcast::Sender<ProgressEvent>,
+    sessions: ImportSessions,
+    session_id: String,
+    imported: usize,
+    skipped: usize,
+    updated: usize,
+    errors: usize,
+}
+
+impl ImportObserver for WebImportObserver {
+    fn on_event(&mut self, event: &ImportEvent) -> Result<(), toku_import::ImportError> {
+        match &event.outcome {
+            RowOutcome::Imported => self.imported += 1,
+            RowOutcome::Skipped => self.skipped += 1,
+            RowOutcome::Updated => self.updated += 1,
+            RowOutcome::Error(_) => self.errors += 1,
+        }
+        let progress = ProgressEvent {
+            event_type: "progress".to_string(),
+            row: event.row,
+            total: event.total,
+            title: event.title.clone(),
+            imported: self.imported,
+            skipped: self.skipped,
+            updated: self.updated,
+            errors: self.errors,
+        };
+        // Store latest progress for SSE replay
+        if let Ok(mut sessions) = self.sessions.lock()
+            && let Some(session) = sessions.get_mut(&self.session_id)
+        {
+            session.latest_progress = Some(progress.clone());
+        }
+        // Ignore send errors — no listeners should not abort import
+        let _ = self.tx.send(progress);
+        Ok(())
+    }
+}
+
+// ── Handlers ────────────────────────────────────────────────────────
+
+/// `GET /import` — import type selection page.
+pub async fn import_page() -> Html<String> {
+    Html(import_views::import_page().into_string())
+}
+
+/// `POST /import/upload` — handle CSV file upload (Goodreads or StoryGraph).
+pub async fn upload_csv(
+    State(state): State<AppState>,
+    mut multipart: Multipart,
+) -> Result<Redirect, WebError> {
+    let mut source: Option<String> = None;
+    let mut file_data: Option<Vec<u8>> = None;
+
+    while let Some(field) = multipart
+        .next_field()
+        .await
+        .map_err(|e| WebError::Internal(format!("multipart error: {e}")))?
+    {
+        match field.name() {
+            Some("source") => {
+                source = Some(
+                    field
+                        .text()
+                        .await
+                        .map_err(|e| WebError::Internal(e.to_string()))?,
+                );
+            }
+            Some("file") => {
+                file_data = Some(
+                    field
+                        .bytes()
+                        .await
+                        .map_err(|e| WebError::Internal(e.to_string()))?
+                        .to_vec(),
+                );
+            }
+            _ => {}
+        }
+    }
+
+    let source_str = source.ok_or_else(|| WebError::Internal("missing source field".into()))?;
+    let data = file_data.ok_or_else(|| WebError::Internal("no file uploaded".into()))?;
+
+    if data.is_empty() {
+        return Err(WebError::Internal("uploaded file is empty".into()));
+    }
+
+    let source_kind = match source_str.as_str() {
+        "goodreads" => ImportSourceKind::Goodreads,
+        "storygraph" => ImportSourceKind::StoryGraph,
+        _ => return Err(WebError::Internal(format!("unknown source: {source_str}"))),
+    };
+
+    // Save uploaded file to temp directory
+    let session_id = uuid::Uuid::now_v7().to_string();
+    let temp_path = state.temp_dir.join(format!("{session_id}.csv"));
+    let mut file = std::fs::File::create(&temp_path)
+        .map_err(|e| WebError::Internal(format!("failed to create temp file: {e}")))?;
+    file.write_all(&data)
+        .map_err(|e| WebError::Internal(format!("failed to write temp file: {e}")))?;
+
+    // Run dry-run
+    let db_path = state.db_path.clone();
+    let temp_path_clone = temp_path.clone();
+    let source_clone = source_kind.clone();
+
+    let report = tokio::task::spawn_blocking(move || -> Result<ImportReport, WebError> {
+        let db = toku_db::Database::open_no_migrate(&db_path)?;
+        match &source_clone {
+            ImportSourceKind::Goodreads => {
+                let opts = toku_import::GoodreadsImportOptions { dry_run: true };
+                Ok(toku_import::import_goodreads(
+                    &db,
+                    &temp_path_clone,
+                    &opts,
+                    None,
+                )?)
+            }
+            ImportSourceKind::StoryGraph => {
+                let opts = toku_import::StorygraphImportOptions { dry_run: true };
+                Ok(toku_import::import_storygraph(
+                    &db,
+                    &temp_path_clone,
+                    &opts,
+                    None,
+                )?)
+            }
+            ImportSourceKind::Calibre { .. } => unreachable!(),
+        }
+    })
+    .await
+    .map_err(|e| WebError::Internal(e.to_string()))??;
+
+    // Create session
+    let session = ImportSession {
+        id: session_id.clone(),
+        source: source_kind,
+        file_path: temp_path,
+        status: ImportSessionStatus::Preview,
+        dry_run_report: Some(report),
+        final_report: None,
+        progress_tx: None,
+        latest_progress: None,
+    };
+
+    state
+        .import_sessions
+        .lock()
+        .map_err(|e| WebError::Internal(e.to_string()))?
+        .insert(session_id.clone(), session);
+
+    Ok(Redirect::to(&format!("/import/preview/{session_id}")))
+}
+
+/// `POST /import/calibre` — handle Calibre library path submission.
+pub async fn submit_calibre_path(
+    State(state): State<AppState>,
+    form: axum::extract::Form<CalibreForm>,
+) -> Result<Redirect, WebError> {
+    let path = PathBuf::from(&form.path);
+
+    // Validate: canonicalize and check metadata.db exists
+    let canonical = path
+        .canonicalize()
+        .map_err(|_| WebError::Internal(format!("path not found: {}", form.path)))?;
+
+    if !canonical.is_dir() {
+        return Err(WebError::Internal(format!(
+            "not a directory: {}",
+            canonical.display()
+        )));
+    }
+
+    let metadata_db = canonical.join("metadata.db");
+    if !metadata_db.exists() {
+        return Err(WebError::Internal(format!(
+            "metadata.db not found in {}",
+            canonical.display()
+        )));
+    }
+
+    let import_covers = form.import_covers.is_some();
+    let session_id = uuid::Uuid::now_v7().to_string();
+
+    // Run dry-run
+    let db_path = state.db_path.clone();
+    let cal_path = canonical.clone();
+
+    let report = tokio::task::spawn_blocking(move || -> Result<ImportReport, WebError> {
+        let db = toku_db::Database::open_no_migrate(&db_path)?;
+        let opts = toku_import::CalibreImportOptions {
+            dry_run: true,
+            import_covers,
+        };
+        Ok(toku_import::import_calibre(&db, &cal_path, &opts)?)
+    })
+    .await
+    .map_err(|e| WebError::Internal(e.to_string()))??;
+
+    let session = ImportSession {
+        id: session_id.clone(),
+        source: ImportSourceKind::Calibre { import_covers },
+        file_path: canonical,
+        status: ImportSessionStatus::Preview,
+        dry_run_report: Some(report),
+        final_report: None,
+        progress_tx: None,
+        latest_progress: None,
+    };
+
+    state
+        .import_sessions
+        .lock()
+        .map_err(|e| WebError::Internal(e.to_string()))?
+        .insert(session_id.clone(), session);
+
+    Ok(Redirect::to(&format!("/import/preview/{session_id}")))
+}
+
+#[derive(serde::Deserialize)]
+pub struct CalibreForm {
+    pub path: String,
+    pub import_covers: Option<String>,
+}
+
+/// `GET /import/preview/{id}` — show dry-run preview.
+pub async fn import_preview(
+    State(state): State<AppState>,
+    Path(id): Path<String>,
+) -> Result<Html<String>, WebError> {
+    let sessions = state
+        .import_sessions
+        .lock()
+        .map_err(|e| WebError::Internal(e.to_string()))?;
+
+    let session = sessions
+        .get(&id)
+        .ok_or_else(|| WebError::Internal("import session not found".into()))?;
+
+    let report = session
+        .dry_run_report
+        .as_ref()
+        .ok_or_else(|| WebError::Internal("no preview available".into()))?;
+
+    Ok(Html(
+        import_views::preview_page(&id, &session.source, report).into_string(),
+    ))
+}
+
+/// `POST /import/execute/{id}` — start the actual import, redirect to progress page.
+pub async fn execute_import(
+    State(state): State<AppState>,
+    Path(id): Path<String>,
+) -> Result<Redirect, WebError> {
+    let (tx, source, file_path) = {
+        let mut sessions = state
+            .import_sessions
+            .lock()
+            .map_err(|e| WebError::Internal(e.to_string()))?;
+
+        let session = sessions
+            .get_mut(&id)
+            .ok_or_else(|| WebError::Internal("import session not found".into()))?;
+
+        let (tx, _rx) = broadcast::channel::<ProgressEvent>(512);
+        session.progress_tx = Some(tx.clone());
+        session.status = ImportSessionStatus::Running;
+
+        (
+            tx.clone(),
+            session.source.clone(),
+            session.file_path.clone(),
+        )
+    }; // Mutex dropped here
+
+    // Spawn the actual import in background
+    let db_path = state.db_path.clone();
+    let sessions = state.import_sessions.clone();
+    let session_id = id.clone();
+    let tx_complete = tx.clone();
+
+    tokio::task::spawn_blocking(move || {
+        let result = run_import(
+            &db_path,
+            &source,
+            &file_path,
+            tx.clone(),
+            sessions.clone(),
+            &session_id,
+        );
+
+        let mut sessions_guard = sessions.lock().unwrap();
+        if let Some(session) = sessions_guard.get_mut(&session_id) {
+            match result {
+                Ok(report) => {
+                    session.final_report = Some(report);
+                    session.status = ImportSessionStatus::Complete;
+                }
+                Err(e) => {
+                    session.status = ImportSessionStatus::Failed(e.to_string());
+                }
+            }
+        }
+
+        // Send terminal event
+        let _ = tx_complete.send(ProgressEvent {
+            event_type: "complete".to_string(),
+            row: 0,
+            total: 0,
+            title: String::new(),
+            imported: 0,
+            skipped: 0,
+            updated: 0,
+            errors: 0,
+        });
+    });
+
+    Ok(Redirect::to(&format!("/import/progress-page/{id}")))
+}
+
+/// `GET /import/progress-page/{id}` — render the progress page (HTML with SSE client).
+pub async fn progress_page(
+    State(state): State<AppState>,
+    Path(id): Path<String>,
+) -> Result<Html<String>, WebError> {
+    let sessions = state
+        .import_sessions
+        .lock()
+        .map_err(|e| WebError::Internal(e.to_string()))?;
+
+    let session = sessions
+        .get(&id)
+        .ok_or_else(|| WebError::Internal("import session not found".into()))?;
+
+    // If already complete, redirect to results
+    if matches!(
+        session.status,
+        ImportSessionStatus::Complete | ImportSessionStatus::Failed(_)
+    ) {
+        drop(sessions);
+        return Ok(Html(format!(
+            r#"<meta http-equiv="refresh" content="0;url=/import/results/{id}">"#
+        )));
+    }
+
+    Ok(Html(
+        import_views::progress_page(&id, &session.source).into_string(),
+    ))
+}
+
+/// `GET /import/progress/{id}` — SSE endpoint streaming progress events.
+pub async fn import_progress_sse(
+    State(state): State<AppState>,
+    Path(id): Path<String>,
+) -> Result<Sse<impl tokio_stream::Stream<Item = Result<Event, std::convert::Infallible>>>, WebError>
+{
+    let (rx, latest, status) = {
+        let sessions = state
+            .import_sessions
+            .lock()
+            .map_err(|e| WebError::Internal(e.to_string()))?;
+
+        let session = sessions
+            .get(&id)
+            .ok_or_else(|| WebError::Internal("import session not found".into()))?;
+
+        let rx = session.progress_tx.as_ref().map(|tx| tx.subscribe());
+        let latest = session.latest_progress.clone();
+        let status = session.status.clone();
+
+        (rx, latest, status)
+    };
+
+    let is_done = matches!(
+        status,
+        ImportSessionStatus::Complete | ImportSessionStatus::Failed(_)
+    );
+
+    // Use an mpsc channel to unify replay + live events into one stream
+    let (tx, mpsc_rx) = tokio::sync::mpsc::channel::<Result<Event, std::convert::Infallible>>(128);
+
+    // Spawn a task to feed events into the channel
+    tokio::spawn(async move {
+        // Replay latest progress
+        if let Some(p) = latest {
+            let json = serde_json::to_string(&p).unwrap_or_default();
+            let _ = tx.send(Ok(Event::default().data(json))).await;
+        }
+
+        if is_done {
+            let complete = complete_event();
+            let json = serde_json::to_string(&complete).unwrap_or_default();
+            let _ = tx.send(Ok(Event::default().data(json))).await;
+            return;
+        }
+
+        // Stream live events from broadcast
+        if let Some(rx) = rx {
+            let mut stream = tokio_stream::wrappers::BroadcastStream::new(rx);
+            while let Some(result) = stream.next().await {
+                if let Ok(event) = result {
+                    let json = serde_json::to_string(&event).unwrap_or_default();
+                    if tx.send(Ok(Event::default().data(json))).await.is_err() {
+                        break; // client disconnected
+                    }
+                }
+            }
+        }
+    });
+
+    let stream = tokio_stream::wrappers::ReceiverStream::new(mpsc_rx);
+    Ok(Sse::new(stream).keep_alive(KeepAlive::default()))
+}
+
+fn complete_event() -> ProgressEvent {
+    ProgressEvent {
+        event_type: "complete".to_string(),
+        row: 0,
+        total: 0,
+        title: String::new(),
+        imported: 0,
+        skipped: 0,
+        updated: 0,
+        errors: 0,
+    }
+}
+
+/// `GET /import/results/{id}` — show final import results.
+pub async fn import_results(
+    State(state): State<AppState>,
+    Path(id): Path<String>,
+) -> Result<Html<String>, WebError> {
+    let sessions = state
+        .import_sessions
+        .lock()
+        .map_err(|e| WebError::Internal(e.to_string()))?;
+
+    let session = sessions
+        .get(&id)
+        .ok_or_else(|| WebError::Internal("import session not found".into()))?;
+
+    match &session.status {
+        ImportSessionStatus::Complete => {
+            let report = session
+                .final_report
+                .as_ref()
+                .ok_or_else(|| WebError::Internal("no report available".into()))?;
+            Ok(Html(
+                import_views::results_page(&session.source, report).into_string(),
+            ))
+        }
+        ImportSessionStatus::Failed(err) => {
+            // Show error as a simple results page
+            let mut report = ImportReport::default();
+            report.error_details.push(err.clone());
+            report.errors = 1;
+            Ok(Html(
+                import_views::results_page(&session.source, &report).into_string(),
+            ))
+        }
+        _ => Err(WebError::Internal("import not yet complete".into())),
+    }
+}
+
+// ── Import execution ────────────────────────────────────────────────
+
+/// Run the actual import (called inside spawn_blocking).
+fn run_import(
+    db_path: &std::path::Path,
+    source: &ImportSourceKind,
+    file_path: &std::path::Path,
+    tx: broadcast::Sender<ProgressEvent>,
+    sessions: ImportSessions,
+    session_id: &str,
+) -> Result<ImportReport, WebError> {
+    let db = toku_db::Database::open_no_migrate(db_path)?;
+
+    match source {
+        ImportSourceKind::Goodreads => {
+            let opts = toku_import::GoodreadsImportOptions { dry_run: false };
+            let mut observer = WebImportObserver {
+                tx,
+                sessions,
+                session_id: session_id.to_string(),
+                imported: 0,
+                skipped: 0,
+                updated: 0,
+                errors: 0,
+            };
+            Ok(toku_import::import_goodreads(
+                &db,
+                file_path,
+                &opts,
+                Some(&mut observer),
+            )?)
+        }
+        ImportSourceKind::StoryGraph => {
+            let opts = toku_import::StorygraphImportOptions { dry_run: false };
+            let mut observer = WebImportObserver {
+                tx,
+                sessions,
+                session_id: session_id.to_string(),
+                imported: 0,
+                skipped: 0,
+                updated: 0,
+                errors: 0,
+            };
+            Ok(toku_import::import_storygraph(
+                &db,
+                file_path,
+                &opts,
+                Some(&mut observer),
+            )?)
+        }
+        ImportSourceKind::Calibre { import_covers } => {
+            let opts = toku_import::CalibreImportOptions {
+                dry_run: false,
+                import_covers: *import_covers,
+            };
+            Ok(toku_import::import_calibre(&db, file_path, &opts)?)
+        }
+    }
+}

--- a/crates/toku-web/src/import_views.rs
+++ b/crates/toku-web/src/import_views.rs
@@ -1,0 +1,568 @@
+//! HTML views for the import wizard.
+
+use maud::{DOCTYPE, Markup, PreEscaped, html};
+use toku_import::ImportReport;
+
+use crate::import_handlers::ImportSourceKind;
+
+/// Wrap content in the base HTML layout (shared with stats views).
+fn base(title: &str, content: Markup) -> Markup {
+    html! {
+        (DOCTYPE)
+        html lang="en" {
+            head {
+                meta charset="utf-8";
+                meta name="viewport" content="width=device-width, initial-scale=1";
+                title { (title) " — Toku" }
+                style { (PreEscaped(CSS)) }
+            }
+            body {
+                header.site-header {
+                    div.header-inner {
+                        a.logo href="/" { "📚 Toku" }
+                        nav {
+                            a.nav-link href="/stats" { "Dashboard" }
+                            " "
+                            a.nav-link href="/import" { "Import" }
+                        }
+                    }
+                }
+                main { (content) }
+            }
+        }
+    }
+}
+
+/// Import type selection page.
+pub fn import_page() -> Markup {
+    base(
+        "Import Library",
+        html! {
+            div.import-page {
+                h1 { "Import Your Library" }
+                p.subtitle { "Choose an import source to get started." }
+
+                div.import-cards {
+                    // Goodreads
+                    div.import-card {
+                        h2 { "📗 Goodreads" }
+                        p { "Import from a Goodreads CSV export." }
+                        form action="/import/upload" method="post" enctype="multipart/form-data" {
+                            input type="hidden" name="source" value="goodreads";
+                            div.form-field {
+                                label for="gr-file" { "CSV file" }
+                                input id="gr-file" type="file" name="file" accept=".csv" required;
+                            }
+                            button.btn type="submit" { "Upload & Preview" }
+                        }
+                    }
+
+                    // StoryGraph
+                    div.import-card {
+                        h2 { "📘 StoryGraph" }
+                        p { "Import from a StoryGraph CSV export." }
+                        form action="/import/upload" method="post" enctype="multipart/form-data" {
+                            input type="hidden" name="source" value="storygraph";
+                            div.form-field {
+                                label for="sg-file" { "CSV file" }
+                                input id="sg-file" type="file" name="file" accept=".csv" required;
+                            }
+                            button.btn type="submit" { "Upload & Preview" }
+                        }
+                    }
+
+                    // Calibre
+                    div.import-card {
+                        h2 { "📙 Calibre" }
+                        p { "Import from a Calibre library directory." }
+                        form action="/import/calibre" method="post" {
+                            div.form-field {
+                                label for="cal-path" { "Library path" }
+                                input id="cal-path" type="text" name="path"
+                                      placeholder="/path/to/Calibre Library" required;
+                            }
+                            div.form-field.checkbox-field {
+                                input id="cal-covers" type="checkbox" name="import_covers" checked;
+                                label for="cal-covers" { "Import cover images" }
+                            }
+                            button.btn type="submit" { "Preview Import" }
+                        }
+                    }
+                }
+            }
+        },
+    )
+}
+
+/// Dry-run preview page.
+pub fn preview_page(session_id: &str, source: &ImportSourceKind, report: &ImportReport) -> Markup {
+    let source_name = match source {
+        ImportSourceKind::Goodreads => "Goodreads",
+        ImportSourceKind::Calibre { .. } => "Calibre",
+        ImportSourceKind::StoryGraph => "StoryGraph",
+    };
+
+    base(
+        &format!("{source_name} Import Preview"),
+        html! {
+            div.preview-page {
+                h1 { (source_name) " Import Preview" }
+                p.subtitle { "This is a dry run — no changes have been made." }
+
+                // Summary counts
+                section.preview-summary {
+                    div.preview-stat.stat-import {
+                        span.stat-value { (report.imported) }
+                        span.stat-label { "to import" }
+                    }
+                    div.preview-stat.stat-skip {
+                        span.stat-value { (report.skipped) }
+                        span.stat-label { "duplicates (skip)" }
+                    }
+                    div.preview-stat.stat-update {
+                        span.stat-value { (report.updated) }
+                        span.stat-label { "to update" }
+                    }
+                    @if report.errors > 0 {
+                        div.preview-stat.stat-error {
+                            span.stat-value { (report.errors) }
+                            span.stat-label { "errors" }
+                        }
+                    }
+                }
+
+                // Status breakdown
+                @if !report.status_counts.is_empty() {
+                    section.preview-section {
+                        h3 { "Status Breakdown" }
+                        div.status-pills {
+                            @for (status, count) in &report.status_counts {
+                                span.status-pill { (status) ": " (count) }
+                            }
+                        }
+                    }
+                }
+
+                // Sample tables
+                @if !report.imported_samples.is_empty() {
+                    section.preview-section {
+                        h3 { "Books to Import (sample)" }
+                        table.sample-table {
+                            thead { tr { th { "Title" } th { "Author" } th { "Status" } } }
+                            tbody {
+                                @for row in &report.imported_samples {
+                                    tr {
+                                        td { (row.title) }
+                                        td { (row.author) }
+                                        td { (row.status) }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+
+                @if !report.skipped_samples.is_empty() {
+                    section.preview-section {
+                        h3 { "Duplicates to Skip (sample)" }
+                        table.sample-table {
+                            thead { tr { th { "Title" } th { "Author" } th { "Status" } } }
+                            tbody {
+                                @for row in &report.skipped_samples {
+                                    tr.row-skipped {
+                                        td { (row.title) }
+                                        td { (row.author) }
+                                        td { (row.status) }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+
+                @if !report.updated_samples.is_empty() {
+                    section.preview-section {
+                        h3 { "Books to Update (sample)" }
+                        table.sample-table {
+                            thead { tr { th { "Title" } th { "Author" } th { "Status" } } }
+                            tbody {
+                                @for row in &report.updated_samples {
+                                    tr.row-updated {
+                                        td { (row.title) }
+                                        td { (row.author) }
+                                        td { (row.status) }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+
+                // Warnings
+                @if !report.warnings.is_empty() {
+                    section.preview-section {
+                        h3 { "Warnings" }
+                        ul.warning-list {
+                            @for w in &report.warnings {
+                                li { (w) }
+                            }
+                        }
+                    }
+                }
+
+                // Errors
+                @if !report.error_details.is_empty() {
+                    section.preview-section {
+                        h3 { "Errors" }
+                        ul.error-list {
+                            @for e in report.error_details.iter().take(10) {
+                                li { (e) }
+                            }
+                        }
+                    }
+                }
+
+                // Actions
+                div.preview-actions {
+                    form action={ "/import/execute/" (session_id) } method="post" {
+                        button.btn.btn-primary type="submit" { "Confirm Import" }
+                    }
+                    a.btn.btn-secondary href="/import" { "Cancel" }
+                }
+            }
+        },
+    )
+}
+
+/// Progress page with SSE-powered live updates.
+pub fn progress_page(session_id: &str, source: &ImportSourceKind) -> Markup {
+    let source_name = match source {
+        ImportSourceKind::Goodreads => "Goodreads",
+        ImportSourceKind::Calibre { .. } => "Calibre",
+        ImportSourceKind::StoryGraph => "StoryGraph",
+    };
+
+    base(
+        &format!("{source_name} Import"),
+        html! {
+            div.progress-page {
+                h1 { "Importing from " (source_name) "…" }
+
+                div.progress-container {
+                    div.progress-bar-outer {
+                        div id="progress-bar" class="progress-bar-inner" style="width:0%" {}
+                    }
+                    p id="progress-text" class="progress-text" { "Starting…" }
+                }
+
+                div.progress-counters {
+                    div.counter { span id="imported-count" class="counter-value" { "0" } span.counter-label { "Imported" } }
+                    div.counter { span id="skipped-count" class="counter-value" { "0" } span.counter-label { "Skipped" } }
+                    div.counter { span id="updated-count" class="counter-value" { "0" } span.counter-label { "Updated" } }
+                    div.counter { span id="error-count" class="counter-value" { "0" } span.counter-label { "Errors" } }
+                }
+
+                p id="current-title" class="current-title" {}
+            }
+
+            // Inline JS for SSE (minimal, offline-compatible)
+            script {
+                (PreEscaped(format!(r#"
+(function() {{
+    var id = '{session_id}';
+    var src = new EventSource('/import/progress/' + id);
+    src.onmessage = function(e) {{
+        var d = JSON.parse(e.data);
+        if (d.event_type === 'complete' || d.event_type === 'error') {{
+            src.close();
+            window.location.href = '/import/results/' + id;
+            return;
+        }}
+        if (d.total > 0) {{
+            var pct = Math.round((d.row / d.total) * 100);
+            document.getElementById('progress-bar').style.width = pct + '%';
+            document.getElementById('progress-text').textContent = d.row + ' / ' + d.total;
+        }}
+        document.getElementById('imported-count').textContent = d.imported;
+        document.getElementById('skipped-count').textContent = d.skipped;
+        document.getElementById('updated-count').textContent = d.updated;
+        document.getElementById('error-count').textContent = d.errors;
+        if (d.title) document.getElementById('current-title').textContent = d.title;
+    }};
+    src.onerror = function() {{
+        src.close();
+        window.location.href = '/import/results/' + id;
+    }};
+}})();
+"#)))
+            }
+        },
+    )
+}
+
+/// Final results page.
+pub fn results_page(source: &ImportSourceKind, report: &ImportReport) -> Markup {
+    let source_name = match source {
+        ImportSourceKind::Goodreads => "Goodreads",
+        ImportSourceKind::Calibre { .. } => "Calibre",
+        ImportSourceKind::StoryGraph => "StoryGraph",
+    };
+
+    base(
+        &format!("{source_name} Import Results"),
+        html! {
+            div.results-page {
+                h1 { "Import Complete" }
+
+                // Summary
+                section.results-summary {
+                    div.result-stat {
+                        span.stat-value { (report.total_rows) }
+                        span.stat-label { "Total Rows" }
+                    }
+                    div.result-stat.stat-import {
+                        span.stat-value { (report.imported) }
+                        span.stat-label { "Imported" }
+                    }
+                    div.result-stat.stat-skip {
+                        span.stat-value { (report.skipped) }
+                        span.stat-label { "Skipped" }
+                    }
+                    div.result-stat.stat-update {
+                        span.stat-value { (report.updated) }
+                        span.stat-label { "Updated" }
+                    }
+                    @if report.errors > 0 {
+                        div.result-stat.stat-error {
+                            span.stat-value { (report.errors) }
+                            span.stat-label { "Errors" }
+                        }
+                    }
+                }
+
+                // Import ID
+                @if let Some(ref id) = report.import_id {
+                    section.import-id-section {
+                        p {
+                            "Import ID: " code { (id) }
+                        }
+                        p.undo-hint {
+                            "To undo: " code { "toku import undo " (id) }
+                        }
+                    }
+                }
+
+                // Status breakdown
+                @if !report.status_counts.is_empty() {
+                    section.results-section {
+                        h3 { "By Status" }
+                        div.status-pills {
+                            @for (status, count) in &report.status_counts {
+                                span.status-pill { (status) ": " (count) }
+                            }
+                        }
+                    }
+                }
+
+                // Samples
+                @if !report.imported_samples.is_empty() {
+                    section.results-section {
+                        h3 { "Imported (sample)" }
+                        table.sample-table {
+                            thead { tr { th { "Title" } th { "Author" } th { "Status" } } }
+                            tbody {
+                                @for row in &report.imported_samples {
+                                    tr { td { (row.title) } td { (row.author) } td { (row.status) } }
+                                }
+                            }
+                        }
+                    }
+                }
+
+                // Warnings
+                @if !report.warnings.is_empty() {
+                    section.results-section {
+                        h3 { "Warnings (" (report.warnings.len()) ")" }
+                        ul.warning-list {
+                            @for w in report.warnings.iter().take(10) {
+                                li { (w) }
+                            }
+                            @if report.warnings.len() > 10 {
+                                li.more { "… and " (report.warnings.len() - 10) " more" }
+                            }
+                        }
+                    }
+                }
+
+                // Error details
+                @if !report.error_details.is_empty() {
+                    section.results-section {
+                        h3 { "Errors (" (report.error_details.len()) ")" }
+                        ul.error-list {
+                            @for e in report.error_details.iter().take(10) {
+                                li { (e) }
+                            }
+                            @if report.error_details.len() > 10 {
+                                li.more { "… and " (report.error_details.len() - 10) " more" }
+                            }
+                        }
+                    }
+                }
+
+                // Actions
+                div.results-actions {
+                    a.btn href="/import" { "Import Another" }
+                    a.btn.btn-primary href="/stats" { "View Dashboard" }
+                }
+            }
+        },
+    )
+}
+
+// ── CSS ─────────────────────────────────────────────────────────────
+
+const CSS: &str = r#"
+:root {
+    --bg: #fafafa; --bg-card: #ffffff; --text: #1a1a2e;
+    --text-secondary: #64748b; --border: #e2e8f0;
+    --accent: #6366f1; --accent-hover: #4f46e5;
+    --success: #10b981; --warning: #f59e0b; --danger: #ef4444;
+    --info: #06b6d4;
+    --progress-bg: #e2e8f0; --progress-fill: #6366f1;
+}
+@media (prefers-color-scheme: dark) {
+    :root {
+        --bg: #0f172a; --bg-card: #1e293b; --text: #e2e8f0;
+        --text-secondary: #94a3b8; --border: #334155;
+        --accent: #818cf8; --accent-hover: #6366f1;
+        --success: #34d399; --warning: #fbbf24; --danger: #f87171;
+        --info: #22d3ee;
+        --progress-bg: #334155; --progress-fill: #818cf8;
+    }
+}
+
+* { margin: 0; padding: 0; box-sizing: border-box; }
+body {
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
+                 "Helvetica Neue", Arial, sans-serif;
+    background: var(--bg); color: var(--text); line-height: 1.6;
+}
+
+/* Header */
+.site-header { background: var(--bg-card); border-bottom: 1px solid var(--border); padding: 0.75rem 1.5rem; }
+.header-inner { max-width: 1100px; margin: 0 auto; display: flex; align-items: center; justify-content: space-between; }
+.logo { font-size: 1.25rem; font-weight: 700; color: var(--text); text-decoration: none; }
+.nav-link { color: var(--accent); text-decoration: none; font-weight: 500; }
+.nav-link:hover { text-decoration: underline; }
+main { max-width: 900px; margin: 0 auto; padding: 1.5rem; }
+
+/* Import page */
+.import-page h1 { font-size: 1.75rem; margin-bottom: 0.25rem; }
+.subtitle { color: var(--text-secondary); margin-bottom: 1.5rem; }
+.import-cards { display: grid; grid-template-columns: repeat(auto-fit, minmax(260px, 1fr)); gap: 1rem; }
+.import-card {
+    background: var(--bg-card); border: 1px solid var(--border);
+    border-radius: 10px; padding: 1.5rem;
+}
+.import-card h2 { font-size: 1.15rem; margin-bottom: 0.5rem; }
+.import-card p { font-size: 0.9rem; color: var(--text-secondary); margin-bottom: 1rem; }
+
+/* Forms */
+.form-field { margin-bottom: 1rem; }
+.form-field label { display: block; font-size: 0.85rem; font-weight: 500; margin-bottom: 0.25rem; }
+.form-field input[type="text"],
+.form-field input[type="file"] {
+    width: 100%; padding: 0.5rem 0.75rem; border: 1px solid var(--border);
+    border-radius: 6px; background: var(--bg); color: var(--text); font-size: 0.9rem;
+}
+.checkbox-field { display: flex; align-items: center; gap: 0.5rem; }
+.checkbox-field label { margin-bottom: 0; }
+.btn {
+    display: inline-block; padding: 0.5rem 1.25rem; border-radius: 6px;
+    font-size: 0.9rem; font-weight: 500; cursor: pointer; text-decoration: none;
+    border: 1px solid var(--border); background: var(--bg-card); color: var(--text);
+    transition: background 0.15s, border-color 0.15s;
+}
+.btn:hover { border-color: var(--accent); color: var(--accent); }
+.btn-primary { background: var(--accent); color: #fff; border-color: var(--accent); }
+.btn-primary:hover { background: var(--accent-hover); }
+.btn-secondary { margin-left: 0.5rem; }
+
+/* Preview */
+.preview-page h1 { font-size: 1.5rem; margin-bottom: 0.25rem; }
+.preview-summary, .results-summary {
+    display: flex; flex-wrap: wrap; gap: 1rem; margin: 1.5rem 0;
+}
+.preview-stat, .result-stat {
+    background: var(--bg-card); border: 1px solid var(--border);
+    border-radius: 10px; padding: 1rem 1.5rem; text-align: center; min-width: 120px;
+}
+.stat-value { display: block; font-size: 2rem; font-weight: 700; }
+.stat-label { display: block; font-size: 0.8rem; color: var(--text-secondary); }
+.stat-import .stat-value { color: var(--success); }
+.stat-skip .stat-value { color: var(--text-secondary); }
+.stat-update .stat-value { color: var(--info); }
+.stat-error .stat-value { color: var(--danger); }
+
+.preview-section, .results-section { margin-bottom: 1.5rem; }
+.preview-section h3, .results-section h3 {
+    font-size: 1rem; margin-bottom: 0.5rem; color: var(--text-secondary);
+}
+.status-pills { display: flex; flex-wrap: wrap; gap: 0.5rem; }
+.status-pill {
+    background: var(--bg-card); border: 1px solid var(--border);
+    border-radius: 20px; padding: 0.25rem 0.75rem; font-size: 0.85rem;
+}
+
+/* Tables */
+.sample-table { width: 100%; border-collapse: collapse; font-size: 0.9rem; }
+.sample-table th { text-align: left; padding: 0.5rem; border-bottom: 2px solid var(--border); color: var(--text-secondary); font-weight: 600; }
+.sample-table td { padding: 0.5rem; border-bottom: 1px solid var(--border); }
+.row-skipped td { color: var(--text-secondary); }
+.row-updated td { color: var(--info); }
+
+.warning-list, .error-list { list-style: none; padding: 0; }
+.warning-list li { padding: 0.25rem 0; color: var(--warning); font-size: 0.9rem; }
+.error-list li { padding: 0.25rem 0; color: var(--danger); font-size: 0.9rem; }
+.more { color: var(--text-secondary); font-style: italic; }
+
+.preview-actions, .results-actions { margin-top: 2rem; display: flex; gap: 0.5rem; }
+
+/* Progress */
+.progress-page { text-align: center; }
+.progress-page h1 { font-size: 1.5rem; margin-bottom: 1.5rem; }
+.progress-container { max-width: 500px; margin: 0 auto 2rem; }
+.progress-bar-outer {
+    height: 12px; background: var(--progress-bg); border-radius: 6px; overflow: hidden;
+}
+.progress-bar-inner {
+    height: 100%; background: var(--progress-fill); border-radius: 6px;
+    transition: width 0.2s; min-width: 2%;
+}
+.progress-text { margin-top: 0.5rem; color: var(--text-secondary); font-size: 0.9rem; }
+.progress-counters {
+    display: flex; justify-content: center; gap: 1.5rem; margin-bottom: 1.5rem; flex-wrap: wrap;
+}
+.counter { text-align: center; }
+.counter-value { display: block; font-size: 1.5rem; font-weight: 700; }
+.counter-label { font-size: 0.8rem; color: var(--text-secondary); }
+.current-title { color: var(--text-secondary); font-size: 0.9rem; min-height: 1.5em; }
+
+/* Import ID */
+.import-id-section {
+    background: var(--bg-card); border: 1px solid var(--border);
+    border-radius: 10px; padding: 1rem 1.25rem; margin-bottom: 1.5rem;
+}
+.import-id-section code {
+    background: var(--bg); padding: 0.15rem 0.4rem; border-radius: 4px;
+    font-size: 0.85rem;
+}
+.undo-hint { font-size: 0.85rem; color: var(--text-secondary); margin-top: 0.25rem; }
+
+/* Responsive */
+@media (max-width: 640px) {
+    .import-cards { grid-template-columns: 1fr; }
+    .preview-summary, .results-summary { flex-direction: column; }
+    .progress-counters { gap: 1rem; }
+}
+"#;

--- a/crates/toku-web/src/lib.rs
+++ b/crates/toku-web/src/lib.rs
@@ -1,0 +1,95 @@
+//! Web dashboard for Toku — serves the statistics UI and import wizard.
+//!
+//! Built with Axum and maud (server-side HTML). Charts are rendered as
+//! inline SVG — no external JavaScript dependencies.
+
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::sync::{Arc, Mutex};
+
+use axum::Router;
+use axum::routing::{get, post};
+
+mod charts;
+mod error;
+mod handlers;
+pub mod import_handlers;
+mod import_views;
+mod views;
+
+pub use error::WebError;
+
+/// Shared application state for Axum handlers.
+#[derive(Clone)]
+pub struct AppState {
+    pub db_path: PathBuf,
+    pub import_sessions: import_handlers::ImportSessions,
+    pub temp_dir: PathBuf,
+}
+
+/// Build the Axum router for the web dashboard.
+pub fn build_router(db_path: PathBuf, temp_dir: PathBuf) -> Router {
+    let state = AppState {
+        db_path,
+        import_sessions: Arc::new(Mutex::new(HashMap::new())),
+        temp_dir,
+    };
+
+    Router::new()
+        // Stats
+        .route("/", get(handlers::root))
+        .route("/stats", get(handlers::stats_dashboard))
+        .route("/stats/wrap/{year}", get(handlers::yearly_wrap))
+        .route("/api/stats", get(handlers::stats_json))
+        // Import wizard
+        .route("/import", get(import_handlers::import_page))
+        .route("/import/upload", post(import_handlers::upload_csv))
+        .route(
+            "/import/calibre",
+            post(import_handlers::submit_calibre_path),
+        )
+        .route("/import/preview/{id}", get(import_handlers::import_preview))
+        .route(
+            "/import/execute/{id}",
+            post(import_handlers::execute_import),
+        )
+        .route(
+            "/import/progress-page/{id}",
+            get(import_handlers::progress_page),
+        )
+        .route(
+            "/import/progress/{id}",
+            get(import_handlers::import_progress_sse),
+        )
+        .route("/import/results/{id}", get(import_handlers::import_results))
+        .with_state(state)
+}
+
+/// Start the web dashboard server.
+///
+/// Runs migrations once, then serves the dashboard on `{host}:{port}`.
+pub async fn serve(db_path: PathBuf, host: &str, port: u16) -> Result<(), WebError> {
+    // Run migrations once at startup
+    toku_db::Database::open(&db_path)
+        .map_err(|e| WebError::Internal(format!("failed to open database: {e}")))?;
+
+    // Create temp directory for uploads
+    let temp_dir = std::env::temp_dir().join("toku-web-uploads");
+    std::fs::create_dir_all(&temp_dir)
+        .map_err(|e| WebError::Internal(format!("failed to create temp dir: {e}")))?;
+
+    let app = build_router(db_path, temp_dir);
+
+    let addr = format!("{host}:{port}");
+    let listener = tokio::net::TcpListener::bind(&addr)
+        .await
+        .map_err(|e| WebError::Internal(format!("failed to bind {addr}: {e}")))?;
+
+    eprintln!("Toku dashboard → http://{addr}/stats");
+
+    axum::serve(listener, app)
+        .await
+        .map_err(|e| WebError::Internal(format!("server error: {e}")))?;
+
+    Ok(())
+}

--- a/crates/toku-web/src/views.rs
+++ b/crates/toku-web/src/views.rs
@@ -1,0 +1,697 @@
+//! HTML view rendering using maud.
+
+use maud::{DOCTYPE, Markup, PreEscaped, html};
+use toku_core::ReadingStats;
+
+use crate::charts;
+
+/// Wrap content in the base HTML layout.
+fn base(title: &str, content: Markup) -> Markup {
+    html! {
+        (DOCTYPE)
+        html lang="en" {
+            head {
+                meta charset="utf-8";
+                meta name="viewport" content="width=device-width, initial-scale=1";
+                title { (title) " — Toku" }
+                style { (PreEscaped(CSS)) }
+            }
+            body {
+                header.site-header {
+                    div.header-inner {
+                        a.logo href="/" { "📚 Toku" }
+                        nav {
+                            a.nav-link href="/stats" { "Dashboard" }
+                            " "
+                            a.nav-link href="/import" { "Import" }
+                        }
+                    }
+                }
+                main { (content) }
+                footer.site-footer {
+                    p { "Toku — your private reading tracker" }
+                }
+            }
+        }
+    }
+}
+
+/// Render the main statistics dashboard.
+pub fn dashboard(stats: &ReadingStats, year: Option<i32>, available_years: &[i32]) -> Markup {
+    let content = dashboard_content(stats, year, available_years);
+    let title = match year {
+        Some(y) => format!("{y} Reading Dashboard"),
+        None => "Reading Dashboard".to_string(),
+    };
+    base(&title, content)
+}
+
+/// Just the dashboard content (for potential HTMX partial updates).
+pub fn dashboard_content(
+    stats: &ReadingStats,
+    year: Option<i32>,
+    available_years: &[i32],
+) -> Markup {
+    html! {
+        div.dashboard {
+            // Header with year selector
+            div.dashboard-header {
+                h1 {
+                    @if let Some(y) = year {
+                        (y) " Reading Dashboard"
+                    } @else {
+                        "Reading Dashboard"
+                    }
+                }
+                @if !available_years.is_empty() {
+                    nav.year-nav {
+                        @let all_cls = if year.is_none() { "year-link active" } else { "year-link" };
+                        a class=(all_cls) href="/stats" { "All Time" }
+                        @for &y in available_years {
+                            @let cls = if year == Some(y) { "year-link active" } else { "year-link" };
+                            a class=(cls)
+                              href={ "/stats?year=" (y) }
+                            { (y) }
+                        }
+                    }
+                }
+            }
+
+            // Key metrics
+            section.metrics {
+                (metric_card("Books Read", &stats.books_read.to_string(), "📖"))
+                (metric_card("Currently Reading", &stats.books_reading.to_string(), "📕"))
+                (metric_card("Want to Read", &stats.books_want_to_read.to_string(), "📋"))
+                (metric_card("Total Pages", &format_number(stats.total_pages_read), "📄"))
+                (metric_card(
+                    "Avg Rating",
+                    &match stats.average_rating_stars {
+                        Some(r) => format!("{r:.1}★"),
+                        None => "—".to_string(),
+                    },
+                    "⭐"
+                ))
+                (metric_card(
+                    "Books/Month",
+                    &format!("{:.1}", stats.books_per_month),
+                    "📅"
+                ))
+                (metric_card(
+                    "Pages/Day",
+                    &format!("{:.0}", stats.pages_per_day),
+                    "🏃"
+                ))
+                (metric_card(
+                    "Avg Days to Finish",
+                    &match stats.avg_days_to_finish {
+                        Some(d) => format!("{d:.0}"),
+                        None => "—".to_string(),
+                    },
+                    "⏱️"
+                ))
+            }
+
+            // Streaks
+            section.streaks {
+                h2 { "Reading Streaks" }
+                div.streak-cards {
+                    div.streak-card {
+                        span.streak-value { (stats.reading_streaks.current_streak_days) }
+                        span.streak-label { "Current streak (days)" }
+                    }
+                    div.streak-card {
+                        span.streak-value { (stats.reading_streaks.longest_streak_days) }
+                        span.streak-label { "Longest streak (days)" }
+                    }
+                    div.streak-card {
+                        span.streak-value { (stats.reading_streaks.total_active_days) }
+                        span.streak-label { "Total active days" }
+                    }
+                }
+            }
+
+            // Charts row 1: rating + monthly pace
+            section.charts-row {
+                div.chart-card {
+                    h3 { "Rating Distribution" }
+                    (PreEscaped(charts::rating_histogram(&stats.rating_distribution)))
+                }
+                div.chart-card {
+                    h3 { "Monthly Pace" }
+                    (PreEscaped(charts::monthly_pace(&stats.monthly_finished)))
+                }
+            }
+
+            // Charts row 2: format donut + tags
+            section.charts-row {
+                div.chart-card {
+                    h3 { "Format Breakdown" }
+                    (PreEscaped(charts::format_donut(&stats.format_breakdown)))
+                }
+                div.chart-card {
+                    h3 { "Top Tags" }
+                    (PreEscaped(charts::tag_bar_chart(&stats.tag_distribution, 10)))
+                }
+            }
+
+            // Charts row 3: authors
+            section.charts-row {
+                div.chart-card {
+                    h3 { "Top Authors" }
+                    p.chart-subtitle {
+                        (stats.author_stats.unique_count) " unique author(s)"
+                    }
+                    (PreEscaped(charts::author_bar_chart(&stats.author_stats.top_authors, 10)))
+                }
+
+                // Shortest / Longest
+                div.chart-card {
+                    h3 { "Extremes" }
+                    @if let Some(ref shortest) = stats.shortest_book {
+                        p.extremes-item {
+                            span.extremes-label { "Shortest: " }
+                            span.extremes-value { (shortest.title) }
+                            span.extremes-pages { " (" (shortest.page_count) " pp)" }
+                        }
+                    }
+                    @if let Some(ref longest) = stats.longest_book {
+                        p.extremes-item {
+                            span.extremes-label { "Longest: " }
+                            span.extremes-value { (longest.title) }
+                            span.extremes-pages { " (" (longest.page_count) " pp)" }
+                        }
+                    }
+                    @if stats.shortest_book.is_none() && stats.longest_book.is_none() {
+                        p.chart-empty-text { "No page count data" }
+                    }
+                }
+            }
+
+            // Currently reading
+            @if !stats.currently_reading.is_empty() {
+                section.currently-reading {
+                    h2 { "Currently Reading" }
+                    div.reading-list {
+                        @for book in &stats.currently_reading {
+                            div.reading-item {
+                                div.reading-info {
+                                    span.reading-title { (book.title) }
+                                    span.reading-author { (book.author) }
+                                }
+                                @if let Some(pct) = book.percent {
+                                    div.progress-bar {
+                                        div.progress-fill style=(format!("width:{pct:.0}%")) {}
+                                    }
+                                    span.progress-text {
+                                        @if let (Some(page), Some(total)) = (book.latest_page, book.total_pages) {
+                                            (page) "/" (total) " (" (format!("{pct:.0}")) "%)"
+                                        } @else {
+                                            (format!("{pct:.0}")) "%"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
+            // Reading speed
+            @if let Some(speed) = stats.reading_speed_pages_per_hour {
+                section.speed-note {
+                    p {
+                        "Reading speed: " strong { (format!("{speed:.0}")) " pages/hour" }
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// Render the yearly wrap-up page.
+pub fn yearly_wrap(stats: &ReadingStats, year: i32) -> Markup {
+    let content = html! {
+        div.wrap {
+            div.wrap-hero {
+                h1 { (year) " Year in Reading" }
+                p.wrap-subtitle { "Your reading journey this year" }
+            }
+
+            // Headline stats
+            section.wrap-highlights {
+                div.wrap-stat {
+                    span.wrap-big { (stats.books_read) }
+                    span { "books finished" }
+                }
+                div.wrap-stat {
+                    span.wrap-big { (format_number(stats.total_pages_read)) }
+                    span { "pages read" }
+                }
+                div.wrap-stat {
+                    span.wrap-big {
+                        @match stats.average_rating_stars {
+                            Some(r) => { (format!("{r:.1}")) "★" },
+                            None => { "—" },
+                        }
+                    }
+                    span { "average rating" }
+                }
+                div.wrap-stat {
+                    span.wrap-big { (format!("{:.1}", stats.books_per_month)) }
+                    span { "books/month" }
+                }
+            }
+
+            // Streaks
+            section.wrap-section {
+                h2 { "Streaks" }
+                div.streak-cards {
+                    div.streak-card {
+                        span.streak-value { (stats.reading_streaks.longest_streak_days) }
+                        span.streak-label { "Longest streak" }
+                    }
+                    div.streak-card {
+                        span.streak-value { (stats.reading_streaks.total_active_days) }
+                        span.streak-label { "Active days" }
+                    }
+                }
+            }
+
+            // Monthly pace chart
+            @if !stats.monthly_finished.is_empty() {
+                section.wrap-section {
+                    h2 { "Month by Month" }
+                    div.chart-card {
+                        (PreEscaped(charts::monthly_pace(&stats.monthly_finished)))
+                    }
+                }
+            }
+
+            // Rating distribution
+            section.wrap-section {
+                h2 { "Your Ratings" }
+                div.chart-card {
+                    (PreEscaped(charts::rating_histogram(&stats.rating_distribution)))
+                }
+            }
+
+            // Format + Tags
+            section.charts-row {
+                div.chart-card {
+                    h3 { "Formats" }
+                    (PreEscaped(charts::format_donut(&stats.format_breakdown)))
+                }
+                div.chart-card {
+                    h3 { "Top Tags" }
+                    (PreEscaped(charts::tag_bar_chart(&stats.tag_distribution, 10)))
+                }
+            }
+
+            // Authors
+            section.wrap-section {
+                h2 { "Authors" }
+                p { (stats.author_stats.unique_count) " unique author(s) this year" }
+                div.chart-card {
+                    (PreEscaped(charts::author_bar_chart(&stats.author_stats.top_authors, 10)))
+                }
+            }
+
+            // Extremes
+            section.wrap-section {
+                h2 { "Extremes" }
+                div.wrap-extremes {
+                    @if let Some(ref shortest) = stats.shortest_book {
+                        div.wrap-extreme {
+                            span.extremes-label { "Shortest book" }
+                            span.extremes-value { (shortest.title) }
+                            span.extremes-pages { (shortest.page_count) " pages" }
+                        }
+                    }
+                    @if let Some(ref longest) = stats.longest_book {
+                        div.wrap-extreme {
+                            span.extremes-label { "Longest book" }
+                            span.extremes-value { (longest.title) }
+                            span.extremes-pages { (longest.page_count) " pages" }
+                        }
+                    }
+                }
+            }
+
+            div.wrap-footer {
+                a href="/stats" { "← Back to Dashboard" }
+            }
+        }
+    };
+
+    base(&format!("{year} Year in Reading"), content)
+}
+
+// ── Helpers ─────────────────────────────────────────────────────────
+
+fn metric_card(label: &str, value: &str, icon: &str) -> Markup {
+    html! {
+        div.metric-card {
+            span.metric-icon { (icon) }
+            span.metric-value { (value) }
+            span.metric-label { (label) }
+        }
+    }
+}
+
+fn format_number(n: i64) -> String {
+    if n >= 1_000_000 {
+        format!("{:.1}M", n as f64 / 1_000_000.0)
+    } else if n >= 1_000 {
+        format!("{:.1}k", n as f64 / 1_000.0)
+    } else {
+        n.to_string()
+    }
+}
+
+// ── CSS ─────────────────────────────────────────────────────────────
+
+const CSS: &str = r#"
+:root {
+    --bg: #fafafa;
+    --bg-card: #ffffff;
+    --text: #1a1a2e;
+    --text-secondary: #64748b;
+    --border: #e2e8f0;
+    --accent: #6366f1;
+    --accent-hover: #4f46e5;
+    --chart-1: #6366f1;
+    --chart-2: #06b6d4;
+    --chart-3: #10b981;
+    --chart-bar: #6366f1;
+    --chart-bar-hover: #4f46e5;
+    --chart-axis: #cbd5e1;
+    --chart-text: #64748b;
+    --chart-value: #1a1a2e;
+    --streak-bg: #eef2ff;
+    --streak-text: #4338ca;
+    --progress-bg: #e2e8f0;
+    --progress-fill: #6366f1;
+}
+
+@media (prefers-color-scheme: dark) {
+    :root {
+        --bg: #0f172a;
+        --bg-card: #1e293b;
+        --text: #e2e8f0;
+        --text-secondary: #94a3b8;
+        --border: #334155;
+        --accent: #818cf8;
+        --accent-hover: #6366f1;
+        --chart-1: #818cf8;
+        --chart-2: #22d3ee;
+        --chart-3: #34d399;
+        --chart-bar: #818cf8;
+        --chart-bar-hover: #a5b4fc;
+        --chart-axis: #475569;
+        --chart-text: #94a3b8;
+        --chart-value: #e2e8f0;
+        --streak-bg: #312e81;
+        --streak-text: #c7d2fe;
+        --progress-bg: #334155;
+        --progress-fill: #818cf8;
+    }
+}
+
+* { margin: 0; padding: 0; box-sizing: border-box; }
+
+body {
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
+                 "Helvetica Neue", Arial, sans-serif;
+    background: var(--bg);
+    color: var(--text);
+    line-height: 1.6;
+}
+
+/* Header */
+.site-header {
+    background: var(--bg-card);
+    border-bottom: 1px solid var(--border);
+    padding: 0.75rem 1.5rem;
+}
+.header-inner {
+    max-width: 1100px;
+    margin: 0 auto;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+}
+.logo {
+    font-size: 1.25rem;
+    font-weight: 700;
+    color: var(--text);
+    text-decoration: none;
+}
+.nav-link {
+    color: var(--accent);
+    text-decoration: none;
+    font-weight: 500;
+}
+.nav-link:hover { text-decoration: underline; }
+
+/* Footer */
+.site-footer {
+    text-align: center;
+    padding: 2rem 1rem;
+    color: var(--text-secondary);
+    font-size: 0.85rem;
+}
+
+/* Main */
+main {
+    max-width: 1100px;
+    margin: 0 auto;
+    padding: 1.5rem;
+}
+
+/* Dashboard */
+.dashboard-header {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    flex-wrap: wrap;
+    gap: 1rem;
+    margin-bottom: 1.5rem;
+}
+.dashboard-header h1 { font-size: 1.75rem; }
+
+/* Year navigation */
+.year-nav {
+    display: flex;
+    gap: 0.25rem;
+    flex-wrap: wrap;
+}
+.year-link {
+    display: inline-block;
+    padding: 0.3rem 0.75rem;
+    border-radius: 6px;
+    text-decoration: none;
+    font-size: 0.85rem;
+    color: var(--text-secondary);
+    background: var(--bg-card);
+    border: 1px solid var(--border);
+    transition: background 0.15s, color 0.15s;
+}
+.year-link:hover { color: var(--accent); border-color: var(--accent); }
+.year-link.active {
+    background: var(--accent);
+    color: #fff;
+    border-color: var(--accent);
+}
+
+/* Metric cards */
+.metrics {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(140px, 1fr));
+    gap: 0.75rem;
+    margin-bottom: 2rem;
+}
+.metric-card {
+    background: var(--bg-card);
+    border: 1px solid var(--border);
+    border-radius: 10px;
+    padding: 1rem;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    text-align: center;
+}
+.metric-icon { font-size: 1.5rem; margin-bottom: 0.25rem; }
+.metric-value { font-size: 1.5rem; font-weight: 700; }
+.metric-label { font-size: 0.8rem; color: var(--text-secondary); }
+
+/* Streaks */
+.streaks { margin-bottom: 2rem; }
+.streaks h2 { margin-bottom: 0.75rem; }
+.streak-cards {
+    display: flex;
+    gap: 1rem;
+    flex-wrap: wrap;
+}
+.streak-card {
+    background: var(--streak-bg);
+    color: var(--streak-text);
+    border-radius: 10px;
+    padding: 1rem 1.5rem;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    min-width: 140px;
+}
+.streak-value { font-size: 2rem; font-weight: 700; }
+.streak-label { font-size: 0.8rem; }
+
+/* Chart layout */
+.charts-row {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+    gap: 1rem;
+    margin-bottom: 1.5rem;
+}
+.chart-card {
+    background: var(--bg-card);
+    border: 1px solid var(--border);
+    border-radius: 10px;
+    padding: 1.25rem;
+}
+.chart-card h3 {
+    font-size: 1rem;
+    margin-bottom: 0.75rem;
+    color: var(--text-secondary);
+}
+.chart-subtitle {
+    font-size: 0.85rem;
+    color: var(--text-secondary);
+    margin-bottom: 0.5rem;
+}
+
+/* SVG chart styles */
+.chart { width: 100%; height: auto; }
+.chart-bar { fill: var(--chart-bar); transition: fill 0.15s; }
+.chart-bar:hover { fill: var(--chart-bar-hover); }
+.chart-axis { stroke: var(--chart-axis); stroke-width: 1; }
+.chart-label { font-size: 11px; fill: var(--chart-text); }
+.chart-value { font-size: 11px; fill: var(--chart-value); font-weight: 600; }
+.chart-h-label { font-size: 12px; fill: var(--chart-text); }
+.chart-h-value { font-size: 12px; fill: var(--chart-value); font-weight: 600; }
+.chart-center-value { font-size: 24px; font-weight: 700; fill: var(--text); }
+.chart-center-label { font-size: 12px; fill: var(--text-secondary); }
+.chart-legend { font-size: 12px; fill: var(--text-secondary); }
+.chart-empty-text { font-size: 14px; fill: var(--text-secondary); }
+.chart-axis-title { font-size: 11px; fill: var(--text-secondary); }
+
+/* Currently reading */
+.currently-reading { margin-bottom: 2rem; }
+.currently-reading h2 { margin-bottom: 0.75rem; }
+.reading-list { display: flex; flex-direction: column; gap: 0.75rem; }
+.reading-item {
+    background: var(--bg-card);
+    border: 1px solid var(--border);
+    border-radius: 10px;
+    padding: 1rem;
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+    flex-wrap: wrap;
+}
+.reading-info { flex: 1; min-width: 200px; }
+.reading-title { display: block; font-weight: 600; }
+.reading-author { display: block; font-size: 0.85rem; color: var(--text-secondary); }
+.progress-bar {
+    width: 120px;
+    height: 8px;
+    background: var(--progress-bg);
+    border-radius: 4px;
+    overflow: hidden;
+}
+.progress-fill {
+    height: 100%;
+    background: var(--progress-fill);
+    border-radius: 4px;
+    transition: width 0.3s;
+}
+.progress-text { font-size: 0.8rem; color: var(--text-secondary); }
+
+/* Extremes */
+.extremes-item { margin-bottom: 0.5rem; }
+.extremes-label { color: var(--text-secondary); font-size: 0.85rem; }
+.extremes-value { font-weight: 600; }
+.extremes-pages { font-size: 0.85rem; color: var(--text-secondary); }
+
+/* Speed note */
+.speed-note {
+    background: var(--bg-card);
+    border: 1px solid var(--border);
+    border-radius: 10px;
+    padding: 1rem 1.25rem;
+    margin-bottom: 2rem;
+    color: var(--text-secondary);
+}
+
+/* Wrap (yearly) */
+.wrap-hero {
+    text-align: center;
+    padding: 2rem 0;
+}
+.wrap-hero h1 { font-size: 2.25rem; }
+.wrap-subtitle { color: var(--text-secondary); font-size: 1.1rem; }
+
+.wrap-highlights {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+    gap: 1rem;
+    margin-bottom: 2.5rem;
+}
+.wrap-stat {
+    background: var(--bg-card);
+    border: 1px solid var(--border);
+    border-radius: 12px;
+    padding: 1.5rem;
+    text-align: center;
+}
+.wrap-big {
+    display: block;
+    font-size: 2.5rem;
+    font-weight: 800;
+    color: var(--accent);
+}
+
+.wrap-section { margin-bottom: 2rem; }
+.wrap-section h2 { margin-bottom: 0.75rem; }
+
+.wrap-extremes { display: flex; flex-wrap: wrap; gap: 1.5rem; }
+.wrap-extreme {
+    background: var(--bg-card);
+    border: 1px solid var(--border);
+    border-radius: 10px;
+    padding: 1rem 1.25rem;
+    display: flex;
+    flex-direction: column;
+}
+.wrap-extreme .extremes-label { font-size: 0.8rem; text-transform: uppercase; letter-spacing: 0.05em; }
+.wrap-extreme .extremes-value { font-size: 1.1rem; }
+.wrap-extreme .extremes-pages { font-size: 0.85rem; }
+
+.wrap-footer {
+    text-align: center;
+    padding: 2rem 0;
+}
+.wrap-footer a {
+    color: var(--accent);
+    text-decoration: none;
+    font-weight: 500;
+}
+.wrap-footer a:hover { text-decoration: underline; }
+
+/* Responsive */
+@media (max-width: 640px) {
+    .dashboard-header { flex-direction: column; }
+    .metrics { grid-template-columns: repeat(2, 1fr); }
+    .charts-row { grid-template-columns: 1fr; }
+    .streak-cards { flex-direction: column; }
+}
+"#;


### PR DESCRIPTION
## Description

Add a web dashboard to Toku via `toku serve`, providing a browser-based statistics dashboard and import wizard — no JavaScript frameworks required.

### What's included

- **New `toku-web` crate** — Axum server with maud for server-side HTML rendering
- **Statistics dashboard** (`/stats`) — books read, pages, average rating, reading pace, streaks, and five SVG charts (rating histogram, monthly pace, format donut, top authors, top tags) with automatic dark mode
- **Yearly wrap-up** (`/stats/wrap/{year}`) — single-year reading summary
- **JSON API** (`/api/stats`) — programmatic statistics access
- **Import wizard** (`/import`) — four-step flow: select source → dry-run preview → live progress → results summary
- **SSE progress streaming** — real-time import progress with reconnect replay
- **`toku serve` CLI command** — starts the web server with configurable `--port` and `--host`
- **`Database::open_no_migrate()`** — skip migration overhead on per-request DB opens after startup migration
- **`Clone` + `Serialize` derives** on `ImportReport`, `RowSummary`, `RowOutcome`, `ImportEvent` for web serialization

All rendering is server-side (maud + inline SVG). No CDN dependencies — fully offline-capable.

## Related Issues

Closes #47
Closes #48

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI / infrastructure
- [ ] Other (describe below)

## Crate

- [ ] `toku-core` — Domain models, traits, state machine
- [x] `toku-db` — SQLite persistence, migrations, FTS5
- [x] `toku-import` — Importers (Goodreads, Calibre, StoryGraph)
- [ ] `toku-meta` — Metadata fetching (Open Library, Google Books)
- [x] `toku-cli` — CLI binary
- [ ] `toku-export` — Exporters (CSV, JSON, Markdown, BibTeX)
- [ ] `docs/` — Documentation

## Data Integrity Checklist

- [x] No user data is sent to any server without explicit opt-in
- [x] Import operations are idempotent (re-importing the same file creates no duplicates)
- [x] User edits to metadata are never overwritten by auto-enrichment
- [x] New fields track provenance (source + timestamp)
- [x] Export round-trip is preserved (if applicable)

## Checklist

- [x] I have read [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] `cargo fmt --check` passes
- [x] `cargo clippy --workspace -- -D warnings` passes
- [x] `cargo test --workspace` passes
- [x] I have updated documentation (if applicable)