### PR TITLE
feat: sync data model with HLC and local op-log

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Sync data model: `sync_ops`, `sync_cursors`, and `sync_device` tables (migration V12) for local op-log staging
+- Hybrid Logical Clock (HLC) implementation with fixed-width canonical format for causal ordering across devices
+- `SyncRepository` for sync persistence: insert ops, query unpushed, mark pushed, device identity, cursor management
+- `SyncOp` domain model with SHA-256 content checksums and `serde_json::Value` fields for canonical JSON
 - Web statistics dashboard (`toku serve`): reading stats, rating histogram, monthly pace chart, format breakdown donut, top authors and tags — all rendered as server-side SVG with dark mode support
 - Yearly wrap-up pages at `/stats/wrap/{year}` summarizing a single year's reading
 - JSON statistics API at `/api/stats` for programmatic access

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4587,6 +4587,7 @@ dependencies = [
  "chrono",
  "serde",
  "serde_json",
+ "sha2 0.10.9",
  "thiserror 2.0.18",
  "toml 1.1.2+spec-1.1.0",
  "uuid",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,4 +35,5 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
 tokio = { version = "1", features = ["rt", "macros"] }
+sha2 = "0.10"
 toml = "1.1"

--- a/crates/toku-core/Cargo.toml
+++ b/crates/toku-core/Cargo.toml
@@ -13,4 +13,5 @@ uuid.workspace = true
 chrono.workspace = true
 serde.workspace = true
 serde_json.workspace = true
+sha2.workspace = true
 toml.workspace = true

--- a/crates/toku-core/src/error.rs
+++ b/crates/toku-core/src/error.rs
@@ -41,4 +41,13 @@ pub enum TokuError {
 
     #[error("invalid filter: {0}")]
     InvalidFilter(String),
+
+    #[error("invalid HLC timestamp: {0}")]
+    InvalidHlc(String),
+
+    #[error("invalid entity type: {0}")]
+    InvalidEntityType(String),
+
+    #[error("invalid op type: {0}")]
+    InvalidOpType(String),
 }

--- a/crates/toku-core/src/lib.rs
+++ b/crates/toku-core/src/lib.rs
@@ -4,6 +4,7 @@ mod error;
 pub mod filter;
 mod isbn;
 pub mod stats;
+pub mod sync;
 
 pub use book::*;
 pub use config::*;
@@ -11,3 +12,4 @@ pub use error::*;
 pub use filter::*;
 pub use isbn::*;
 pub use stats::*;
+pub use sync::*;

--- a/crates/toku-core/src/sync.rs
+++ b/crates/toku-core/src/sync.rs
@@ -1,0 +1,718 @@
+use std::collections::BTreeMap;
+use std::fmt;
+use std::str::FromStr;
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use uuid::Uuid;
+
+// ---------------------------------------------------------------------------
+// HLC Timestamp
+// ---------------------------------------------------------------------------
+
+/// A Hybrid Logical Clock timestamp providing causal ordering across devices.
+///
+/// Format: `YYYY-MM-DDTHH:MM:SS.mmmZ-CCCC-DDDDDDDDDDDD`
+///   - Fixed-width ISO-8601 UTC with millisecond precision
+///   - 4-digit zero-padded logical counter
+///   - 12-character hex device prefix (from UUID without hyphens)
+///
+/// Lexicographic string comparison produces correct causal ordering.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct HlcTimestamp {
+    pub physical: DateTime<Utc>,
+    pub counter: u16,
+    pub device_prefix: String,
+}
+
+impl HlcTimestamp {
+    /// Create a new HLC timestamp.
+    pub fn new(physical: DateTime<Utc>, counter: u16, device_prefix: impl Into<String>) -> Self {
+        Self {
+            physical,
+            counter,
+            device_prefix: device_prefix.into(),
+        }
+    }
+
+    /// Returns the canonical fixed-width string representation.
+    pub fn to_canonical(&self) -> String {
+        format!(
+            "{}-{:04}-{}",
+            self.physical.format("%Y-%m-%dT%H:%M:%S%.3fZ"),
+            self.counter,
+            self.device_prefix,
+        )
+    }
+}
+
+impl fmt::Display for HlcTimestamp {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.to_canonical())
+    }
+}
+
+impl FromStr for HlcTimestamp {
+    type Err = crate::TokuError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        // Expected: "2026-06-15T10:30:00.000Z-0001-019726a3abcd"
+        //            ^--- 24 chars ---^     ^4 ^ ^--- 12 ---^
+        let parts: Vec<&str> = s.rsplitn(3, '-').collect();
+        if parts.len() != 3 {
+            return Err(crate::TokuError::InvalidHlc(s.to_string()));
+        }
+        // rsplitn reverses: [device_prefix, counter, timestamp]
+        let device_prefix = parts[0];
+        let counter_str = parts[1];
+        let timestamp_str = parts[2];
+
+        if device_prefix.len() != 12 {
+            return Err(crate::TokuError::InvalidHlc(s.to_string()));
+        }
+
+        let counter: u16 = counter_str
+            .parse()
+            .map_err(|_| crate::TokuError::InvalidHlc(s.to_string()))?;
+
+        let physical = DateTime::parse_from_rfc3339(timestamp_str)
+            .map(|dt| dt.with_timezone(&Utc))
+            .map_err(|_| crate::TokuError::InvalidHlc(s.to_string()))?;
+
+        Ok(Self {
+            physical,
+            counter,
+            device_prefix: device_prefix.to_string(),
+        })
+    }
+}
+
+impl Ord for HlcTimestamp {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.to_canonical().cmp(&other.to_canonical())
+    }
+}
+
+impl PartialOrd for HlcTimestamp {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Hybrid Clock
+// ---------------------------------------------------------------------------
+
+/// Generates monotonically increasing HLC timestamps.
+///
+/// Tracks the highest physical time seen and a logical counter for ordering
+/// events within the same millisecond.
+pub struct HybridClock {
+    last_physical: DateTime<Utc>,
+    counter: u16,
+    device_prefix: String,
+}
+
+impl HybridClock {
+    /// Create a new clock for the given device.
+    pub fn new(device_id: &Uuid) -> Self {
+        let hex = device_id
+            .as_simple()
+            .to_string()
+            .chars()
+            .take(12)
+            .collect::<String>();
+        Self {
+            last_physical: DateTime::UNIX_EPOCH,
+            counter: 0,
+            device_prefix: hex,
+        }
+    }
+
+    /// Generate a new HLC timestamp using the system clock.
+    pub fn now(&mut self) -> HlcTimestamp {
+        self.now_at(Utc::now())
+    }
+
+    /// Truncate a DateTime to millisecond precision.
+    ///
+    /// Our canonical HLC format uses millisecond precision (`%.3fZ`), so
+    /// comparisons must also use millisecond granularity to avoid the
+    /// counter resetting when two calls happen within the same millisecond
+    /// but at different nanoseconds.
+    fn truncate_to_millis(dt: DateTime<Utc>) -> DateTime<Utc> {
+        DateTime::from_timestamp_millis(dt.timestamp_millis()).unwrap_or(dt)
+    }
+
+    /// Generate a new HLC timestamp at a specific physical time.
+    ///
+    /// This is the primary method — `now()` is a convenience wrapper.
+    /// Use `now_at` in tests for deterministic behavior.
+    pub fn now_at(&mut self, physical: DateTime<Utc>) -> HlcTimestamp {
+        let physical = Self::truncate_to_millis(physical);
+        if physical > self.last_physical {
+            self.last_physical = physical;
+            self.counter = 0;
+        } else if self.counter == u16::MAX {
+            // Counter overflow: advance physical time by 1ms to maintain monotonicity
+            self.last_physical += chrono::Duration::milliseconds(1);
+            self.counter = 0;
+        } else {
+            self.counter += 1;
+        }
+
+        HlcTimestamp::new(self.last_physical, self.counter, &self.device_prefix)
+    }
+
+    /// Update the clock after receiving a remote HLC timestamp.
+    ///
+    /// Ensures the next local timestamp is causally after the remote one.
+    pub fn update(&mut self, remote: &HlcTimestamp) -> HlcTimestamp {
+        self.update_at(remote, Utc::now())
+    }
+
+    /// Update the clock with a remote timestamp at a specific physical time.
+    pub fn update_at(&mut self, remote: &HlcTimestamp, physical: DateTime<Utc>) -> HlcTimestamp {
+        let physical = Self::truncate_to_millis(physical);
+        let max_physical = physical.max(self.last_physical).max(remote.physical);
+
+        if max_physical == physical && physical > self.last_physical && physical > remote.physical {
+            // Wall clock is ahead — reset counter
+            self.last_physical = physical;
+            self.counter = 0;
+        } else if max_physical == remote.physical && remote.physical > self.last_physical {
+            // Remote is ahead — adopt remote physical, increment remote counter
+            self.last_physical = remote.physical;
+            self.counter = remote.counter.saturating_add(1);
+            if self.counter == 0 {
+                // Overflow from saturating_add on u16::MAX
+                self.last_physical += chrono::Duration::milliseconds(1);
+            }
+        } else if max_physical == self.last_physical && self.last_physical > remote.physical {
+            // Local is ahead — keep local physical, increment local counter
+            self.counter += 1;
+            if self.counter == 0 {
+                self.last_physical += chrono::Duration::milliseconds(1);
+            }
+        } else {
+            // Same physical time — take max counter + 1
+            self.counter = self.counter.max(remote.counter) + 1;
+            if self.counter == 0 {
+                self.last_physical += chrono::Duration::milliseconds(1);
+            }
+        }
+
+        HlcTimestamp::new(self.last_physical, self.counter, &self.device_prefix)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Entity Type
+// ---------------------------------------------------------------------------
+
+/// The type of entity a sync operation refers to.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum EntityType {
+    Book,
+    Session,
+    Progress,
+    Tag,
+    Note,
+    Review,
+    Setting,
+    Device,
+}
+
+impl EntityType {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Book => "book",
+            Self::Session => "session",
+            Self::Progress => "progress",
+            Self::Tag => "tag",
+            Self::Note => "note",
+            Self::Review => "review",
+            Self::Setting => "setting",
+            Self::Device => "device",
+        }
+    }
+}
+
+impl fmt::Display for EntityType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl FromStr for EntityType {
+    type Err = crate::TokuError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "book" => Ok(Self::Book),
+            "session" => Ok(Self::Session),
+            "progress" => Ok(Self::Progress),
+            "tag" => Ok(Self::Tag),
+            "note" => Ok(Self::Note),
+            "review" => Ok(Self::Review),
+            "setting" => Ok(Self::Setting),
+            "device" => Ok(Self::Device),
+            _ => Err(crate::TokuError::InvalidEntityType(s.to_string())),
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Op Type
+// ---------------------------------------------------------------------------
+
+/// The type of mutation a sync operation represents.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum OpType {
+    Create,
+    Update,
+    Delete,
+}
+
+impl OpType {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Create => "create",
+            Self::Update => "update",
+            Self::Delete => "delete",
+        }
+    }
+}
+
+impl fmt::Display for OpType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl FromStr for OpType {
+    type Err = crate::TokuError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "create" => Ok(Self::Create),
+            "update" => Ok(Self::Update),
+            "delete" => Ok(Self::Delete),
+            _ => Err(crate::TokuError::InvalidOpType(s.to_string())),
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Sync Op
+// ---------------------------------------------------------------------------
+
+/// A sync operation representing a single mutation to a library entity.
+///
+/// Every local mutation produces a `SyncOp` that can be pushed to the sync
+/// server. The op carries a versioned envelope format (see ADR-008).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SyncOp {
+    /// Envelope version (currently 1).
+    pub v: u16,
+    /// Globally unique, time-sortable op identifier.
+    pub op_id: Uuid,
+    /// The device that created this op.
+    pub device_id: Uuid,
+    /// Hybrid Logical Clock timestamp for causal ordering.
+    pub hlc: HlcTimestamp,
+    /// The type of entity being modified.
+    pub entity_type: EntityType,
+    /// The UUID of the entity being modified.
+    pub entity_id: Uuid,
+    /// The type of mutation.
+    pub op_type: OpType,
+    /// Field-level changes as a canonical JSON object. `None` for deletes.
+    pub fields: Option<serde_json::Value>,
+    /// SHA-256 hash of the canonical op (without the checksum field).
+    pub checksum: String,
+    /// When this op was created locally.
+    pub created_at: DateTime<Utc>,
+}
+
+impl SyncOp {
+    /// Create a new sync op with an auto-computed checksum.
+    pub fn new(
+        device_id: Uuid,
+        hlc: HlcTimestamp,
+        entity_type: EntityType,
+        entity_id: Uuid,
+        op_type: OpType,
+        fields: Option<serde_json::Value>,
+    ) -> Self {
+        let mut op = Self {
+            v: 1,
+            op_id: Uuid::now_v7(),
+            device_id,
+            hlc,
+            entity_type,
+            entity_id,
+            op_type,
+            fields,
+            checksum: String::new(),
+            created_at: Utc::now(),
+        };
+        op.checksum = op.compute_checksum();
+        op
+    }
+
+    /// Compute the SHA-256 checksum of this op's canonical representation.
+    ///
+    /// The checksum covers all fields except `checksum` itself, serialized
+    /// as a canonical JSON object with sorted keys.
+    pub fn compute_checksum(&self) -> String {
+        let mut map = BTreeMap::new();
+        map.insert("v", serde_json::json!(self.v));
+        map.insert("op_id", serde_json::json!(self.op_id.to_string()));
+        map.insert("device_id", serde_json::json!(self.device_id.to_string()));
+        map.insert("hlc", serde_json::json!(self.hlc.to_canonical()));
+        map.insert("entity_type", serde_json::json!(self.entity_type.as_str()));
+        map.insert("entity_id", serde_json::json!(self.entity_id.to_string()));
+        map.insert("op_type", serde_json::json!(self.op_type.as_str()));
+        map.insert(
+            "fields",
+            self.fields.clone().unwrap_or(serde_json::Value::Null),
+        );
+        map.insert(
+            "created_at",
+            serde_json::json!(self.created_at.to_rfc3339()),
+        );
+
+        let canonical = serde_json::to_string(&map).expect("BTreeMap serialization cannot fail");
+        let hash = Sha256::digest(canonical.as_bytes());
+        format!("sha256:{:x}", hash)
+    }
+
+    /// Verify this op's checksum is correct.
+    pub fn verify_checksum(&self) -> bool {
+        self.checksum == self.compute_checksum()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Device Identity
+// ---------------------------------------------------------------------------
+
+/// Identifies this device for sync purposes.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DeviceIdentity {
+    pub device_id: Uuid,
+    pub device_name: String,
+    pub created_at: DateTime<Utc>,
+}
+
+impl DeviceIdentity {
+    pub fn new(name: impl Into<String>) -> Self {
+        Self {
+            device_id: Uuid::now_v7(),
+            device_name: name.into(),
+            created_at: Utc::now(),
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::TimeZone;
+
+    fn fixed_time(millis: i64) -> DateTime<Utc> {
+        Utc.timestamp_millis_opt(millis).unwrap()
+    }
+
+    fn test_device_id() -> Uuid {
+        Uuid::parse_str("01972123-abcd-7000-8000-000000000001").unwrap()
+    }
+
+    fn test_device_prefix() -> String {
+        test_device_id()
+            .as_simple()
+            .to_string()
+            .chars()
+            .take(12)
+            .collect()
+    }
+
+    // --- HlcTimestamp ---
+
+    #[test]
+    fn hlc_display_format_is_fixed_width() {
+        let ts = HlcTimestamp::new(fixed_time(1718444400000), 1, test_device_prefix());
+        let s = ts.to_canonical();
+        // Fixed 42-char format
+        assert_eq!(s.len(), 42);
+        assert!(s.ends_with(&test_device_prefix()));
+    }
+
+    #[test]
+    fn hlc_display_roundtrip() {
+        let ts = HlcTimestamp::new(fixed_time(1718444400123), 42, test_device_prefix());
+        let s = ts.to_string();
+        let parsed: HlcTimestamp = s.parse().unwrap();
+        assert_eq!(parsed.physical, ts.physical);
+        assert_eq!(parsed.counter, 42);
+        assert_eq!(parsed.device_prefix, test_device_prefix());
+    }
+
+    #[test]
+    fn hlc_lexicographic_ordering_by_time() {
+        let early = HlcTimestamp::new(fixed_time(1000), 0, "aaaaaaaaaaaa");
+        let late = HlcTimestamp::new(fixed_time(2000), 0, "aaaaaaaaaaaa");
+        assert!(early < late);
+    }
+
+    #[test]
+    fn hlc_lexicographic_ordering_by_counter() {
+        let low = HlcTimestamp::new(fixed_time(1000), 1, "aaaaaaaaaaaa");
+        let high = HlcTimestamp::new(fixed_time(1000), 2, "aaaaaaaaaaaa");
+        assert!(low < high);
+    }
+
+    #[test]
+    fn hlc_lexicographic_ordering_by_device() {
+        let a = HlcTimestamp::new(fixed_time(1000), 0, "aaaaaaaaaaaa");
+        let b = HlcTimestamp::new(fixed_time(1000), 0, "bbbbbbbbbbbb");
+        assert!(a < b);
+    }
+
+    #[test]
+    fn hlc_parse_rejects_invalid() {
+        assert!("not-a-timestamp".parse::<HlcTimestamp>().is_err());
+        assert!(
+            "2026-01-01T00:00:00.000Z-0001-short"
+                .parse::<HlcTimestamp>()
+                .is_err()
+        );
+    }
+
+    // --- HybridClock ---
+
+    #[test]
+    fn clock_monotonically_increasing() {
+        let mut clock = HybridClock::new(&test_device_id());
+        let t1 = clock.now_at(fixed_time(1000));
+        let t2 = clock.now_at(fixed_time(2000));
+        assert!(t2 > t1);
+    }
+
+    #[test]
+    fn clock_same_millis_increments_counter() {
+        let mut clock = HybridClock::new(&test_device_id());
+        let t1 = clock.now_at(fixed_time(1000));
+        let t2 = clock.now_at(fixed_time(1000));
+        assert_eq!(t1.counter, 0);
+        assert_eq!(t2.counter, 1);
+        assert!(t2 > t1);
+    }
+
+    #[test]
+    fn clock_backward_time_stays_monotonic() {
+        let mut clock = HybridClock::new(&test_device_id());
+        let t1 = clock.now_at(fixed_time(2000));
+        let t2 = clock.now_at(fixed_time(1000)); // clock goes backward
+        assert!(t2 > t1, "backward clock must still produce increasing HLC");
+        assert_eq!(t2.physical, fixed_time(2000)); // physical stays at max seen
+        assert_eq!(t2.counter, 1); // counter incremented
+    }
+
+    #[test]
+    fn clock_counter_overflow_advances_physical() {
+        let mut clock = HybridClock::new(&test_device_id());
+        let base = fixed_time(1000);
+        // Exhaust the counter
+        clock.last_physical = base;
+        clock.counter = u16::MAX;
+        let ts = clock.now_at(base);
+        // Should have advanced physical by 1ms and reset counter
+        assert_eq!(ts.physical, base + chrono::Duration::milliseconds(1));
+        assert_eq!(ts.counter, 0);
+    }
+
+    #[test]
+    fn clock_update_adopts_ahead_remote() {
+        let mut clock = HybridClock::new(&test_device_id());
+        let local_time = fixed_time(1000);
+        let remote = HlcTimestamp::new(fixed_time(5000), 3, "bbbbbbbbbbbb");
+
+        let merged = clock.update_at(&remote, local_time);
+        assert!(merged > remote, "merged must be after remote");
+        assert_eq!(merged.physical, fixed_time(5000));
+        assert_eq!(merged.counter, 4);
+    }
+
+    #[test]
+    fn clock_update_local_ahead_of_remote() {
+        let mut clock = HybridClock::new(&test_device_id());
+        let _ = clock.now_at(fixed_time(5000));
+
+        let remote = HlcTimestamp::new(fixed_time(2000), 0, "bbbbbbbbbbbb");
+        let local_time = fixed_time(3000); // behind local clock's last_physical
+
+        let merged = clock.update_at(&remote, local_time);
+        assert!(merged > remote);
+        assert_eq!(merged.physical, fixed_time(5000)); // keeps local max
+    }
+
+    #[test]
+    fn clock_update_wall_clock_ahead_of_both() {
+        let mut clock = HybridClock::new(&test_device_id());
+        let _ = clock.now_at(fixed_time(1000));
+
+        let remote = HlcTimestamp::new(fixed_time(2000), 0, "bbbbbbbbbbbb");
+        let local_time = fixed_time(5000); // wall clock ahead of both
+
+        let merged = clock.update_at(&remote, local_time);
+        assert!(merged > remote);
+        assert_eq!(merged.physical, fixed_time(5000));
+        assert_eq!(merged.counter, 0); // reset since wall clock is newest
+    }
+
+    #[test]
+    fn two_devices_deterministic_ordering() {
+        let dev_a = Uuid::parse_str("01972123-aaaa-7000-8000-000000000001").unwrap();
+        let dev_b = Uuid::parse_str("01972123-bbbb-7000-8000-000000000001").unwrap();
+
+        let mut clock_a = HybridClock::new(&dev_a);
+        let mut clock_b = HybridClock::new(&dev_b);
+
+        let same_time = fixed_time(1000);
+        let ts_a = clock_a.now_at(same_time);
+        let ts_b = clock_b.now_at(same_time);
+
+        // Same physical, same counter — device prefix breaks tie
+        assert_ne!(ts_a, ts_b);
+        // One is deterministically before the other
+        assert!(ts_a < ts_b || ts_b < ts_a);
+    }
+
+    // --- EntityType ---
+
+    #[test]
+    fn entity_type_roundtrip() {
+        for variant in [
+            EntityType::Book,
+            EntityType::Session,
+            EntityType::Progress,
+            EntityType::Tag,
+            EntityType::Note,
+            EntityType::Review,
+            EntityType::Setting,
+            EntityType::Device,
+        ] {
+            let s = variant.as_str();
+            let parsed: EntityType = s.parse().unwrap();
+            assert_eq!(parsed, variant);
+        }
+    }
+
+    #[test]
+    fn entity_type_invalid() {
+        assert!("invalid".parse::<EntityType>().is_err());
+    }
+
+    // --- OpType ---
+
+    #[test]
+    fn op_type_roundtrip() {
+        for variant in [OpType::Create, OpType::Update, OpType::Delete] {
+            let s = variant.as_str();
+            let parsed: OpType = s.parse().unwrap();
+            assert_eq!(parsed, variant);
+        }
+    }
+
+    #[test]
+    fn op_type_invalid() {
+        assert!("invalid".parse::<OpType>().is_err());
+    }
+
+    // --- SyncOp checksum ---
+
+    #[test]
+    fn sync_op_checksum_is_stable() {
+        let op = SyncOp::new(
+            test_device_id(),
+            HlcTimestamp::new(fixed_time(1000), 0, test_device_prefix()),
+            EntityType::Book,
+            Uuid::parse_str("01972123-0000-7000-8000-000000000002").unwrap(),
+            OpType::Update,
+            Some(serde_json::json!({"rating": 8})),
+        );
+        assert!(op.checksum.starts_with("sha256:"));
+        assert!(op.verify_checksum());
+    }
+
+    #[test]
+    fn sync_op_different_fields_produce_different_checksum() {
+        let hlc = HlcTimestamp::new(fixed_time(1000), 0, test_device_prefix());
+        let entity_id = Uuid::parse_str("01972123-0000-7000-8000-000000000002").unwrap();
+
+        let op_a = SyncOp::new(
+            test_device_id(),
+            hlc.clone(),
+            EntityType::Book,
+            entity_id,
+            OpType::Update,
+            Some(serde_json::json!({"rating": 8})),
+        );
+        let op_b = SyncOp::new(
+            test_device_id(),
+            hlc,
+            EntityType::Book,
+            entity_id,
+            OpType::Update,
+            Some(serde_json::json!({"rating": 9})),
+        );
+        assert_ne!(op_a.checksum, op_b.checksum);
+    }
+
+    #[test]
+    fn sync_op_canonical_json_key_order_stable() {
+        // Regardless of field insertion order, BTreeMap sorts keys
+        let op = SyncOp::new(
+            test_device_id(),
+            HlcTimestamp::new(fixed_time(1000), 0, test_device_prefix()),
+            EntityType::Book,
+            Uuid::nil(),
+            OpType::Create,
+            Some(serde_json::json!({"z_field": 1, "a_field": 2})),
+        );
+        let checksum1 = op.compute_checksum();
+        let checksum2 = op.compute_checksum();
+        assert_eq!(checksum1, checksum2);
+    }
+
+    #[test]
+    fn sync_op_delete_has_no_fields() {
+        let op = SyncOp::new(
+            test_device_id(),
+            HlcTimestamp::new(fixed_time(1000), 0, test_device_prefix()),
+            EntityType::Book,
+            Uuid::nil(),
+            OpType::Delete,
+            None,
+        );
+        assert!(op.fields.is_none());
+        assert!(op.verify_checksum());
+    }
+
+    // --- DeviceIdentity ---
+
+    #[test]
+    fn device_identity_creates_with_uuid_v7() {
+        let dev = DeviceIdentity::new("Test Laptop");
+        assert_eq!(dev.device_name, "Test Laptop");
+        // UUID v7 — version nibble is 7
+        assert_eq!(dev.device_id.get_version_num(), 7);
+    }
+}

--- a/crates/toku-db/migrations/V12__sync.sql
+++ b/crates/toku-db/migrations/V12__sync.sql
@@ -1,0 +1,31 @@
+-- Sync operations: local staging for push/pull sync.
+-- Each mutation appends an op that can be pushed to a sync server.
+CREATE TABLE sync_ops (
+    op_id TEXT PRIMARY KEY NOT NULL,
+    device_id TEXT NOT NULL,
+    hlc TEXT NOT NULL,
+    entity_type TEXT NOT NULL CHECK (entity_type IN ('book', 'session', 'progress', 'tag', 'note', 'review', 'setting', 'device')),
+    entity_id TEXT NOT NULL,
+    op_type TEXT NOT NULL CHECK (op_type IN ('create', 'update', 'delete')),
+    fields_json TEXT,
+    checksum TEXT NOT NULL,
+    pushed_at TEXT,
+    created_at TEXT NOT NULL
+);
+
+CREATE INDEX idx_sync_ops_pushed ON sync_ops(pushed_at);
+CREATE INDEX idx_sync_ops_entity ON sync_ops(entity_type, entity_id);
+CREATE INDEX idx_sync_ops_hlc ON sync_ops(hlc);
+
+-- Sync cursors: track push/pull progress.
+CREATE TABLE sync_cursors (
+    key TEXT PRIMARY KEY NOT NULL CHECK (key IN ('push_cursor', 'pull_cursor')),
+    value TEXT NOT NULL
+);
+
+-- Device identity: identifies this installation for sync.
+CREATE TABLE sync_device (
+    device_id TEXT PRIMARY KEY NOT NULL,
+    device_name TEXT NOT NULL,
+    created_at TEXT NOT NULL
+);

--- a/crates/toku-db/src/lib.rs
+++ b/crates/toku-db/src/lib.rs
@@ -1,7 +1,9 @@
 mod database;
 mod error;
 mod repo;
+mod sync_repo;
 
 pub use database::Database;
 pub use error::DbError;
 pub use repo::BookRepository;
+pub use sync_repo::SyncRepository;

--- a/crates/toku-db/src/sync_repo.rs
+++ b/crates/toku-db/src/sync_repo.rs
@@ -1,0 +1,424 @@
+use rusqlite::{OptionalExtension, params};
+use toku_core::{DeviceIdentity, EntityType, HlcTimestamp, OpType, SyncOp};
+use uuid::Uuid;
+
+use crate::{Database, DbError};
+
+/// Sync persistence operations: ops, cursors, and device identity.
+pub struct SyncRepository<'a> {
+    db: &'a Database,
+}
+
+impl<'a> SyncRepository<'a> {
+    pub fn new(db: &'a Database) -> Self {
+        Self { db }
+    }
+
+    /// Insert a sync op into the local staging table.
+    pub fn insert_op(&self, op: &SyncOp) -> Result<(), DbError> {
+        let fields_json = op.fields.as_ref().map(|v| v.to_string());
+        self.db.conn.execute(
+            "INSERT INTO sync_ops (op_id, device_id, hlc, entity_type, entity_id,
+             op_type, fields_json, checksum, pushed_at, created_at)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, NULL, ?9)",
+            params![
+                op.op_id.to_string(),
+                op.device_id.to_string(),
+                op.hlc.to_canonical(),
+                op.entity_type.as_str(),
+                op.entity_id.to_string(),
+                op.op_type.as_str(),
+                fields_json,
+                op.checksum,
+                op.created_at.to_rfc3339(),
+            ],
+        )?;
+        Ok(())
+    }
+
+    /// Get all ops that have not been pushed yet, ordered by HLC.
+    pub fn get_unpushed_ops(&self) -> Result<Vec<SyncOp>, DbError> {
+        let mut stmt = self.db.conn.prepare(
+            "SELECT op_id, device_id, hlc, entity_type, entity_id,
+                    op_type, fields_json, checksum, created_at
+             FROM sync_ops
+             WHERE pushed_at IS NULL
+             ORDER BY hlc ASC",
+        )?;
+
+        let ops = stmt
+            .query_map([], |row| {
+                let op_id_str: String = row.get(0)?;
+                let device_id_str: String = row.get(1)?;
+                let hlc_str: String = row.get(2)?;
+                let entity_type_str: String = row.get(3)?;
+                let entity_id_str: String = row.get(4)?;
+                let op_type_str: String = row.get(5)?;
+                let fields_json: Option<String> = row.get(6)?;
+                let checksum: String = row.get(7)?;
+                let created_at_str: String = row.get(8)?;
+
+                Ok(SyncOpRow {
+                    op_id_str,
+                    device_id_str,
+                    hlc_str,
+                    entity_type_str,
+                    entity_id_str,
+                    op_type_str,
+                    fields_json,
+                    checksum,
+                    created_at_str,
+                })
+            })?
+            .collect::<Result<Vec<_>, _>>()?;
+
+        ops.into_iter().map(|r| r.into_sync_op()).collect()
+    }
+
+    /// Mark the given ops as pushed (set pushed_at to now).
+    pub fn mark_ops_pushed(&self, op_ids: &[Uuid]) -> Result<u64, DbError> {
+        if op_ids.is_empty() {
+            return Ok(0);
+        }
+        let now = chrono::Utc::now().to_rfc3339();
+        let placeholders: Vec<String> = op_ids.iter().map(|_| "?".to_string()).collect();
+        let sql = format!(
+            "UPDATE sync_ops SET pushed_at = ?1 WHERE op_id IN ({})",
+            placeholders.join(", ")
+        );
+
+        let mut stmt = self.db.conn.prepare(&sql)?;
+        let mut param_values: Vec<Box<dyn rusqlite::types::ToSql>> = vec![Box::new(now)];
+        for id in op_ids {
+            param_values.push(Box::new(id.to_string()));
+        }
+        let refs: Vec<&dyn rusqlite::types::ToSql> =
+            param_values.iter().map(|b| b.as_ref()).collect();
+        let count = stmt.execute(refs.as_slice())?;
+        Ok(count as u64)
+    }
+
+    /// Get the current device identity, if one has been set.
+    pub fn get_device(&self) -> Result<Option<DeviceIdentity>, DbError> {
+        let result = self
+            .db
+            .conn
+            .query_row(
+                "SELECT device_id, device_name, created_at FROM sync_device LIMIT 1",
+                [],
+                |row| {
+                    let id_str: String = row.get(0)?;
+                    let name: String = row.get(1)?;
+                    let created_str: String = row.get(2)?;
+                    Ok((id_str, name, created_str))
+                },
+            )
+            .optional()?;
+
+        match result {
+            Some((id_str, name, created_str)) => {
+                let device_id = Uuid::parse_str(&id_str)
+                    .map_err(|e| DbError::InvalidOperation(e.to_string()))?;
+                let created_at = chrono::DateTime::parse_from_rfc3339(&created_str)
+                    .map(|dt| dt.with_timezone(&chrono::Utc))
+                    .map_err(|e| DbError::InvalidOperation(e.to_string()))?;
+                Ok(Some(DeviceIdentity {
+                    device_id,
+                    device_name: name,
+                    created_at,
+                }))
+            }
+            None => Ok(None),
+        }
+    }
+
+    /// Get or create the device identity. If no device exists, create one
+    /// with the given name.
+    pub fn get_or_create_device(&self, name: &str) -> Result<DeviceIdentity, DbError> {
+        if let Some(existing) = self.get_device()? {
+            return Ok(existing);
+        }
+
+        let device = DeviceIdentity::new(name);
+        self.db.conn.execute(
+            "INSERT INTO sync_device (device_id, device_name, created_at) VALUES (?1, ?2, ?3)",
+            params![
+                device.device_id.to_string(),
+                device.device_name,
+                device.created_at.to_rfc3339(),
+            ],
+        )?;
+        Ok(device)
+    }
+
+    /// Get a sync cursor value by key ("push_cursor" or "pull_cursor").
+    pub fn get_cursor(&self, key: &str) -> Result<Option<String>, DbError> {
+        let result = self
+            .db
+            .conn
+            .query_row(
+                "SELECT value FROM sync_cursors WHERE key = ?1",
+                params![key],
+                |row| row.get(0),
+            )
+            .optional()?;
+        Ok(result)
+    }
+
+    /// Set a sync cursor value (upsert).
+    pub fn set_cursor(&self, key: &str, value: &str) -> Result<(), DbError> {
+        self.db.conn.execute(
+            "INSERT INTO sync_cursors (key, value) VALUES (?1, ?2)
+             ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+            params![key, value],
+        )?;
+        Ok(())
+    }
+
+    /// Count the number of unpushed ops.
+    pub fn count_unpushed_ops(&self) -> Result<i64, DbError> {
+        let count: i64 = self.db.conn.query_row(
+            "SELECT COUNT(*) FROM sync_ops WHERE pushed_at IS NULL",
+            [],
+            |row| row.get(0),
+        )?;
+        Ok(count)
+    }
+}
+
+/// Internal helper for deserializing rows before parsing UUIDs/HLC.
+struct SyncOpRow {
+    op_id_str: String,
+    device_id_str: String,
+    hlc_str: String,
+    entity_type_str: String,
+    entity_id_str: String,
+    op_type_str: String,
+    fields_json: Option<String>,
+    checksum: String,
+    created_at_str: String,
+}
+
+impl SyncOpRow {
+    fn into_sync_op(self) -> Result<SyncOp, DbError> {
+        let op_id = Uuid::parse_str(&self.op_id_str)
+            .map_err(|e| DbError::InvalidOperation(e.to_string()))?;
+        let device_id = Uuid::parse_str(&self.device_id_str)
+            .map_err(|e| DbError::InvalidOperation(e.to_string()))?;
+        let hlc: HlcTimestamp = self
+            .hlc_str
+            .parse()
+            .map_err(|e: toku_core::TokuError| DbError::InvalidOperation(e.to_string()))?;
+        let entity_type: EntityType = self
+            .entity_type_str
+            .parse()
+            .map_err(|e: toku_core::TokuError| DbError::InvalidOperation(e.to_string()))?;
+        let entity_id = Uuid::parse_str(&self.entity_id_str)
+            .map_err(|e| DbError::InvalidOperation(e.to_string()))?;
+        let op_type: OpType = self
+            .op_type_str
+            .parse()
+            .map_err(|e: toku_core::TokuError| DbError::InvalidOperation(e.to_string()))?;
+        let fields = self
+            .fields_json
+            .as_deref()
+            .map(serde_json::from_str)
+            .transpose()
+            .map_err(|e| DbError::InvalidOperation(e.to_string()))?;
+        let created_at = chrono::DateTime::parse_from_rfc3339(&self.created_at_str)
+            .map(|dt| dt.with_timezone(&chrono::Utc))
+            .map_err(|e| DbError::InvalidOperation(e.to_string()))?;
+
+        Ok(SyncOp {
+            v: 1,
+            op_id,
+            device_id,
+            hlc,
+            entity_type,
+            entity_id,
+            op_type,
+            fields,
+            checksum: self.checksum,
+            created_at,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use toku_core::HybridClock;
+
+    fn test_db() -> Database {
+        Database::open_in_memory().unwrap()
+    }
+
+    fn test_device() -> Uuid {
+        Uuid::parse_str("01972123-abcd-7000-8000-000000000001").unwrap()
+    }
+
+    fn make_op(clock: &mut HybridClock, entity_type: EntityType, op_type: OpType) -> SyncOp {
+        let hlc = clock.now();
+        SyncOp::new(
+            test_device(),
+            hlc,
+            entity_type,
+            Uuid::now_v7(),
+            op_type,
+            Some(serde_json::json!({"title": "Dune"})),
+        )
+    }
+
+    #[test]
+    fn insert_and_query_unpushed() {
+        let db = test_db();
+        let repo = SyncRepository::new(&db);
+        let mut clock = HybridClock::new(&test_device());
+
+        let op = make_op(&mut clock, EntityType::Book, OpType::Create);
+        repo.insert_op(&op).unwrap();
+
+        let unpushed = repo.get_unpushed_ops().unwrap();
+        assert_eq!(unpushed.len(), 1);
+        assert_eq!(unpushed[0].op_id, op.op_id);
+        assert_eq!(unpushed[0].entity_type, EntityType::Book);
+        assert_eq!(unpushed[0].op_type, OpType::Create);
+        assert!(unpushed[0].verify_checksum());
+    }
+
+    #[test]
+    fn mark_ops_pushed_excludes_from_unpushed() {
+        let db = test_db();
+        let repo = SyncRepository::new(&db);
+        let mut clock = HybridClock::new(&test_device());
+
+        let op1 = make_op(&mut clock, EntityType::Book, OpType::Create);
+        let op2 = make_op(&mut clock, EntityType::Book, OpType::Update);
+        repo.insert_op(&op1).unwrap();
+        repo.insert_op(&op2).unwrap();
+
+        assert_eq!(repo.count_unpushed_ops().unwrap(), 2);
+
+        let marked = repo.mark_ops_pushed(&[op1.op_id]).unwrap();
+        assert_eq!(marked, 1);
+
+        let unpushed = repo.get_unpushed_ops().unwrap();
+        assert_eq!(unpushed.len(), 1);
+        assert_eq!(unpushed[0].op_id, op2.op_id);
+    }
+
+    #[test]
+    fn mark_ops_pushed_empty_ids() {
+        let db = test_db();
+        let repo = SyncRepository::new(&db);
+        let marked = repo.mark_ops_pushed(&[]).unwrap();
+        assert_eq!(marked, 0);
+    }
+
+    #[test]
+    fn device_identity_get_or_create() {
+        let db = test_db();
+        let repo = SyncRepository::new(&db);
+
+        assert!(repo.get_device().unwrap().is_none());
+
+        let dev = repo.get_or_create_device("Test Laptop").unwrap();
+        assert_eq!(dev.device_name, "Test Laptop");
+
+        // Second call returns the same device
+        let dev2 = repo.get_or_create_device("Different Name").unwrap();
+        assert_eq!(dev2.device_id, dev.device_id);
+        assert_eq!(dev2.device_name, "Test Laptop"); // original name preserved
+    }
+
+    #[test]
+    fn cursor_get_set_roundtrip() {
+        let db = test_db();
+        let repo = SyncRepository::new(&db);
+
+        assert!(repo.get_cursor("push_cursor").unwrap().is_none());
+
+        repo.set_cursor("push_cursor", "op-123").unwrap();
+        assert_eq!(
+            repo.get_cursor("push_cursor").unwrap().as_deref(),
+            Some("op-123")
+        );
+
+        // Upsert overwrites
+        repo.set_cursor("push_cursor", "op-456").unwrap();
+        assert_eq!(
+            repo.get_cursor("push_cursor").unwrap().as_deref(),
+            Some("op-456")
+        );
+    }
+
+    #[test]
+    fn unpushed_ops_ordered_by_hlc() {
+        let db = test_db();
+        let repo = SyncRepository::new(&db);
+        let mut clock = HybridClock::new(&test_device());
+
+        let op1 = make_op(&mut clock, EntityType::Book, OpType::Create);
+        let op2 = make_op(&mut clock, EntityType::Session, OpType::Create);
+        let op3 = make_op(&mut clock, EntityType::Book, OpType::Update);
+
+        // Insert out of order
+        repo.insert_op(&op3).unwrap();
+        repo.insert_op(&op1).unwrap();
+        repo.insert_op(&op2).unwrap();
+
+        let unpushed = repo.get_unpushed_ops().unwrap();
+        assert_eq!(unpushed.len(), 3);
+        // Verify HLC ordering
+        assert!(unpushed[0].hlc < unpushed[1].hlc);
+        assert!(unpushed[1].hlc < unpushed[2].hlc);
+    }
+
+    #[test]
+    fn sync_op_delete_no_fields() {
+        let db = test_db();
+        let repo = SyncRepository::new(&db);
+        let mut clock = HybridClock::new(&test_device());
+
+        let hlc = clock.now();
+        let op = SyncOp::new(
+            test_device(),
+            hlc,
+            EntityType::Book,
+            Uuid::now_v7(),
+            OpType::Delete,
+            None,
+        );
+        repo.insert_op(&op).unwrap();
+
+        let unpushed = repo.get_unpushed_ops().unwrap();
+        assert_eq!(unpushed.len(), 1);
+        assert!(unpushed[0].fields.is_none());
+        assert!(unpushed[0].verify_checksum());
+    }
+
+    #[test]
+    fn migration_is_backward_compatible() {
+        // Opening a new in-memory DB runs all migrations including V12.
+        // If any migration fails, open_in_memory() would return an error.
+        let db = test_db();
+        // Verify sync tables exist
+        let count: i64 = db
+            .conn
+            .query_row("SELECT COUNT(*) FROM sync_ops", [], |row| row.get(0))
+            .unwrap();
+        assert_eq!(count, 0);
+
+        let count: i64 = db
+            .conn
+            .query_row("SELECT COUNT(*) FROM sync_cursors", [], |row| row.get(0))
+            .unwrap();
+        assert_eq!(count, 0);
+
+        let count: i64 = db
+            .conn
+            .query_row("SELECT COUNT(*) FROM sync_device", [], |row| row.get(0))
+            .unwrap();
+        assert_eq!(count, 0);
+    }
+}


### PR DESCRIPTION
## Description

Adds the sync data model foundation for multi-device sync: a local op-log table, Hybrid Logical Clock (HLC) for causal ordering, and a persistence layer for sync operations.

### What's included

- **Hybrid Logical Clock** (`toku-core/src/sync.rs`): `HlcTimestamp` with a fixed-width canonical format (`YYYY-MM-DDTHH:MM:SS.mmmZ-CCCC-DDDDDDDDDDDD`) that sorts lexicographically for correct causal ordering. `HybridClock` provides monotonic tick generation, remote clock merge, counter overflow handling, and deterministic `now_at()`/`update_at()` methods for testing. Physical time is truncated to millisecond precision to match the canonical format granularity.
- **Domain models**: `SyncOp` (op envelope with SHA-256 content checksum, versioned per ADR-008), `EntityType` (book, session, progress, tag, note, review, setting, device), `OpType` (create, update, delete), `DeviceIdentity` (UUID v7 + device name).
- **Migration V12** (`V12__sync.sql`): `sync_ops` table with CHECK constraints on entity_type/op_type columns, `sync_cursors` for push/pull progress tracking, `sync_device` for local device identity. Includes indexes on `pushed_at`, `(entity_type, entity_id)`, and `hlc`.
- **SyncRepository** (`toku-db/src/sync_repo.rs`): Insert ops, query unpushed ops (ordered by HLC), batch mark-as-pushed, device identity get-or-create, cursor get/set upsert, unpushed count.
- **31 new tests**: 23 unit tests in toku-core (HLC monotonicity, clock skew, counter overflow, cross-device ordering, checksum stability) + 8 integration tests in toku-db (CRUD roundtrips, HLC ordering, migration compatibility).

## Related Issues

Closes #65

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI / infrastructure
- [ ] Other (describe below)

## Crate

- [x] `toku-core` — Domain models, traits, state machine
- [x] `toku-db` — SQLite persistence, migrations, FTS5
- [ ] `toku-import` — Importers (Goodreads, Calibre, StoryGraph)
- [ ] `toku-meta` — Metadata fetching (Open Library, Google Books)
- [ ] `toku-cli` — CLI binary
- [ ] `toku-export` — Exporters (CSV, JSON, Markdown, BibTeX)
- [ ] `docs/` — Documentation

## Data Integrity Checklist

- [x] No user data is sent to any server without explicit opt-in
- [x] Import operations are idempotent (re-importing the same file creates no duplicates)
- [x] User edits to metadata are never overwritten by auto-enrichment
- [x] New fields track provenance (source + timestamp)
- [x] Export round-trip is preserved (if applicable)

## Checklist

- [x] I have read [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] `cargo fmt --check` passes
- [x] `cargo clippy --workspace -- -D warnings` passes
- [x] `cargo test --workspace` passes (237 passed, 0 failed, 17 ignored)
- [x] I have updated documentation (if applicable)
