### PR TITLE
feat(web): add web interface with library browser, stats, import, and search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Web import wizard with step-by-step flow: upload CSV or enter Calibre path → dry-run preview → live progress via SSE → results summary
 - Real-time import progress streaming with Server-Sent Events and automatic reconnect replay
 - Support for Goodreads, StoryGraph, and Calibre imports through the web interface
+- Library grid view with book covers, titles, authors, ratings, and status badges in a responsive layout
+- Library list view with sortable table (title, author, status, rating, format, pages, date added)
+- Book detail page with full metadata, reading sessions timeline, progress log, and tags grouped by type
+- FTS5-powered search with status and tag filter dropdowns
+- Cover image serving with content-addressed caching
+- Pagination for large libraries (60 books per page)
+- Filter bar with status, tag, sort controls, and grid/list view toggle
+- ADR-007: Web framework decision documenting the choice of Axum + maud over HTMX and Leptos
 
 ## [0.2.1] - 2026-05-30
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2567,6 +2567,7 @@ dependencies = [
  "toku-core",
  "toku-db",
  "toku-import",
+ "urlencoding",
  "uuid",
 ]
 
@@ -2792,6 +2793,12 @@ dependencies = [
  "percent-encoding",
  "serde",
 ]
+
+[[package]]
+name = "urlencoding"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
 name = "utf8_iter"

--- a/crates/toku-web/Cargo.toml
+++ b/crates/toku-web/Cargo.toml
@@ -20,3 +20,4 @@ axum = { version = "0.8", features = ["multipart"] }
 maud = "0.26"
 tokio = { workspace = true, features = ["rt-multi-thread", "net", "sync"] }
 tokio-stream = { version = "0.1", features = ["sync"] }
+urlencoding = "2"

--- a/crates/toku-web/src/error.rs
+++ b/crates/toku-web/src/error.rs
@@ -9,6 +9,9 @@ pub enum WebError {
     #[error("import error: {0}")]
     Import(#[from] toku_import::ImportError),
 
+    #[error("not found: {0}")]
+    NotFound(String),
+
     #[error("internal error: {0}")]
     Internal(String),
 }
@@ -18,6 +21,7 @@ impl IntoResponse for WebError {
         let status = match &self {
             WebError::Database(_) => StatusCode::INTERNAL_SERVER_ERROR,
             WebError::Import(_) => StatusCode::INTERNAL_SERVER_ERROR,
+            WebError::NotFound(_) => StatusCode::NOT_FOUND,
             WebError::Internal(_) => StatusCode::INTERNAL_SERVER_ERROR,
         };
         (status, self.to_string()).into_response()

--- a/crates/toku-web/src/handlers.rs
+++ b/crates/toku-web/src/handlers.rs
@@ -12,9 +12,9 @@ use crate::AppState;
 use crate::error::WebError;
 use crate::views;
 
-/// `GET /` → redirect to `/stats`.
+/// `GET /` → redirect to `/library`.
 pub async fn root() -> Redirect {
-    Redirect::permanent("/stats")
+    Redirect::permanent("/library")
 }
 
 #[derive(serde::Deserialize)]

--- a/crates/toku-web/src/import_views.rs
+++ b/crates/toku-web/src/import_views.rs
@@ -21,6 +21,10 @@ fn base(title: &str, content: Markup) -> Markup {
                     div.header-inner {
                         a.logo href="/" { "📚 Toku" }
                         nav {
+                            a.nav-link href="/library" { "Library" }
+                            " "
+                            a.nav-link href="/search" { "Search" }
+                            " "
                             a.nav-link href="/stats" { "Dashboard" }
                             " "
                             a.nav-link href="/import" { "Import" }

--- a/crates/toku-web/src/lib.rs
+++ b/crates/toku-web/src/lib.rs
@@ -15,6 +15,8 @@ mod error;
 mod handlers;
 pub mod import_handlers;
 mod import_views;
+pub mod library_handlers;
+mod library_views;
 mod views;
 
 pub use error::WebError;
@@ -25,19 +27,32 @@ pub struct AppState {
     pub db_path: PathBuf,
     pub import_sessions: import_handlers::ImportSessions,
     pub temp_dir: PathBuf,
+    pub covers_dir: PathBuf,
 }
 
 /// Build the Axum router for the web dashboard.
 pub fn build_router(db_path: PathBuf, temp_dir: PathBuf) -> Router {
+    let covers_dir = db_path
+        .parent()
+        .unwrap_or_else(|| std::path::Path::new("."))
+        .join("covers");
+
     let state = AppState {
         db_path,
         import_sessions: Arc::new(Mutex::new(HashMap::new())),
         temp_dir,
+        covers_dir,
     };
 
     Router::new()
-        // Stats
+        // Root
         .route("/", get(handlers::root))
+        // Library
+        .route("/library", get(library_handlers::library_page))
+        .route("/books/{id}", get(library_handlers::book_detail))
+        .route("/search", get(library_handlers::search_page))
+        .route("/covers/{hash}", get(library_handlers::serve_cover))
+        // Stats
         .route("/stats", get(handlers::stats_dashboard))
         .route("/stats/wrap/{year}", get(handlers::yearly_wrap))
         .route("/api/stats", get(handlers::stats_json))

--- a/crates/toku-web/src/library_handlers.rs
+++ b/crates/toku-web/src/library_handlers.rs
@@ -1,0 +1,298 @@
+//! Axum route handlers for the library browser, book detail, search, and cover serving.
+
+use axum::extract::{Path, Query, State};
+use axum::http::{StatusCode, header};
+use axum::response::{Html, IntoResponse};
+use toku_core::{
+    Author, Book, BookAuthor, ContributorRole, ReadingProgress, ReadingSession, ReadingStatus, Tag,
+    TagCount,
+};
+use toku_db::{BookRepository, Database};
+
+use crate::AppState;
+use crate::error::WebError;
+use crate::library_views;
+
+// ── Query params ────────────────────────────────────────────────────
+
+#[derive(serde::Deserialize)]
+pub struct LibraryQuery {
+    pub view: Option<String>,
+    pub status: Option<String>,
+    pub tag: Option<String>,
+    pub sort: Option<String>,
+    pub page: Option<usize>,
+}
+
+#[derive(serde::Deserialize)]
+pub struct SearchQuery {
+    pub q: Option<String>,
+    pub status: Option<String>,
+    pub tag: Option<String>,
+}
+
+// ── Data bundles ────────────────────────────────────────────────────
+
+/// Lightweight book summary for grid/list views.
+pub struct BookCard {
+    pub book: Book,
+    pub author_display: String,
+}
+
+/// Full book detail data bundle.
+pub struct BookDetailData {
+    pub book: Book,
+    pub authors: Vec<(Author, BookAuthor)>,
+    pub tags: Vec<Tag>,
+    pub sessions: Vec<ReadingSession>,
+    pub progress_log: Vec<ReadingProgress>,
+    pub latest_progress: Option<ReadingProgress>,
+}
+
+const PAGE_SIZE: usize = 60;
+
+// ── Handlers ────────────────────────────────────────────────────────
+
+/// `GET /library` — library grid/list view with filters and pagination.
+pub async fn library_page(
+    State(state): State<AppState>,
+    Query(query): Query<LibraryQuery>,
+) -> Result<Html<String>, WebError> {
+    let db_path = state.db_path.clone();
+    let status = query.status.clone();
+    let tag = query.tag.clone();
+    let sort = query.sort.clone().unwrap_or_else(|| "title".into());
+    let page = query.page.unwrap_or(1).max(1);
+
+    let (cards, total, tag_counts) = tokio::task::spawn_blocking(move || {
+        gather_library(&db_path, status.as_deref(), tag.as_deref(), &sort, page)
+    })
+    .await
+    .map_err(|e| WebError::Internal(e.to_string()))??;
+
+    let view = query.view.as_deref().unwrap_or("grid");
+    let total_pages = (total + PAGE_SIZE - 1) / PAGE_SIZE.max(1);
+
+    Ok(Html(
+        library_views::library_page(
+            &cards,
+            view,
+            query.status.as_deref(),
+            query.tag.as_deref(),
+            query.sort.as_deref().unwrap_or("title"),
+            page,
+            total,
+            total_pages,
+            &tag_counts,
+        )
+        .into_string(),
+    ))
+}
+
+/// `GET /books/{id}` — book detail page.
+pub async fn book_detail(
+    State(state): State<AppState>,
+    Path(id): Path<String>,
+) -> Result<Html<String>, WebError> {
+    let db_path = state.db_path.clone();
+
+    let detail = tokio::task::spawn_blocking(move || gather_book_detail(&db_path, &id))
+        .await
+        .map_err(|e| WebError::Internal(e.to_string()))??;
+
+    Ok(Html(library_views::book_detail_page(&detail).into_string()))
+}
+
+/// `GET /search` — search with FTS5 and filters.
+pub async fn search_page(
+    State(state): State<AppState>,
+    Query(query): Query<SearchQuery>,
+) -> Result<Html<String>, WebError> {
+    let db_path = state.db_path.clone();
+    let q = query.q.clone();
+    let status = query.status.clone();
+    let tag = query.tag.clone();
+
+    let (results, tag_counts) = tokio::task::spawn_blocking(move || {
+        gather_search(&db_path, q.as_deref(), status.as_deref(), tag.as_deref())
+    })
+    .await
+    .map_err(|e| WebError::Internal(e.to_string()))??;
+
+    Ok(Html(
+        library_views::search_page(
+            query.q.as_deref(),
+            query.status.as_deref(),
+            query.tag.as_deref(),
+            &results,
+            &tag_counts,
+        )
+        .into_string(),
+    ))
+}
+
+/// `GET /covers/{hash}` — serve a cover image from disk.
+pub async fn serve_cover(
+    State(state): State<AppState>,
+    Path(hash): Path<String>,
+) -> Result<impl IntoResponse, StatusCode> {
+    // Strict validation: hex chars only, max 64 chars
+    if hash.is_empty() || hash.len() > 64 || !hash.chars().all(|c| c.is_ascii_hexdigit()) {
+        return Err(StatusCode::NOT_FOUND);
+    }
+
+    let path = state.covers_dir.join(format!("{hash}.jpg"));
+
+    let data = tokio::task::spawn_blocking(move || std::fs::read(path))
+        .await
+        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?
+        .map_err(|_| StatusCode::NOT_FOUND)?;
+
+    Ok((
+        [(header::CONTENT_TYPE, "image/jpeg")],
+        [(header::CACHE_CONTROL, "public, max-age=31536000, immutable")],
+        data,
+    ))
+}
+
+// ── Data gathering (runs on blocking thread) ────────────────────────
+
+fn gather_library(
+    db_path: &std::path::Path,
+    status: Option<&str>,
+    tag: Option<&str>,
+    sort: &str,
+    page: usize,
+) -> Result<(Vec<BookCard>, usize, Vec<TagCount>), WebError> {
+    let db = Database::open_no_migrate(db_path)?;
+    let repo = BookRepository::new(&db);
+
+    let mut books = match tag {
+        Some(t) => repo.list_books_by_tag(t)?,
+        None => repo.list_books()?,
+    };
+
+    if let Some(s) = status
+        && let Ok(target) = s.parse::<ReadingStatus>()
+    {
+        books.retain(|b| b.status == target);
+    }
+
+    let total = books.len();
+
+    match sort {
+        "rating" => books.sort_by_key(|b| std::cmp::Reverse(b.rating)),
+        "added" => books.sort_by_key(|b| std::cmp::Reverse(b.created_at)),
+        "author" => {
+            // Sort by primary author — requires fetching authors
+            let mut book_authors: Vec<(Book, String)> = books
+                .into_iter()
+                .map(|b| {
+                    let author = primary_author(&repo, &b);
+                    (b, author)
+                })
+                .collect();
+            book_authors.sort_by_key(|a| a.1.to_lowercase());
+
+            let start = (page - 1) * PAGE_SIZE;
+            let cards = book_authors
+                .into_iter()
+                .skip(start)
+                .take(PAGE_SIZE)
+                .map(|(book, author_display)| BookCard {
+                    book,
+                    author_display,
+                })
+                .collect();
+
+            let tag_counts = repo.list_tag_counts()?;
+            return Ok((cards, total, tag_counts));
+        }
+        _ => {} // already sorted by title from repo
+    }
+
+    let start = (page - 1) * PAGE_SIZE;
+    let page_books: Vec<Book> = books.into_iter().skip(start).take(PAGE_SIZE).collect();
+
+    let cards: Vec<BookCard> = page_books
+        .into_iter()
+        .map(|book| {
+            let author_display = primary_author(&repo, &book);
+            BookCard {
+                book,
+                author_display,
+            }
+        })
+        .collect();
+
+    let tag_counts = repo.list_tag_counts()?;
+    Ok((cards, total, tag_counts))
+}
+
+fn gather_book_detail(db_path: &std::path::Path, id_str: &str) -> Result<BookDetailData, WebError> {
+    let id =
+        uuid::Uuid::parse_str(id_str).map_err(|_| WebError::NotFound("invalid book ID".into()))?;
+
+    let db = Database::open_no_migrate(db_path)?;
+    let repo = BookRepository::new(&db);
+
+    let book = repo
+        .get_book(&id)
+        .map_err(|_| WebError::NotFound("book not found".into()))?;
+    let authors = repo.get_book_authors(&id)?;
+    let tags = repo.get_book_tags(&id)?;
+    let sessions = repo.list_sessions_for_books(&[id.to_string()])?;
+    let progress_log = repo.get_reading_log(&id)?;
+    let latest_progress = repo.get_latest_progress(&id)?;
+
+    Ok(BookDetailData {
+        book,
+        authors,
+        tags,
+        sessions,
+        progress_log,
+        latest_progress,
+    })
+}
+
+fn gather_search(
+    db_path: &std::path::Path,
+    q: Option<&str>,
+    status: Option<&str>,
+    tag: Option<&str>,
+) -> Result<(Vec<BookCard>, Vec<TagCount>), WebError> {
+    let db = Database::open_no_migrate(db_path)?;
+    let repo = BookRepository::new(&db);
+
+    let books = match q {
+        Some(query) if !query.trim().is_empty() => {
+            repo.search_books_filtered(query, status, None, tag)?
+        }
+        _ => Vec::new(),
+    };
+
+    let cards: Vec<BookCard> = books
+        .into_iter()
+        .map(|book| {
+            let author_display = primary_author(&repo, &book);
+            BookCard {
+                book,
+                author_display,
+            }
+        })
+        .collect();
+
+    let tag_counts = repo.list_tag_counts()?;
+    Ok((cards, tag_counts))
+}
+
+/// Get the primary author display string for a book.
+fn primary_author(repo: &BookRepository, book: &Book) -> String {
+    repo.get_book_authors(&book.id)
+        .unwrap_or_default()
+        .into_iter()
+        .filter(|(_, ba)| ba.role == ContributorRole::Author)
+        .map(|(a, _)| a.name)
+        .collect::<Vec<_>>()
+        .join(", ")
+}

--- a/crates/toku-web/src/library_views.rs
+++ b/crates/toku-web/src/library_views.rs
@@ -1,0 +1,1040 @@
+//! HTML views for the library browser, book detail, and search pages.
+
+use maud::{DOCTYPE, Markup, PreEscaped, html};
+use toku_core::{BookFormat, ContributorRole, ReadingStatus, TagCount, TagType};
+
+use crate::library_handlers::{BookCard, BookDetailData};
+
+// ── Shared layout ───────────────────────────────────────────────────
+
+fn base(title: &str, content: Markup) -> Markup {
+    html! {
+        (DOCTYPE)
+        html lang="en" {
+            head {
+                meta charset="utf-8";
+                meta name="viewport" content="width=device-width, initial-scale=1";
+                title { (title) " — Toku" }
+                style { (PreEscaped(CSS)) }
+            }
+            body {
+                header.site-header {
+                    div.header-inner {
+                        a.logo href="/" { "📚 Toku" }
+                        nav {
+                            a.nav-link href="/library" { "Library" }
+                            " "
+                            a.nav-link href="/search" { "Search" }
+                            " "
+                            a.nav-link href="/stats" { "Dashboard" }
+                            " "
+                            a.nav-link href="/import" { "Import" }
+                        }
+                    }
+                }
+                main { (content) }
+                footer.site-footer {
+                    p { "Toku — your private reading tracker" }
+                }
+            }
+        }
+    }
+}
+
+// ── Rating helpers ──────────────────────────────────────────────────
+
+fn star_rating(rating: Option<i32>) -> Markup {
+    let r = match rating {
+        Some(r) if r > 0 => r,
+        _ => {
+            return html! {
+                span.rating.rating-none { "No rating" }
+            };
+        }
+    };
+    let full = r / 2;
+    let half = r % 2;
+    let empty = 5 - full - half;
+    html! {
+        span.rating title=(format!("{}.{}/5", r / 2, if r % 2 == 1 { "5" } else { "0" })) {
+            @for _ in 0..full { "★" }
+            @if half > 0 { "½" }
+            @for _ in 0..empty { "☆" }
+        }
+    }
+}
+
+fn status_badge(status: &ReadingStatus) -> Markup {
+    let (label, class) = match status {
+        ReadingStatus::WantToRead => ("Want to Read", "badge-want"),
+        ReadingStatus::Reading => ("Reading", "badge-reading"),
+        ReadingStatus::Read => ("Read", "badge-read"),
+        ReadingStatus::Abandoned => ("Abandoned", "badge-abandoned"),
+        ReadingStatus::OnHold => ("On Hold", "badge-onhold"),
+    };
+    html! { span class={"badge " (class)} { (label) } }
+}
+
+fn format_icon(fmt: &BookFormat) -> &'static str {
+    match fmt {
+        BookFormat::Physical => "📖",
+        BookFormat::Ebook => "📱",
+        BookFormat::Audiobook => "🎧",
+    }
+}
+
+// ── Library page ────────────────────────────────────────────────────
+
+#[allow(clippy::too_many_arguments)]
+pub fn library_page(
+    books: &[BookCard],
+    view: &str,
+    status: Option<&str>,
+    tag: Option<&str>,
+    sort: &str,
+    page: usize,
+    total: usize,
+    total_pages: usize,
+    tag_counts: &[TagCount],
+) -> Markup {
+    let content = html! {
+        div.library-page {
+            div.library-header {
+                h1 { "Library" }
+                span.book-count { (total) " book" @if total != 1 { "s" } }
+            }
+
+            // Filter bar
+            form.filter-bar action="/library" method="get" {
+                // Preserve view mode
+                input type="hidden" name="view" value=(view);
+
+                div.filter-group {
+                    label for="status-filter" { "Status" }
+                    select id="status-filter" name="status" onchange="this.form.submit()" {
+                        option value="" selected[status.is_none()] { "All" }
+                        @for (val, label) in STATUS_OPTIONS {
+                            option value=(val) selected[status == Some(val)] { (label) }
+                        }
+                    }
+                }
+
+                div.filter-group {
+                    label for="tag-filter" { "Tag" }
+                    select id="tag-filter" name="tag" onchange="this.form.submit()" {
+                        option value="" selected[tag.is_none()] { "All" }
+                        @for tc in tag_counts {
+                            option value=(&tc.name) selected[tag == Some(tc.name.as_str())] {
+                                (&tc.name) " (" (tc.count) ")"
+                            }
+                        }
+                    }
+                }
+
+                div.filter-group {
+                    label for="sort-select" { "Sort" }
+                    select id="sort-select" name="sort" onchange="this.form.submit()" {
+                        option value="title" selected[sort == "title"] { "Title" }
+                        option value="author" selected[sort == "author"] { "Author" }
+                        option value="rating" selected[sort == "rating"] { "Rating" }
+                        option value="added" selected[sort == "added"] { "Date Added" }
+                    }
+                }
+
+                div.view-toggle {
+                    a class={"view-btn" @if view == "grid" { " active" }}
+                      href=(view_link("grid", status, tag, sort)) { "▦" }
+                    a class={"view-btn" @if view == "list" { " active" }}
+                      href=(view_link("list", status, tag, sort)) { "☰" }
+                }
+            }
+
+            // Book content
+            @if books.is_empty() {
+                div.empty-state {
+                    p { "No books found." }
+                    @if status.is_some() || tag.is_some() {
+                        a href="/library" { "Clear filters" }
+                    }
+                }
+            } @else if view == "list" {
+                (book_list_table(books))
+            } @else {
+                (book_grid(books))
+            }
+
+            // Pagination
+            @if total_pages > 1 {
+                (pagination(page, total_pages, status, tag, sort, view))
+            }
+        }
+    };
+    base("Library", content)
+}
+
+fn book_grid(books: &[BookCard]) -> Markup {
+    html! {
+        div.book-grid {
+            @for card in books {
+                a.book-card href=(format!("/books/{}", card.book.id)) {
+                    div.card-cover {
+                        @if let Some(hash) = &card.book.cover_hash {
+                            img src=(format!("/covers/{hash}"))
+                                alt=(format!("Cover of {}", card.book.title))
+                                loading="lazy";
+                        } @else {
+                            div.cover-placeholder {
+                                span { (format_icon(&card.book.format)) }
+                            }
+                        }
+                    }
+                    div.card-info {
+                        div.card-title { (&card.book.title) }
+                        @if !card.author_display.is_empty() {
+                            div.card-author { (&card.author_display) }
+                        }
+                        (star_rating(card.book.rating))
+                        (status_badge(&card.book.status))
+                    }
+                }
+            }
+        }
+    }
+}
+
+fn book_list_table(books: &[BookCard]) -> Markup {
+    html! {
+        div.table-wrap {
+            table.book-table {
+                thead {
+                    tr {
+                        th { "Title" }
+                        th { "Author" }
+                        th { "Status" }
+                        th { "Rating" }
+                        th { "Format" }
+                        th.col-pages { "Pages" }
+                        th.col-date { "Added" }
+                    }
+                }
+                tbody {
+                    @for card in books {
+                        tr {
+                            td {
+                                a href=(format!("/books/{}", card.book.id)) {
+                                    (&card.book.title)
+                                }
+                            }
+                            td { (&card.author_display) }
+                            td { (status_badge(&card.book.status)) }
+                            td { (star_rating(card.book.rating)) }
+                            td { (format_icon(&card.book.format)) " " (card.book.format.as_str()) }
+                            td.col-pages {
+                                @if let Some(p) = card.book.page_count {
+                                    (p)
+                                }
+                            }
+                            td.col-date {
+                                (card.book.created_at.format("%Y-%m-%d"))
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+fn pagination(
+    page: usize,
+    total_pages: usize,
+    status: Option<&str>,
+    tag: Option<&str>,
+    sort: &str,
+    view: &str,
+) -> Markup {
+    html! {
+        nav.pagination {
+            @if page > 1 {
+                a.page-link href=(page_link(page - 1, status, tag, sort, view)) { "← Prev" }
+            }
+            span.page-info {
+                "Page " (page) " of " (total_pages)
+            }
+            @if page < total_pages {
+                a.page-link href=(page_link(page + 1, status, tag, sort, view)) { "Next →" }
+            }
+        }
+    }
+}
+
+fn page_link(
+    page: usize,
+    status: Option<&str>,
+    tag: Option<&str>,
+    sort: &str,
+    view: &str,
+) -> String {
+    let mut url = format!("/library?page={page}&view={view}&sort={sort}");
+    if let Some(s) = status {
+        url.push_str(&format!("&status={}", urlencoding::encode(s)));
+    }
+    if let Some(t) = tag {
+        url.push_str(&format!("&tag={}", urlencoding::encode(t)));
+    }
+    url
+}
+
+fn view_link(view: &str, status: Option<&str>, tag: Option<&str>, sort: &str) -> String {
+    let mut url = format!("/library?view={view}&sort={sort}");
+    if let Some(s) = status {
+        url.push_str(&format!("&status={}", urlencoding::encode(s)));
+    }
+    if let Some(t) = tag {
+        url.push_str(&format!("&tag={}", urlencoding::encode(t)));
+    }
+    url
+}
+
+// ── Book detail page ────────────────────────────────────────────────
+
+pub fn book_detail_page(detail: &BookDetailData) -> Markup {
+    let book = &detail.book;
+    let authors_display: Vec<String> = detail
+        .authors
+        .iter()
+        .map(|(a, ba)| {
+            if ba.role == ContributorRole::Author {
+                a.name.clone()
+            } else {
+                format!("{} ({})", a.name, ba.role)
+            }
+        })
+        .collect();
+
+    let general_tags: Vec<&str> = detail
+        .tags
+        .iter()
+        .filter(|t| t.tag_type == TagType::General)
+        .map(|t| t.name.as_str())
+        .collect();
+    let mood_tags: Vec<&str> = detail
+        .tags
+        .iter()
+        .filter(|t| t.tag_type == TagType::Mood)
+        .map(|t| t.name.as_str())
+        .collect();
+    let pace_tags: Vec<&str> = detail
+        .tags
+        .iter()
+        .filter(|t| t.tag_type == TagType::Pace)
+        .map(|t| t.name.as_str())
+        .collect();
+    let cw_tags: Vec<&str> = detail
+        .tags
+        .iter()
+        .filter(|t| t.tag_type == TagType::ContentWarning)
+        .map(|t| t.name.as_str())
+        .collect();
+
+    let content = html! {
+        div.detail-page {
+            a.back-link href="/library" { "← Back to Library" }
+
+            div.detail-layout {
+                // Cover
+                div.detail-cover {
+                    @if let Some(hash) = &book.cover_hash {
+                        img src=(format!("/covers/{hash}"))
+                            alt=(format!("Cover of {}", book.title));
+                    } @else {
+                        div.cover-placeholder-lg {
+                            span { (format_icon(&book.format)) }
+                        }
+                    }
+                }
+
+                // Metadata
+                div.detail-meta {
+                    h1 { (&book.title) }
+                    @if let Some(sub) = &book.subtitle {
+                        p.subtitle { (sub) }
+                    }
+
+                    @if !authors_display.is_empty() {
+                        p.authors {
+                            "by "
+                            @for (i, name) in authors_display.iter().enumerate() {
+                                @if i > 0 { ", " }
+                                (name)
+                            }
+                        }
+                    }
+
+                    div.meta-row {
+                        (status_badge(&book.status))
+                        " "
+                        (star_rating(book.rating))
+                    }
+
+                    div.meta-details {
+                        @if let Some(pages) = book.page_count {
+                            span.meta-item { "📄 " (pages) " pages" }
+                        }
+                        @if let Some(mins) = book.duration_minutes {
+                            span.meta-item {
+                                "🎧 " (mins / 60) "h " (mins % 60) "m"
+                            }
+                        }
+                        span.meta-item { (format_icon(&book.format)) " " (book.format.as_str()) }
+                        @if let Some(lang) = &book.language {
+                            span.meta-item { "🌐 " (lang) }
+                        }
+                        @if let Some(date) = &book.pub_date {
+                            span.meta-item { "📅 " (date) }
+                        }
+                    }
+
+                    // Progress
+                    @if let Some(progress) = &detail.latest_progress {
+                        div.progress-section {
+                            h3 { "Current Progress" }
+                            p {
+                                (progress.progress_type) ": " (progress.value)
+                                @if let Some(pages) = book.page_count {
+                                    @if progress.progress_type == toku_core::ProgressType::Page {
+                                        " / " (pages)
+                                        @if pages > 0 {
+                                            " (" (progress.value * 100 / pages) "%)"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+
+                    // Description
+                    @if let Some(desc) = &book.description {
+                        div.description {
+                            h3 { "Description" }
+                            p { (desc) }
+                        }
+                    }
+
+                    // Tags
+                    @if !detail.tags.is_empty() {
+                        div.tags-section {
+                            h3 { "Tags" }
+                            @if !general_tags.is_empty() {
+                                div.tag-group {
+                                    @for t in &general_tags {
+                                        span.tag.tag-general { (t) }
+                                    }
+                                }
+                            }
+                            @if !mood_tags.is_empty() {
+                                div.tag-group {
+                                    span.tag-label { "Mood: " }
+                                    @for t in &mood_tags {
+                                        span.tag.tag-mood { (t) }
+                                    }
+                                }
+                            }
+                            @if !pace_tags.is_empty() {
+                                div.tag-group {
+                                    span.tag-label { "Pace: " }
+                                    @for t in &pace_tags {
+                                        span.tag.tag-pace { (t) }
+                                    }
+                                }
+                            }
+                            @if !cw_tags.is_empty() {
+                                div.tag-group {
+                                    span.tag-label { "CW: " }
+                                    @for t in &cw_tags {
+                                        span.tag.tag-cw { (t) }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
+            // Reading Sessions
+            @if !detail.sessions.is_empty() {
+                div.sessions-section {
+                    h2 { "Reading Sessions" }
+                    table.session-table {
+                        thead {
+                            tr {
+                                th { "Started" }
+                                th { "Finished" }
+                                th { "Rating" }
+                                th { "Notes" }
+                            }
+                        }
+                        tbody {
+                            @for session in &detail.sessions {
+                                tr {
+                                    td { (session.started_at.format("%Y-%m-%d")) }
+                                    td {
+                                        @if let Some(f) = session.finished_at {
+                                            (f.format("%Y-%m-%d"))
+                                        } @else {
+                                            em { "In progress" }
+                                        }
+                                    }
+                                    td { (star_rating(session.rating)) }
+                                    td.notes-cell {
+                                        @if let Some(notes) = &session.notes {
+                                            (notes)
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
+            // Reading Progress Log
+            @if !detail.progress_log.is_empty() {
+                div.progress-log-section {
+                    h2 { "Progress Log" }
+                    table.progress-table {
+                        thead {
+                            tr {
+                                th { "Date" }
+                                th { "Type" }
+                                th { "Value" }
+                                th { "Note" }
+                            }
+                        }
+                        tbody {
+                            @for entry in &detail.progress_log {
+                                tr {
+                                    td { (entry.logged_at.format("%Y-%m-%d %H:%M")) }
+                                    td { (entry.progress_type) }
+                                    td { (entry.value) }
+                                    td.notes-cell {
+                                        @if let Some(n) = &entry.note {
+                                            (n)
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    };
+    base(&book.title, content)
+}
+
+// ── Search page ─────────────────────────────────────────────────────
+
+pub fn search_page(
+    q: Option<&str>,
+    status: Option<&str>,
+    tag: Option<&str>,
+    results: &[BookCard],
+    tag_counts: &[TagCount],
+) -> Markup {
+    let content = html! {
+        div.search-page {
+            h1 { "Search" }
+
+            form.search-form action="/search" method="get" {
+                div.search-input-row {
+                    input type="search" name="q" placeholder="Search books…"
+                          value=(q.unwrap_or("")) autofocus;
+                    button type="submit" { "Search" }
+                }
+                div.search-filters {
+                    div.filter-group {
+                        label for="search-status" { "Status" }
+                        select id="search-status" name="status" {
+                            option value="" selected[status.is_none()] { "All" }
+                            @for (val, label) in STATUS_OPTIONS {
+                                option value=(val) selected[status == Some(val)] { (label) }
+                            }
+                        }
+                    }
+                    div.filter-group {
+                        label for="search-tag" { "Tag" }
+                        select id="search-tag" name="tag" {
+                            option value="" selected[tag.is_none()] { "All" }
+                            @for tc in tag_counts {
+                                option value=(&tc.name) selected[tag == Some(tc.name.as_str())] {
+                                    (&tc.name) " (" (tc.count) ")"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
+            @if let Some(query) = q {
+                @if !query.is_empty() {
+                    p.search-summary {
+                        (results.len()) " result" @if results.len() != 1 { "s" }
+                        " for "" (query) """
+                    }
+
+                    @if results.is_empty() {
+                        div.empty-state {
+                            p { "No books matched your search." }
+                        }
+                    } @else {
+                        div.search-results {
+                            @for card in results {
+                                a.search-result href=(format!("/books/{}", card.book.id)) {
+                                    div.result-cover {
+                                        @if let Some(hash) = &card.book.cover_hash {
+                                            img src=(format!("/covers/{hash}"))
+                                                alt="" loading="lazy";
+                                        } @else {
+                                            div.cover-placeholder-sm {
+                                                (format_icon(&card.book.format))
+                                            }
+                                        }
+                                    }
+                                    div.result-info {
+                                        div.result-title { (&card.book.title) }
+                                        @if !card.author_display.is_empty() {
+                                            div.result-author { (&card.author_display) }
+                                        }
+                                        div.result-meta {
+                                            (status_badge(&card.book.status))
+                                            " "
+                                            (star_rating(card.book.rating))
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    };
+    base("Search", content)
+}
+
+// ── Constants ───────────────────────────────────────────────────────
+
+const STATUS_OPTIONS: &[(&str, &str)] = &[
+    ("want-to-read", "Want to Read"),
+    ("reading", "Reading"),
+    ("read", "Read"),
+    ("abandoned", "Abandoned"),
+    ("on-hold", "On Hold"),
+];
+
+// ── CSS ─────────────────────────────────────────────────────────────
+
+const CSS: &str = r#"
+:root {
+    --bg: #fafafa;
+    --bg-card: #ffffff;
+    --text: #1a1a2e;
+    --text-secondary: #64748b;
+    --border: #e2e8f0;
+    --accent: #6366f1;
+    --accent-hover: #4f46e5;
+    --badge-want: #3b82f6;
+    --badge-reading: #10b981;
+    --badge-read: #8b5cf6;
+    --badge-abandoned: #ef4444;
+    --badge-onhold: #f59e0b;
+    --tag-bg: #eef2ff;
+    --tag-text: #4338ca;
+    --tag-mood-bg: #fef3c7;
+    --tag-mood-text: #92400e;
+    --tag-pace-bg: #d1fae5;
+    --tag-pace-text: #065f46;
+    --tag-cw-bg: #fee2e2;
+    --tag-cw-text: #991b1b;
+}
+
+@media (prefers-color-scheme: dark) {
+    :root {
+        --bg: #0f172a;
+        --bg-card: #1e293b;
+        --text: #e2e8f0;
+        --text-secondary: #94a3b8;
+        --border: #334155;
+        --accent: #818cf8;
+        --accent-hover: #6366f1;
+        --badge-want: #60a5fa;
+        --badge-reading: #34d399;
+        --badge-read: #a78bfa;
+        --badge-abandoned: #f87171;
+        --badge-onhold: #fbbf24;
+        --tag-bg: #312e81;
+        --tag-text: #c7d2fe;
+        --tag-mood-bg: #78350f;
+        --tag-mood-text: #fde68a;
+        --tag-pace-bg: #064e3b;
+        --tag-pace-text: #a7f3d0;
+        --tag-cw-bg: #7f1d1d;
+        --tag-cw-text: #fecaca;
+    }
+}
+
+* { margin: 0; padding: 0; box-sizing: border-box; }
+
+body {
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
+                 "Helvetica Neue", Arial, sans-serif;
+    background: var(--bg);
+    color: var(--text);
+    line-height: 1.6;
+}
+
+a { color: var(--accent); text-decoration: none; }
+a:hover { text-decoration: underline; }
+
+/* Header */
+.site-header {
+    background: var(--bg-card);
+    border-bottom: 1px solid var(--border);
+    padding: 0.75rem 1.5rem;
+}
+.header-inner {
+    max-width: 1200px;
+    margin: 0 auto;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+}
+.logo { font-size: 1.25rem; font-weight: 700; color: var(--text); text-decoration: none; }
+.nav-link { color: var(--accent); text-decoration: none; font-weight: 500; }
+.nav-link:hover { text-decoration: underline; }
+
+/* Footer */
+.site-footer { text-align: center; padding: 2rem 1rem; color: var(--text-secondary); font-size: 0.85rem; }
+
+/* Main */
+main { max-width: 1200px; margin: 0 auto; padding: 1.5rem; }
+
+/* ── Library page ─────────────────────────────── */
+
+.library-header {
+    display: flex; align-items: baseline; gap: 1rem;
+    margin-bottom: 1rem;
+}
+.library-header h1 { font-size: 1.75rem; }
+.book-count { color: var(--text-secondary); font-size: 0.9rem; }
+
+.filter-bar {
+    display: flex; align-items: flex-end; gap: 1rem;
+    flex-wrap: wrap;
+    margin-bottom: 1.5rem;
+    padding: 0.75rem 1rem;
+    background: var(--bg-card);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+}
+.filter-group { display: flex; flex-direction: column; gap: 0.25rem; }
+.filter-group label { font-size: 0.75rem; color: var(--text-secondary); font-weight: 600; text-transform: uppercase; letter-spacing: 0.05em; }
+.filter-group select {
+    padding: 0.4rem 0.6rem;
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    background: var(--bg);
+    color: var(--text);
+    font-size: 0.9rem;
+}
+
+.view-toggle {
+    display: flex; gap: 0.25rem; margin-left: auto; align-self: flex-end;
+}
+.view-btn {
+    display: inline-flex; align-items: center; justify-content: center;
+    width: 36px; height: 36px;
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    background: var(--bg);
+    color: var(--text-secondary);
+    text-decoration: none;
+    font-size: 1.1rem;
+}
+.view-btn.active, .view-btn:hover {
+    background: var(--accent);
+    color: white;
+    border-color: var(--accent);
+}
+
+/* Grid view */
+.book-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(170px, 1fr));
+    gap: 1.25rem;
+}
+
+.book-card {
+    display: flex; flex-direction: column;
+    background: var(--bg-card);
+    border: 1px solid var(--border);
+    border-radius: 10px;
+    overflow: hidden;
+    text-decoration: none;
+    color: var(--text);
+    transition: transform 0.15s, box-shadow 0.15s;
+}
+.book-card:hover {
+    transform: translateY(-3px);
+    box-shadow: 0 8px 25px rgba(0,0,0,0.1);
+    text-decoration: none;
+}
+
+.card-cover {
+    aspect-ratio: 2 / 3;
+    overflow: hidden;
+    background: var(--border);
+}
+.card-cover img {
+    width: 100%; height: 100%;
+    object-fit: cover;
+}
+
+.cover-placeholder, .cover-placeholder-lg, .cover-placeholder-sm {
+    display: flex; align-items: center; justify-content: center;
+    background: var(--border);
+    color: var(--text-secondary);
+}
+.cover-placeholder { width: 100%; height: 100%; font-size: 2.5rem; }
+.cover-placeholder-lg { width: 100%; aspect-ratio: 2/3; font-size: 4rem; border-radius: 8px; }
+.cover-placeholder-sm { width: 60px; height: 90px; font-size: 1.5rem; border-radius: 4px; flex-shrink: 0; }
+
+.card-info { padding: 0.6rem 0.75rem; }
+.card-title { font-weight: 600; font-size: 0.85rem; margin-bottom: 0.15rem; overflow: hidden; text-overflow: ellipsis; display: -webkit-box; -webkit-line-clamp: 2; -webkit-box-orient: vertical; }
+.card-author { font-size: 0.78rem; color: var(--text-secondary); margin-bottom: 0.3rem; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+
+.rating { color: #f59e0b; font-size: 0.8rem; }
+.rating-none { color: var(--text-secondary); font-size: 0.75rem; font-style: italic; }
+
+/* Badges */
+.badge {
+    display: inline-block;
+    padding: 0.15rem 0.5rem;
+    border-radius: 12px;
+    font-size: 0.7rem;
+    font-weight: 600;
+    color: white;
+}
+.badge-want { background: var(--badge-want); }
+.badge-reading { background: var(--badge-reading); }
+.badge-read { background: var(--badge-read); }
+.badge-abandoned { background: var(--badge-abandoned); }
+.badge-onhold { background: var(--badge-onhold); }
+
+/* List view */
+.table-wrap { overflow-x: auto; }
+.book-table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 0.9rem;
+}
+.book-table th, .book-table td {
+    padding: 0.6rem 0.75rem;
+    text-align: left;
+    border-bottom: 1px solid var(--border);
+}
+.book-table th {
+    font-size: 0.75rem;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: var(--text-secondary);
+    font-weight: 600;
+    background: var(--bg-card);
+    position: sticky;
+    top: 0;
+}
+.book-table tbody tr:hover { background: var(--bg-card); }
+.col-pages, .col-date { white-space: nowrap; }
+
+/* Pagination */
+.pagination {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 1rem;
+    margin-top: 2rem;
+    padding: 1rem;
+}
+.page-link {
+    padding: 0.4rem 1rem;
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    background: var(--bg-card);
+    color: var(--accent);
+    text-decoration: none;
+    font-weight: 500;
+}
+.page-link:hover { background: var(--accent); color: white; border-color: var(--accent); text-decoration: none; }
+.page-info { color: var(--text-secondary); font-size: 0.9rem; }
+
+/* Empty state */
+.empty-state { text-align: center; padding: 3rem 1rem; color: var(--text-secondary); }
+
+/* ── Book detail ──────────────────────────────── */
+
+.detail-page { max-width: 960px; margin: 0 auto; }
+
+.back-link {
+    display: inline-block;
+    margin-bottom: 1.5rem;
+    color: var(--accent);
+    font-size: 0.9rem;
+}
+
+.detail-layout {
+    display: grid;
+    grid-template-columns: 240px 1fr;
+    gap: 2rem;
+    margin-bottom: 2rem;
+}
+
+.detail-cover img {
+    width: 100%;
+    border-radius: 8px;
+    box-shadow: 0 4px 15px rgba(0,0,0,0.15);
+}
+
+.detail-meta h1 { font-size: 1.6rem; margin-bottom: 0.25rem; }
+.detail-meta .subtitle { color: var(--text-secondary); font-size: 1.1rem; margin-bottom: 0.5rem; }
+.detail-meta .authors { font-size: 1rem; color: var(--text-secondary); margin-bottom: 0.75rem; }
+.meta-row { display: flex; align-items: center; gap: 0.75rem; margin-bottom: 1rem; }
+
+.meta-details {
+    display: flex; flex-wrap: wrap; gap: 0.75rem;
+    margin-bottom: 1rem;
+    font-size: 0.9rem;
+}
+.meta-item {
+    background: var(--bg-card);
+    border: 1px solid var(--border);
+    padding: 0.3rem 0.7rem;
+    border-radius: 6px;
+}
+
+.description { margin-bottom: 1.5rem; }
+.description h3, .tags-section h3, .progress-section h3 { font-size: 1rem; margin-bottom: 0.5rem; }
+.description p { color: var(--text-secondary); line-height: 1.7; }
+
+.progress-section {
+    background: var(--bg-card);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    padding: 1rem;
+    margin-bottom: 1rem;
+}
+
+/* Tags */
+.tags-section { margin-bottom: 1.5rem; }
+.tag-group { display: flex; flex-wrap: wrap; gap: 0.4rem; align-items: center; margin-bottom: 0.5rem; }
+.tag-label { font-size: 0.8rem; color: var(--text-secondary); font-weight: 600; margin-right: 0.25rem; }
+.tag {
+    display: inline-block;
+    padding: 0.2rem 0.6rem;
+    border-radius: 12px;
+    font-size: 0.78rem;
+    font-weight: 500;
+}
+.tag-general { background: var(--tag-bg); color: var(--tag-text); }
+.tag-mood { background: var(--tag-mood-bg); color: var(--tag-mood-text); }
+.tag-pace { background: var(--tag-pace-bg); color: var(--tag-pace-text); }
+.tag-cw { background: var(--tag-cw-bg); color: var(--tag-cw-text); }
+
+/* Sessions & progress tables */
+.sessions-section, .progress-log-section { margin-bottom: 2rem; }
+.sessions-section h2, .progress-log-section h2 { font-size: 1.25rem; margin-bottom: 0.75rem; }
+
+.session-table, .progress-table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 0.9rem;
+}
+.session-table th, .session-table td,
+.progress-table th, .progress-table td {
+    padding: 0.5rem 0.75rem;
+    text-align: left;
+    border-bottom: 1px solid var(--border);
+}
+.session-table th, .progress-table th {
+    font-size: 0.75rem;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: var(--text-secondary);
+    font-weight: 600;
+}
+.notes-cell { max-width: 300px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+
+/* ── Search ───────────────────────────────────── */
+
+.search-page h1 { font-size: 1.75rem; margin-bottom: 1rem; }
+
+.search-form { margin-bottom: 1.5rem; }
+.search-input-row {
+    display: flex; gap: 0.5rem; margin-bottom: 0.75rem;
+}
+.search-input-row input {
+    flex: 1;
+    padding: 0.6rem 1rem;
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    font-size: 1rem;
+    background: var(--bg-card);
+    color: var(--text);
+}
+.search-input-row input:focus { outline: 2px solid var(--accent); border-color: var(--accent); }
+.search-input-row button {
+    padding: 0.6rem 1.5rem;
+    background: var(--accent);
+    color: white;
+    border: none;
+    border-radius: 8px;
+    font-size: 1rem;
+    font-weight: 600;
+    cursor: pointer;
+}
+.search-input-row button:hover { background: var(--accent-hover); }
+
+.search-filters { display: flex; gap: 1rem; flex-wrap: wrap; }
+
+.search-summary { color: var(--text-secondary); margin-bottom: 1rem; font-size: 0.95rem; }
+
+.search-results { display: flex; flex-direction: column; gap: 0.75rem; }
+.search-result {
+    display: flex; gap: 1rem; align-items: flex-start;
+    padding: 0.75rem 1rem;
+    background: var(--bg-card);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    text-decoration: none;
+    color: var(--text);
+    transition: border-color 0.15s;
+}
+.search-result:hover { border-color: var(--accent); text-decoration: none; }
+
+.result-cover img { width: 60px; height: 90px; object-fit: cover; border-radius: 4px; }
+.result-title { font-weight: 600; margin-bottom: 0.15rem; }
+.result-author { font-size: 0.85rem; color: var(--text-secondary); margin-bottom: 0.3rem; }
+.result-meta { display: flex; gap: 0.5rem; align-items: center; }
+
+/* ── Responsive ───────────────────────────────── */
+
+@media (max-width: 768px) {
+    .detail-layout { grid-template-columns: 1fr; }
+    .detail-cover { max-width: 200px; }
+    .book-grid { grid-template-columns: repeat(auto-fill, minmax(140px, 1fr)); gap: 0.75rem; }
+    .filter-bar { flex-direction: column; align-items: stretch; }
+    .view-toggle { margin-left: 0; justify-content: flex-end; }
+    .header-inner { flex-direction: column; gap: 0.5rem; }
+    .col-pages, .col-date { display: none; }
+}
+"#;

--- a/crates/toku-web/src/views.rs
+++ b/crates/toku-web/src/views.rs
@@ -21,6 +21,10 @@ fn base(title: &str, content: Markup) -> Markup {
                     div.header-inner {
                         a.logo href="/" { "📚 Toku" }
                         nav {
+                            a.nav-link href="/library" { "Library" }
+                            " "
+                            a.nav-link href="/search" { "Search" }
+                            " "
                             a.nav-link href="/stats" { "Dashboard" }
                             " "
                             a.nav-link href="/import" { "Import" }

--- a/docs/adr/007-web-framework.md
+++ b/docs/adr/007-web-framework.md
@@ -1,0 +1,134 @@
+# ADR-007: Web Framework — Axum + Maud (Server-Side Rendering)
+
+**Status**: Accepted
+**Date**: 2026-05-30
+**Decision**: Use Axum for the HTTP server and maud for server-side HTML rendering,
+with inline SVG charts and minimal inline JavaScript. No HTMX. No Leptos.
+
+## Context
+
+Phase 4 requires a web interface for statistics, import, library browsing, and search.
+The ROADMAP identified two candidate stacks — both keep the codebase in Rust:
+
+- **Option A: Axum + HTMX** — Axum serves server-rendered HTML; HTMX handles dynamic
+  interactions via HTML attributes with minimal JavaScript.
+- **Option B: Leptos** — Full-stack Rust framework with SSR + client-side hydration
+  via WASM. No handwritten JavaScript, but requires WASM output and client-side
+  glue code.
+
+A third option emerged during implementation: **Axum + maud** — server-side rendering
+with a Rust macro-based HTML DSL, no template files, and no client-side framework.
+
+## Decision
+
+**Axum + maud** with server-side rendering, inline SVG charts, and targeted inline
+JavaScript only where strictly necessary (SSE event handling for import progress).
+
+### Stack
+
+| Layer | Choice | Role |
+|-------|--------|------|
+| HTTP server | Axum 0.8 | Routing, middleware, SSE, multipart uploads |
+| HTML rendering | maud 0.26 | Type-checked HTML via Rust macros |
+| Charts | Inline SVG | Server-generated, no charting library |
+| Interactivity | Minimal inline JS (~15 lines) | SSE `EventSource` for import progress only |
+| Styling | Embedded `<style>` | CSS custom properties, `prefers-color-scheme` dark mode |
+| Assets | None external | No CDN, no npm, no bundler — fully offline |
+
+### Architecture
+
+- `toku-web` is a **library crate**, not a binary. The CLI calls `toku_web::serve()`
+  via `toku serve`.
+- All HTML is rendered server-side. No hydration, no virtual DOM, no client state.
+- Database access uses `tokio::task::spawn_blocking` wrapping synchronous rusqlite
+  calls. Migrations run once at startup; per-request opens use
+  `Database::open_no_migrate()`.
+- Import progress uses Server-Sent Events (SSE) with `tokio::sync::broadcast`
+  channels. The client-side EventSource listener is the only JavaScript in the app.
+
+## Rationale
+
+### Why not HTMX?
+
+HTMX was the ROADMAP's default recommendation alongside Axum. We chose not to use it
+because:
+
+1. **No dynamic interactions needed yet.** The Phase 4 deliverables (statistics
+   dashboard, import wizard) are read-heavy pages with full-page navigation. HTMX
+   shines for partial-page updates (inline editing, live search, dynamic forms) — none
+   of which are needed in the current scope.
+2. **SSE is simpler than HTMX for progress streaming.** The import wizard's live
+   progress bar uses native `EventSource` (4 lines of JS). HTMX's SSE extension adds
+   abstraction without reducing complexity.
+3. **No external web assets.** HTMX is small (~14KB) and could be vendored for
+   offline use, but omitting it removes even that from the maintenance surface.
+   The entire web interface ships with zero external assets — no vendored JS, no
+   CDN, no npm, no bundler.
+4. **Easy to adopt later.** HTMX is additive. If Phase 4+ features need partial-page
+   updates (library grid filtering, inline book editing), HTMX can be added to
+   specific pages without rearchitecting.
+
+### Why not Leptos?
+
+1. **Build complexity.** Leptos requires WASM compilation (`wasm-pack` or `trunk`),
+   a separate client build step, and hydration logic. This adds CI time and a new
+   failure mode for a feature set that doesn't need client-side Rust.
+2. **Ecosystem maturity.** Leptos is pre-1.0 (0.7.x as of writing). API churn and
+   migration burden are a risk for a solo-developer project.
+3. **Contributor accessibility.** Server-rendered HTML + CSS is universally understood.
+   Leptos's reactive signal system (`create_signal`, `create_effect`) has a learning
+   curve even for experienced Rust developers.
+4. **Offline-first already satisfied.** Toku's offline-first design means the
+   SQLite database lives on the local machine. The Axum server reads it directly
+   on `localhost`. A hydrated WASM client would still need to fetch data from the
+   Axum backend — the WASM layer adds complexity without increasing offline
+   capability beyond what a service worker provides.
+
+### Why maud over other template engines?
+
+1. **Compile-checked HTML construction.** Syntax errors in HTML are caught by
+   `rustc` at compile time. Maud also escapes values by default, preventing
+   accidental injection. (Note: it does not guarantee semantic HTML correctness
+   or accessibility — those require manual review.)
+2. **Raw SVG embedding.** `maud::PreEscaped` cleanly embeds server-generated SVG
+   chart markup. Other template engines (askama, tera) require escaping workarounds
+   for raw HTML injection.
+3. **No template files.** Views are Rust functions returning `Markup`. No separate
+   `.html` files to keep in sync, no template discovery at runtime.
+4. **Familiar to Rust developers.** The maud macro syntax reads like a Rust DSL —
+   natural for contributors already working in the crate.
+
+### Alignment with constraints
+
+| Constraint | How this stack satisfies it |
+|------------|---------------------------|
+| Local-first / offline | No CDN, no external assets, no network calls. Works on `localhost` with no internet. |
+| No social features | Server renders pages for the local user only. No auth, no multi-user, no sharing. |
+| User data ownership | All data stays in the local SQLite database. The web server is `127.0.0.1` by default. |
+| CLI-first | `toku serve` is a CLI command. The web interface reuses the same `toku-core` and `toku-db` crates. |
+
+## Consequences
+
+- **No client-side routing.** Every page is a full server render. This is acceptable
+  for the current feature set but may feel slow for data-dense pages (library grid
+  with hundreds of books). Mitigation: add HTMX for specific interactions if needed.
+- **maud's Rust 2021 prefix conflict.** The `element#id` shorthand syntax conflicts
+  with Rust 2021 reserved prefixes. Use `element id="value"` instead. This is a minor
+  ergonomic cost.
+- **maud's axum feature targets axum-core 0.4 (axum 0.7)**, not axum-core 0.5
+  (axum 0.8). Workaround: render to `Html<String>` instead of returning `Markup`
+  directly. This is invisible to handler code.
+- **Chart rendering is manual.** Inline SVG charts are hand-built string builders.
+  If chart complexity grows significantly, consider a Rust SVG library (e.g.,
+  `plotters` with SVG backend). Current scope (5 chart types) is manageable.
+- **`PreEscaped` requires manual escaping.** SVG charts use `maud::PreEscaped` to
+  embed raw markup. Any user-derived content (book titles, author names, tags)
+  must be HTML-escaped before entering `PreEscaped` to prevent injection. The
+  `charts.rs` module uses a dedicated `esc()` function for this — all new chart
+  code must follow the same pattern.
+- **Inline CSS/JS limits future CSP hardening.** Embedded `<style>` and
+  `<script>` blocks are acceptable for Phase 4 but would conflict with a strict
+  Content Security Policy. If the UI grows or is wrapped in Tauri (Phase 5),
+  assets may need to move to local static files with nonces or hashes.
+- **HTMX adoption path remains open.** The server-rendered architecture is fully
+  compatible with adding HTMX incrementally. No rearchitecting needed.


### PR DESCRIPTION
## Description

Add the `toku-web` crate — a complete web interface for Toku, accessible via `toku serve`.

### What's included

- **Statistics dashboard** (`/stats`) — books read, pages, average rating, reading pace, streaks, and five SVG charts (rating histogram, monthly pace, format donut, top authors, top tags) with dark mode
- **Yearly wrap-up** (`/stats/wrap/{year}`) — single-year reading summary
- **JSON API** (`/api/stats`) — programmatic statistics access
- **Import wizard** (`/import`) — four-step flow: select source → dry-run preview → real-time SSE progress → results summary. Supports Goodreads, StoryGraph, and Calibre
- **Library browser** (`/library`) — responsive grid and list views with cover images, sortable by title/author/rating/date, filterable by status and tag, paginated (60/page)
- **Book detail** (`/books/{id}`) — full metadata, reading sessions, progress log, tags grouped by type (general, mood, pace, content warning)
- **Search** (`/search`) — FTS5-powered full-text search with status and tag filter dropdowns
- **Cover serving** (`/covers/{hash}`) — content-addressed image serving with strict hex validation and immutable cache headers
- **`toku serve` CLI command** — starts the web server with configurable `--port` and `--host`
- **`Database::open_no_migrate()`** — skip migration overhead on per-request DB opens
- **ADR-007** — documents the Axum + maud decision with rationale for not using HTMX or Leptos

All rendering is server-side (maud + inline SVG). No CDN, no npm, no JavaScript frameworks — fully offline-capable.

## Related Issues

Closes #47
Closes #48
Closes #49
Closes #50

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI / infrastructure
- [ ] Other (describe below)

## Crate

- [ ] `toku-core` — Domain models, traits, state machine
- [x] `toku-db` — SQLite persistence, migrations, FTS5
- [x] `toku-import` — Importers (Goodreads, Calibre, StoryGraph)
- [ ] `toku-meta` — Metadata fetching (Open Library, Google Books)
- [x] `toku-cli` — CLI binary
- [ ] `toku-export` — Exporters (CSV, JSON, Markdown, BibTeX)
- [x] `docs/` — Documentation

## Data Integrity Checklist

- [x] No user data is sent to any server without explicit opt-in
- [x] Import operations are idempotent (re-importing the same file creates no duplicates)
- [x] User edits to metadata are never overwritten by auto-enrichment
- [x] New fields track provenance (source + timestamp)
- [x] Export round-trip is preserved (if applicable)

## Checklist

- [x] I have read [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] `cargo fmt --check` passes
- [x] `cargo clippy --workspace -- -D warnings` passes
- [x] `cargo test --workspace` passes
- [x] I have updated documentation (if applicable)