### PR TITLE
feat: sync server scaffold with device registration and CLI commands

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -87,7 +87,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@1.100
+      - uses: dtolnay/rust-toolchain@1.88
       - uses: Swatinem/rust-cache@v2
         with:
           key: msrv

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Hybrid Logical Clock (HLC) implementation with fixed-width canonical format for causal ordering across devices
 - `SyncRepository` for sync persistence: insert ops, query unpushed, mark pushed, device identity, cursor management
 - `SyncOp` domain model with SHA-256 content checksums and `serde_json::Value` fields for canonical JSON
+- Sync relay server (`toku-sync`): standalone Axum HTTP service that stores and relays sync operations between devices
+- Device registration and authentication: `POST /api/v1/register` generates a 256-bit base64url auth token, stored as SHA-256 hash on the server
+- Sync REST API: push ops, pull ops (with cursor-based pagination), device management, and health check
+- `toku sync register` CLI command to register a device with a sync server and store the auth token in the OS keychain
+- `toku sync devices` to list registered devices with `--format table|json|csv` support
+- `toku sync deregister` to remove another device from the sync server
+- `toku sync logout` to remove locally stored sync credentials
+- Platform-native credential storage via OS keychain (macOS Keychain, Windows Credential Manager, Linux Secret Service) with secure file fallback
 - Web statistics dashboard (`toku serve`): reading stats, rating histogram, monthly pace chart, format breakdown donut, top authors and tags — all rendered as server-side SVG with dark mode support
 - Yearly wrap-up pages at `/stats/wrap/{year}` summarizing a single year's reading
 - JSON statistics API at `/api/stats` for programmatic access

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2188,6 +2188,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "keyring"
+version = "3.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eebcc3aff044e5944a8fbaf69eb277d11986064cba30c468730e8b9909fb551c"
+dependencies = [
+ "log",
+ "zeroize",
+]
+
+[[package]]
 name = "leb128fmt"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3428,7 +3438,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4505,6 +4515,7 @@ dependencies = [
  "libc",
  "mio",
  "pin-project-lite",
+ "signal-hook-registry",
  "socket2",
  "tokio-macros",
  "windows-sys 0.61.2",
@@ -4566,7 +4577,9 @@ dependencies = [
  "clap_complete",
  "crossterm",
  "csv",
+ "keyring",
  "ratatui",
+ "reqwest 0.12.28",
  "serde",
  "serde_json",
  "tabled",
@@ -4578,6 +4591,7 @@ dependencies = [
  "toku-meta",
  "toku-web",
  "toml 1.1.2+spec-1.1.0",
+ "uuid",
 ]
 
 [[package]]
@@ -4677,6 +4691,28 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "toku-core",
+]
+
+[[package]]
+name = "toku-sync"
+version = "0.2.1"
+dependencies = [
+ "anyhow",
+ "axum",
+ "base64 0.22.1",
+ "chrono",
+ "clap",
+ "rand",
+ "refinery",
+ "reqwest 0.12.28",
+ "rusqlite",
+ "serde",
+ "serde_json",
+ "sha2 0.10.9",
+ "thiserror 2.0.18",
+ "tokio",
+ "tower",
+ "uuid",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ members = [
     "crates/toku-ffi",
     "crates/toku-web",
     "crates/toku-desktop",
+    "crates/toku-sync",
 ]
 
 [workspace.package]

--- a/crates/toku-cli/Cargo.toml
+++ b/crates/toku-cli/Cargo.toml
@@ -22,6 +22,8 @@ clap = { version = "4", features = ["derive", "env"] }
 clap_complete = "4"
 anyhow = "1"
 chrono.workspace = true
+keyring = "3"
+reqwest = { workspace = true, features = ["json"] }
 serde.workspace = true
 serde_json.workspace = true
 toml.workspace = true
@@ -30,3 +32,4 @@ tabled = "0.20"
 ratatui = "0.29"
 crossterm = "0.28"
 csv = "1"
+uuid.workspace = true

--- a/crates/toku-cli/src/main.rs
+++ b/crates/toku-cli/src/main.rs
@@ -13,6 +13,7 @@ use toku_core::{
 use toku_db::{BookRepository, Database};
 
 mod import_ui;
+mod sync;
 mod tui;
 
 /// Toku — a private, offline-first personal book manager.
@@ -246,6 +247,12 @@ enum Commands {
     Shelf {
         #[command(subcommand)]
         action: ShelfAction,
+    },
+
+    /// Manage sync with a toku-sync server
+    Sync {
+        #[command(subcommand)]
+        action: SyncAction,
     },
 }
 
@@ -549,6 +556,49 @@ enum ExportTarget {
     },
 }
 
+#[derive(Clone, Subcommand)]
+enum SyncAction {
+    /// Register this device with a sync server
+    Register {
+        /// Sync server URL (e.g. https://sync.example.com)
+        #[arg(long)]
+        server: String,
+
+        /// Library ID (UUID — use the same ID across all devices for one library)
+        #[arg(long)]
+        library_id: String,
+
+        /// Name for this device (e.g. "work-laptop")
+        #[arg(long)]
+        device_name: String,
+    },
+
+    /// List all devices registered to this library
+    Devices {
+        /// Sync server URL
+        #[arg(long)]
+        server: String,
+    },
+
+    /// Deregister another device from the sync server
+    Deregister {
+        /// Sync server URL
+        #[arg(long)]
+        server: String,
+
+        /// Device ID to deregister
+        #[arg(long)]
+        device_id: String,
+    },
+
+    /// Remove locally stored sync credentials
+    Logout {
+        /// Sync server URL
+        #[arg(long)]
+        server: String,
+    },
+}
+
 #[derive(Clone, ValueEnum)]
 enum OutputFormat {
     Table,
@@ -585,6 +635,9 @@ fn main() -> Result<()> {
                     .await
                     .map_err(|e| anyhow::anyhow!("{e}"))
             });
+        }
+        Commands::Sync { action } => {
+            return cmd_sync(&data_dir, action.clone(), &cli.format);
         }
         _ => {}
     }
@@ -674,8 +727,10 @@ fn main() -> Result<()> {
         Commands::Work { action } => cmd_work(&repo, action, &cli.format),
         Commands::Merge { keep, remove } => cmd_merge(&repo, &keep, &remove, &cli.format),
         Commands::Shelf { action } => cmd_shelf(&repo, action, &cli.format),
-        // Already handled above
-        Commands::Config { .. } | Commands::Completions { .. } | Commands::Serve { .. } => {
+        Commands::Config { .. }
+        | Commands::Completions { .. }
+        | Commands::Serve { .. }
+        | Commands::Sync { .. } => {
             unreachable!()
         }
     }
@@ -2856,6 +2911,144 @@ fn cmd_shelf(
             let found = resolve_book(repo, &book)?;
             repo.remove_book_from_shelf(&found.id, &shelf)?;
             eprintln!("✓ Removed \"{}\" from shelf \"{shelf}\"", found.title);
+            Ok(())
+        }
+    }
+}
+
+fn cmd_sync(data_dir: &Path, action: SyncAction, output_format: &OutputFormat) -> Result<()> {
+    let rt = tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+        .context("failed to build tokio runtime")?;
+
+    let token_store = sync::token_store::TokenStore::new(data_dir);
+
+    match action {
+        SyncAction::Register {
+            server,
+            library_id,
+            device_name,
+        } => {
+            let client = sync::client::SyncClient::new(&server)?;
+            let resp = rt.block_on(client.register(&library_id, &device_name))?;
+
+            token_store
+                .store(&server, &resp.auth_token)
+                .context("failed to store auth token")?;
+
+            match output_format {
+                OutputFormat::Json => {
+                    println!(
+                        "{}",
+                        serde_json::to_string_pretty(&serde_json::json!({
+                            "device_id": resp.device_id,
+                            "library_id": resp.library_id,
+                            "server": server,
+                        }))?
+                    );
+                }
+                OutputFormat::Csv => {
+                    println!("device_id,library_id,server");
+                    println!("{},{},{server}", resp.device_id, resp.library_id);
+                }
+                OutputFormat::Table => {
+                    eprintln!("✓ Registered as \"{}\"", device_name);
+                    eprintln!("  Device ID:  {}", resp.device_id);
+                    eprintln!("  Library ID: {}", resp.library_id);
+                    eprintln!("  Token stored securely");
+                }
+            }
+            Ok(())
+        }
+
+        SyncAction::Devices { server } => {
+            let token = token_store.load(&server)?.ok_or_else(|| {
+                anyhow::anyhow!("no auth token found for {server}. Run `toku sync register` first.")
+            })?;
+
+            let client = sync::client::SyncClient::new(&server)?;
+            let devices = rt.block_on(client.list_devices(&token))?;
+
+            match output_format {
+                OutputFormat::Json => {
+                    println!("{}", serde_json::to_string_pretty(&devices)?);
+                }
+                OutputFormat::Csv => {
+                    println!("device_id,device_name,last_seen,created_at");
+                    for d in &devices {
+                        println!(
+                            "{},{},{},{}",
+                            d.device_id,
+                            d.device_name,
+                            d.last_seen.as_deref().unwrap_or(""),
+                            d.created_at
+                        );
+                    }
+                }
+                OutputFormat::Table => {
+                    if devices.is_empty() {
+                        eprintln!("No devices registered.");
+                        return Ok(());
+                    }
+                    use tabled::{Table, Tabled};
+                    #[derive(Tabled)]
+                    struct Row {
+                        #[tabled(rename = "Device ID")]
+                        id: String,
+                        #[tabled(rename = "Name")]
+                        name: String,
+                        #[tabled(rename = "Last Seen")]
+                        last_seen: String,
+                        #[tabled(rename = "Registered")]
+                        created: String,
+                    }
+                    let rows: Vec<Row> = devices
+                        .iter()
+                        .map(|d| Row {
+                            id: d.device_id.clone(),
+                            name: d.device_name.clone(),
+                            last_seen: d.last_seen.clone().unwrap_or_else(|| "—".into()),
+                            created: d.created_at.clone(),
+                        })
+                        .collect();
+                    println!("{}", Table::new(rows));
+                }
+            }
+            Ok(())
+        }
+
+        SyncAction::Deregister { server, device_id } => {
+            let token = token_store.load(&server)?.ok_or_else(|| {
+                anyhow::anyhow!("no auth token found for {server}. Run `toku sync register` first.")
+            })?;
+
+            let client = sync::client::SyncClient::new(&server)?;
+            rt.block_on(client.deregister_device(&token, &device_id))?;
+
+            match output_format {
+                OutputFormat::Json => {
+                    println!(
+                        "{}",
+                        serde_json::to_string_pretty(&serde_json::json!({
+                            "deleted": true,
+                            "device_id": device_id,
+                        }))?
+                    );
+                }
+                _ => {
+                    eprintln!("✓ Deregistered device {device_id}");
+                }
+            }
+            Ok(())
+        }
+
+        SyncAction::Logout { server } => {
+            token_store
+                .delete(&server)
+                .context("failed to remove stored token")?;
+
+            eprintln!("✓ Removed local credentials for {server}");
             Ok(())
         }
     }

--- a/crates/toku-cli/src/sync/client.rs
+++ b/crates/toku-cli/src/sync/client.rs
@@ -1,0 +1,104 @@
+use std::time::Duration;
+
+use serde::{Deserialize, Serialize};
+
+/// HTTP client for communicating with the toku-sync server.
+pub struct SyncClient {
+    http: reqwest::Client,
+    base_url: String,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct RegisterResponse {
+    pub device_id: String,
+    pub library_id: String,
+    pub auth_token: String,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct DeviceInfo {
+    pub device_id: String,
+    pub device_name: String,
+    pub last_seen: Option<String>,
+    pub created_at: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct ErrorBody {
+    error: String,
+}
+
+impl SyncClient {
+    pub fn new(server_url: &str) -> anyhow::Result<Self> {
+        let http = reqwest::Client::builder()
+            .timeout(Duration::from_secs(30))
+            .connect_timeout(Duration::from_secs(10))
+            .build()?;
+
+        let mut base = server_url.to_string();
+        while base.ends_with('/') {
+            base.pop();
+        }
+
+        Ok(Self {
+            http,
+            base_url: base,
+        })
+    }
+
+    /// Register a new device with the sync server.
+    pub async fn register(
+        &self,
+        library_id: &str,
+        device_name: &str,
+    ) -> anyhow::Result<RegisterResponse> {
+        let url = format!("{}/api/v1/register", self.base_url);
+        let resp = self
+            .http
+            .post(&url)
+            .json(&serde_json::json!({
+                "library_id": library_id,
+                "device_name": device_name,
+            }))
+            .send()
+            .await?;
+
+        if !resp.status().is_success() {
+            return Err(extract_error(resp).await);
+        }
+
+        Ok(resp.json().await?)
+    }
+
+    /// List all devices registered to this library.
+    pub async fn list_devices(&self, token: &str) -> anyhow::Result<Vec<DeviceInfo>> {
+        let url = format!("{}/api/v1/devices", self.base_url);
+        let resp = self.http.get(&url).bearer_auth(token).send().await?;
+
+        if !resp.status().is_success() {
+            return Err(extract_error(resp).await);
+        }
+
+        Ok(resp.json().await?)
+    }
+
+    /// Deregister a device from the sync server.
+    pub async fn deregister_device(&self, token: &str, device_id: &str) -> anyhow::Result<()> {
+        let url = format!("{}/api/v1/devices/{device_id}", self.base_url);
+        let resp = self.http.delete(&url).bearer_auth(token).send().await?;
+
+        if !resp.status().is_success() {
+            return Err(extract_error(resp).await);
+        }
+
+        Ok(())
+    }
+}
+
+async fn extract_error(resp: reqwest::Response) -> anyhow::Error {
+    let status = resp.status();
+    match resp.json::<ErrorBody>().await {
+        Ok(body) => anyhow::anyhow!("server error ({status}): {}", body.error),
+        Err(_) => anyhow::anyhow!("server error ({status})"),
+    }
+}

--- a/crates/toku-cli/src/sync/mod.rs
+++ b/crates/toku-cli/src/sync/mod.rs
@@ -1,0 +1,2 @@
+pub mod client;
+pub mod token_store;

--- a/crates/toku-cli/src/sync/token_store.rs
+++ b/crates/toku-cli/src/sync/token_store.rs
@@ -1,0 +1,203 @@
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+
+/// Stores sync auth tokens using the OS keychain or a local file fallback.
+///
+/// Tokens are keyed by the normalized server URL.
+pub struct TokenStore {
+    data_dir: PathBuf,
+}
+
+const KEYRING_SERVICE: &str = "toku-sync";
+
+impl TokenStore {
+    pub fn new(data_dir: &Path) -> Self {
+        Self {
+            data_dir: data_dir.to_path_buf(),
+        }
+    }
+
+    /// Store a token for the given server URL.
+    pub fn store(&self, server_url: &str, token: &str) -> anyhow::Result<()> {
+        let key = normalize_url(server_url);
+
+        // Try OS keychain first
+        match keyring::Entry::new(KEYRING_SERVICE, &key) {
+            Ok(entry) => match entry.set_password(token) {
+                Ok(()) => return Ok(()),
+                Err(e) => {
+                    eprintln!(
+                        "warning: could not store token in OS keychain ({e}), using file fallback"
+                    );
+                }
+            },
+            Err(e) => {
+                eprintln!("warning: keychain unavailable ({e}), using file fallback");
+            }
+        }
+
+        self.store_file(&key, token)
+    }
+
+    /// Load a token for the given server URL.
+    pub fn load(&self, server_url: &str) -> anyhow::Result<Option<String>> {
+        let key = normalize_url(server_url);
+
+        // Try OS keychain first
+        if let Ok(entry) = keyring::Entry::new(KEYRING_SERVICE, &key) {
+            match entry.get_password() {
+                Ok(token) => return Ok(Some(token)),
+                Err(keyring::Error::NoEntry) => {}
+                Err(_) => {}
+            }
+        }
+
+        // Fall back to file
+        self.load_file(&key)
+    }
+
+    /// Delete a token for the given server URL.
+    pub fn delete(&self, server_url: &str) -> anyhow::Result<()> {
+        let key = normalize_url(server_url);
+
+        // Try OS keychain
+        if let Ok(entry) = keyring::Entry::new(KEYRING_SERVICE, &key) {
+            let _ = entry.delete_credential();
+        }
+
+        // Also remove from file fallback
+        self.delete_file(&key)
+    }
+
+    // ── File fallback ───────────────────────────────────────────────────
+
+    fn tokens_path(&self) -> PathBuf {
+        self.data_dir.join("sync").join("tokens.json")
+    }
+
+    fn read_tokens_file(&self) -> HashMap<String, String> {
+        let path = self.tokens_path();
+        match std::fs::read_to_string(&path) {
+            Ok(contents) => serde_json::from_str(&contents).unwrap_or_default(),
+            Err(_) => HashMap::new(),
+        }
+    }
+
+    fn write_tokens_file(&self, tokens: &HashMap<String, String>) -> anyhow::Result<()> {
+        let path = self.tokens_path();
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        let json = serde_json::to_string_pretty(tokens)?;
+        std::fs::write(&path, json)?;
+
+        // On Unix, restrict file permissions to owner-only
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600))?;
+        }
+
+        Ok(())
+    }
+
+    fn store_file(&self, key: &str, token: &str) -> anyhow::Result<()> {
+        let mut tokens = self.read_tokens_file();
+        tokens.insert(key.to_string(), token.to_string());
+        self.write_tokens_file(&tokens)
+    }
+
+    fn load_file(&self, key: &str) -> anyhow::Result<Option<String>> {
+        let tokens = self.read_tokens_file();
+        Ok(tokens.get(key).cloned())
+    }
+
+    fn delete_file(&self, key: &str) -> anyhow::Result<()> {
+        let mut tokens = self.read_tokens_file();
+        if tokens.remove(key).is_some() {
+            self.write_tokens_file(&tokens)?;
+        }
+        Ok(())
+    }
+}
+
+/// Normalize a server URL to a consistent key for token storage.
+fn normalize_url(url: &str) -> String {
+    let mut s = url.to_lowercase();
+    // Strip trailing slashes
+    while s.ends_with('/') {
+        s.pop();
+    }
+    // Strip trailing /api or /api/v1 paths
+    for suffix in &["/api/v1", "/api"] {
+        if s.ends_with(suffix) {
+            s.truncate(s.len() - suffix.len());
+            break;
+        }
+    }
+    s
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn normalize_url_strips_trailing_slashes() {
+        assert_eq!(
+            normalize_url("https://sync.example.com/"),
+            "https://sync.example.com"
+        );
+        assert_eq!(
+            normalize_url("https://sync.example.com///"),
+            "https://sync.example.com"
+        );
+    }
+
+    #[test]
+    fn normalize_url_strips_api_paths() {
+        assert_eq!(
+            normalize_url("https://sync.example.com/api/v1"),
+            "https://sync.example.com"
+        );
+        assert_eq!(
+            normalize_url("https://sync.example.com/api"),
+            "https://sync.example.com"
+        );
+    }
+
+    #[test]
+    fn normalize_url_lowercases() {
+        assert_eq!(
+            normalize_url("HTTPS://Sync.Example.COM"),
+            "https://sync.example.com"
+        );
+    }
+
+    #[test]
+    fn file_fallback_roundtrip() {
+        let dir = std::env::temp_dir().join(format!("toku-token-test-{}", uuid::Uuid::now_v7()));
+        let store = TokenStore::new(&dir);
+
+        store.store_file("https://a.com", "token-a").unwrap();
+        store.store_file("https://b.com", "token-b").unwrap();
+
+        assert_eq!(
+            store.load_file("https://a.com").unwrap(),
+            Some("token-a".into())
+        );
+        assert_eq!(
+            store.load_file("https://b.com").unwrap(),
+            Some("token-b".into())
+        );
+
+        store.delete_file("https://a.com").unwrap();
+        assert_eq!(store.load_file("https://a.com").unwrap(), None);
+        assert_eq!(
+            store.load_file("https://b.com").unwrap(),
+            Some("token-b".into())
+        );
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+}

--- a/crates/toku-sync/Cargo.toml
+++ b/crates/toku-sync/Cargo.toml
@@ -1,0 +1,32 @@
+[package]
+name = "toku-sync"
+description = "Sync relay server for Toku personal book manager"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[[bin]]
+name = "toku-sync"
+path = "src/main.rs"
+
+[dependencies]
+anyhow = "1"
+axum = "0.8"
+base64 = "0.22"
+clap = { version = "4", features = ["derive", "env"] }
+chrono.workspace = true
+rand = "0.9"
+rusqlite.workspace = true
+refinery = { version = "0.9", features = ["rusqlite"] }
+serde.workspace = true
+serde_json.workspace = true
+sha2.workspace = true
+thiserror.workspace = true
+tokio = { workspace = true, features = ["rt-multi-thread", "net", "signal"] }
+uuid.workspace = true
+
+[dev-dependencies]
+reqwest = { workspace = true, features = ["json"] }
+tower = "0.5"

--- a/crates/toku-sync/migrations/V1__initial_schema.sql
+++ b/crates/toku-sync/migrations/V1__initial_schema.sql
@@ -1,0 +1,35 @@
+CREATE TABLE libraries (
+  id TEXT PRIMARY KEY,
+  created_at TEXT NOT NULL
+);
+
+CREATE TABLE devices (
+  device_id TEXT PRIMARY KEY,
+  library_id TEXT NOT NULL REFERENCES libraries(id),
+  device_name TEXT NOT NULL,
+  auth_token_hash TEXT NOT NULL,
+  last_seen TEXT,
+  created_at TEXT NOT NULL
+);
+
+CREATE TABLE ops (
+  op_id TEXT PRIMARY KEY,
+  library_id TEXT NOT NULL,
+  device_id TEXT NOT NULL,
+  hlc TEXT NOT NULL,
+  entity_type TEXT NOT NULL,
+  entity_id TEXT NOT NULL,
+  op_type TEXT NOT NULL,
+  payload TEXT NOT NULL,
+  received_at TEXT NOT NULL
+);
+
+CREATE INDEX idx_ops_library_hlc ON ops(library_id, hlc);
+
+CREATE TABLE cursors (
+  device_id TEXT NOT NULL,
+  cursor_type TEXT NOT NULL,
+  op_id TEXT NOT NULL,
+  updated_at TEXT NOT NULL,
+  PRIMARY KEY (device_id, cursor_type)
+);

--- a/crates/toku-sync/src/auth.rs
+++ b/crates/toku-sync/src/auth.rs
@@ -1,0 +1,92 @@
+use std::fmt::Write;
+use std::path::PathBuf;
+
+use axum::extract::{FromRequestParts, Request, State};
+use axum::http::header::AUTHORIZATION;
+use axum::http::request::Parts;
+use axum::middleware::Next;
+use axum::response::Response;
+use sha2::{Digest, Sha256};
+
+use crate::db::SyncDatabase;
+use crate::error::SyncError;
+
+/// Authenticated device identity, injected by the auth middleware.
+#[derive(Debug, Clone)]
+pub struct AuthDevice {
+    pub device_id: String,
+    pub library_id: String,
+}
+
+impl<S: Send + Sync> FromRequestParts<S> for AuthDevice {
+    type Rejection = SyncError;
+
+    async fn from_request_parts(parts: &mut Parts, _state: &S) -> Result<Self, Self::Rejection> {
+        parts
+            .extensions
+            .get::<AuthDevice>()
+            .cloned()
+            .ok_or(SyncError::Unauthorized)
+    }
+}
+
+/// SHA-256 hash a string and return the hex-encoded digest.
+pub fn sha256_hex(input: &str) -> String {
+    let hash = Sha256::digest(input.as_bytes());
+    let mut hex = String::with_capacity(64);
+    for byte in hash {
+        let _ = write!(hex, "{byte:02x}");
+    }
+    hex
+}
+
+/// Middleware that validates Bearer tokens and injects `AuthDevice`.
+pub async fn require_auth(
+    State(db_path): State<PathBuf>,
+    mut req: Request,
+    next: Next,
+) -> Result<Response, SyncError> {
+    let header = req
+        .headers()
+        .get(AUTHORIZATION)
+        .and_then(|v| v.to_str().ok())
+        .ok_or(SyncError::Unauthorized)?;
+
+    let token = header
+        .strip_prefix("Bearer ")
+        .ok_or(SyncError::Unauthorized)?;
+
+    let token_hash = sha256_hex(token);
+
+    let device = tokio::task::spawn_blocking({
+        let db_path = db_path.clone();
+        let token_hash = token_hash.clone();
+        move || -> Result<AuthDevice, SyncError> {
+            let db = SyncDatabase::open_no_migrate(&db_path)?;
+            let mut stmt = db
+                .conn
+                .prepare("SELECT device_id, library_id FROM devices WHERE auth_token_hash = ?1")?;
+            let device = stmt
+                .query_row([&token_hash], |row| {
+                    Ok(AuthDevice {
+                        device_id: row.get(0)?,
+                        library_id: row.get(1)?,
+                    })
+                })
+                .map_err(|_| SyncError::Unauthorized)?;
+
+            // Update last_seen
+            db.conn.execute(
+                "UPDATE devices SET last_seen = datetime('now') WHERE device_id = ?1",
+                [&device.device_id],
+            )?;
+
+            Ok(device)
+        }
+    })
+    .await
+    .map_err(|e| SyncError::Internal(format!("task join error: {e}")))??;
+
+    req.extensions_mut().insert(device);
+    Ok(next.run(req).await)
+}

--- a/crates/toku-sync/src/config.rs
+++ b/crates/toku-sync/src/config.rs
@@ -1,0 +1,28 @@
+use clap::Parser;
+
+/// Toku sync relay server — stores and relays sync operations between devices.
+#[derive(Debug, Parser)]
+#[command(name = "toku-sync", version)]
+pub struct Config {
+    /// Port to listen on
+    #[arg(long, default_value = "8080", env = "TOKU_SYNC_PORT")]
+    pub port: u16,
+
+    /// Address to bind to
+    #[arg(long, default_value = "0.0.0.0", env = "TOKU_SYNC_BIND")]
+    pub bind: String,
+
+    /// Directory for server data (SQLite database)
+    #[arg(long, default_value = "./toku-sync-data", env = "TOKU_SYNC_DATA_DIR")]
+    pub data_dir: String,
+}
+
+impl Config {
+    pub fn db_path(&self) -> std::path::PathBuf {
+        std::path::PathBuf::from(&self.data_dir).join("sync.db")
+    }
+
+    pub fn bind_addr(&self) -> String {
+        format!("{}:{}", self.bind, self.port)
+    }
+}

--- a/crates/toku-sync/src/db.rs
+++ b/crates/toku-sync/src/db.rs
@@ -1,0 +1,43 @@
+use std::path::Path;
+
+use refinery::embed_migrations;
+use rusqlite::Connection;
+
+use crate::error::SyncError;
+
+embed_migrations!("migrations");
+
+/// Server-side SQLite database for sync op storage.
+pub struct SyncDatabase {
+    pub conn: Connection,
+}
+
+impl SyncDatabase {
+    /// Open (or create) the database at the given path and run migrations.
+    pub fn open(path: &Path) -> Result<Self, SyncError> {
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)
+                .map_err(|e| SyncError::Internal(format!("failed to create data dir: {e}")))?;
+        }
+
+        let mut conn = Connection::open(path)?;
+        conn.pragma_update(None, "journal_mode", "WAL")?;
+        conn.pragma_update(None, "foreign_keys", "ON")?;
+        conn.pragma_update(None, "busy_timeout", 5000)?;
+
+        migrations::runner()
+            .run(&mut conn)
+            .map_err(|e| SyncError::Migration(e.to_string()))?;
+
+        Ok(Self { conn })
+    }
+
+    /// Open without running migrations (for per-request connections).
+    pub fn open_no_migrate(path: &Path) -> Result<Self, SyncError> {
+        let conn = Connection::open(path)?;
+        conn.pragma_update(None, "journal_mode", "WAL")?;
+        conn.pragma_update(None, "foreign_keys", "ON")?;
+        conn.pragma_update(None, "busy_timeout", 5000)?;
+        Ok(Self { conn })
+    }
+}

--- a/crates/toku-sync/src/error.rs
+++ b/crates/toku-sync/src/error.rs
@@ -1,0 +1,46 @@
+use axum::http::StatusCode;
+use axum::response::{IntoResponse, Response};
+
+use crate::models::ErrorBody;
+
+#[derive(Debug, thiserror::Error)]
+pub enum SyncError {
+    #[error("database error: {0}")]
+    Database(#[from] rusqlite::Error),
+
+    #[error("migration error: {0}")]
+    Migration(String),
+
+    #[error("not found: {0}")]
+    NotFound(String),
+
+    #[error("unauthorized")]
+    Unauthorized,
+
+    #[error("forbidden: {0}")]
+    Forbidden(String),
+
+    #[error("bad request: {0}")]
+    BadRequest(String),
+
+    #[error("internal error: {0}")]
+    Internal(String),
+}
+
+impl IntoResponse for SyncError {
+    fn into_response(self) -> Response {
+        let status = match &self {
+            SyncError::Database(_) => StatusCode::INTERNAL_SERVER_ERROR,
+            SyncError::Migration(_) => StatusCode::INTERNAL_SERVER_ERROR,
+            SyncError::NotFound(_) => StatusCode::NOT_FOUND,
+            SyncError::Unauthorized => StatusCode::UNAUTHORIZED,
+            SyncError::Forbidden(_) => StatusCode::FORBIDDEN,
+            SyncError::BadRequest(_) => StatusCode::BAD_REQUEST,
+            SyncError::Internal(_) => StatusCode::INTERNAL_SERVER_ERROR,
+        };
+        let body = ErrorBody {
+            error: self.to_string(),
+        };
+        (status, axum::Json(body)).into_response()
+    }
+}

--- a/crates/toku-sync/src/handlers.rs
+++ b/crates/toku-sync/src/handlers.rs
@@ -1,0 +1,360 @@
+use std::path::PathBuf;
+
+use axum::Json;
+use axum::extract::{Path, Query, State};
+
+use crate::auth::{AuthDevice, sha256_hex};
+use crate::db::SyncDatabase;
+use crate::error::SyncError;
+use crate::models::{
+    DeviceResponse, HealthResponse, OpPayload, PullQuery, PullResponse, PushRequest, PushResponse,
+    RegisterRequest, RegisterResponse,
+};
+
+const MAX_BATCH_SIZE: usize = 1000;
+const MAX_BATCH_SIZE_SQL: i64 = MAX_BATCH_SIZE as i64;
+
+// ── Health ──────────────────────────────────────────────────────────────────
+
+pub async fn health() -> Json<HealthResponse> {
+    Json(HealthResponse {
+        status: "ok",
+        version: env!("CARGO_PKG_VERSION"),
+    })
+}
+
+// ── Register ────────────────────────────────────────────────────────────────
+
+pub async fn register(
+    State(db_path): State<PathBuf>,
+    Json(req): Json<RegisterRequest>,
+) -> Result<Json<RegisterResponse>, SyncError> {
+    if req.device_name.is_empty() {
+        return Err(SyncError::BadRequest("device_name is required".into()));
+    }
+    if req.library_id.is_empty() {
+        return Err(SyncError::BadRequest("library_id is required".into()));
+    }
+
+    let token = generate_token();
+    let token_hash = sha256_hex(&token);
+    let device_id = uuid::Uuid::now_v7().to_string();
+
+    let resp = tokio::task::spawn_blocking({
+        let db_path = db_path.clone();
+        let library_id = req.library_id.clone();
+        let device_name = req.device_name.clone();
+        let device_id = device_id.clone();
+        let token_hash = token_hash.clone();
+        move || -> Result<RegisterResponse, SyncError> {
+            let db = SyncDatabase::open_no_migrate(&db_path)?;
+
+            // Auto-create library if it doesn't exist
+            db.conn.execute(
+                "INSERT OR IGNORE INTO libraries (id, created_at) VALUES (?1, datetime('now'))",
+                [&library_id],
+            )?;
+
+            db.conn.execute(
+                "INSERT INTO devices (device_id, library_id, device_name, auth_token_hash, created_at)
+                 VALUES (?1, ?2, ?3, ?4, datetime('now'))",
+                rusqlite::params![device_id, library_id, device_name, token_hash],
+            )?;
+
+            Ok(RegisterResponse {
+                device_id,
+                library_id,
+                auth_token: String::new(), // filled in below
+            })
+        }
+    })
+    .await
+    .map_err(|e| SyncError::Internal(format!("task join error: {e}")))??;
+
+    Ok(Json(RegisterResponse {
+        auth_token: token,
+        ..resp
+    }))
+}
+
+// ── Devices ─────────────────────────────────────────────────────────────────
+
+pub async fn list_devices(
+    State(db_path): State<PathBuf>,
+    device: AuthDevice,
+) -> Result<Json<Vec<DeviceResponse>>, SyncError> {
+    let devices = tokio::task::spawn_blocking({
+        let db_path = db_path.clone();
+        let library_id = device.library_id.clone();
+        move || -> Result<Vec<DeviceResponse>, SyncError> {
+            let db = SyncDatabase::open_no_migrate(&db_path)?;
+            let mut stmt = db.conn.prepare(
+                "SELECT device_id, device_name, last_seen, created_at
+                 FROM devices WHERE library_id = ?1 ORDER BY created_at",
+            )?;
+            let rows = stmt
+                .query_map([&library_id], |row| {
+                    Ok(DeviceResponse {
+                        device_id: row.get(0)?,
+                        device_name: row.get(1)?,
+                        last_seen: row.get(2)?,
+                        created_at: row.get(3)?,
+                    })
+                })?
+                .collect::<Result<Vec<_>, _>>()?;
+            Ok(rows)
+        }
+    })
+    .await
+    .map_err(|e| SyncError::Internal(format!("task join error: {e}")))??;
+
+    Ok(Json(devices))
+}
+
+pub async fn delete_device(
+    State(db_path): State<PathBuf>,
+    device: AuthDevice,
+    Path(target_id): Path<String>,
+) -> Result<Json<serde_json::Value>, SyncError> {
+    if target_id == device.device_id {
+        return Err(SyncError::Forbidden("cannot delete your own device".into()));
+    }
+
+    tokio::task::spawn_blocking({
+        let db_path = db_path.clone();
+        let library_id = device.library_id.clone();
+        move || -> Result<(), SyncError> {
+            let db = SyncDatabase::open_no_migrate(&db_path)?;
+
+            // Only allow deleting devices in the same library
+            let affected = db.conn.execute(
+                "DELETE FROM devices WHERE device_id = ?1 AND library_id = ?2",
+                rusqlite::params![target_id, library_id],
+            )?;
+            if affected == 0 {
+                return Err(SyncError::NotFound(format!("device {target_id} not found")));
+            }
+
+            // Clean up cursors for the deleted device
+            db.conn
+                .execute("DELETE FROM cursors WHERE device_id = ?1", [&target_id])?;
+
+            Ok(())
+        }
+    })
+    .await
+    .map_err(|e| SyncError::Internal(format!("task join error: {e}")))??;
+
+    Ok(Json(serde_json::json!({ "deleted": true })))
+}
+
+// ── Push ────────────────────────────────────────────────────────────────────
+
+pub async fn push_ops(
+    State(db_path): State<PathBuf>,
+    device: AuthDevice,
+    Json(req): Json<PushRequest>,
+) -> Result<Json<PushResponse>, SyncError> {
+    if req.ops.is_empty() {
+        return Err(SyncError::BadRequest("ops array is empty".into()));
+    }
+    if req.ops.len() > MAX_BATCH_SIZE {
+        return Err(SyncError::BadRequest(format!(
+            "batch too large: {} ops (max {MAX_BATCH_SIZE})",
+            req.ops.len()
+        )));
+    }
+
+    let resp = tokio::task::spawn_blocking({
+        let db_path = db_path.clone();
+        let library_id = device.library_id.clone();
+        let device_id = device.device_id.clone();
+        let ops = req.ops;
+        move || -> Result<PushResponse, SyncError> {
+            let db = SyncDatabase::open_no_migrate(&db_path)?;
+            let tx = db.conn.unchecked_transaction()?;
+
+            let mut accepted = 0usize;
+            let mut duplicates = 0usize;
+
+            for op in &ops {
+                let payload_str = serde_json::to_string(&op.payload)
+                    .map_err(|e| SyncError::BadRequest(format!("invalid payload: {e}")))?;
+
+                let result = tx.execute(
+                    "INSERT OR IGNORE INTO ops (op_id, library_id, device_id, hlc, entity_type, entity_id, op_type, payload, received_at)
+                     VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, datetime('now'))",
+                    rusqlite::params![
+                        op.op_id,
+                        library_id,
+                        op.device_id,
+                        op.hlc,
+                        op.entity_type,
+                        op.entity_id,
+                        op.op_type,
+                        payload_str,
+                    ],
+                )?;
+
+                if result > 0 {
+                    accepted += 1;
+                } else {
+                    duplicates += 1;
+                }
+            }
+
+            // Update push cursor to the last accepted op
+            if let Some(last_op) = ops.last() {
+                tx.execute(
+                    "INSERT INTO cursors (device_id, cursor_type, op_id, updated_at)
+                     VALUES (?1, 'push', ?2, datetime('now'))
+                     ON CONFLICT (device_id, cursor_type) DO UPDATE SET
+                       op_id = excluded.op_id,
+                       updated_at = excluded.updated_at",
+                    rusqlite::params![device_id, last_op.op_id],
+                )?;
+            }
+
+            tx.commit()?;
+
+            Ok(PushResponse {
+                accepted,
+                duplicates,
+            })
+        }
+    })
+    .await
+    .map_err(|e| SyncError::Internal(format!("task join error: {e}")))??;
+
+    Ok(Json(resp))
+}
+
+// ── Pull ────────────────────────────────────────────────────────────────────
+
+pub async fn pull_ops(
+    State(db_path): State<PathBuf>,
+    device: AuthDevice,
+    Query(query): Query<PullQuery>,
+) -> Result<Json<PullResponse>, SyncError> {
+    let resp = tokio::task::spawn_blocking({
+        let db_path = db_path.clone();
+        let library_id = device.library_id.clone();
+        let device_id = device.device_id.clone();
+        let since = query.since;
+        move || -> Result<PullResponse, SyncError> {
+            let db = SyncDatabase::open_no_migrate(&db_path)?;
+
+            let ops: Vec<OpPayload> = if let Some(ref since_op_id) = since {
+                // Get the HLC of the cursor op to filter from
+                let cursor_hlc: Option<String> = db
+                    .conn
+                    .query_row(
+                        "SELECT hlc FROM ops WHERE op_id = ?1 AND library_id = ?2",
+                        rusqlite::params![since_op_id, library_id],
+                        |row| row.get(0),
+                    )
+                    .ok();
+
+                match cursor_hlc {
+                    Some(hlc) => {
+                        let mut stmt = db.conn.prepare(
+                            "SELECT op_id, device_id, hlc, entity_type, entity_id, op_type, payload
+                             FROM ops
+                             WHERE library_id = ?1 AND (hlc > ?2 OR (hlc = ?2 AND op_id > ?3))
+                             ORDER BY hlc, op_id
+                             LIMIT ?4",
+                        )?;
+                        stmt.query_map(
+                            rusqlite::params![library_id, hlc, since_op_id, MAX_BATCH_SIZE_SQL],
+                            row_to_op,
+                        )?
+                        .collect::<Result<Vec<_>, _>>()?
+                    }
+                    None => {
+                        return Err(SyncError::BadRequest(format!(
+                            "cursor op_id not found: {since_op_id}"
+                        )));
+                    }
+                }
+            } else {
+                // No cursor — return all ops from the beginning
+                let mut stmt = db.conn.prepare(
+                    "SELECT op_id, device_id, hlc, entity_type, entity_id, op_type, payload
+                     FROM ops
+                     WHERE library_id = ?1
+                     ORDER BY hlc, op_id
+                     LIMIT ?2",
+                )?;
+                stmt.query_map(rusqlite::params![library_id, MAX_BATCH_SIZE_SQL], row_to_op)?
+                    .collect::<Result<Vec<_>, _>>()?
+            };
+
+            let cursor = ops.last().map(|op| op.op_id.clone());
+
+            // Update pull cursor
+            if let Some(ref cursor_op_id) = cursor {
+                db.conn.execute(
+                    "INSERT INTO cursors (device_id, cursor_type, op_id, updated_at)
+                     VALUES (?1, 'pull', ?2, datetime('now'))
+                     ON CONFLICT (device_id, cursor_type) DO UPDATE SET
+                       op_id = excluded.op_id,
+                       updated_at = excluded.updated_at",
+                    rusqlite::params![device_id, cursor_op_id],
+                )?;
+            }
+
+            Ok(PullResponse { ops, cursor })
+        }
+    })
+    .await
+    .map_err(|e| SyncError::Internal(format!("task join error: {e}")))??;
+
+    Ok(Json(resp))
+}
+
+// ── Snapshot / Rekey stubs ──────────────────────────────────────────────────
+
+pub async fn snapshot() -> (axum::http::StatusCode, Json<serde_json::Value>) {
+    (
+        axum::http::StatusCode::NOT_IMPLEMENTED,
+        Json(serde_json::json!({
+            "error": "snapshots are not yet implemented"
+        })),
+    )
+}
+
+pub async fn rekey() -> (axum::http::StatusCode, Json<serde_json::Value>) {
+    (
+        axum::http::StatusCode::NOT_IMPLEMENTED,
+        Json(serde_json::json!({
+            "error": "re-keying is not yet implemented"
+        })),
+    )
+}
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
+
+fn row_to_op(row: &rusqlite::Row) -> rusqlite::Result<OpPayload> {
+    let payload_str: String = row.get(6)?;
+    let payload: serde_json::Value =
+        serde_json::from_str(&payload_str).unwrap_or(serde_json::Value::String(payload_str));
+
+    Ok(OpPayload {
+        op_id: row.get(0)?,
+        device_id: row.get(1)?,
+        hlc: row.get(2)?,
+        entity_type: row.get(3)?,
+        entity_id: row.get(4)?,
+        op_type: row.get(5)?,
+        payload,
+    })
+}
+
+/// Generate a cryptographically random auth token (256-bit, base64url no-pad).
+fn generate_token() -> String {
+    use base64::Engine;
+    use rand::Rng;
+    let mut bytes = [0u8; 32];
+    rand::rng().fill(&mut bytes);
+    base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(bytes)
+}

--- a/crates/toku-sync/src/main.rs
+++ b/crates/toku-sync/src/main.rs
@@ -1,0 +1,833 @@
+mod auth;
+mod config;
+mod db;
+mod error;
+mod handlers;
+mod models;
+
+use std::path::PathBuf;
+
+use axum::Router;
+use axum::extract::DefaultBodyLimit;
+use axum::middleware;
+use axum::routing::{delete, get, post};
+use clap::Parser;
+
+use crate::config::Config;
+use crate::db::SyncDatabase;
+
+fn build_router(db_path: PathBuf) -> Router {
+    // Routes that require authentication
+    let authenticated = Router::new()
+        .route("/api/v1/devices", get(handlers::list_devices))
+        .route("/api/v1/devices/{id}", delete(handlers::delete_device))
+        .route("/api/v1/push", post(handlers::push_ops))
+        .route("/api/v1/pull", get(handlers::pull_ops))
+        .route("/api/v1/snapshot", get(handlers::snapshot))
+        .route("/api/v1/rekey", post(handlers::rekey))
+        .layer(middleware::from_fn_with_state(
+            db_path.clone(),
+            auth::require_auth,
+        ));
+
+    // Public routes
+    Router::new()
+        .route("/health", get(handlers::health))
+        .route("/api/v1/register", post(handlers::register))
+        .merge(authenticated)
+        .layer(DefaultBodyLimit::max(2 * 1024 * 1024)) // 2 MB
+        .with_state(db_path)
+}
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let config = Config::parse();
+    let db_path = config.db_path();
+
+    // Run migrations once at startup
+    SyncDatabase::open(&db_path)
+        .map_err(|e| anyhow::anyhow!("failed to initialize database: {e}"))?;
+
+    let app = build_router(db_path);
+    let addr = config.bind_addr();
+
+    let listener = tokio::net::TcpListener::bind(&addr).await?;
+    eprintln!("toku-sync listening on http://{addr}");
+
+    axum::serve(listener, app)
+        .with_graceful_shutdown(shutdown_signal())
+        .await?;
+
+    Ok(())
+}
+
+async fn shutdown_signal() {
+    tokio::signal::ctrl_c()
+        .await
+        .expect("failed to listen for ctrl+c");
+    eprintln!("\nshutting down...");
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::body::Body;
+    use axum::http::{Request, StatusCode};
+    use tower::ServiceExt;
+
+    fn test_db_path() -> PathBuf {
+        let dir = std::env::temp_dir().join(format!("toku-sync-test-{}", uuid::Uuid::now_v7()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("test.db");
+        SyncDatabase::open(&path).unwrap();
+        path
+    }
+
+    fn cleanup(path: &std::path::Path) {
+        if let Some(parent) = path.parent() {
+            let _ = std::fs::remove_dir_all(parent);
+        }
+    }
+
+    #[tokio::test]
+    async fn health_check() {
+        let db_path = test_db_path();
+        let app = build_router(db_path.clone());
+
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri("/health")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(json["status"], "ok");
+
+        cleanup(&db_path);
+    }
+
+    #[tokio::test]
+    async fn register_and_list_devices() {
+        let db_path = test_db_path();
+        let app = build_router(db_path.clone());
+
+        // Register a device
+        let resp = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/v1/register")
+                    .header("Content-Type", "application/json")
+                    .body(Body::from(
+                        serde_json::to_string(&serde_json::json!({
+                            "library_id": "lib-1",
+                            "device_name": "test-laptop"
+                        }))
+                        .unwrap(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let register: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(register["library_id"], "lib-1");
+        assert!(!register["auth_token"].as_str().unwrap().is_empty());
+        let token = register["auth_token"].as_str().unwrap().to_string();
+
+        // List devices
+        let resp = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri("/api/v1/devices")
+                    .header("Authorization", format!("Bearer {token}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let devices: Vec<serde_json::Value> = serde_json::from_slice(&body).unwrap();
+        assert_eq!(devices.len(), 1);
+        assert_eq!(devices[0]["device_name"], "test-laptop");
+
+        cleanup(&db_path);
+    }
+
+    #[tokio::test]
+    async fn unauthorized_without_token() {
+        let db_path = test_db_path();
+        let app = build_router(db_path.clone());
+
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri("/api/v1/devices")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+
+        cleanup(&db_path);
+    }
+
+    #[tokio::test]
+    async fn push_and_pull_ops() {
+        let db_path = test_db_path();
+        let app = build_router(db_path.clone());
+
+        // Register
+        let resp = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/v1/register")
+                    .header("Content-Type", "application/json")
+                    .body(Body::from(
+                        serde_json::to_string(&serde_json::json!({
+                            "library_id": "lib-1",
+                            "device_name": "test-device"
+                        }))
+                        .unwrap(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let register: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        let token = register["auth_token"].as_str().unwrap().to_string();
+
+        // Push ops
+        let resp = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/v1/push")
+                    .header("Content-Type", "application/json")
+                    .header("Authorization", format!("Bearer {token}"))
+                    .body(Body::from(
+                        serde_json::to_string(&serde_json::json!({
+                            "ops": [
+                                {
+                                    "op_id": "op-1",
+                                    "device_id": "dev-1",
+                                    "hlc": "2026-06-01T00:00:00.000Z-0001-dev1",
+                                    "entity_type": "book",
+                                    "entity_id": "book-1",
+                                    "op_type": "create",
+                                    "payload": {"title": "Dune"}
+                                },
+                                {
+                                    "op_id": "op-2",
+                                    "device_id": "dev-1",
+                                    "hlc": "2026-06-01T00:00:01.000Z-0001-dev1",
+                                    "entity_type": "book",
+                                    "entity_id": "book-1",
+                                    "op_type": "update",
+                                    "payload": {"rating": 9}
+                                }
+                            ]
+                        }))
+                        .unwrap(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let push: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(push["accepted"], 2);
+        assert_eq!(push["duplicates"], 0);
+
+        // Pull all ops
+        let resp = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri("/api/v1/pull")
+                    .header("Authorization", format!("Bearer {token}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let pull: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(pull["ops"].as_array().unwrap().len(), 2);
+        assert_eq!(pull["cursor"], "op-2");
+
+        // Pull since cursor (should return empty)
+        let resp = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri("/api/v1/pull?since=op-2")
+                    .header("Authorization", format!("Bearer {token}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let pull: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert!(pull["ops"].as_array().unwrap().is_empty());
+
+        cleanup(&db_path);
+    }
+
+    #[tokio::test]
+    async fn push_duplicate_ops_are_idempotent() {
+        let db_path = test_db_path();
+        let app = build_router(db_path.clone());
+
+        // Register
+        let resp = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/v1/register")
+                    .header("Content-Type", "application/json")
+                    .body(Body::from(
+                        serde_json::to_string(&serde_json::json!({
+                            "library_id": "lib-1",
+                            "device_name": "dev"
+                        }))
+                        .unwrap(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let register: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        let token = register["auth_token"].as_str().unwrap().to_string();
+
+        let ops_json = serde_json::json!({
+            "ops": [{
+                "op_id": "dup-1",
+                "device_id": "d",
+                "hlc": "2026-01-01T00:00:00.000Z-0001-d",
+                "entity_type": "book",
+                "entity_id": "b1",
+                "op_type": "create",
+                "payload": {}
+            }]
+        });
+
+        // Push once
+        let resp = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/v1/push")
+                    .header("Content-Type", "application/json")
+                    .header("Authorization", format!("Bearer {token}"))
+                    .body(Body::from(serde_json::to_string(&ops_json).unwrap()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let push: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(push["accepted"], 1);
+
+        // Push same op again
+        let resp = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/v1/push")
+                    .header("Content-Type", "application/json")
+                    .header("Authorization", format!("Bearer {token}"))
+                    .body(Body::from(serde_json::to_string(&ops_json).unwrap()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let push: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(push["accepted"], 0);
+        assert_eq!(push["duplicates"], 1);
+
+        cleanup(&db_path);
+    }
+
+    #[tokio::test]
+    async fn delete_device() {
+        let db_path = test_db_path();
+        let app = build_router(db_path.clone());
+
+        // Register two devices
+        let resp = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/v1/register")
+                    .header("Content-Type", "application/json")
+                    .body(Body::from(
+                        serde_json::to_string(&serde_json::json!({
+                            "library_id": "lib-1",
+                            "device_name": "device-a"
+                        }))
+                        .unwrap(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let reg_a: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        let token_a = reg_a["auth_token"].as_str().unwrap().to_string();
+
+        let resp = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/v1/register")
+                    .header("Content-Type", "application/json")
+                    .body(Body::from(
+                        serde_json::to_string(&serde_json::json!({
+                            "library_id": "lib-1",
+                            "device_name": "device-b"
+                        }))
+                        .unwrap(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let reg_b: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        let device_b_id = reg_b["device_id"].as_str().unwrap().to_string();
+
+        // Delete device B using device A's token
+        let resp = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("DELETE")
+                    .uri(format!("/api/v1/devices/{device_b_id}"))
+                    .header("Authorization", format!("Bearer {token_a}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        // Verify only one device remains
+        let resp = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri("/api/v1/devices")
+                    .header("Authorization", format!("Bearer {token_a}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let devices: Vec<serde_json::Value> = serde_json::from_slice(&body).unwrap();
+        assert_eq!(devices.len(), 1);
+        assert_eq!(devices[0]["device_name"], "device-a");
+
+        cleanup(&db_path);
+    }
+
+    #[tokio::test]
+    async fn register_validates_required_fields() {
+        let db_path = test_db_path();
+        let app = build_router(db_path.clone());
+
+        let resp = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/v1/register")
+                    .header("Content-Type", "application/json")
+                    .body(Body::from(
+                        serde_json::to_string(&serde_json::json!({
+                            "library_id": "",
+                            "device_name": "test"
+                        }))
+                        .unwrap(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+
+        cleanup(&db_path);
+    }
+
+    #[tokio::test]
+    async fn snapshot_returns_501() {
+        let db_path = test_db_path();
+        let app = build_router(db_path.clone());
+
+        // Register to get a token
+        let resp = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/v1/register")
+                    .header("Content-Type", "application/json")
+                    .body(Body::from(
+                        serde_json::to_string(&serde_json::json!({
+                            "library_id": "lib-1",
+                            "device_name": "dev"
+                        }))
+                        .unwrap(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let register: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        let token = register["auth_token"].as_str().unwrap().to_string();
+
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri("/api/v1/snapshot")
+                    .header("Authorization", format!("Bearer {token}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::NOT_IMPLEMENTED);
+
+        cleanup(&db_path);
+    }
+
+    #[tokio::test]
+    async fn push_rejects_oversized_batch() {
+        let db_path = test_db_path();
+        let app = build_router(db_path.clone());
+
+        // Register
+        let resp = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/v1/register")
+                    .header("Content-Type", "application/json")
+                    .body(Body::from(
+                        serde_json::to_string(&serde_json::json!({
+                            "library_id": "lib-1",
+                            "device_name": "dev"
+                        }))
+                        .unwrap(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let register: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        let token = register["auth_token"].as_str().unwrap().to_string();
+
+        // Build a batch with 1001 ops
+        let ops: Vec<serde_json::Value> = (0..1001)
+            .map(|i| {
+                serde_json::json!({
+                    "op_id": format!("op-{i}"),
+                    "device_id": "d",
+                    "hlc": format!("2026-01-01T00:00:{i:02}.000Z-0001-d"),
+                    "entity_type": "book",
+                    "entity_id": "b1",
+                    "op_type": "create",
+                    "payload": {}
+                })
+            })
+            .collect();
+
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/v1/push")
+                    .header("Content-Type", "application/json")
+                    .header("Authorization", format!("Bearer {token}"))
+                    .body(Body::from(
+                        serde_json::to_string(&serde_json::json!({ "ops": ops })).unwrap(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+
+        cleanup(&db_path);
+    }
+
+    #[tokio::test]
+    async fn register_returns_base64url_token() {
+        use base64::Engine;
+
+        let db_path = test_db_path();
+        let app = build_router(db_path.clone());
+
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/v1/register")
+                    .header("Content-Type", "application/json")
+                    .body(Body::from(
+                        serde_json::to_string(&serde_json::json!({
+                            "library_id": "lib-1",
+                            "device_name": "test"
+                        }))
+                        .unwrap(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        let token = json["auth_token"].as_str().unwrap();
+
+        // Must be valid base64url with no padding
+        assert!(!token.contains('+'), "token must not contain '+'");
+        assert!(!token.contains('/'), "token must not contain '/'");
+        assert!(!token.contains('='), "token must not contain '='");
+
+        // Must decode to exactly 32 bytes (256 bits)
+        let decoded = base64::engine::general_purpose::URL_SAFE_NO_PAD
+            .decode(token)
+            .expect("token must be valid base64url");
+        assert_eq!(decoded.len(), 32, "token must be 256 bits");
+
+        cleanup(&db_path);
+    }
+
+    #[tokio::test]
+    async fn cannot_delete_own_device() {
+        let db_path = test_db_path();
+        let app = build_router(db_path.clone());
+
+        // Register a device
+        let resp = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/v1/register")
+                    .header("Content-Type", "application/json")
+                    .body(Body::from(
+                        serde_json::to_string(&serde_json::json!({
+                            "library_id": "lib-1",
+                            "device_name": "my-device"
+                        }))
+                        .unwrap(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let reg: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        let token = reg["auth_token"].as_str().unwrap().to_string();
+        let device_id = reg["device_id"].as_str().unwrap().to_string();
+
+        // Try to delete self — should be 403 Forbidden
+        let resp = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("DELETE")
+                    .uri(format!("/api/v1/devices/{device_id}"))
+                    .header("Authorization", format!("Bearer {token}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+
+        // Verify the device still exists
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri("/api/v1/devices")
+                    .header("Authorization", format!("Bearer {token}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let devices: Vec<serde_json::Value> = serde_json::from_slice(&body).unwrap();
+        assert_eq!(devices.len(), 1);
+
+        cleanup(&db_path);
+    }
+
+    #[tokio::test]
+    async fn deleted_device_token_is_invalidated() {
+        let db_path = test_db_path();
+        let app = build_router(db_path.clone());
+
+        // Register two devices
+        let resp = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/v1/register")
+                    .header("Content-Type", "application/json")
+                    .body(Body::from(
+                        serde_json::to_string(&serde_json::json!({
+                            "library_id": "lib-1",
+                            "device_name": "keeper"
+                        }))
+                        .unwrap(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let reg_a: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        let token_a = reg_a["auth_token"].as_str().unwrap().to_string();
+
+        let resp = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/v1/register")
+                    .header("Content-Type", "application/json")
+                    .body(Body::from(
+                        serde_json::to_string(&serde_json::json!({
+                            "library_id": "lib-1",
+                            "device_name": "doomed"
+                        }))
+                        .unwrap(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let reg_b: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        let token_b = reg_b["auth_token"].as_str().unwrap().to_string();
+        let device_b_id = reg_b["device_id"].as_str().unwrap().to_string();
+
+        // Delete device B using device A's token
+        let resp = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("DELETE")
+                    .uri(format!("/api/v1/devices/{device_b_id}"))
+                    .header("Authorization", format!("Bearer {token_a}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        // Device B's token should now be rejected
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri("/api/v1/devices")
+                    .header("Authorization", format!("Bearer {token_b}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+
+        cleanup(&db_path);
+    }
+}

--- a/crates/toku-sync/src/models.rs
+++ b/crates/toku-sync/src/models.rs
@@ -1,0 +1,70 @@
+use serde::{Deserialize, Serialize};
+
+// ── Requests ────────────────────────────────────────────────────────────────
+
+#[derive(Debug, Deserialize)]
+pub struct RegisterRequest {
+    pub library_id: String,
+    pub device_name: String,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct PushRequest {
+    pub ops: Vec<OpPayload>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct OpPayload {
+    pub op_id: String,
+    pub device_id: String,
+    pub hlc: String,
+    pub entity_type: String,
+    pub entity_id: String,
+    pub op_type: String,
+    pub payload: serde_json::Value,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct PullQuery {
+    pub since: Option<String>,
+}
+
+// ── Responses ───────────────────────────────────────────────────────────────
+
+#[derive(Debug, Serialize)]
+pub struct RegisterResponse {
+    pub device_id: String,
+    pub library_id: String,
+    pub auth_token: String,
+}
+
+#[derive(Debug, Serialize)]
+pub struct DeviceResponse {
+    pub device_id: String,
+    pub device_name: String,
+    pub last_seen: Option<String>,
+    pub created_at: String,
+}
+
+#[derive(Debug, Serialize)]
+pub struct PushResponse {
+    pub accepted: usize,
+    pub duplicates: usize,
+}
+
+#[derive(Debug, Serialize)]
+pub struct PullResponse {
+    pub ops: Vec<OpPayload>,
+    pub cursor: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct HealthResponse {
+    pub status: &'static str,
+    pub version: &'static str,
+}
+
+#[derive(Debug, Serialize)]
+pub struct ErrorBody {
+    pub error: String,
+}


### PR DESCRIPTION
## Description

Implement the sync server scaffold and device authentication (Phase 7 groundwork). This adds the `toku-sync` crate — a standalone Axum REST server that acts as a thin relay for sync operations — and client-side CLI commands for device registration and credential management.

### What's included

**Sync server (`toku-sync` crate)**
- New binary crate producing the `toku-sync` executable
- SQLite storage with refinery migrations (libraries, devices, ops, cursors tables)
- 8 REST endpoints: health, register, list/delete devices, push/pull ops, snapshot/rekey stubs
- Bearer token authentication middleware with SHA-256 hashed token storage
- 256-bit CSPRNG tokens encoded as base64url (no padding)
- Self-deletion guard (403 Forbidden when trying to delete your own device)
- Request body size limits (2 MB) and batch size cap (1000 ops)
- Transactional push with duplicate-op idempotency
- CLI config via clap: `--port`, `--bind`, `--data-dir` with env var fallbacks

**CLI sync commands (`toku-cli`)**
- `toku sync register --server <url> --library-id <id> --device-name <name>`
- `toku sync devices --server <url>` with `--format table|json|csv`
- `toku sync deregister --server <url> --device-id <id>`
- `toku sync logout --server <url>` (local credential removal)

**Client-side token storage**
- OS keychain integration via `keyring` crate (macOS Keychain, Windows Credential Manager, Linux Secret Service)
- JSON file fallback at `{data_dir}/sync/tokens.json` with 0600 permissions on Unix
- Tokens keyed by normalized server URL (case-insensitive, trailing slash/path stripped)

## Related Issues

Closes #66
Closes #67

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI / infrastructure
- [ ] Other (describe below)

## Crate

- [ ] `toku-core` — Domain models, traits, state machine
- [ ] `toku-db` — SQLite persistence, migrations, FTS5
- [ ] `toku-import` — Importers (Goodreads, Calibre, StoryGraph)
- [ ] `toku-meta` — Metadata fetching (Open Library, Google Books)
- [x] `toku-cli` — CLI binary
- [ ] `toku-export` — Exporters (CSV, JSON, Markdown, BibTeX)
- [ ] `docs/` — Documentation

## Data Integrity Checklist

- [x] No user data is sent to any server without explicit opt-in
- [ ] Import operations are idempotent (re-importing the same file creates no duplicates)
- [ ] User edits to metadata are never overwritten by auto-enrichment
- [ ] New fields track provenance (source + timestamp)
- [ ] Export round-trip is preserved (if applicable)

## Checklist

- [x] I have read [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] `cargo fmt --check` passes
- [x] `cargo clippy --workspace -- -D warnings` passes
- [x] `cargo test --workspace` passes (253 tests, 0 failures)
- [x] I have updated documentation (if applicable)
