### PR TITLE
docs: update documentation for Phase 5 completion and Phase 7 roadmap

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -2,7 +2,7 @@
 
 ## Project Overview
 
-Toku (読く — Japanese for "to read") is a private, offline-first personal book manager. It combines the metadata depth of Calibre, the reading tracking of Goodreads, and the analytics of StoryGraph — without any social features. The project is in early development (Phase 0).
+Toku (読く — Japanese for "to read") is a private, offline-first personal book manager. It combines the metadata depth of Calibre, the reading tracking of Goodreads, and the analytics of StoryGraph — without any social features. Phases 0–5 are complete (CLI, imports, analytics, web dashboard, native apps). Phase 6 (file management) and Phase 7 (sync) are next.
 
 ## Non-Negotiable Constraints
 
@@ -16,7 +16,7 @@ Every code contribution, architecture decision, and feature design must uphold t
 
 ## Architecture
 
-Cargo workspace with 6 crates:
+Cargo workspace with 9 crates:
 
 - `toku-core/` — Domain models, traits, state machine, statistics engine. Pure Rust, no I/O. Compiles to native, WASM, FFI.
 - `toku-db/` — SQLite persistence, schema migrations (refinery), FTS5 full-text search.
@@ -24,6 +24,9 @@ Cargo workspace with 6 crates:
 - `toku-meta/` — Metadata fetching: Open Library API (primary), Google Books (fallback). Cover image downloading.
 - `toku-cli/` — CLI binary (clap v4). The main entry point.
 - `toku-export/` — Export implementations: CSV, JSON, Markdown, BibTeX, canonical backup.
+- `toku-ffi/` — C FFI bindings for Swift/Kotlin via `cbindgen`. Used by macOS and iOS apps.
+- `toku-web/` — Axum + maud web server. Library views, statistics dashboard, import wizard. Started via `toku serve`.
+- `toku-desktop/` — Tauri v2 Windows desktop app wrapping the web UI.
 
 ### Data Boundary Rule
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -130,4 +130,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Export to Markdown: `toku export markdown` with books grouped by reading status and star ratings
 - Canonical backup: `toku export backup --output toku-backup.zip` with library data + cover images in a self-contained ZIP
 
-[Unreleased]: https://github.com/kafkade/toku/compare/v0.1.0...HEAD
+[Unreleased]: https://github.com/kafkade/toku/compare/v0.2.1...HEAD

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,11 +54,32 @@ cargo test --workspace
 
 # Run the CLI
 cargo run -p toku-cli -- --help
+
+# Run the web dashboard locally
+cargo run -p toku-cli -- serve
 ```
+
+### Web UI Development
+
+The web interface lives in `crates/toku-web/` and uses Axum + maud for server-side
+rendering. Start the dev server with `cargo run -p toku-cli -- serve` and visit
+`http://localhost:3000`. All HTML is generated server-side — no JavaScript build step.
+
+### FFI Development (macOS/iOS)
+
+The `toku-ffi` crate (`crates/toku-ffi/`) provides C FFI bindings for the Swift layer.
+After changing FFI functions, regenerate the C header with `cbindgen`. The Swift wrapper
+lives in `toku-apple/TokuKit/`. FFI methods must run on the same thread that opened the
+database handle.
+
+### Windows Desktop (Tauri)
+
+The Tauri v2 desktop app (`crates/toku-desktop/`) wraps the web UI. Build with
+`cargo tauri build` from the `crates/toku-desktop/` directory.
 
 ## Architecture
 
-See `.github/copilot-instructions.md` for the full architecture overview and `docs/adr/` for Architecture Decision Records.
+See `.github/copilot-instructions.md` for the full architecture overview, `docs/adr/` for Architecture Decision Records, and `toku-apple/` for the macOS/iOS Swift projects.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@ toku stats --year 2025                 # See your reading stats
 toku browse                            # Interactive TUI browser
 ```
 
-> **Status**: Early development — functional CLI with import, tracking, search,
-> TUI browser, and export. Usable for personal reading management.
+> **Status**: Active development (v0.2.1) — full-featured CLI, web dashboard,
+> macOS/iOS apps, and Windows desktop app. Phases 0–5 complete.
 
 ---
 
@@ -62,19 +62,26 @@ their ever-growing libraries.
 - 📊 Reading progress tracking (pages, percentage, chapters, audiobook time)
 - 🏷️ Tags for organizing your library (imported Goodreads shelves become tags)
 - 📈 Reading statistics and analytics (pace, format breakdown, yearly filtering)
-- 📥 Import from Goodreads CSV and Calibre (with dry-run, dedup, and tag preservation)
+- 📥 Import from Goodreads CSV, Calibre, and StoryGraph (with dry-run, dedup, and tag preservation)
 - 📤 Export to CSV, JSON, Markdown, and canonical backup (ZIP)
 - 🔍 Full-text search across your entire library (titles, authors, descriptions)
 - 🖥️ Interactive TUI browser with split-pane layout, filters, and live detail view
 - 🔄 Bulk operations for tagging, status changes, and deletions across filtered sets
+- 🌐 Web dashboard (`toku serve`) with statistics, import wizard, library views, and dark mode
+- 🍎 macOS app (SwiftUI) with sidebar navigation, sortable table/grid views, and Swift Charts
+- 📱 iOS app (iPhone + iPad) with cover grid, barcode scanner, and reading progress updates
+- 🪟 Windows desktop app (Tauri v2) wrapping the web UI in a native window with system tray
 
 ## Tech Stack
 
 - **Language**: Rust
 - **Database**: SQLite with FTS5
 - **CLI**: clap v4
-- **Architecture**: Cargo workspace with separate crates for core, database, import,
-  metadata, CLI, and export
+- **Web**: Axum + maud (server-side rendered HTML with inline SVG charts)
+- **Desktop**: Tauri v2 (Windows)
+- **Mobile/macOS**: SwiftUI via Rust FFI (`toku-ffi` crate)
+- **Architecture**: Cargo workspace with 9 crates — core, database, import, export,
+  metadata, CLI, FFI, web, and desktop
 
 ## License
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -6,7 +6,7 @@
 **Repository**: `kafkade/toku`
 **Core Language**: Rust
 **Primary Interface**: CLI
-**Date**: July 2025
+**Date**: May 2026
 **Author**: kafkade
 
 ---
@@ -158,7 +158,7 @@
 
 **Recommendation**: Monorepo with Cargo workspace from day one.
 
-The crate count is small enough (4–6 crates) that the overhead is minimal, and the boundaries enforce the layered architecture. A monolith-first approach risks coupling the CLI to the core in ways that are painful to untangle when the web UI arrives.
+The crate count is small enough (9 crates) that the overhead is minimal, and the boundaries enforce the layered architecture. A monolith-first approach risks coupling the CLI to the core in ways that are painful to untangle when the web UI arrives.
 
 ```sh
 kafkade/toku/
@@ -169,7 +169,12 @@ kafkade/toku/
 │   ├── toku-import/        # Goodreads CSV, Calibre, StoryGraph parsers
 │   ├── toku-meta/          # Open Library, Google Books API clients
 │   ├── toku-cli/           # CLI binary (clap-based)
-│   └── toku-export/        # CSV, JSON, Markdown, BibTeX exporters
+│   ├── toku-export/        # CSV, JSON, Markdown, BibTeX exporters
+│   ├── toku-ffi/           # C FFI bindings for Swift/Kotlin (cbindgen)
+│   ├── toku-web/           # Axum + maud web server (library crate)
+│   └── toku-desktop/       # Tauri v2 Windows desktop app
+├── toku-apple/             # macOS + iOS SwiftUI apps (Xcode project)
+│   └── TokuKit/            # Swift FFI wrapper + shared UI components
 ├── docs/                   # User and developer documentation
 ├── tests/                  # Integration tests, test fixtures
 │   └── fixtures/           # Sample Goodreads CSVs, Calibre DBs
@@ -784,9 +789,10 @@ File management lives in a new `toku-files` crate that depends on `toku-core` an
 
 ### 7.5 — Self-Hosted Sync Server 🔴
 
-- Deferred to Phase 7. cr-sqlite is the preferred approach (see Section 2.5).
-- Alternative: lightweight Axum server with REST API + Docker deployment.
-- All data encrypted at rest on server.
+- Deferred to Phase 7. Changeset-based REST sync is the chosen approach (see ADR-006).
+- Axum server with REST API + Docker deployment.
+- All data optionally encrypted at rest on server (client-side encryption).
+- cr-sqlite kept as a research alternative if it matures for iOS/WASM.
 
 ---
 
@@ -1092,13 +1098,17 @@ fallback_source = "google_books"
 default_status = "want_to_read"
 ```
 
-### 9.3 — Web UI Design (Phase 4)
+### 9.3 — Web UI Design (Phase 4) ✅
 
-- **Technology**: Axum backend serving HTMX + minimal JS, or Leptos for full Rust stack.
-- **Key screens**: Library grid/list, book detail, progress dashboard, statistics, import wizard, search.
-- **Dark mode**: System-preference detection + toggle.
-- **PWA**: Service worker for offline browsing of cached library data.
-- **Responsive**: Mobile-friendly layouts.
+- **Technology**: Axum backend with maud for server-side HTML rendering (see ADR-007).
+  Inline SVG charts, CSS custom properties with `prefers-color-scheme` dark mode.
+  Minimal inline JavaScript (~15 lines for SSE import progress only).
+- **Key screens**: Library grid/list with cover images, book detail with reading timeline,
+  statistics dashboard with rating histogram / monthly pace / format breakdown / top authors,
+  import wizard with dry-run preview and live SSE progress, FTS5-powered search.
+- **Dark mode**: Automatic via `prefers-color-scheme` CSS media query.
+- **Fully offline**: No CDN, no npm, no external assets. Works on `localhost` with no internet.
+- **Responsive**: Pagination (60 books/page), grid/list toggle, sort controls.
 
 ### 9.4 — Key Screens Per Platform
 
@@ -1220,7 +1230,7 @@ Rejected alternatives:
 | **Documentation** | **mdBook** (user docs) + **rustdoc** (API docs) | mdBook for the user guide. Rustdoc for crate documentation. |
 | **Distribution** | **cargo install** + **GitHub Releases** (pre-built binaries) | `cargo-dist` automates cross-compilation and release. Homebrew tap in Phase 2. |
 
-**Web stack (Phase 4)**: **Axum** (backend) + **HTMX** (frontend) or **Leptos** (full Rust). Decision deferred — both are viable. HTMX is simpler; Leptos keeps the entire stack in Rust.
+**Web stack (Phase 4)**: **Axum** (backend) + **maud** (server-side rendering). See ADR-007 for the decision against HTMX and Leptos. Inline SVG charts, no external JavaScript dependencies.
 
 **iOS/macOS (Phase 5)**: **SwiftUI** consuming Rust core via C FFI (`toku-ffi` crate using `cbindgen`). Rejected React Native / Tauri for iOS due to UX quality concerns.
 
@@ -1243,7 +1253,7 @@ Before committing to the architecture, validate:
 
 ## Section 13: Phased Roadmap with Milestones
 
-### Phase 0: First Book 🟢
+### Phase 0: First Book ✅
 
 **Theme**: "One book, stored and retrieved."
 **Goal**: Add one book from the CLI, store it in SQLite, retrieve it. Validate the entire stack.
@@ -1267,7 +1277,7 @@ Before committing to the architecture, validate:
 
 ---
 
-### Phase 1: Minimum Usable Library (MVP) 🟡
+### Phase 1: Minimum Usable Library (MVP) ✅
 
 **Theme**: "My Goodreads library is here. I use this daily."
 **Goal**: Import a full Goodreads library, track reading status, search and organize.
@@ -1297,7 +1307,7 @@ Before committing to the architecture, validate:
 
 ---
 
-### Phase 2: Reading Tracker 🟡
+### Phase 2: Reading Tracker ✅
 
 **Theme**: "I track my reading progress and can see my history."
 **Goal**: Page-by-page progress tracking, reading sessions (including re-reads), basic statistics, Calibre import, export.
@@ -1323,7 +1333,7 @@ Before committing to the architecture, validate:
 
 ---
 
-### Phase 3: Analytics & Polish (1.0 Release) 🟡
+### Phase 3: Analytics & Polish (1.0 Release) ✅
 
 **Theme**: "This is genuinely better than Goodreads for personal use."
 **Goal**: Full statistics, mood/pace tags, goals, work grouping, smart shelves, StoryGraph import.
@@ -1346,7 +1356,7 @@ Before committing to the architecture, validate:
 
 ---
 
-### Phase 4: Web Interface 🟡
+### Phase 4: Web Interface ✅
 
 **Theme**: "Non-CLI users can use Toku."
 **Goal**: Web UI for library browsing, book management, statistics, and import.
@@ -1362,7 +1372,7 @@ Before committing to the architecture, validate:
 
 ---
 
-### Phase 5: Native Apps 🔴
+### Phase 5: Native Apps ✅
 
 **Theme**: "Toku on every device."
 
@@ -1383,10 +1393,40 @@ Before committing to the architecture, validate:
 
 ---
 
-### Phase 7: Sync & Multi-Device 🔴
+### Phase 7: Sync & Multi-Device 🟡
 
 **Theme**: "My library everywhere."
-**Deliverables**: cr-sqlite integration, multi-device sync, conflict resolution UI.
+**Goal**: Opt-in multi-device sync via a lightweight changeset-based REST API. Users can sync between CLI, iOS, macOS, web, and Windows — without sacrificing the local-first guarantee. Sync is additive: a user who never enables sync loses nothing.
+
+**Architecture**: See Section 2.5 (Sync Strategy) and ADR-006 for the full design. Summary: append-only op-log synced over REST with optional client-side symmetric encryption (Argon2id + AES-256-GCM).
+
+**Deliverables** (5):
+
+1. **Sync data model + op-log**: Local `sync_ops` table with Hybrid Logical Clock (HLC) timestamps, op IDs (UUID v7), entity type/ID, and encrypted-or-plaintext payload. Every mutation writes to both the domain table and the op-log in a single transaction.
+2. **Sync server (`toku-sync` crate)**: Axum REST API for push/pull/snapshot/device management. Thin relay — stores ops and cursors, does not interpret content. Deployable as a Docker image (`kafkade/toku-sync`).
+3. **Push/pull protocol with entity-specific merge rules**: Push sends new ops since last cursor. Pull receives ops and applies entity-specific merge: LWW per field for books, append-only for reading sessions, monotonic for progress, LWW with conflict detection for notes/reviews. Soft deletes with 30-day tombstone retention.
+4. **Optional client-side encryption**: Passphrase → Argon2id → AES-256-GCM. Key stored in OS keychain. Server stores opaque blobs. Passphrase change triggers re-keying (pull, re-encrypt, push snapshot, purge old ops).
+5. **CLI sync commands + device management**: `toku sync init`, `toku sync push`, `toku sync pull`, `toku sync status`, `toku sync devices`. Device registration with UUID + human-readable name.
+
+**Acceptance criteria**:
+
+- Two devices (e.g., CLI on laptop + iOS app) can sync a library through the server with no data loss
+- Offline edits on both devices merge correctly when both push/pull
+- A deleted book on device A does not reappear on device B after sync
+- A new device can bootstrap from a server snapshot + subsequent ops
+- With encryption enabled, the server cannot decrypt any book content (verified by inspecting server storage)
+- Sync resumes correctly after network failure (idempotent push/pull)
+- `toku sync status` shows last sync time, pending ops count, and device list
+
+**Dependencies**: Phase 3 (stable data model). Phase 4/5 (clients exist to sync between).
+
+**Risks**:
+
+- Schema migration during sync — ops from different app versions must coexist. **Mitigation**: version field in op envelope, backward-compatible op format.
+- Conflict resolution UX — what happens when two devices edit the same book's title? **Mitigation**: LWW per field is invisible to the user in most cases; only note/review conflicts surface for manual resolution.
+- Encryption complexity — nonce management, key storage, rotation. **Mitigation**: dedicated security review before merge; use well-audited crates (ring, aes-gcm).
+
+**Cut line**: Managed hosted instance (`sync.toku.dev`) — self-hosted first. Browser-local SQLite for web app (web remains a connected companion). File sync for ebooks (Phase 6 files are not synced in Phase 7).
 
 ---
 
@@ -1486,7 +1526,7 @@ Phase 3: Analytics & Polish (1.0)
         │       └─── Phase 6: File Management (independent of web)
         │
         └─── Phase 7: Sync (depends on stable schema)
-                │
+                │     Changeset REST API, see ADR-006
                 └─── Phase 8: Moonshots
 ```
 
@@ -1650,7 +1690,7 @@ The name must satisfy:
 | 7 | Rating scale | 5-star / 10-point / 5-star with halves | **0–10 integer (displayed as 5★ with halves)** — Goodreads-compatible | Decided |
 | 8 | Sync strategy | File copy / REST server / CRDTs / SQLite replication | **Changeset-based REST sync with optional symmetric encryption** — lighter than Pildora's ZK, privacy-respecting | Deferred (Phase 7) |
 | 9 | License | MIT / Apache 2.0 / GPL / Dual | **MIT** — maximum contributor friendliness | Decided |
-| 10 | Web framework | Axum+HTMX / Leptos / SvelteKit / Next.js | **Axum + HTMX or Leptos** — full Rust stack | Deferred (Phase 4) |
+| 10 | Web framework | Axum+HTMX / Leptos / SvelteKit / Next.js | **Axum + maud** — server-rendered HTML, inline SVG charts, no client-side framework (see ADR-007) | Decided |
 | 11 | Cover storage | Filesystem / Database blobs / Content-addressed | **Filesystem, content-addressed (SHA-256)** — keeps DB small | Decided |
 | 12 | Project name | 15 candidates evaluated | **Toku** — short, non-English, evokes reading, terminal-friendly | Decided `[Validation Required]` crates.io |
 | 13 | File management | MVP / Post-1.0 / Never | **Deferred to Phase 6 (post-1.0)** — MVP is a tracker, not file manager | Decided |

--- a/docs/adr/008-sync-wire-protocol.md
+++ b/docs/adr/008-sync-wire-protocol.md
@@ -1,0 +1,162 @@
+# ADR-008: Sync Wire Protocol — Op-Log Format, HLC, and Encryption Envelope
+
+**Status**: Proposed (implementation in Phase 7)
+**Date**: 2026-05-31
+**Decision**: Define the sync wire protocol using UUID v7 op IDs, Hybrid Logical Clocks
+for ordering, a versioned JSON op envelope, and an optional AES-256-GCM encryption layer.
+
+## Context
+
+ADR-006 established the sync architecture: changeset-based REST with optional symmetric
+encryption. This ADR specifies the wire-level details that ADR-006 left open: op format,
+clock semantics, cursor contracts, encryption envelope, and versioning strategy.
+
+These decisions must be made before implementation because they affect the local database
+schema (`sync_ops` table), the server storage format, and the client-server API contract.
+Changing the wire format after devices are syncing requires a migration path.
+
+## Decision
+
+### Op envelope format
+
+Every mutation produces an op. The canonical JSON representation:
+
+```json
+{
+  "v": 1,
+  "op_id": "019726a4-...",
+  "device_id": "019726a3-...",
+  "hlc": "2026-06-15T10:30:00.000Z-0001-019726a3",
+  "entity_type": "book",
+  "entity_id": "01972123-...",
+  "op_type": "update",
+  "fields": {"rating": 8, "status": "read"},
+  "checksum": "sha256:abcdef..."
+}
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `v` | integer | Envelope version. Currently `1`. Clients reject ops with `v` > their max supported. |
+| `op_id` | UUID v7 | Globally unique, time-sortable op identifier. |
+| `device_id` | UUID v7 | Originating device. |
+| `hlc` | string | Hybrid Logical Clock timestamp (see below). |
+| `entity_type` | string | One of: `book`, `session`, `progress`, `tag`, `note`, `review`, `setting`, `device`. |
+| `entity_id` | UUID | The entity being modified. |
+| `op_type` | string | One of: `create`, `update`, `delete`. |
+| `fields` | object | Field-level changes. Only present for `create` and `update`. Keys are field names; values are the new values. |
+| `checksum` | string | `sha256:` prefixed hash of the canonical JSON without the checksum field. Detects corruption. |
+
+### Hybrid Logical Clock (HLC)
+
+Format: `{ISO-8601-timestamp}-{counter:04d}-{device_id_prefix:12}`
+
+- Physical clock: system UTC time, clamped to never go backward.
+- Logical counter: monotonically increasing per device within the same millisecond.
+- Device prefix: first 12 characters of the device UUID for tie-breaking.
+
+HLC comparison: lexicographic string comparison produces correct causal ordering.
+
+**Why HLC over simple timestamps?** Wall clocks drift. Two devices editing the same
+field at "the same time" need deterministic ordering. HLC provides causality guarantees
+that wall clocks cannot.
+
+### Cursor contract
+
+- Each device maintains two cursors: `push_cursor` (last op ID pushed) and `pull_cursor`
+  (last op ID received from server).
+- Cursors are op IDs (UUID v7), not timestamps — immune to clock skew.
+- Push is idempotent: the server deduplicates by `op_id`. Retrying a failed push is safe.
+- Pull is idempotent: requesting the same cursor returns the same ops.
+- The server stores one cursor pair per device per library.
+
+### Encryption envelope
+
+When encryption is enabled, the `fields` value is replaced with an encrypted blob:
+
+```json
+{
+  "v": 1,
+  "op_id": "...",
+  "device_id": "...",
+  "hlc": "...",
+  "entity_type": "book",
+  "entity_id": "...",
+  "op_type": "update",
+  "encrypted": {
+    "ev": 1,
+    "alg": "aes-256-gcm",
+    "nonce": "base64...",
+    "ciphertext": "base64...",
+    "aad": "v=1,entity_type=book,op_type=update"
+  },
+  "checksum": "sha256:..."
+}
+```
+
+| Field | Description |
+|-------|-------------|
+| `ev` | Encryption envelope version. |
+| `alg` | Algorithm identifier. Only `aes-256-gcm` for v1. |
+| `nonce` | 96-bit random nonce, base64-encoded. Must be unique per op. |
+| `ciphertext` | Encrypted `fields` JSON, base64-encoded. |
+| `aad` | Additional Authenticated Data — unencrypted metadata bound to the ciphertext. Prevents op type/entity type from being swapped. |
+
+**Nonce uniqueness**: Generated via OS CSPRNG (`getrandom`). UUID v7 op IDs provide
+a secondary uniqueness guarantee — if the same nonce were reused (astronomically unlikely),
+the different op IDs in the AAD would cause decryption to fail rather than silently
+produce wrong data.
+
+**Key derivation**: Passphrase → Argon2id (m=64MB, t=3, p=1) → 256-bit key. Salt is
+per-library (generated at `toku sync init`), stored on the server alongside the library ID.
+
+### Schema versioning during sync
+
+- Each op carries `v` (envelope version). The server stores ops as-is.
+- Clients must handle all `v` values ≤ their current version.
+- A new envelope version means a new op field or structural change. Old fields are
+  never removed — only added.
+- App-level schema migrations (e.g., new columns on `books`) are separate from sync
+  envelope versions. A new database column appears as a new field key in `fields` —
+  older clients ignore unknown keys.
+
+### Error semantics
+
+| Error | Client behavior |
+|-------|----------------|
+| Push conflict (duplicate op_id) | Ignore — op already stored. |
+| Pull cursor not found | Full re-sync from latest snapshot. |
+| Auth failure (401) | Prompt for device re-authentication. |
+| Envelope version too high | Log warning, skip op, prompt user to update app. |
+| Checksum mismatch | Reject op, log error, do not apply. |
+| Decryption failure | Reject op, log error. May indicate wrong passphrase. |
+
+## Rationale
+
+- **UUID v7 op IDs** are time-sortable and globally unique without coordination —
+  ideal for offline-first devices that generate ops independently.
+- **HLC** provides causal ordering without requiring synchronized clocks. It's well-studied
+  and used by CockroachDB, Jepsen-tested systems, and other distributed databases.
+- **Field-level ops** (not row-level) minimize conflict surface. Two devices editing
+  different fields of the same book produce two ops that merge without conflict.
+- **Versioned envelope** avoids the "big bang migration" problem — new features can be
+  added without breaking existing clients.
+- **AAD in encryption** binds the entity type and op type to the ciphertext, preventing
+  an attacker from swapping encrypted payloads between ops.
+
+## Consequences
+
+- The `sync_ops` table grows linearly with mutations. Snapshot compaction (periodic
+  full-state snapshots that allow op-log truncation) is required for long-lived libraries.
+- Field-level ops mean the op payload varies by entity type. Clients must validate
+  field names against the current schema.
+- The encryption envelope adds ~33% size overhead (base64) and CPU cost (AES-GCM per op).
+  Acceptable for book metadata; would not scale to high-frequency data.
+- Changing the passphrase requires re-encrypting all ops — this is a client-side batch
+  operation that can take minutes for large libraries.
+
+## Open Questions
+
+- [ ] Maximum op batch size for push/pull requests (start with 1000 ops per request)
+- [ ] Snapshot format (full library JSON vs. compacted op sequence)
+- [ ] Rate limiting strategy for the sync server

--- a/docs/adr/009-native-app-architecture.md
+++ b/docs/adr/009-native-app-architecture.md
@@ -1,0 +1,127 @@
+# ADR-009: Native App Architecture — SwiftUI + FFI for Apple, Tauri v2 for Windows
+
+**Status**: Accepted
+**Date**: 2026-05-31
+**Decision**: Use SwiftUI consuming Rust core via C FFI for macOS and iOS apps. Use
+Tauri v2 wrapping the `toku-web` server-rendered UI for the Windows desktop app.
+
+## Context
+
+Phase 5 required native apps for macOS, iOS, and Windows. The core library (`toku-core`,
+`toku-db`) is written in Rust. The challenge is bridging Rust to native UI frameworks
+on each platform while maximizing code reuse and maintaining native UX quality.
+
+Three approaches were evaluated:
+
+1. **SwiftUI + Rust FFI** — Native Apple UI calling Rust via C function exports.
+2. **Tauri v2** — Web-based UI in a native window, with Rust backend.
+3. **Cross-platform framework** — React Native, Flutter, or Kotlin Multiplatform.
+
+## Decision
+
+### Apple platforms (macOS + iOS): SwiftUI + `toku-ffi`
+
+- The `toku-ffi` crate exports a C API using `#[no_mangle]` and `extern "C"` functions.
+- `cbindgen` generates the C header (`toku.h`) from Rust source.
+- `TokuKit` (Swift package in `toku-apple/TokuKit/`) wraps the C API in a Swift-native
+  interface: `TokuFFI` class with safe Swift types, error handling, and JSON decoding.
+- SwiftUI views consume `TokuFFI` methods. The Xcode project builds `toku-ffi` as a
+  static library and links it into the Swift app.
+
+**FFI API surface** (9 core functions):
+
+| Function | Purpose |
+|----------|---------|
+| `toku_open` | Open database, run migrations |
+| `toku_list_books` | List all books as JSON |
+| `toku_get_book` | Get single book detail as JSON |
+| `toku_search` | Full-text search, return JSON results |
+| `toku_delete_book` | Delete a book by ID |
+| `toku_update_status` | Change reading status |
+| `toku_update_rating` | Set book rating |
+| `toku_get_stats` | Get statistics as JSON |
+| `toku_import_goodreads` | Import Goodreads CSV, return report JSON |
+
+**Threading model**: All `TokuFFI` methods must run on the same thread that opened the
+database handle. The Swift layer uses a dedicated serial `DispatchQueue` for all FFI
+calls, with `@MainActor` bridging for UI updates.
+
+**Shared UI components**: `TokuKitUI` (SwiftUI package) provides reusable views used
+by both macOS and iOS apps: `StarRatingView`, `FlowLayout`, `MetadataRow`, `StatCard`.
+
+### iOS-specific features
+
+- Barcode scanner (ISBN-13 via `AVCaptureSession` + `VNBarcodeObservation`)
+- Adaptive navigation: `TabView` on iPhone, `NavigationSplitView` on iPad
+- Quick progress update sheet
+- Pull-to-refresh on library grid
+
+### macOS-specific features
+
+- Sidebar navigation with `NavigationSplitView`
+- Sortable table view (SwiftUI `Table`)
+- Book detail inspector pane
+- Swift Charts statistics dashboard
+
+### Windows: Tauri v2 + `toku-web`
+
+- The `toku-desktop` crate wraps the `toku-web` server in a Tauri v2 window.
+- Tauri starts an embedded Axum server and loads the web UI in a native WebView2 window.
+- System tray support with minimize-to-tray.
+- No separate Windows-native UI code — the web UI is the Windows UI.
+
+## Rationale
+
+### Why SwiftUI + FFI over Tauri for Apple?
+
+1. **UX quality**: SwiftUI produces genuinely native Apple UI — system fonts, animations,
+   navigation patterns, accessibility, Dynamic Type, and Dark Mode work automatically.
+   A WebView-based app on macOS/iOS feels foreign.
+2. **Platform features**: Barcode scanning (AVFoundation), Swift Charts, system Share
+   sheet, Spotlight integration, and Shortcuts are trivial with SwiftUI, difficult or
+   impossible through a WebView.
+3. **App Store expectations**: iOS App Store review favors native UI. WebView-only apps
+   risk rejection under guideline 4.2 (Minimum Functionality).
+4. **Performance**: Native rendering with no WebView overhead. Instant launch.
+
+### Why Tauri for Windows over WinUI?
+
+1. **Code reuse**: The web UI (`toku-web`) already exists from Phase 4. Wrapping it in
+   Tauri requires minimal Windows-specific code.
+2. **Maintenance cost**: Building a WinUI 3 app would require learning a new framework,
+   maintaining a separate C#/XAML codebase, and duplicating UI logic. Solo developer
+   cannot sustain two native UI stacks plus a web UI.
+3. **Quality bar**: Windows users are accustomed to Electron/WebView apps (VS Code,
+   Discord, Slack, Notion). The quality bar for a WebView-based Windows app is lower
+   than on macOS.
+4. **Tauri v2 maturity**: Tauri v2 uses WebView2 (Edge-based), is stable, and provides
+   system tray, auto-update, and native window management.
+
+### Why not React Native / Flutter / Kotlin Multiplatform?
+
+1. **React Native**: Requires a JavaScript runtime, adds a Node.js build chain, and the
+   Rust FFI bridge is more complex (JSI + Turbo Modules). Doesn't solve the "web UI
+   already exists" problem for Windows.
+2. **Flutter**: Requires Dart, a separate build system, and the Rust FFI bridge uses
+   `dart:ffi`. Flutter on macOS/iOS does not feel native — custom rendering engine
+   bypasses system controls.
+3. **Kotlin Multiplatform**: Strong for Android but weak on iOS/macOS (still maturing).
+   No Windows story. Doesn't leverage existing Rust core.
+
+All three add a new language and build system without meaningfully improving the outcome
+over SwiftUI (Apple) + Tauri (Windows).
+
+## Consequences
+
+- **Two UI paradigms**: SwiftUI for Apple and web UI for Windows means UI changes need
+  to be made in two places (Swift views + maud templates). The core logic is shared via
+  Rust, but presentation is duplicated. This is an accepted trade-off for native quality.
+- **FFI maintenance**: Changes to `toku-core` or `toku-db` may require updating `toku-ffi`
+  exports, regenerating `toku.h`, and updating `TokuFFI.swift`. This is a manual process.
+- **JSON bridge**: FFI functions return JSON strings decoded on the Swift side. This is
+  simple and debuggable but adds serialization overhead. For the data volumes involved
+  (hundreds of books, not millions), this is negligible.
+- **No Android**: This ADR does not address Android. When Android is needed, Kotlin +
+  Rust FFI (via JNI or UniFFI) is the expected path — similar to the Swift approach.
+- **Tauri v2 dependency**: The Windows app depends on WebView2, which requires Windows 10
+  (build 17763+) or Windows 11. Older Windows versions are not supported.


### PR DESCRIPTION
## Description

Update project documentation to reflect the current state (v0.2.1, Phases 0–5 complete) and flesh out Phase 7 (Sync & Multi-Device) with comprehensive GitHub issues.

### What's included

- **README.md**: Updated status line, added web/native app features, expanded tech stack to cover all 9 workspace crates
- **ROADMAP.md**: Marked Phases 0–5 as ✅ complete, expanded Phase 7 from a one-line stub into full detail with deliverables, acceptance criteria, risks, and cut line. Updated workspace layout (9 crates + toku-apple), fixed web framework decision (Axum + maud per ADR-007), removed stale cr-sqlite reference in Section 7.5
- **copilot-instructions.md**: Updated from "Phase 0, 6 crates" to current state (Phases 0–5 complete, 9 crates including toku-ffi, toku-web, toku-desktop)
- **CONTRIBUTING.md**: Added development setup instructions for web UI, FFI (macOS/iOS), and Tauri desktop
- **CHANGELOG.md**: Fixed stale compare link (was v0.1.0, now v0.2.1)
- **ADR-008**: Sync wire protocol specification — op envelope format, HLC semantics, cursor contracts, encryption envelope with AES-256-GCM + Argon2id, schema versioning, error handling
- **ADR-009**: Native app architecture (post-hoc) — documents SwiftUI + FFI for Apple platforms and Tauri v2 for Windows, with rationale against React Native/Flutter/KMP

### GitHub issues created

16 issues (#65–#80) under the "Phase 7: Sync and Multi-Device" milestone, covering: sync data model + HLC, server scaffold, device auth, push/pull protocol, merge rules, tombstones, encryption, re-keying, snapshot compaction, CLI commands, conflict resolution UI, native client integration, Docker deployment, integration tests, and ADR tracking. Version bump (MINOR 0.3.0) comments added to foundational issues (#65, #66, #71, #74).

## Related Issues

Phase 7 issues: #65, #66, #67, #68, #69, #70, #71, #72, #73, #74, #75, #76, #77, #78, #79, #80

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI / infrastructure
- [ ] Other (describe below)

## Crate

- [ ] `toku-core` — Domain models, traits, state machine
- [ ] `toku-db` — SQLite persistence, migrations, FTS5
- [ ] `toku-import` — Importers (Goodreads, Calibre, StoryGraph)
- [ ] `toku-meta` — Metadata fetching (Open Library, Google Books)
- [ ] `toku-cli` — CLI binary
- [ ] `toku-export` — Exporters (CSV, JSON, Markdown, BibTeX)
- [x] `docs/` — Documentation

## Data Integrity Checklist

- [x] No user data is sent to any server without explicit opt-in
- [x] Import operations are idempotent (re-importing the same file creates no duplicates)
- [x] User edits to metadata are never overwritten by auto-enrichment
- [x] New fields track provenance (source + timestamp)
- [x] Export round-trip is preserved (if applicable)

## Checklist

- [x] I have read [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] `cargo fmt --check` passes
- [x] `cargo clippy --workspace -- -D warnings` passes
- [x] `cargo test --workspace` passes
- [x] I have updated documentation (if applicable)
