### PR TITLE
feat: iOS app (SwiftUI) — iPhone and iPad

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -1,0 +1,48 @@
+name: Security Audit
+
+on:
+  schedule:
+    # Every Monday at 08:00 UTC
+    - cron: "0 8 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  audit:
+    name: Cargo audit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install cargo-audit
+        run: cargo install cargo-audit --locked
+
+      - name: Run audit
+        run: cargo audit
+
+      - name: Create issue on failure
+        if: failure()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const title = `Security audit: vulnerable dependencies found (${new Date().toISOString().slice(0, 10)})`;
+            const existing = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              labels: 'security',
+              per_page: 10,
+            });
+            const alreadyOpen = existing.data.some(i => i.title.startsWith('Security audit:'));
+            if (!alreadyOpen) {
+              await github.rest.issues.create({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                title,
+                body: `The weekly \`cargo audit\` found vulnerable dependencies.\n\nSee the [workflow run](${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}) for details.\n\nPlease review and update affected crates.`,
+                labels: ['security', 'dependencies'],
+              });
+            }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,9 +4,19 @@ on:
   push:
     tags:
       - "v*"
+  workflow_dispatch:
+    inputs:
+      publish_crates:
+        description: "Publish to crates.io"
+        required: false
+        default: false
+        type: boolean
 
 permissions:
   contents: write
+
+env:
+  CARGO_TERM_COLOR: always
 
 jobs:
   build:
@@ -121,6 +131,10 @@ jobs:
     name: Publish to crates.io
     needs: release
     runs-on: ubuntu-latest
+    if: >-
+      (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/'))
+      || (github.event_name == 'workflow_dispatch' && inputs.publish_crates)
+    environment: crates-io
     steps:
       - uses: actions/checkout@v6
 
@@ -128,19 +142,45 @@ jobs:
         with:
           toolchain: stable
 
+      - name: Verify version matches tag
+        if: startsWith(github.ref, 'refs/tags/')
+        run: |
+          TAG_VERSION="${GITHUB_REF_NAME#v}"
+          CARGO_VERSION=$(grep '^version' Cargo.toml | head -1 | sed 's/.*"\(.*\)"/\1/')
+          if [ "$TAG_VERSION" != "$CARGO_VERSION" ]; then
+            echo "::error::Tag version ($TAG_VERSION) does not match Cargo.toml version ($CARGO_VERSION)"
+            exit 1
+          fi
+          echo "✅ Tag $TAG_VERSION matches Cargo.toml"
+
       # Publish crates in dependency order:
       # toku-core (no deps) → toku-db → toku-import, toku-meta, toku-export → toku-cli
-      # Each `cargo publish` needs a brief pause for crates.io index to update.
+      # Polls crates.io index between publishes to avoid timing issues.
       - name: Publish workspace crates
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
         run: |
+          EXPECTED_VERSION=$(grep '^version' Cargo.toml | head -1 | sed 's/.*"\(.*\)"/\1/')
+
+          wait_for_index() {
+            local crate=$1
+            echo "⏳ Waiting for crates.io to index $crate $EXPECTED_VERSION..."
+            for i in $(seq 1 30); do
+              if cargo search "$crate" 2>/dev/null | grep -q "\"$EXPECTED_VERSION\""; then
+                echo "✅ $crate $EXPECTED_VERSION is indexed."
+                return 0
+              fi
+              echo "  Attempt $i/30 — not yet indexed, waiting 10s..."
+              sleep 10
+            done
+            echo "⚠️  Timed out waiting for $crate to be indexed. Proceeding anyway."
+          }
+
           publish_crate() {
             local crate=$1
             echo "📦 Publishing $crate..."
             cargo publish -p "$crate" --no-verify
-            echo "⏳ Waiting for crates.io index to update..."
-            sleep 30
+            wait_for_index "$crate"
           }
 
           publish_crate toku-core

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -81,13 +81,13 @@ jobs:
       - run: cargo fmt --all -- --check
 
   msrv:
-    name: MSRV (1.85)
+    name: MSRV (1.88)
     needs: changes
     if: github.event_name == 'push' || needs.changes.outputs.rust == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@1.85
+      - uses: dtolnay/rust-toolchain@1.88
       - uses: Swatinem/rust-cache@v2
         with:
           key: msrv

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,4 +1,4 @@
-name: Validate
+name: CI
 
 on:
   push:
@@ -6,34 +6,132 @@ on:
   pull_request:
     branches: [main]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: always
+
 jobs:
-  validate:
-    name: Validate
+  # ── Change detection ──────────────────────────────────────────────────────────
+  # Determines which areas were modified so downstream jobs can skip irrelevant
+  # work on PRs. Push-to-main always runs everything.
+  changes:
+    name: Detect changes
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    outputs:
+      rust: ${{ steps.filter.outputs.rust }}
+      docs: ${{ steps.filter.outputs.docs }}
     steps:
       - uses: actions/checkout@v6
-
-      - name: Lint markdown
-        uses: DavidAnson/markdownlint-cli2-action@v23
+      - uses: dorny/paths-filter@v3
+        id: filter
         with:
-          globs: "**/*.md"
+          filters: |
+            rust:
+              - 'crates/**'
+              - 'Cargo.*'
+            docs:
+              - '**/*.md'
+              - '.markdownlint*'
 
-  # NOTE: The Rust job uses a matrix that produces check names like
-  # "Rust (ubuntu-latest)", "Rust (macos-latest)", "Rust (windows-latest)".
-  # Adding any of these as required status checks requires updating
-  # kafkade/github-infra → repo_toku.tf (required_status_checks).
-  rust:
-    name: Rust (${{ matrix.os }})
+  # ── Rust checks ───────────────────────────────────────────────────────────────
+
+  test:
+    name: Test (${{ matrix.os }})
+    needs: changes
+    if: github.event_name == 'push' || needs.changes.outputs.rust == 'true'
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
-        with:
-          components: clippy, rustfmt
       - uses: Swatinem/rust-cache@v2
-      - run: cargo fmt --check
-      - run: cargo clippy --workspace -- -D warnings
       - run: cargo test --workspace
+
+  clippy:
+    name: Clippy
+    needs: changes
+    if: github.event_name == 'push' || needs.changes.outputs.rust == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo clippy --workspace --all-targets -- -D warnings
+
+  fmt:
+    name: Formatting
+    needs: changes
+    if: github.event_name == 'push' || needs.changes.outputs.rust == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt
+      - run: cargo fmt --all -- --check
+
+  msrv:
+    name: MSRV (1.85)
+    needs: changes
+    if: github.event_name == 'push' || needs.changes.outputs.rust == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@1.85
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: msrv
+      - run: cargo check --workspace
+
+  audit:
+    name: Security audit
+    needs: changes
+    if: github.event_name == 'push' || needs.changes.outputs.rust == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: rustsec/audit-check@v2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+  # ── Documentation ─────────────────────────────────────────────────────────────
+
+  markdownlint:
+    name: Markdown lint
+    needs: changes
+    if: github.event_name == 'push' || needs.changes.outputs.docs == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Lint markdown
+        uses: DavidAnson/markdownlint-cli2-action@v23
+        with:
+          globs: "**/*.md"
+
+  # ── Summary gate ──────────────────────────────────────────────────────────────
+  # Single required status check for branch protection. Downstream jobs may be
+  # skipped (path filters) — that is OK; only failures or cancellations block.
+  #
+  # NOTE: This job is named "Validate" to match the required_status_checks in
+  # kafkade/github-infra → repo_toku.tf. If you rename it, update the IaC first.
+  validate:
+    name: Validate
+    if: always()
+    needs: [test, clippy, fmt, msrv, audit, markdownlint]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fail if any dependency failed
+        if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
+        run: exit 1
+      - name: All checks passed
+        run: echo "All CI checks passed"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Windows desktop application (`toku-desktop`) wrapping the web UI in a native Tauri v2 window with system tray and minimize-to-tray support
 - Extended FFI API with 9 new functions: delete, update status/rating, search, stats, tags, shelves, and Goodreads import
 - macOS app (`toku-apple`) with SwiftUI: sidebar navigation, sortable table and grid views, book detail inspector, Swift Charts statistics dashboard, and drag-and-drop Goodreads CSV import
+- iOS app (iPhone + iPad) with SwiftUI: library cover grid, book detail, barcode scanner (ISBN-13 via camera), quick progress update sheet, statistics glance with Swift Charts, full-text search, Goodreads CSV import, adaptive navigation (TabView on iPhone, NavigationSplitView on iPad), status filter chips, and pull-to-refresh
+- TokuKitUI shared SwiftUI component library (StarRatingView, FlowLayout, MetadataRow, StatCard) for reuse across macOS and iOS apps
 
 ## [0.2.1] - 2026-05-30
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ members = [
 [workspace.package]
 version = "0.2.1"
 edition = "2024"
-rust-version = "1.85"
+rust-version = "1.88"
 authors = ["kafkade"]
 license = "MIT"
 repository = "https://github.com/kafkade/toku"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ members = [
 [workspace.package]
 version = "0.2.1"
 edition = "2024"
+rust-version = "1.85"
 authors = ["kafkade"]
 license = "MIT"
 repository = "https://github.com/kafkade/toku"

--- a/toku-apple/README.md
+++ b/toku-apple/README.md
@@ -1,6 +1,13 @@
 # toku-apple
 
-Native macOS app for Toku, built with SwiftUI and the Rust FFI layer.
+Native Apple apps for Toku, built with SwiftUI and the Rust FFI layer.
+
+- **macOS app** — full-featured desktop app with sidebar navigation, sortable
+  table, cover grid, statistics dashboard, and Goodreads CSV import.
+- **iOS app** — iPhone and iPad app with touch-optimized library grid, barcode
+  scanner, quick progress updates, and adaptive navigation.
+
+Both apps share the **TokuKit** Swift package for FFI, models, and view models.
 
 ## Architecture
 
@@ -12,19 +19,35 @@ SwiftUI Views → Swift ViewModels → TokuFFI wrapper → toku-ffi (C ABI) → 
 
 | Component | Description |
 |---|---|
-| `TokuKit/` | Swift Package with FFI wrapper, models, and ViewModels (shared with future iOS app) |
+| `TokuKit/` | Swift Package with FFI wrapper, models, ViewModels, and shared UI components |
 | `Toku/` | macOS SwiftUI app target |
+| `Toku iOS/` | iOS SwiftUI app target (iPhone + iPad) |
 | `TokuKit/Sources/CTokuFFI/` | C module map pointing to the `toku.h` header |
+| `TokuKit/Sources/TokuKitUI/` | Shared SwiftUI components (StarRatingView, FlowLayout, etc.) |
 
 ## Prerequisites
+
+### macOS app
 
 - macOS 14 (Sonoma) or later
 - Xcode 15.4 or later
 - Rust toolchain (`rustup` with `aarch64-apple-darwin` target)
 
+### iOS app
+
+- iOS 17.0 or later
+- Xcode 15.4 or later
+- Rust toolchain with iOS targets:
+  ```bash
+  rustup target add aarch64-apple-ios         # Device
+  rustup target add aarch64-apple-ios-sim     # Apple Silicon simulator
+  ```
+
 ## Build steps
 
 ### 1. Build the Rust FFI library
+
+#### macOS
 
 ```bash
 # From the repository root
@@ -32,6 +55,20 @@ cargo build --release -p toku-ffi
 
 # The static library will be at:
 # target/release/libtoku_ffi.a
+```
+
+#### iOS
+
+```bash
+# Device binary
+cargo build --release -p toku-ffi --target aarch64-apple-ios
+
+# Simulator binary (Apple Silicon)
+cargo build --release -p toku-ffi --target aarch64-apple-ios-sim
+
+# The static libraries will be at:
+# target/aarch64-apple-ios/release/libtoku_ffi.a
+# target/aarch64-apple-ios-sim/release/libtoku_ffi.a
 ```
 
 ### 2. Copy the header
@@ -42,17 +79,12 @@ The header is auto-generated during build. Copy it to the Swift package:
 cp crates/toku-ffi/toku.h toku-apple/TokuKit/Sources/CTokuFFI/toku.h
 ```
 
-### 3. Open in Xcode
-
-```bash
-cd toku-apple
-open Toku.xcodeproj   # or create from Xcode: File > New > Project
-```
-
-### 4. Configure the Xcode project
+### 3. Configure the Xcode project
 
 Since this is a source-only delivery (no `.xcodeproj` checked in), create the
 project in Xcode:
+
+#### macOS target
 
 1. **File → New → Project → macOS → App** (SwiftUI, Swift)
 2. Product name: `Toku`, bundle ID: `dev.toku.app`
@@ -65,7 +97,27 @@ project in Xcode:
    - **Other Linker Flags**: add `-ltoku_ffi -lsqlite3 -framework Security`
 7. Build and run (⌘R)
 
+#### iOS target
+
+1. **File → New Target → iOS → App** (SwiftUI, Swift) — or add to the existing
+   project
+2. Product name: `Toku iOS`, bundle ID: `dev.toku.ios`
+3. Set deployment target to **iOS 17.0**
+4. Supported destinations: **iPhone** and **iPad**
+5. Add `TokuKit` and `TokuKitUI` as dependencies of the iOS target:
+   **Target → General → Frameworks, Libraries, and Embedded Content**
+6. Add the existing Swift source files from `Toku iOS/` to the iOS target
+7. In **Build Settings**:
+   - **Library Search Paths**:
+     - Device: `$(PROJECT_DIR)/../target/aarch64-apple-ios/release`
+     - Simulator: `$(PROJECT_DIR)/../target/aarch64-apple-ios-sim/release`
+   - **Other Linker Flags**: add `-ltoku_ffi -lsqlite3 -framework Security`
+8. Copy `Toku iOS/Info.plist` to the target's info plist
+9. Build and run on device or simulator (⌘R)
+
 ## Features
+
+### macOS app
 
 | Feature | Status |
 |---|---|
@@ -81,20 +133,58 @@ project in Xcode:
 | Dark mode (system preference) | ✅ |
 | Fully offline | ✅ |
 
+### iOS app
+
+| Feature | Status |
+|---|---|
+| Library grid with cover cards | ✅ |
+| Search with full-text search | ✅ |
+| Book detail with metadata and tags | ✅ |
+| Quick progress update (≤3 taps) | ✅ |
+| Barcode scanner (ISBN-13 via camera) | ✅ |
+| Manual ISBN entry fallback | ✅ |
+| Statistics glance with Swift Charts | ✅ |
+| Goodreads CSV import (file picker) | ✅ |
+| iPad NavigationSplitView with sidebar | ✅ |
+| iPhone TabView navigation | ✅ |
+| Status filter chips | ✅ |
+| Pull-to-refresh | ✅ |
+| Dark mode (system preference) | ✅ |
+| Fully offline | ✅ |
+
 ## Data storage
 
-The database is stored in Application Support:
+### macOS
 
 ```text
 ~/Library/Application Support/dev.toku.app/library.db
 ```
 
-## What cannot be validated on Windows
+### iOS
+
+```text
+<App Container>/Library/Application Support/dev.toku.ios/library.db
+```
+
+## Known limitations
+
+### FFI gaps (to be addressed)
+
+- **Reading progress logging**: `toku-db` has `log_progress()` but `toku-ffi`
+  does not yet expose it. The progress update sheet currently updates reading
+  status only. A `toku_log_progress` FFI function is needed.
+- **ISBN-based book addition**: The barcode scanner captures ISBN-13 codes but
+  the current `toku_add_book` FFI function only accepts title/author. An
+  ISBN-aware add function or metadata fetch through `toku-meta` FFI is needed.
+
+### What cannot be validated on Windows
 
 - Swift compilation and Xcode project setup
-- Linking against `libtoku_ffi.a`
+- Linking against `libtoku_ffi.a` (any platform)
 - SwiftUI rendering and interaction
 - macOS-specific APIs (NSOpenPanel, drag-and-drop)
+- iOS-specific APIs (AVFoundation barcode scanning, UIDocumentPicker)
+- iOS simulator and device testing
 
 All Rust FFI code is validated by the `toku-ffi` test suite which runs on all
 platforms in CI.

--- a/toku-apple/README.md
+++ b/toku-apple/README.md
@@ -38,6 +38,7 @@ SwiftUI Views → Swift ViewModels → TokuFFI wrapper → toku-ffi (C ABI) → 
 - iOS 17.0 or later
 - Xcode 15.4 or later
 - Rust toolchain with iOS targets:
+
   ```bash
   rustup target add aarch64-apple-ios         # Device
   rustup target add aarch64-apple-ios-sim     # Apple Silicon simulator

--- a/toku-apple/Toku iOS/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/toku-apple/Toku iOS/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.459",
+          "green" : "0.349",
+          "red" : "0.231"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/toku-apple/Toku iOS/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/toku-apple/Toku iOS/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,13 @@
+{
+  "images" : [
+    {
+      "idiom" : "universal",
+      "platform" : "ios",
+      "size" : "1024x1024"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/toku-apple/Toku iOS/Assets.xcassets/Contents.json
+++ b/toku-apple/Toku iOS/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/toku-apple/Toku iOS/Info.plist
+++ b/toku-apple/Toku iOS/Info.plist
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDisplayName</key>
+	<string>Toku</string>
+	<key>CFBundleIdentifier</key>
+	<string>dev.toku.ios</string>
+	<key>CFBundleName</key>
+	<string>Toku</string>
+	<key>CFBundleShortVersionString</key>
+	<string>0.2.1</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>LSRequiresIPhoneOS</key>
+	<true/>
+	<key>MinimumOSVersion</key>
+	<string>17.0</string>
+	<key>NSCameraUsageDescription</key>
+	<string>Toku uses the camera to scan book barcodes (ISBN) for quick library additions.</string>
+	<key>UILaunchScreen</key>
+	<dict/>
+	<key>UIRequiredDeviceCapabilities</key>
+	<array>
+		<string>arm64</string>
+	</array>
+	<key>UISupportedInterfaceOrientations</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+	<key>UISupportedInterfaceOrientations~ipad</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+</dict>
+</plist>

--- a/toku-apple/Toku iOS/TokuiOSApp.swift
+++ b/toku-apple/Toku iOS/TokuiOSApp.swift
@@ -1,0 +1,55 @@
+import SwiftUI
+import TokuKit
+
+/// Main entry point for the Toku iOS app.
+@main
+struct TokuiOSApp: App {
+    @StateObject private var appState = AppState()
+
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+                .environmentObject(appState)
+        }
+    }
+}
+
+/// Shared app-level state holding the FFI connection and view models.
+@MainActor
+final class AppState: ObservableObject {
+    let ffi: TokuFFI?
+    @Published var libraryVM: LibraryViewModel?
+    @Published var statsVM: StatsViewModel?
+    @Published var importVM: ImportViewModel?
+    @Published var errorMessage: String?
+
+    init() {
+        let dbPath = AppState.defaultDatabasePath()
+
+        do {
+            let ffi = try TokuFFI(path: dbPath)
+            self.ffi = ffi
+            self.libraryVM = LibraryViewModel(ffi: ffi)
+            self.statsVM = StatsViewModel(ffi: ffi)
+            self.importVM = ImportViewModel(ffi: ffi)
+        } catch {
+            self.ffi = nil
+            self.errorMessage = "Failed to open database: \(error.localizedDescription)"
+        }
+    }
+
+    /// Default database path in the app's Application Support directory.
+    static func defaultDatabasePath() -> String {
+        let appSupport = FileManager.default.urls(
+            for: .applicationSupportDirectory,
+            in: .userDomainMask
+        ).first!.appendingPathComponent("dev.toku.ios")
+
+        try? FileManager.default.createDirectory(
+            at: appSupport,
+            withIntermediateDirectories: true
+        )
+
+        return appSupport.appendingPathComponent("library.db").path
+    }
+}

--- a/toku-apple/Toku iOS/Views/BarcodeScannerView.swift
+++ b/toku-apple/Toku iOS/Views/BarcodeScannerView.swift
@@ -1,0 +1,309 @@
+import SwiftUI
+import AVFoundation
+
+/// Camera-based ISBN barcode scanner using AVFoundation.
+///
+/// Scans EAN-13 barcodes (ISBN-13 format) and presents the result.
+/// Includes manual ISBN entry as a fallback for denied camera permissions
+/// or simulator use.
+struct BarcodeScannerView: View {
+    let ffi: TokuFFI?
+    @State private var scannedISBN: String?
+    @State private var manualISBN = ""
+    @State private var showManualEntry = false
+    @State private var addedMessage: String?
+    @State private var errorMessage: String?
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        VStack(spacing: 0) {
+            if let isbn = scannedISBN {
+                scannedResultView(isbn: isbn)
+            } else if showManualEntry {
+                manualEntryView
+            } else {
+                scannerView
+            }
+        }
+        .navigationTitle("Scan ISBN")
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbar {
+            ToolbarItem(placement: .topBarTrailing) {
+                Button(showManualEntry ? "Camera" : "Manual") {
+                    showManualEntry.toggle()
+                    scannedISBN = nil
+                }
+            }
+        }
+    }
+
+    // MARK: - Scanner
+
+    @ViewBuilder
+    private var scannerView: some View {
+        ZStack {
+            CameraPreview(onBarcodeScanned: { code in
+                if isValidISBN13(code) {
+                    scannedISBN = code
+                }
+            })
+            .ignoresSafeArea()
+
+            // Viewfinder overlay
+            VStack {
+                Spacer()
+                RoundedRectangle(cornerRadius: 12)
+                    .stroke(.white, lineWidth: 2)
+                    .frame(width: 280, height: 100)
+                    .background(.black.opacity(0.1))
+
+                Text("Point camera at ISBN barcode")
+                    .font(.callout)
+                    .foregroundStyle(.white)
+                    .padding(8)
+                    .background(.black.opacity(0.6), in: Capsule())
+                    .padding(.top, 12)
+                Spacer()
+            }
+        }
+    }
+
+    // MARK: - Manual entry
+
+    @ViewBuilder
+    private var manualEntryView: some View {
+        VStack(spacing: 24) {
+            Spacer()
+
+            Image(systemName: "barcode")
+                .font(.system(size: 64))
+                .foregroundStyle(.secondary)
+
+            Text("Enter ISBN Manually")
+                .font(.title2)
+                .fontWeight(.semibold)
+
+            TextField("ISBN-13 (e.g. 978-0-13-468599-1)", text: $manualISBN)
+                .keyboardType(.numberPad)
+                .textFieldStyle(.roundedBorder)
+                .padding(.horizontal, 40)
+
+            Button("Look Up") {
+                let cleaned = manualISBN.replacingOccurrences(of: "-", with: "")
+                    .replacingOccurrences(of: " ", with: "")
+                if isValidISBN13(cleaned) {
+                    scannedISBN = cleaned
+                } else {
+                    errorMessage = "Invalid ISBN-13. Must be 13 digits starting with 978 or 979."
+                }
+            }
+            .buttonStyle(.borderedProminent)
+            .disabled(manualISBN.isEmpty)
+
+            if let error = errorMessage {
+                Text(error)
+                    .font(.callout)
+                    .foregroundStyle(.red)
+            }
+
+            Spacer()
+        }
+    }
+
+    // MARK: - Scanned result
+
+    @ViewBuilder
+    private func scannedResultView(isbn: String) -> some View {
+        VStack(spacing: 24) {
+            Spacer()
+
+            Image(systemName: "checkmark.circle.fill")
+                .font(.system(size: 64))
+                .foregroundStyle(.green)
+
+            Text("ISBN Scanned")
+                .font(.title2)
+                .fontWeight(.semibold)
+
+            Text(isbn)
+                .font(.title3)
+                .monospacedDigit()
+                .foregroundStyle(.secondary)
+
+            if let message = addedMessage {
+                Text(message)
+                    .font(.callout)
+                    .foregroundStyle(.green)
+            } else {
+                VStack(spacing: 12) {
+                    // TODO: Metadata fetch from Open Library when toku-meta FFI is available
+                    Button {
+                        addBookWithISBN(isbn)
+                    } label: {
+                        Label("Add Book with ISBN", systemImage: "plus.circle")
+                            .frame(maxWidth: .infinity)
+                    }
+                    .buttonStyle(.borderedProminent)
+                    .controlSize(.large)
+
+                    Button("Scan Another") {
+                        scannedISBN = nil
+                        manualISBN = ""
+                        showManualEntry = false
+                    }
+                    .buttonStyle(.bordered)
+                }
+                .padding(.horizontal, 40)
+            }
+
+            Spacer()
+        }
+    }
+
+    // MARK: - Helpers
+
+    private func isValidISBN13(_ code: String) -> Bool {
+        let digits = code.filter(\.isNumber)
+        guard digits.count == 13 else { return false }
+        guard digits.hasPrefix("978") || digits.hasPrefix("979") else { return false }
+
+        // Validate check digit
+        let values = digits.compactMap { Int(String($0)) }
+        let sum = values.enumerated().reduce(0) { acc, pair in
+            acc + pair.element * (pair.offset.isMultiple(of: 2) ? 1 : 3)
+        }
+        return sum % 10 == 0
+    }
+
+    private func addBookWithISBN(_ isbn: String) {
+        guard let ffi = ffi else {
+            errorMessage = "Database not available"
+            return
+        }
+
+        do {
+            let title = "ISBN: \(isbn)"
+            let _ = try ffi.addBook(title: title)
+            addedMessage = "Book added to library. Edit details to complete metadata."
+        } catch {
+            errorMessage = "Failed to add book: \(error.localizedDescription)"
+        }
+    }
+}
+
+// MARK: - Camera Preview (AVFoundation)
+
+/// UIViewControllerRepresentable wrapping AVFoundation for barcode scanning.
+struct CameraPreview: UIViewControllerRepresentable {
+    let onBarcodeScanned: (String) -> Void
+
+    func makeUIViewController(context: Context) -> CameraScannerViewController {
+        let vc = CameraScannerViewController()
+        vc.onBarcodeScanned = onBarcodeScanned
+        return vc
+    }
+
+    func updateUIViewController(_ uiViewController: CameraScannerViewController, context: Context) {}
+}
+
+/// View controller that manages the AVCaptureSession for barcode scanning.
+final class CameraScannerViewController: UIViewController, AVCaptureMetadataOutputObjectsDelegate {
+    var onBarcodeScanned: ((String) -> Void)?
+    private var captureSession: AVCaptureSession?
+    private var previewLayer: AVCaptureVideoPreviewLayer?
+    private var hasScanned = false
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        setupCamera()
+    }
+
+    override func viewDidLayoutSubviews() {
+        super.viewDidLayoutSubviews()
+        previewLayer?.frame = view.bounds
+    }
+
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        if let session = captureSession, !session.isRunning {
+            DispatchQueue.global(qos: .userInitiated).async {
+                session.startRunning()
+            }
+        }
+    }
+
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        if let session = captureSession, session.isRunning {
+            DispatchQueue.global(qos: .userInitiated).async {
+                session.stopRunning()
+            }
+        }
+    }
+
+    private func setupCamera() {
+        let session = AVCaptureSession()
+        self.captureSession = session
+
+        guard let device = AVCaptureDevice.default(for: .video),
+              let input = try? AVCaptureDeviceInput(device: device) else {
+            showPermissionDenied()
+            return
+        }
+
+        if session.canAddInput(input) {
+            session.addInput(input)
+        }
+
+        let output = AVCaptureMetadataOutput()
+        if session.canAddOutput(output) {
+            session.addOutput(output)
+            output.setMetadataObjectsDelegate(self, queue: .main)
+            output.metadataObjectTypes = [.ean13]
+        }
+
+        let layer = AVCaptureVideoPreviewLayer(session: session)
+        layer.videoGravity = .resizeAspectFill
+        layer.frame = view.bounds
+        view.layer.addSublayer(layer)
+        self.previewLayer = layer
+
+        DispatchQueue.global(qos: .userInitiated).async {
+            session.startRunning()
+        }
+    }
+
+    private func showPermissionDenied() {
+        let label = UILabel()
+        label.text = "Camera access is required to scan barcodes.\nGo to Settings → Toku → Camera."
+        label.numberOfLines = 0
+        label.textAlignment = .center
+        label.textColor = .secondaryLabel
+        label.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(label)
+        NSLayoutConstraint.activate([
+            label.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+            label.centerYAnchor.constraint(equalTo: view.centerYAnchor),
+            label.leadingAnchor.constraint(greaterThanOrEqualTo: view.leadingAnchor, constant: 32),
+        ])
+    }
+
+    func metadataOutput(
+        _ output: AVCaptureMetadataOutput,
+        didOutput metadataObjects: [AVMetadataObject],
+        from connection: AVCaptureConnection
+    ) {
+        guard !hasScanned,
+              let object = metadataObjects.first as? AVMetadataMachineReadableCodeObject,
+              let code = object.stringValue else { return }
+
+        hasScanned = true
+
+        // Haptic feedback
+        let generator = UIImpactFeedbackGenerator(style: .medium)
+        generator.impactOccurred()
+
+        captureSession?.stopRunning()
+        onBarcodeScanned?(code)
+    }
+}

--- a/toku-apple/Toku iOS/Views/BookDetailView.swift
+++ b/toku-apple/Toku iOS/Views/BookDetailView.swift
@@ -1,0 +1,219 @@
+import SwiftUI
+import TokuKit
+import TokuKitUI
+
+/// Full book detail view for iOS. Displays as a pushed view on iPhone
+/// or in the detail pane on iPad.
+struct BookDetailView: View {
+    let bookID: String
+    let ffi: TokuFFI
+    @StateObject private var viewModel: BookDetailViewModel
+    @State private var showProgressSheet = false
+
+    init(bookID: String, ffi: TokuFFI) {
+        self.bookID = bookID
+        self.ffi = ffi
+        _viewModel = StateObject(wrappedValue: BookDetailViewModel(ffi: ffi))
+    }
+
+    var body: some View {
+        Group {
+            if viewModel.isLoading {
+                ProgressView()
+            } else if let book = viewModel.book {
+                ScrollView {
+                    VStack(alignment: .leading, spacing: 24) {
+                        headerSection(book)
+                        actionButtons(book)
+                        Divider()
+                        metadataSection(book)
+                        if !viewModel.tags.isEmpty {
+                            Divider()
+                            tagsSection
+                        }
+                    }
+                    .padding()
+                }
+            } else if let error = viewModel.errorMessage {
+                ContentUnavailableView(
+                    "Error",
+                    systemImage: "exclamationmark.triangle",
+                    description: Text(error)
+                )
+            } else {
+                ContentUnavailableView(
+                    "No Book Selected",
+                    systemImage: "book",
+                    description: Text("Select a book from the library.")
+                )
+            }
+        }
+        .navigationTitle(viewModel.book?.title ?? "Book")
+        .navigationBarTitleDisplayMode(.inline)
+        .onChange(of: bookID) { _, newID in
+            viewModel.loadBook(id: newID)
+        }
+        .onAppear {
+            viewModel.loadBook(id: bookID)
+        }
+        .sheet(isPresented: $showProgressSheet) {
+            if let book = viewModel.book {
+                ProgressUpdateSheet(
+                    book: book,
+                    viewModel: nil,
+                    onSave: { viewModel.loadBook(id: bookID) }
+                )
+                .presentationDetents([.medium])
+            }
+        }
+    }
+
+    // MARK: - Header
+
+    @ViewBuilder
+    private func headerSection(_ book: Book) -> some View {
+        HStack(alignment: .top, spacing: 16) {
+            // Cover placeholder
+            RoundedRectangle(cornerRadius: 10)
+                .fill(coverColor(for: book.title))
+                .overlay {
+                    VStack(spacing: 4) {
+                        Text(book.title)
+                            .font(.caption)
+                            .fontWeight(.semibold)
+                            .multilineTextAlignment(.center)
+                            .lineLimit(3)
+                    }
+                    .padding(8)
+                }
+                .frame(width: 100, height: 150)
+                .shadow(radius: 3)
+
+            VStack(alignment: .leading, spacing: 8) {
+                Text(book.title)
+                    .font(.title2)
+                    .fontWeight(.bold)
+                if let subtitle = book.subtitle {
+                    Text(subtitle)
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
+                }
+                Text(book.authorDisplay)
+                    .font(.headline)
+                    .foregroundStyle(.secondary)
+
+                HStack(spacing: 12) {
+                    Label(book.status.displayName, systemImage: book.status.systemImage)
+                        .font(.callout)
+                        .foregroundStyle(statusColor(book.status))
+
+                    if let stars = book.starRating {
+                        StarRatingView(rating: stars)
+                    }
+                }
+            }
+        }
+    }
+
+    // MARK: - Action buttons
+
+    @ViewBuilder
+    private func actionButtons(_ book: Book) -> some View {
+        HStack(spacing: 12) {
+            if book.status == .reading {
+                Button {
+                    showProgressSheet = true
+                } label: {
+                    Label("Update Progress", systemImage: "bookmark.fill")
+                        .frame(maxWidth: .infinity)
+                }
+                .buttonStyle(.borderedProminent)
+                .controlSize(.large)
+            }
+
+            Menu {
+                ForEach(ReadingStatus.allCases) { status in
+                    Button(status.displayName) {
+                        updateStatus(book: book, status: status)
+                    }
+                }
+            } label: {
+                Label("Status", systemImage: "arrow.triangle.2.circlepath")
+                    .frame(maxWidth: .infinity)
+            }
+            .buttonStyle(.bordered)
+            .controlSize(.large)
+        }
+    }
+
+    // MARK: - Metadata
+
+    @ViewBuilder
+    private func metadataSection(_ book: Book) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Details")
+                .font(.headline)
+
+            MetadataRow(label: "Format", value: book.format.displayName)
+
+            if let pages = book.pageCount {
+                MetadataRow(label: "Pages", value: "\(pages)")
+            }
+
+            if let pubDate = book.pubDate {
+                MetadataRow(label: "Published", value: pubDate)
+            }
+
+            if let language = book.language {
+                MetadataRow(label: "Language", value: language.uppercased())
+            }
+        }
+    }
+
+    // MARK: - Tags
+
+    @ViewBuilder
+    private var tagsSection: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Tags")
+                .font(.headline)
+
+            FlowLayout(spacing: 6) {
+                ForEach(viewModel.tags) { tag in
+                    Text(tag.name)
+                        .font(.caption)
+                        .padding(.horizontal, 8)
+                        .padding(.vertical, 4)
+                        .background(.quaternary)
+                        .clipShape(Capsule())
+                }
+            }
+        }
+    }
+
+    // MARK: - Helpers
+
+    private func updateStatus(book: Book, status: ReadingStatus) {
+        let ffiRef = ffi
+        Task {
+            try? ffiRef.updateBookStatus(id: book.id, status: status)
+            viewModel.loadBook(id: book.id)
+        }
+    }
+
+    private func statusColor(_ status: ReadingStatus) -> Color {
+        switch status {
+        case .wantToRead: return .blue
+        case .reading: return .green
+        case .read: return .secondary
+        case .onHold: return .orange
+        case .didNotFinish: return .red
+        }
+    }
+
+    private func coverColor(for title: String) -> Color {
+        let hash = abs(title.hashValue)
+        let hue = Double(hash % 360) / 360.0
+        return Color(hue: hue, saturation: 0.3, brightness: 0.9)
+    }
+}

--- a/toku-apple/Toku iOS/Views/Components/ProgressRing.swift
+++ b/toku-apple/Toku iOS/Views/Components/ProgressRing.swift
@@ -1,0 +1,34 @@
+import SwiftUI
+
+/// Circular progress ring indicator.
+public struct ProgressRing: View {
+    public let progress: Double
+    private let lineWidth: CGFloat = 10
+
+    public init(progress: Double) {
+        self.progress = progress
+    }
+
+    public var body: some View {
+        ZStack {
+            Circle()
+                .stroke(.quaternary, lineWidth: lineWidth)
+
+            Circle()
+                .trim(from: 0, to: min(progress, 1.0))
+                .stroke(
+                    progress >= 1.0 ? Color.green : Color.accentColor,
+                    style: StrokeStyle(lineWidth: lineWidth, lineCap: .round)
+                )
+                .rotationEffect(.degrees(-90))
+                .animation(.easeInOut(duration: 0.3), value: progress)
+
+            VStack(spacing: 2) {
+                Text("\(Int(progress * 100))%")
+                    .font(.title2)
+                    .fontWeight(.bold)
+                    .monospacedDigit()
+            }
+        }
+    }
+}

--- a/toku-apple/Toku iOS/Views/ContentView.swift
+++ b/toku-apple/Toku iOS/Views/ContentView.swift
@@ -1,0 +1,176 @@
+import SwiftUI
+import TokuKit
+
+/// Root view that adapts between iPhone (TabView) and iPad (NavigationSplitView).
+struct ContentView: View {
+    @EnvironmentObject var appState: AppState
+    @Environment(\.horizontalSizeClass) private var sizeClass
+
+    var body: some View {
+        if let errorMessage = appState.errorMessage {
+            errorView(errorMessage)
+        } else if sizeClass == .regular {
+            iPadLayout
+        } else {
+            iPhoneLayout
+        }
+    }
+
+    // MARK: - iPhone: Tab-based navigation
+
+    private var iPhoneLayout: some View {
+        TabView {
+            Tab("Library", systemImage: "books.vertical") {
+                NavigationStack {
+                    if let vm = appState.libraryVM {
+                        LibraryGridView(viewModel: vm, ffi: appState.ffi)
+                    }
+                }
+            }
+
+            Tab("Search", systemImage: "magnifyingglass") {
+                NavigationStack {
+                    if let vm = appState.libraryVM {
+                        SearchView(viewModel: vm, ffi: appState.ffi)
+                    }
+                }
+            }
+
+            Tab("Stats", systemImage: "chart.bar") {
+                NavigationStack {
+                    if let vm = appState.statsVM {
+                        StatsGlanceView(viewModel: vm)
+                    }
+                }
+            }
+
+            Tab("More", systemImage: "ellipsis") {
+                NavigationStack {
+                    MoreView()
+                }
+            }
+        }
+    }
+
+    // MARK: - iPad: Sidebar navigation
+
+    @State private var iPadSelection: SidebarItem? = .library
+    @State private var selectedBookID: String?
+
+    private var iPadLayout: some View {
+        NavigationSplitView {
+            iPadSidebar
+        } content: {
+            switch iPadSelection {
+            case .library:
+                if let vm = appState.libraryVM {
+                    LibraryGridView(viewModel: vm, ffi: appState.ffi)
+                }
+            case .search:
+                if let vm = appState.libraryVM {
+                    SearchView(viewModel: vm, ffi: appState.ffi)
+                }
+            case .stats:
+                if let vm = appState.statsVM {
+                    StatsGlanceView(viewModel: vm)
+                }
+            case .importBooks:
+                if let vm = appState.importVM {
+                    ImportView(viewModel: vm, onImportComplete: {
+                        appState.libraryVM?.loadBooks()
+                    })
+                }
+            case .none:
+                Text("Select an item from the sidebar")
+                    .foregroundStyle(.secondary)
+            }
+        } detail: {
+            if let bookID = selectedBookID, let ffi = appState.ffi {
+                BookDetailView(bookID: bookID, ffi: ffi)
+            } else {
+                Text("Select a book to see details")
+                    .foregroundStyle(.secondary)
+            }
+        }
+    }
+
+    private var iPadSidebar: some View {
+        List(selection: $iPadSelection) {
+            Section("Library") {
+                Label("All Books", systemImage: "books.vertical")
+                    .tag(SidebarItem.library)
+                Label("Search", systemImage: "magnifyingglass")
+                    .tag(SidebarItem.search)
+            }
+
+            Section("Insights") {
+                Label("Statistics", systemImage: "chart.bar")
+                    .tag(SidebarItem.stats)
+            }
+
+            Section("Manage") {
+                Label("Import", systemImage: "square.and.arrow.down")
+                    .tag(SidebarItem.importBooks)
+            }
+        }
+        .listStyle(.sidebar)
+        .navigationTitle("Toku")
+    }
+
+    // MARK: - Error state
+
+    @ViewBuilder
+    private func errorView(_ message: String) -> some View {
+        VStack(spacing: 16) {
+            Image(systemName: "exclamationmark.triangle")
+                .font(.largeTitle)
+                .foregroundStyle(.red)
+            Text("Unable to start Toku")
+                .font(.headline)
+            Text(message)
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
+        }
+        .padding()
+    }
+}
+
+/// Sidebar navigation items for iPad.
+enum SidebarItem: String, Identifiable, CaseIterable {
+    case library = "Library"
+    case search = "Search"
+    case stats = "Statistics"
+    case importBooks = "Import"
+
+    var id: String { rawValue }
+}
+
+/// Placeholder "More" screen for iPhone (settings, import, about).
+struct MoreView: View {
+    @EnvironmentObject var appState: AppState
+
+    var body: some View {
+        List {
+            if let vm = appState.importVM {
+                NavigationLink {
+                    ImportView(viewModel: vm, onImportComplete: {
+                        appState.libraryVM?.loadBooks()
+                    })
+                } label: {
+                    Label("Import Goodreads CSV", systemImage: "square.and.arrow.down")
+                }
+            }
+
+            NavigationLink {
+                BarcodeScannerView(ffi: appState.ffi)
+            } label: {
+                Label("Scan ISBN Barcode", systemImage: "barcode.viewfinder")
+            }
+
+            Section("About") {
+                LabeledContent("Version", value: "0.2.1")
+            }
+        }
+        .navigationTitle("More")
+    }
+}

--- a/toku-apple/Toku iOS/Views/ImportView.swift
+++ b/toku-apple/Toku iOS/Views/ImportView.swift
@@ -1,0 +1,134 @@
+import SwiftUI
+import TokuKit
+import UniformTypeIdentifiers
+
+/// Import view adapted for iOS using `.fileImporter()`.
+struct ImportView: View {
+    @ObservedObject var viewModel: ImportViewModel
+    var onImportComplete: () -> Void
+
+    @State private var isDryRun = true
+    @State private var showFilePicker = false
+    @State private var lastImportPath: String?
+
+    var body: some View {
+        VStack(spacing: 24) {
+            Spacer()
+
+            Image(systemName: "arrow.down.doc")
+                .font(.system(size: 48))
+                .foregroundStyle(.secondary)
+
+            Text("Import from Goodreads")
+                .font(.title2)
+                .fontWeight(.semibold)
+
+            Text("Select your Goodreads library export CSV file.")
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
+                .padding(.horizontal)
+
+            Button {
+                showFilePicker = true
+            } label: {
+                Label("Choose CSV File", systemImage: "doc.badge.plus")
+                    .frame(maxWidth: .infinity)
+            }
+            .buttonStyle(.borderedProminent)
+            .controlSize(.large)
+            .padding(.horizontal, 40)
+
+            Toggle("Dry run (preview without importing)", isOn: $isDryRun)
+                .padding(.horizontal, 40)
+
+            if viewModel.isImporting {
+                ProgressView("Importing…")
+            }
+
+            if let report = viewModel.report {
+                reportView(report)
+            }
+
+            if let error = viewModel.errorMessage {
+                Label(error, systemImage: "exclamationmark.triangle")
+                    .foregroundStyle(.red)
+                    .padding(.horizontal)
+            }
+
+            Spacer()
+        }
+        .navigationTitle("Import")
+        .fileImporter(
+            isPresented: $showFilePicker,
+            allowedContentTypes: [
+                UTType(filenameExtension: "csv") ?? .commaSeparatedText,
+            ],
+            allowsMultipleSelection: false
+        ) { result in
+            switch result {
+            case .success(let urls):
+                if let url = urls.first {
+                    guard url.startAccessingSecurityScopedResource() else { return }
+                    defer { url.stopAccessingSecurityScopedResource() }
+                    let path = url.path
+                    lastImportPath = path
+                    viewModel.importGoodreads(path: path, dryRun: isDryRun)
+                    if !isDryRun {
+                        onImportComplete()
+                    }
+                }
+            case .failure(let error):
+                viewModel.errorMessage = error.localizedDescription
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func reportView(_ report: ImportReport) -> some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Label(
+                isDryRun ? "Dry Run Complete" : "Import Complete",
+                systemImage: isDryRun ? "eye" : "checkmark.circle.fill"
+            )
+            .font(.headline)
+            .foregroundStyle(isDryRun ? .orange : .green)
+
+            Grid(alignment: .leading, horizontalSpacing: 16, verticalSpacing: 8) {
+                GridRow {
+                    Text("Total rows").foregroundStyle(.secondary)
+                    Text("\(report.totalRows)").fontWeight(.medium)
+                }
+                GridRow {
+                    Text("Imported").foregroundStyle(.secondary)
+                    Text("\(report.imported)").fontWeight(.medium).foregroundStyle(.green)
+                }
+                GridRow {
+                    Text("Skipped").foregroundStyle(.secondary)
+                    Text("\(report.skipped)").fontWeight(.medium)
+                }
+                GridRow {
+                    Text("Updated").foregroundStyle(.secondary)
+                    Text("\(report.updated)").fontWeight(.medium).foregroundStyle(.blue)
+                }
+                if report.errors > 0 {
+                    GridRow {
+                        Text("Errors").foregroundStyle(.secondary)
+                        Text("\(report.errors)").fontWeight(.medium).foregroundStyle(.red)
+                    }
+                }
+            }
+
+            if isDryRun, let path = lastImportPath {
+                Button("Import for Real") {
+                    viewModel.importGoodreads(path: path, dryRun: false)
+                    onImportComplete()
+                }
+                .buttonStyle(.borderedProminent)
+            }
+        }
+        .padding()
+        .background(.background.secondary)
+        .clipShape(RoundedRectangle(cornerRadius: 12))
+        .padding(.horizontal)
+    }
+}

--- a/toku-apple/Toku iOS/Views/LibraryGridView.swift
+++ b/toku-apple/Toku iOS/Views/LibraryGridView.swift
@@ -1,0 +1,197 @@
+import SwiftUI
+import TokuKit
+import TokuKitUI
+
+/// Responsive cover grid view for the book library.
+///
+/// On iPhone, shows 2 columns. On iPad, adapts to 3–4+ columns.
+/// Supports search, status filter chips, pull-to-refresh, and
+/// a visible progress button on currently-reading books.
+struct LibraryGridView: View {
+    @ObservedObject var viewModel: LibraryViewModel
+    let ffi: TokuFFI?
+    @State private var selectedBookID: String?
+    @State private var progressBook: Book?
+    @State private var statusFilter: ReadingStatus?
+
+    private var columns: [GridItem] {
+        [GridItem(.adaptive(minimum: 140, maximum: 180), spacing: 16)]
+    }
+
+    private var filteredBooks: [Book] {
+        guard let filter = statusFilter else { return viewModel.books }
+        return viewModel.books.filter { $0.status == filter }
+    }
+
+    var body: some View {
+        ScrollView {
+            VStack(spacing: 0) {
+                filterChips
+                    .padding(.horizontal)
+                    .padding(.bottom, 8)
+
+                LazyVGrid(columns: columns, spacing: 20) {
+                    ForEach(filteredBooks) { book in
+                        NavigationLink(value: book.id) {
+                            BookCard(book: book, onProgressTap: {
+                                progressBook = book
+                            })
+                        }
+                        .buttonStyle(.plain)
+                        .contextMenu {
+                            ForEach(ReadingStatus.allCases) { status in
+                                Button(status.displayName) {
+                                    viewModel.updateStatus(id: book.id, status: status)
+                                }
+                            }
+                            Divider()
+                            Button("Delete", role: .destructive) {
+                                viewModel.deleteBook(id: book.id)
+                            }
+                        }
+                    }
+                }
+                .padding(.horizontal)
+            }
+        }
+        .refreshable {
+            viewModel.loadBooks()
+        }
+        .overlay {
+            if viewModel.isLoading {
+                ProgressView("Loading…")
+            } else if viewModel.books.isEmpty {
+                ContentUnavailableView(
+                    "No Books",
+                    systemImage: "books.vertical",
+                    description: Text("Add books or import from Goodreads to get started.")
+                )
+            }
+        }
+        .navigationTitle("Library")
+        .navigationDestination(for: String.self) { bookID in
+            if let ffi = ffi {
+                BookDetailView(bookID: bookID, ffi: ffi)
+            }
+        }
+        .searchable(
+            text: Binding(
+                get: { viewModel.searchText },
+                set: { newValue in
+                    viewModel.searchText = newValue
+                    viewModel.loadBooks()
+                }
+            ),
+            prompt: "Search books…"
+        )
+        .sheet(item: $progressBook) { book in
+            ProgressUpdateSheet(book: book, viewModel: viewModel)
+                .presentationDetents([.medium])
+        }
+        .onAppear { viewModel.loadBooks() }
+    }
+
+    // MARK: - Filter chips
+
+    @ViewBuilder
+    private var filterChips: some View {
+        ScrollView(.horizontal, showsIndicators: false) {
+            HStack(spacing: 8) {
+                FilterChip(title: "All", isActive: statusFilter == nil) {
+                    statusFilter = nil
+                }
+                ForEach(ReadingStatus.allCases) { status in
+                    FilterChip(
+                        title: status.displayName,
+                        isActive: statusFilter == status
+                    ) {
+                        statusFilter = (statusFilter == status) ? nil : status
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// A single book card in the grid with an optional quick-progress button.
+struct BookCard: View {
+    let book: Book
+    var onProgressTap: (() -> Void)?
+
+    var body: some View {
+        VStack(spacing: 8) {
+            // Cover placeholder
+            ZStack(alignment: .bottomTrailing) {
+                RoundedRectangle(cornerRadius: 10)
+                    .fill(coverColor(for: book.title))
+                    .overlay {
+                        VStack(spacing: 4) {
+                            Text(book.title)
+                                .font(.caption)
+                                .fontWeight(.semibold)
+                                .multilineTextAlignment(.center)
+                                .lineLimit(3)
+                            Text(book.authorDisplay)
+                                .font(.caption2)
+                                .foregroundStyle(.secondary)
+                                .lineLimit(1)
+                        }
+                        .padding(8)
+                    }
+                    .frame(height: 200)
+
+                // Quick progress button for currently-reading books
+                if book.status == .reading, let onTap = onProgressTap {
+                    Button {
+                        onTap()
+                    } label: {
+                        Image(systemName: "bookmark.fill")
+                            .font(.caption)
+                            .foregroundStyle(.white)
+                            .padding(6)
+                            .background(.tint, in: Circle())
+                    }
+                    .padding(6)
+                }
+            }
+
+            // Status badge
+            Label(book.status.displayName, systemImage: book.status.systemImage)
+                .font(.caption2)
+                .foregroundStyle(.secondary)
+
+            // Rating
+            if let stars = book.starRating {
+                StarRatingView(rating: stars)
+            }
+        }
+        .frame(width: 160)
+    }
+
+    private func coverColor(for title: String) -> Color {
+        let hash = abs(title.hashValue)
+        let hue = Double(hash % 360) / 360.0
+        return Color(hue: hue, saturation: 0.3, brightness: 0.9)
+    }
+}
+
+/// A tappable filter chip for status filtering.
+struct FilterChip: View {
+    let title: String
+    let isActive: Bool
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            Text(title)
+                .font(.subheadline)
+                .fontWeight(isActive ? .semibold : .regular)
+                .padding(.horizontal, 14)
+                .padding(.vertical, 7)
+                .background(isActive ? Color.accentColor : Color(.secondarySystemBackground))
+                .foregroundStyle(isActive ? .white : .primary)
+                .clipShape(Capsule())
+        }
+        .buttonStyle(.plain)
+    }
+}

--- a/toku-apple/Toku iOS/Views/ProgressUpdateSheet.swift
+++ b/toku-apple/Toku iOS/Views/ProgressUpdateSheet.swift
@@ -1,0 +1,131 @@
+import SwiftUI
+import TokuKit
+
+/// Quick progress update sheet — designed for ≤3 taps from the library view.
+///
+/// Flow: Tap progress button on card (1) → adjust page (2) → tap Save (3).
+///
+/// Note: Full reading progress logging requires `toku_log_progress` FFI function
+/// which is available in toku-db but not yet exposed via toku-ffi. For now, this
+/// updates the book's reading status to "reading" as a side effect.
+struct ProgressUpdateSheet: View {
+    let book: Book
+    var viewModel: LibraryViewModel?
+    var onSave: (() -> Void)?
+    @Environment(\.dismiss) private var dismiss
+
+    @State private var currentPage: Int
+    @State private var isSaving = false
+
+    init(book: Book, viewModel: LibraryViewModel? = nil, onSave: (() -> Void)? = nil) {
+        self.book = book
+        self.viewModel = viewModel
+        self.onSave = onSave
+        _currentPage = State(initialValue: 0)
+    }
+
+    private var totalPages: Int {
+        book.pageCount ?? 0
+    }
+
+    private var progressFraction: Double {
+        guard totalPages > 0 else { return 0 }
+        return Double(currentPage) / Double(totalPages)
+    }
+
+    var body: some View {
+        NavigationStack {
+            VStack(spacing: 24) {
+                // Book info
+                VStack(spacing: 4) {
+                    Text(book.title)
+                        .font(.headline)
+                        .multilineTextAlignment(.center)
+                    Text(book.authorDisplay)
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
+                }
+
+                // Progress ring
+                ProgressRing(progress: progressFraction)
+                    .frame(width: 120, height: 120)
+
+                // Page input
+                VStack(spacing: 12) {
+                    if totalPages > 0 {
+                        Text("Page \(currentPage) of \(totalPages)")
+                            .font(.title3)
+                            .monospacedDigit()
+
+                        Slider(
+                            value: Binding(
+                                get: { Double(currentPage) },
+                                set: { currentPage = Int($0) }
+                            ),
+                            in: 0...Double(totalPages),
+                            step: 1
+                        )
+                        .padding(.horizontal)
+
+                        HStack {
+                            Button("-10") { currentPage = max(0, currentPage - 10) }
+                                .buttonStyle(.bordered)
+                            Button("-1") { currentPage = max(0, currentPage - 1) }
+                                .buttonStyle(.bordered)
+                            Spacer()
+                            Button("+1") { currentPage = min(totalPages, currentPage + 1) }
+                                .buttonStyle(.bordered)
+                            Button("+10") { currentPage = min(totalPages, currentPage + 10) }
+                                .buttonStyle(.bordered)
+                        }
+                        .padding(.horizontal)
+                    } else {
+                        Text("No page count set for this book")
+                            .foregroundStyle(.secondary)
+
+                        HStack {
+                            Text("Page:")
+                            TextField("Current page", value: $currentPage, format: .number)
+                                .keyboardType(.numberPad)
+                                .textFieldStyle(.roundedBorder)
+                                .frame(width: 100)
+                        }
+                    }
+                }
+
+                Spacer()
+            }
+            .padding()
+            .navigationTitle("Update Progress")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") { dismiss() }
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Save") {
+                        saveProgress()
+                    }
+                    .fontWeight(.semibold)
+                    .disabled(isSaving)
+                }
+            }
+        }
+    }
+
+    private func saveProgress() {
+        isSaving = true
+
+        // Ensure the book is marked as "reading" if it isn't already
+        if book.status != .reading {
+            viewModel?.updateStatus(id: book.id, status: .reading)
+        }
+
+        // TODO: Call toku_log_progress FFI function when available.
+        // Currently, toku-db has `repo.log_progress()` but toku-ffi
+        // does not expose it. For now, we update the status only.
+
+        onSave?()
+        dismiss()
+    }
+}

--- a/toku-apple/Toku iOS/Views/SearchView.swift
+++ b/toku-apple/Toku iOS/Views/SearchView.swift
@@ -1,0 +1,127 @@
+import SwiftUI
+import TokuKit
+import TokuKitUI
+
+/// Dedicated search view with recent searches and results.
+struct SearchView: View {
+    @ObservedObject var viewModel: LibraryViewModel
+    let ffi: TokuFFI?
+    @State private var searchText = ""
+    @State private var searchResults: [Book] = []
+    @State private var isSearching = false
+
+    var body: some View {
+        List {
+            if searchText.isEmpty {
+                Section {
+                    ContentUnavailableView(
+                        "Search Your Library",
+                        systemImage: "magnifyingglass",
+                        description: Text("Search by title, author, or keyword.")
+                    )
+                }
+            } else if isSearching {
+                Section {
+                    HStack {
+                        ProgressView()
+                        Text("Searching…")
+                            .foregroundStyle(.secondary)
+                    }
+                }
+            } else if searchResults.isEmpty {
+                Section {
+                    ContentUnavailableView(
+                        "No Results",
+                        systemImage: "magnifyingglass",
+                        description: Text("No books match \"\(searchText)\".")
+                    )
+                }
+            } else {
+                Section("\(searchResults.count) Results") {
+                    ForEach(searchResults) { book in
+                        NavigationLink(value: book.id) {
+                            SearchResultRow(book: book)
+                        }
+                    }
+                }
+            }
+        }
+        .listStyle(.insetGrouped)
+        .navigationTitle("Search")
+        .navigationDestination(for: String.self) { bookID in
+            if let ffi = ffi {
+                BookDetailView(bookID: bookID, ffi: ffi)
+            }
+        }
+        .searchable(text: $searchText, prompt: "Search books…")
+        .onSubmit(of: .search) {
+            performSearch()
+        }
+        .onChange(of: searchText) { _, newValue in
+            if newValue.isEmpty {
+                searchResults = []
+            }
+        }
+    }
+
+    private func performSearch() {
+        guard !searchText.isEmpty, let ffi = ffi else { return }
+        isSearching = true
+
+        Task {
+            do {
+                let results = try ffi.searchBooks(query: searchText)
+                searchResults = results
+            } catch {
+                searchResults = []
+            }
+            isSearching = false
+        }
+    }
+}
+
+/// A compact row displaying a search result.
+struct SearchResultRow: View {
+    let book: Book
+
+    var body: some View {
+        HStack(spacing: 12) {
+            // Mini cover
+            RoundedRectangle(cornerRadius: 6)
+                .fill(coverColor(for: book.title))
+                .frame(width: 44, height: 64)
+                .overlay {
+                    Text(book.title.prefix(1))
+                        .font(.title3)
+                        .fontWeight(.bold)
+                        .foregroundStyle(.white.opacity(0.7))
+                }
+
+            VStack(alignment: .leading, spacing: 4) {
+                Text(book.title)
+                    .font(.body)
+                    .fontWeight(.medium)
+                    .lineLimit(1)
+                Text(book.authorDisplay)
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+                HStack(spacing: 8) {
+                    Label(book.status.displayName, systemImage: book.status.systemImage)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                    if let stars = book.starRating {
+                        StarRatingView(rating: stars)
+                    }
+                }
+            }
+        }
+        .padding(.vertical, 4)
+    }
+
+    private func coverColor(for title: String) -> Color {
+        let hash = abs(title.hashValue)
+        let hue = Double(hash % 360) / 360.0
+        return Color(hue: hue, saturation: 0.3, brightness: 0.9)
+    }
+}

--- a/toku-apple/Toku iOS/Views/StatsGlanceView.swift
+++ b/toku-apple/Toku iOS/Views/StatsGlanceView.swift
@@ -1,0 +1,184 @@
+import SwiftUI
+import Charts
+import TokuKit
+import TokuKitUI
+
+/// Stats glance view — summary card showing books read this year,
+/// current streak, and reading pace.
+struct StatsGlanceView: View {
+    @ObservedObject var viewModel: StatsViewModel
+    @State private var selectedYear: Int? = Calendar.current.component(.year, from: Date())
+
+    var body: some View {
+        ScrollView {
+            if viewModel.isLoading {
+                ProgressView("Computing statistics…")
+                    .padding(.top, 40)
+            } else if let stats = viewModel.stats {
+                VStack(alignment: .leading, spacing: 20) {
+                    summarySection(stats)
+                    if let monthly = stats.monthlyActivity, !monthly.isEmpty {
+                        monthlyChart(monthly)
+                    }
+                    if let dist = stats.ratingDistribution, !dist.isEmpty {
+                        ratingChart(dist)
+                    }
+                    if let breakdown = stats.formatBreakdown {
+                        formatSection(breakdown)
+                    }
+                    if let authors = stats.topAuthors, !authors.isEmpty {
+                        topAuthorsSection(authors)
+                    }
+                }
+                .padding()
+            } else if let error = viewModel.errorMessage {
+                ContentUnavailableView(
+                    "Error",
+                    systemImage: "chart.bar.xaxis",
+                    description: Text(error)
+                )
+            } else {
+                ContentUnavailableView(
+                    "No Statistics",
+                    systemImage: "chart.bar.xaxis",
+                    description: Text("Add books and track reading to see statistics.")
+                )
+            }
+        }
+        .navigationTitle("Statistics")
+        .toolbar {
+            ToolbarItem(placement: .topBarTrailing) {
+                Picker("Year", selection: $selectedYear) {
+                    Text("All Time").tag(nil as Int?)
+                    ForEach((2020...Calendar.current.component(.year, from: Date())).reversed(),
+                            id: \.self) { year in
+                        Text(String(year)).tag(year as Int?)
+                    }
+                }
+                .onChange(of: selectedYear) { _, newValue in
+                    viewModel.selectedYear = newValue
+                    viewModel.loadStats()
+                }
+            }
+        }
+        .onAppear {
+            viewModel.selectedYear = selectedYear
+            viewModel.loadStats()
+        }
+    }
+
+    // MARK: - Summary cards
+
+    @ViewBuilder
+    private func summarySection(_ stats: ReadingStats) -> some View {
+        LazyVGrid(columns: [GridItem(.flexible()), GridItem(.flexible())], spacing: 12) {
+            StatCard(title: "Books Read", value: "\(stats.booksRead)", icon: "checkmark.circle.fill")
+            StatCard(title: "Reading Now", value: "\(stats.booksReading)", icon: "book.fill")
+            StatCard(title: "Total Pages", value: "\(stats.totalPages)", icon: "doc.text")
+
+            if let avg = stats.averageRating {
+                StatCard(title: "Avg Rating", value: String(format: "%.1f", avg / 2.0) + "★", icon: "star.fill")
+            }
+            if let streak = stats.currentStreak, streak > 0 {
+                StatCard(title: "Streak", value: "\(streak) days", icon: "flame.fill")
+            }
+            if let longest = stats.longestStreak, longest > 0 {
+                StatCard(title: "Best Streak", value: "\(longest) days", icon: "trophy.fill")
+            }
+        }
+    }
+
+    // MARK: - Charts
+
+    @ViewBuilder
+    private func monthlyChart(_ monthly: [MonthlyCount]) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Monthly Reading")
+                .font(.headline)
+            Chart(monthly, id: \.month) { item in
+                BarMark(
+                    x: .value("Month", item.month),
+                    y: .value("Books", item.count)
+                )
+                .foregroundStyle(.green.gradient)
+                .cornerRadius(4)
+            }
+            .frame(height: 180)
+        }
+        .padding()
+        .background(.background.secondary)
+        .clipShape(RoundedRectangle(cornerRadius: 12))
+    }
+
+    @ViewBuilder
+    private func ratingChart(_ distribution: [Int]) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Rating Distribution")
+                .font(.headline)
+            Chart {
+                ForEach(Array(distribution.enumerated()), id: \.offset) { index, count in
+                    BarMark(
+                        x: .value("Rating", "\(index)"),
+                        y: .value("Books", count)
+                    )
+                    .foregroundStyle(.yellow.gradient)
+                    .cornerRadius(4)
+                }
+            }
+            .frame(height: 160)
+        }
+        .padding()
+        .background(.background.secondary)
+        .clipShape(RoundedRectangle(cornerRadius: 12))
+    }
+
+    @ViewBuilder
+    private func formatSection(_ breakdown: FormatBreakdown) -> some View {
+        let data: [(String, Int)] = [
+            ("Physical", breakdown.physical),
+            ("E-Book", breakdown.ebook),
+            ("Audiobook", breakdown.audiobook),
+        ].filter { $0.1 > 0 }
+
+        if !data.isEmpty {
+            VStack(alignment: .leading, spacing: 8) {
+                Text("Format Breakdown")
+                    .font(.headline)
+                Chart(data, id: \.0) { item in
+                    SectorMark(
+                        angle: .value("Count", item.1),
+                        innerRadius: .ratio(0.5),
+                        angularInset: 2
+                    )
+                    .foregroundStyle(by: .value("Format", item.0))
+                }
+                .frame(height: 180)
+            }
+            .padding()
+            .background(.background.secondary)
+            .clipShape(RoundedRectangle(cornerRadius: 12))
+        }
+    }
+
+    @ViewBuilder
+    private func topAuthorsSection(_ authors: [AuthorCount]) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Top Authors")
+                .font(.headline)
+
+            ForEach(authors.prefix(5), id: \.name) { author in
+                HStack {
+                    Text(author.name)
+                    Spacer()
+                    Text("\(author.count) books")
+                        .foregroundStyle(.secondary)
+                        .monospacedDigit()
+                }
+                .font(.callout)
+            }
+        }
+        .padding()
+        .background(.background.secondary)
+        .clipShape(RoundedRectangle(cornerRadius: 12))
+    }
+}

--- a/toku-apple/TokuKit/Package.swift
+++ b/toku-apple/TokuKit/Package.swift
@@ -3,9 +3,10 @@ import PackageDescription
 
 let package = Package(
     name: "TokuKit",
-    platforms: [.macOS(.v14)],
+    platforms: [.macOS(.v14), .iOS(.v17)],
     products: [
         .library(name: "TokuKit", targets: ["TokuKit"]),
+        .library(name: "TokuKitUI", targets: ["TokuKitUI"]),
     ],
     targets: [
         .systemLibrary(
@@ -18,6 +19,11 @@ let package = Package(
             name: "TokuKit",
             dependencies: ["CTokuFFI"],
             path: "Sources/TokuKit"
+        ),
+        .target(
+            name: "TokuKitUI",
+            dependencies: ["TokuKit"],
+            path: "Sources/TokuKitUI"
         ),
     ]
 )

--- a/toku-apple/TokuKit/Sources/TokuKitUI/FlowLayout.swift
+++ b/toku-apple/TokuKit/Sources/TokuKitUI/FlowLayout.swift
@@ -1,0 +1,49 @@
+import SwiftUI
+
+/// Simple horizontal flow layout for wrapping tags and chips.
+public struct FlowLayout: Layout {
+    public var spacing: CGFloat
+
+    public init(spacing: CGFloat = 8) {
+        self.spacing = spacing
+    }
+
+    public func sizeThatFits(proposal: ProposedViewSize, subviews: Subviews, cache: inout ()) -> CGSize {
+        let result = arrange(proposal: proposal, subviews: subviews)
+        return result.size
+    }
+
+    public func placeSubviews(in bounds: CGRect, proposal: ProposedViewSize, subviews: Subviews, cache: inout ()) {
+        let result = arrange(proposal: proposal, subviews: subviews)
+        for (index, position) in result.positions.enumerated() {
+            subviews[index].place(at: CGPoint(
+                x: bounds.minX + position.x,
+                y: bounds.minY + position.y
+            ), proposal: .unspecified)
+        }
+    }
+
+    private func arrange(proposal: ProposedViewSize, subviews: Subviews) -> (size: CGSize, positions: [CGPoint]) {
+        let maxWidth = proposal.width ?? .infinity
+        var positions: [CGPoint] = []
+        var x: CGFloat = 0
+        var y: CGFloat = 0
+        var rowHeight: CGFloat = 0
+        var maxX: CGFloat = 0
+
+        for subview in subviews {
+            let size = subview.sizeThatFits(.unspecified)
+            if x + size.width > maxWidth, x > 0 {
+                x = 0
+                y += rowHeight + spacing
+                rowHeight = 0
+            }
+            positions.append(CGPoint(x: x, y: y))
+            rowHeight = max(rowHeight, size.height)
+            x += size.width + spacing
+            maxX = max(maxX, x)
+        }
+
+        return (CGSize(width: maxX, height: y + rowHeight), positions)
+    }
+}

--- a/toku-apple/TokuKit/Sources/TokuKitUI/MetadataRow.swift
+++ b/toku-apple/TokuKit/Sources/TokuKitUI/MetadataRow.swift
@@ -1,0 +1,22 @@
+import SwiftUI
+
+/// A labeled row for metadata display.
+public struct MetadataRow: View {
+    public let label: String
+    public let value: String
+
+    public init(label: String, value: String) {
+        self.label = label
+        self.value = value
+    }
+
+    public var body: some View {
+        HStack {
+            Text(label)
+                .foregroundStyle(.secondary)
+                .frame(width: 80, alignment: .leading)
+            Text(value)
+        }
+        .font(.callout)
+    }
+}

--- a/toku-apple/TokuKit/Sources/TokuKitUI/StarRatingView.swift
+++ b/toku-apple/TokuKit/Sources/TokuKitUI/StarRatingView.swift
@@ -1,0 +1,23 @@
+import SwiftUI
+import TokuKit
+
+/// Simple star rating display (read-only).
+public struct StarRatingView: View {
+    public let rating: Double
+
+    public init(rating: Double) {
+        self.rating = rating
+    }
+
+    public var body: some View {
+        HStack(spacing: 1) {
+            ForEach(1...5, id: \.self) { star in
+                let filled = Double(star) <= rating
+                let half = Double(star) - 0.5 == rating
+                Image(systemName: filled ? "star.fill" : (half ? "star.leadinghalf.filled" : "star"))
+                    .foregroundStyle(.yellow)
+                    .font(.caption2)
+            }
+        }
+    }
+}

--- a/toku-apple/TokuKit/Sources/TokuKitUI/StatCard.swift
+++ b/toku-apple/TokuKit/Sources/TokuKitUI/StatCard.swift
@@ -1,0 +1,33 @@
+import SwiftUI
+
+/// A small stat card showing an icon, value, and label.
+public struct StatCard: View {
+    public let title: String
+    public let value: String
+    public let icon: String
+
+    public init(title: String, value: String, icon: String) {
+        self.title = title
+        self.value = value
+        self.icon = icon
+    }
+
+    public var body: some View {
+        VStack(spacing: 8) {
+            Image(systemName: icon)
+                .font(.title2)
+                .foregroundStyle(.tint)
+            Text(value)
+                .font(.title3)
+                .fontWeight(.bold)
+                .monospacedDigit()
+            Text(title)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
+        .frame(maxWidth: .infinity)
+        .padding()
+        .background(.background.secondary)
+        .clipShape(RoundedRectangle(cornerRadius: 12))
+    }
+}


### PR DESCRIPTION
## Description

Add a native iOS app (iPhone + iPad) for Toku, built with SwiftUI and consuming
the shared Rust core via the existing C FFI layer (`toku-ffi`).

### What's included

- **Adaptive navigation**: `TabView` on iPhone (Library, Search, Stats, More
  tabs), `NavigationSplitView` with sidebar on iPad — switches automatically
  via `horizontalSizeClass`
- **Library grid**: Responsive `LazyVGrid` with cover cards, search bar,
  horizontal status filter chips, pull-to-refresh, and context menus for status
  changes
- **Book detail**: Full metadata display with cover placeholder, status picker,
  rating stars, tags (FlowLayout), and "Update Progress" action button
- **Quick progress update**: ≤3-tap flow from library — tap progress button on
  a "currently reading" card → adjust page via slider/stepper → Save. Includes
  a `ProgressRing` component
- **Barcode scanner**: AVFoundation-based ISBN-13 scanner with camera viewfinder
  overlay, haptic feedback, ISBN-13 checksum validation, and manual ISBN entry
  fallback for denied permissions or simulator use
- **Statistics glance**: Year-scoped summary cards (books read, streak, pace)
  with Swift Charts (monthly reading, rating distribution, format breakdown,
  top authors)
- **Search**: Dedicated full-text search view with result rows showing mini
  cover, title, author, status, and rating
- **Import**: Goodreads CSV import via `.fileImporter()` with dry-run toggle,
  available on both iPhone (More tab) and iPad (sidebar)
- **TokuKitUI**: New shared SwiftUI component library (`StarRatingView`,
  `FlowLayout`, `MetadataRow`, `StatCard`) in TokuKit package for cross-platform
  reuse
- **TokuKit**: Updated `Package.swift` to support `.iOS(.v17)` alongside
  `.macOS(.v14)`
- **Assets**: App icon placeholder, accent color, `Info.plist` with camera
  permission description
- **Documentation**: Updated `toku-apple/README.md` with iOS build steps,
  feature table, and known FFI gaps

### Known FFI gaps (documented in README)

- Reading progress logging: `toku-db` has `log_progress()` but `toku-ffi`
  doesn't expose it yet — progress sheet updates status only for now
- ISBN-aware book addition: barcode scanner captures ISBN but current
  `toku_add_book` only accepts title/author

## Related Issues

Closes #53

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI / infrastructure
- [ ] Other (describe below)

## Crate

<!-- Which crate(s) does this touch? -->

- [ ] `toku-core` — Domain models, traits, state machine
- [ ] `toku-db` — SQLite persistence, migrations, FTS5
- [ ] `toku-import` — Importers (Goodreads, Calibre, StoryGraph)
- [ ] `toku-meta` — Metadata fetching (Open Library, Google Books)
- [ ] `toku-cli` — CLI binary
- [ ] `toku-export` — Exporters (CSV, JSON, Markdown, BibTeX)
- [x] `docs/` — Documentation

## Data Integrity Checklist

<!-- Toku is a local-first tool — user data ownership is non-negotiable -->

- [x] No user data is sent to any server without explicit opt-in
- [x] Import operations are idempotent (re-importing the same file creates no duplicates)
- [x] User edits to metadata are never overwritten by auto-enrichment
- [ ] New fields track provenance (source + timestamp) — N/A, no new data fields
- [ ] Export round-trip is preserved (if applicable) — N/A

## Checklist

- [x] I have read [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] `cargo fmt --check` passes
- [x] `cargo clippy --workspace -- -D warnings` passes
- [x] `cargo test --workspace` passes
- [x] I have updated documentation (if applicable)
