### PR TITLE
feat: push and pull sync endpoints with cursor management

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `toku sync deregister` to remove another device from the sync server
 - `toku sync logout` to remove locally stored sync credentials
 - Platform-native credential storage via OS keychain (macOS Keychain, Windows Credential Manager, Linux Secret Service) with secure file fallback
+- `toku sync push --server <url>` to push local changes to the sync server with batched uploads and cursor tracking
+- `toku sync pull --server <url>` to pull remote changes with automatic pagination and cursor-based resumption
+- Pull endpoint excludes the requesting device's own ops to avoid echoing changes back
+- `has_more` pagination flag on pull responses for batched retrieval of large op sets
 - Web statistics dashboard (`toku serve`): reading stats, rating histogram, monthly pace chart, format breakdown donut, top authors and tags — all rendered as server-side SVG with dark mode support
 - Yearly wrap-up pages at `/stats/wrap/{year}` summarizing a single year's reading
 - JSON statistics API at `/api/stats` for programmatic access

--- a/crates/toku-cli/src/main.rs
+++ b/crates/toku-cli/src/main.rs
@@ -597,6 +597,20 @@ enum SyncAction {
         #[arg(long)]
         server: String,
     },
+
+    /// Push local changes to the sync server
+    Push {
+        /// Sync server URL
+        #[arg(long)]
+        server: String,
+    },
+
+    /// Pull remote changes from the sync server
+    Pull {
+        /// Sync server URL
+        #[arg(long)]
+        server: String,
+    },
 }
 
 #[derive(Clone, ValueEnum)]
@@ -3049,6 +3063,149 @@ fn cmd_sync(data_dir: &Path, action: SyncAction, output_format: &OutputFormat) -
                 .context("failed to remove stored token")?;
 
             eprintln!("✓ Removed local credentials for {server}");
+            Ok(())
+        }
+
+        SyncAction::Push { server } => {
+            let token = token_store.load(&server)?.ok_or_else(|| {
+                anyhow::anyhow!("no auth token found for {server}. Run `toku sync register` first.")
+            })?;
+
+            let db_path = data_dir.join("toku.db");
+            let db = Database::open(&db_path).context("failed to open database")?;
+            let sync_repo = toku_db::SyncRepository::new(&db);
+            let client = sync::client::SyncClient::new(&server)?;
+
+            let unpushed = sync_repo.get_unpushed_ops()?;
+            if unpushed.is_empty() {
+                match output_format {
+                    OutputFormat::Json => {
+                        println!(
+                            "{}",
+                            serde_json::to_string_pretty(&serde_json::json!({
+                                "pushed": 0,
+                                "status": "up_to_date",
+                            }))?
+                        );
+                    }
+                    _ => {
+                        eprintln!("✓ Nothing to push — already up to date");
+                    }
+                }
+                return Ok(());
+            }
+
+            let total = unpushed.len();
+            let wire_ops: Vec<sync::client::WireOp> =
+                unpushed.iter().map(sync::wire::to_wire).collect();
+
+            // Push in batches of 1000
+            let mut total_accepted = 0usize;
+            let mut total_duplicates = 0usize;
+            let mut last_cursor = None;
+
+            for chunk in wire_ops.chunks(1000) {
+                let result = rt.block_on(client.push_ops(&token, chunk))?;
+                total_accepted += result.accepted;
+                total_duplicates += result.duplicates;
+                if result.new_cursor.is_some() {
+                    last_cursor = result.new_cursor;
+                }
+            }
+
+            // Mark ops as pushed locally
+            let op_ids: Vec<uuid::Uuid> = unpushed.iter().map(|op| op.op_id).collect();
+            sync_repo.mark_ops_pushed(&op_ids)?;
+
+            // Update local push cursor
+            if let Some(ref cursor) = last_cursor {
+                sync_repo.set_cursor("push_cursor", cursor)?;
+            }
+
+            match output_format {
+                OutputFormat::Json => {
+                    println!(
+                        "{}",
+                        serde_json::to_string_pretty(&serde_json::json!({
+                            "pushed": total,
+                            "accepted": total_accepted,
+                            "duplicates": total_duplicates,
+                            "cursor": last_cursor,
+                        }))?
+                    );
+                }
+                OutputFormat::Csv => {
+                    println!("pushed,accepted,duplicates");
+                    println!("{total},{total_accepted},{total_duplicates}");
+                }
+                OutputFormat::Table => {
+                    eprintln!("✓ Pushed {total_accepted} ops ({total_duplicates} duplicates)");
+                }
+            }
+            Ok(())
+        }
+
+        SyncAction::Pull { server } => {
+            let token = token_store.load(&server)?.ok_or_else(|| {
+                anyhow::anyhow!("no auth token found for {server}. Run `toku sync register` first.")
+            })?;
+
+            let db_path = data_dir.join("toku.db");
+            let db = Database::open(&db_path).context("failed to open database")?;
+            let sync_repo = toku_db::SyncRepository::new(&db);
+            let client = sync::client::SyncClient::new(&server)?;
+
+            let mut cursor = sync_repo.get_cursor("pull_cursor")?;
+            let mut total_pulled = 0usize;
+
+            loop {
+                let result = rt.block_on(client.pull_ops(&token, cursor.as_deref()))?;
+
+                if result.ops.is_empty() {
+                    break;
+                }
+
+                for wire_op in &result.ops {
+                    let sync_op =
+                        sync::wire::from_wire(wire_op).context("failed to parse remote op")?;
+                    sync_repo.insert_remote_op(&sync_op)?;
+                }
+
+                total_pulled += result.ops.len();
+
+                // Update cursor to the last op we received
+                if let Some(new_cursor) = result.cursor {
+                    sync_repo.set_cursor("pull_cursor", &new_cursor)?;
+                    cursor = Some(new_cursor);
+                }
+
+                if !result.has_more {
+                    break;
+                }
+            }
+
+            match output_format {
+                OutputFormat::Json => {
+                    println!(
+                        "{}",
+                        serde_json::to_string_pretty(&serde_json::json!({
+                            "pulled": total_pulled,
+                            "cursor": cursor,
+                        }))?
+                    );
+                }
+                OutputFormat::Csv => {
+                    println!("pulled,cursor");
+                    println!("{total_pulled},{}", cursor.as_deref().unwrap_or(""));
+                }
+                OutputFormat::Table => {
+                    if total_pulled == 0 {
+                        eprintln!("✓ Nothing to pull — already up to date");
+                    } else {
+                        eprintln!("✓ Pulled {total_pulled} ops");
+                    }
+                }
+            }
             Ok(())
         }
     }

--- a/crates/toku-cli/src/sync/client.rs
+++ b/crates/toku-cli/src/sync/client.rs
@@ -23,6 +23,32 @@ pub struct DeviceInfo {
     pub created_at: String,
 }
 
+/// Wire format for a sync op (matches server's OpPayload).
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct WireOp {
+    pub op_id: String,
+    pub device_id: String,
+    pub hlc: String,
+    pub entity_type: String,
+    pub entity_id: String,
+    pub op_type: String,
+    pub payload: serde_json::Value,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct PushResult {
+    pub accepted: usize,
+    pub duplicates: usize,
+    pub new_cursor: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct PullResult {
+    pub ops: Vec<WireOp>,
+    pub cursor: Option<String>,
+    pub has_more: bool,
+}
+
 #[derive(Debug, Deserialize)]
 struct ErrorBody {
     error: String,
@@ -92,6 +118,40 @@ impl SyncClient {
         }
 
         Ok(())
+    }
+
+    /// Push a batch of ops to the sync server.
+    pub async fn push_ops(&self, token: &str, ops: &[WireOp]) -> anyhow::Result<PushResult> {
+        let url = format!("{}/api/v1/push", self.base_url);
+        let resp = self
+            .http
+            .post(&url)
+            .bearer_auth(token)
+            .json(&serde_json::json!({ "ops": ops }))
+            .send()
+            .await?;
+
+        if !resp.status().is_success() {
+            return Err(extract_error(resp).await);
+        }
+
+        Ok(resp.json().await?)
+    }
+
+    /// Pull ops from the sync server since the given cursor.
+    pub async fn pull_ops(&self, token: &str, since: Option<&str>) -> anyhow::Result<PullResult> {
+        let mut url = format!("{}/api/v1/pull", self.base_url);
+        if let Some(cursor) = since {
+            url = format!("{url}?since={cursor}");
+        }
+
+        let resp = self.http.get(&url).bearer_auth(token).send().await?;
+
+        if !resp.status().is_success() {
+            return Err(extract_error(resp).await);
+        }
+
+        Ok(resp.json().await?)
     }
 }
 

--- a/crates/toku-cli/src/sync/mod.rs
+++ b/crates/toku-cli/src/sync/mod.rs
@@ -1,2 +1,3 @@
 pub mod client;
 pub mod token_store;
+pub mod wire;

--- a/crates/toku-cli/src/sync/wire.rs
+++ b/crates/toku-cli/src/sync/wire.rs
@@ -1,0 +1,69 @@
+//! Wire format conversion between `SyncOp` (domain) and `WireOp` (HTTP).
+
+use toku_core::sync::{EntityType, HlcTimestamp, OpType, SyncOp};
+use uuid::Uuid;
+
+use super::client::WireOp;
+
+/// Convert a domain `SyncOp` to wire format for pushing to the server.
+pub fn to_wire(op: &SyncOp) -> WireOp {
+    WireOp {
+        op_id: op.op_id.to_string(),
+        device_id: op.device_id.to_string(),
+        hlc: op.hlc.to_canonical(),
+        entity_type: op.entity_type.as_str().to_string(),
+        entity_id: op.entity_id.to_string(),
+        op_type: op.op_type.as_str().to_string(),
+        payload: op.fields.clone().unwrap_or(serde_json::Value::Null),
+    }
+}
+
+/// Convert a wire format `WireOp` to domain `SyncOp` after pulling from the server.
+pub fn from_wire(wire: &WireOp) -> anyhow::Result<SyncOp> {
+    let op_id: Uuid = wire
+        .op_id
+        .parse()
+        .map_err(|e| anyhow::anyhow!("invalid op_id: {e}"))?;
+    let device_id: Uuid = wire
+        .device_id
+        .parse()
+        .map_err(|e| anyhow::anyhow!("invalid device_id: {e}"))?;
+    let hlc: HlcTimestamp = wire
+        .hlc
+        .parse()
+        .map_err(|_| anyhow::anyhow!("invalid hlc: {}", wire.hlc))?;
+    let entity_type: EntityType = wire
+        .entity_type
+        .parse()
+        .map_err(|_| anyhow::anyhow!("invalid entity_type: {}", wire.entity_type))?;
+    let entity_id: Uuid = wire
+        .entity_id
+        .parse()
+        .map_err(|e| anyhow::anyhow!("invalid entity_id: {e}"))?;
+    let op_type: OpType = wire
+        .op_type
+        .parse()
+        .map_err(|_| anyhow::anyhow!("invalid op_type: {}", wire.op_type))?;
+
+    let fields = if wire.payload.is_null() {
+        None
+    } else {
+        Some(wire.payload.clone())
+    };
+
+    // Build a SyncOp with checksum recomputed from the parsed fields.
+    let mut op = SyncOp {
+        v: 1,
+        op_id,
+        device_id,
+        hlc,
+        entity_type,
+        entity_id,
+        op_type,
+        fields,
+        checksum: String::new(),
+        created_at: chrono::Utc::now(),
+    };
+    op.checksum = op.compute_checksum();
+    Ok(op)
+}

--- a/crates/toku-db/src/sync_repo.rs
+++ b/crates/toku-db/src/sync_repo.rs
@@ -175,6 +175,34 @@ impl<'a> SyncRepository<'a> {
         Ok(())
     }
 
+    /// Insert a sync op received from the server.
+    ///
+    /// Remote ops are stored with `pushed_at` set to now (they don't need
+    /// to be pushed back — they came from the server). Duplicates are
+    /// silently ignored.
+    pub fn insert_remote_op(&self, op: &SyncOp) -> Result<(), DbError> {
+        let fields_json = op.fields.as_ref().map(|v| v.to_string());
+        let now = chrono::Utc::now().to_rfc3339();
+        self.db.conn.execute(
+            "INSERT OR IGNORE INTO sync_ops (op_id, device_id, hlc, entity_type, entity_id,
+             op_type, fields_json, checksum, pushed_at, created_at)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)",
+            params![
+                op.op_id.to_string(),
+                op.device_id.to_string(),
+                op.hlc.to_canonical(),
+                op.entity_type.as_str(),
+                op.entity_id.to_string(),
+                op.op_type.as_str(),
+                fields_json,
+                op.checksum,
+                now,
+                op.created_at.to_rfc3339(),
+            ],
+        )?;
+        Ok(())
+    }
+
     /// Count the number of unpushed ops.
     pub fn count_unpushed_ops(&self) -> Result<i64, DbError> {
         let count: i64 = self.db.conn.query_row(

--- a/crates/toku-sync/src/handlers.rs
+++ b/crates/toku-sync/src/handlers.rs
@@ -204,14 +204,15 @@ pub async fn push_ops(
             }
 
             // Update push cursor to the last accepted op
-            if let Some(last_op) = ops.last() {
+            let new_cursor = ops.last().map(|op| op.op_id.clone());
+            if let Some(ref cursor_op_id) = new_cursor {
                 tx.execute(
                     "INSERT INTO cursors (device_id, cursor_type, op_id, updated_at)
                      VALUES (?1, 'push', ?2, datetime('now'))
                      ON CONFLICT (device_id, cursor_type) DO UPDATE SET
                        op_id = excluded.op_id,
                        updated_at = excluded.updated_at",
-                    rusqlite::params![device_id, last_op.op_id],
+                    rusqlite::params![device_id, cursor_op_id],
                 )?;
             }
 
@@ -220,6 +221,7 @@ pub async fn push_ops(
             Ok(PushResponse {
                 accepted,
                 duplicates,
+                new_cursor,
             })
         }
     })
@@ -244,7 +246,10 @@ pub async fn pull_ops(
         move || -> Result<PullResponse, SyncError> {
             let db = SyncDatabase::open_no_migrate(&db_path)?;
 
-            let ops: Vec<OpPayload> = if let Some(ref since_op_id) = since {
+            // Fetch one extra to determine has_more
+            let fetch_limit = MAX_BATCH_SIZE_SQL + 1;
+
+            let all_ops: Vec<OpPayload> = if let Some(ref since_op_id) = since {
                 // Get the HLC of the cursor op to filter from
                 let cursor_hlc: Option<String> = db
                     .conn
@@ -260,12 +265,14 @@ pub async fn pull_ops(
                         let mut stmt = db.conn.prepare(
                             "SELECT op_id, device_id, hlc, entity_type, entity_id, op_type, payload
                              FROM ops
-                             WHERE library_id = ?1 AND (hlc > ?2 OR (hlc = ?2 AND op_id > ?3))
+                             WHERE library_id = ?1
+                               AND device_id != ?2
+                               AND (hlc > ?3 OR (hlc = ?3 AND op_id > ?4))
                              ORDER BY hlc, op_id
-                             LIMIT ?4",
+                             LIMIT ?5",
                         )?;
                         stmt.query_map(
-                            rusqlite::params![library_id, hlc, since_op_id, MAX_BATCH_SIZE_SQL],
+                            rusqlite::params![library_id, device_id, hlc, since_op_id, fetch_limit],
                             row_to_op,
                         )?
                         .collect::<Result<Vec<_>, _>>()?
@@ -277,17 +284,23 @@ pub async fn pull_ops(
                     }
                 }
             } else {
-                // No cursor — return all ops from the beginning
+                // No cursor — return all ops from the beginning (excluding own)
                 let mut stmt = db.conn.prepare(
                     "SELECT op_id, device_id, hlc, entity_type, entity_id, op_type, payload
                      FROM ops
-                     WHERE library_id = ?1
+                     WHERE library_id = ?1 AND device_id != ?2
                      ORDER BY hlc, op_id
-                     LIMIT ?2",
+                     LIMIT ?3",
                 )?;
-                stmt.query_map(rusqlite::params![library_id, MAX_BATCH_SIZE_SQL], row_to_op)?
-                    .collect::<Result<Vec<_>, _>>()?
+                stmt.query_map(
+                    rusqlite::params![library_id, device_id, fetch_limit],
+                    row_to_op,
+                )?
+                .collect::<Result<Vec<_>, _>>()?
             };
+
+            let has_more = all_ops.len() > MAX_BATCH_SIZE;
+            let ops: Vec<OpPayload> = all_ops.into_iter().take(MAX_BATCH_SIZE).collect();
 
             let cursor = ops.last().map(|op| op.op_id.clone());
 
@@ -303,7 +316,11 @@ pub async fn pull_ops(
                 )?;
             }
 
-            Ok(PullResponse { ops, cursor })
+            Ok(PullResponse {
+                ops,
+                cursor,
+                has_more,
+            })
         }
     })
     .await

--- a/crates/toku-sync/src/main.rs
+++ b/crates/toku-sync/src/main.rs
@@ -374,6 +374,11 @@ mod tests {
             .unwrap();
         let push: serde_json::Value = serde_json::from_slice(&body).unwrap();
         assert_eq!(push["accepted"], 1);
+        assert!(
+            push["new_cursor"].is_string(),
+            "push should return new_cursor"
+        );
+        assert_eq!(push["new_cursor"], "dup-1");
 
         // Push same op again
         let resp = app
@@ -827,6 +832,338 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+
+        cleanup(&db_path);
+    }
+
+    #[tokio::test]
+    async fn pull_excludes_own_device_ops() {
+        let db_path = test_db_path();
+        let app = build_router(db_path.clone());
+
+        // Register two devices
+        let resp = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/v1/register")
+                    .header("Content-Type", "application/json")
+                    .body(Body::from(
+                        serde_json::to_string(&serde_json::json!({
+                            "library_id": "lib-1",
+                            "device_name": "dev-a"
+                        }))
+                        .unwrap(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let reg_a: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        let token_a = reg_a["auth_token"].as_str().unwrap().to_string();
+        let device_a_id = reg_a["device_id"].as_str().unwrap().to_string();
+
+        let resp = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/v1/register")
+                    .header("Content-Type", "application/json")
+                    .body(Body::from(
+                        serde_json::to_string(&serde_json::json!({
+                            "library_id": "lib-1",
+                            "device_name": "dev-b"
+                        }))
+                        .unwrap(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let reg_b: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        let token_b = reg_b["auth_token"].as_str().unwrap().to_string();
+
+        // Device A pushes an op
+        let ops_json = serde_json::json!({
+            "ops": [{
+                "op_id": "op-from-a",
+                "device_id": &device_a_id,
+                "hlc": "2026-01-01T00:00:00.000Z-0001-aaaaaaaaaaaa",
+                "entity_type": "book",
+                "entity_id": "b1",
+                "op_type": "create",
+                "payload": {"title": "Test Book"}
+            }]
+        });
+        let resp = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/v1/push")
+                    .header("Content-Type", "application/json")
+                    .header("Authorization", format!("Bearer {token_a}"))
+                    .body(Body::from(serde_json::to_string(&ops_json).unwrap()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        // Device A pulls — should NOT see its own op
+        let resp = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri("/api/v1/pull")
+                    .header("Authorization", format!("Bearer {token_a}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let pull: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(pull["ops"].as_array().unwrap().len(), 0);
+        assert_eq!(pull["has_more"], false);
+
+        // Device B pulls — SHOULD see device A's op
+        let resp = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri("/api/v1/pull")
+                    .header("Authorization", format!("Bearer {token_b}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let pull: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(pull["ops"].as_array().unwrap().len(), 1);
+        assert_eq!(pull["ops"][0]["op_id"], "op-from-a");
+        assert_eq!(pull["has_more"], false);
+        assert!(pull["cursor"].is_string());
+
+        cleanup(&db_path);
+    }
+
+    #[tokio::test]
+    async fn push_returns_new_cursor() {
+        let db_path = test_db_path();
+        let app = build_router(db_path.clone());
+
+        // Register
+        let resp = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/v1/register")
+                    .header("Content-Type", "application/json")
+                    .body(Body::from(
+                        serde_json::to_string(&serde_json::json!({
+                            "library_id": "lib-1",
+                            "device_name": "dev"
+                        }))
+                        .unwrap(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let reg: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        let token = reg["auth_token"].as_str().unwrap().to_string();
+
+        // Push multiple ops
+        let ops_json = serde_json::json!({
+            "ops": [
+                {
+                    "op_id": "op-1",
+                    "device_id": "d",
+                    "hlc": "2026-01-01T00:00:00.000Z-0001-d",
+                    "entity_type": "book",
+                    "entity_id": "b1",
+                    "op_type": "create",
+                    "payload": {}
+                },
+                {
+                    "op_id": "op-2",
+                    "device_id": "d",
+                    "hlc": "2026-01-01T00:00:01.000Z-0001-d",
+                    "entity_type": "book",
+                    "entity_id": "b1",
+                    "op_type": "update",
+                    "payload": {"title": "Updated"}
+                }
+            ]
+        });
+
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/v1/push")
+                    .header("Content-Type", "application/json")
+                    .header("Authorization", format!("Bearer {token}"))
+                    .body(Body::from(serde_json::to_string(&ops_json).unwrap()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let push: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(push["accepted"], 2);
+        assert_eq!(push["new_cursor"], "op-2");
+
+        cleanup(&db_path);
+    }
+
+    #[tokio::test]
+    async fn pull_has_more_pagination() {
+        let db_path = test_db_path();
+        let app = build_router(db_path.clone());
+
+        // Register two devices
+        let resp = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/v1/register")
+                    .header("Content-Type", "application/json")
+                    .body(Body::from(
+                        serde_json::to_string(&serde_json::json!({
+                            "library_id": "lib-1",
+                            "device_name": "pusher"
+                        }))
+                        .unwrap(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let reg_push: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        let push_token = reg_push["auth_token"].as_str().unwrap().to_string();
+
+        let resp = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/v1/register")
+                    .header("Content-Type", "application/json")
+                    .body(Body::from(
+                        serde_json::to_string(&serde_json::json!({
+                            "library_id": "lib-1",
+                            "device_name": "puller"
+                        }))
+                        .unwrap(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let reg_pull: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        let pull_token = reg_pull["auth_token"].as_str().unwrap().to_string();
+
+        // Push 5 ops from the pusher device (small batch to verify has_more=false)
+        let ops: Vec<serde_json::Value> = (0..5)
+            .map(|i| {
+                serde_json::json!({
+                    "op_id": format!("op-{i}"),
+                    "device_id": "d",
+                    "hlc": format!("2026-01-01T00:00:{i:02}.000Z-0001-d"),
+                    "entity_type": "book",
+                    "entity_id": format!("b{i}"),
+                    "op_type": "create",
+                    "payload": {}
+                })
+            })
+            .collect();
+
+        let resp = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/v1/push")
+                    .header("Content-Type", "application/json")
+                    .header("Authorization", format!("Bearer {push_token}"))
+                    .body(Body::from(
+                        serde_json::to_string(&serde_json::json!({ "ops": ops })).unwrap(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        // Puller pulls — should get all 5 and has_more=false
+        let resp = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri("/api/v1/pull")
+                    .header("Authorization", format!("Bearer {pull_token}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let pull: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(pull["ops"].as_array().unwrap().len(), 5);
+        assert_eq!(pull["has_more"], false);
+        assert!(pull["cursor"].is_string());
+
+        // Pull again with cursor — should get empty
+        let cursor = pull["cursor"].as_str().unwrap();
+        let resp = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri(format!("/api/v1/pull?since={cursor}"))
+                    .header("Authorization", format!("Bearer {pull_token}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let pull: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(pull["ops"].as_array().unwrap().len(), 0);
+        assert_eq!(pull["has_more"], false);
 
         cleanup(&db_path);
     }

--- a/crates/toku-sync/src/models.rs
+++ b/crates/toku-sync/src/models.rs
@@ -50,12 +50,14 @@ pub struct DeviceResponse {
 pub struct PushResponse {
     pub accepted: usize,
     pub duplicates: usize,
+    pub new_cursor: Option<String>,
 }
 
 #[derive(Debug, Serialize)]
 pub struct PullResponse {
     pub ops: Vec<OpPayload>,
     pub cursor: Option<String>,
+    pub has_more: bool,
 }
 
 #[derive(Debug, Serialize)]


### PR DESCRIPTION
## Description

Add push and pull sync endpoints with cursor management, device-exclusion on pull, and full CLI orchestration.

### What's included

- **Server: cursor in push response** — `PushResponse` now returns `new_cursor` (the last accepted op_id) so clients can track progress
- **Server: `has_more` pagination** — Pull fetches `LIMIT + 1` rows; if extra exists, `has_more: true` signals the client to continue
- **Server: device exclusion on pull** — Pull queries add `AND device_id != ?` to exclude the requesting device's own ops (avoids echo)
- **Client: wire format conversion** — New `wire.rs` module converts between `SyncOp` (domain) and `WireOp` (HTTP wire format)
- **Client: `SyncClient.push_ops()` / `pull_ops()`** — HTTP methods for pushing batches and pulling with cursor
- **Client: `toku sync push`** — Queries unpushed ops, batches into 1000-op chunks, POSTs to server, marks pushed locally, updates cursor
- **Client: `toku sync pull`** — GETs ops since cursor, stores via `insert_remote_op()` (with `pushed_at = NOW()` to prevent re-push), loops while `has_more`
- **Database: `insert_remote_op()`** — Stores pulled ops with `pushed_at` set so they're excluded from future pushes; uses `INSERT OR IGNORE` for idempotency
- **4 new server tests** — Device exclusion, push cursor return, pagination, and cursor continuation

## Related Issues

Closes #68

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI / infrastructure
- [ ] Other (describe below)

## Crate

- [ ] `toku-core` — Domain models, traits, state machine
- [x] `toku-db` — SQLite persistence, migrations, FTS5
- [ ] `toku-import` — Importers (Goodreads, Calibre, StoryGraph)
- [ ] `toku-meta` — Metadata fetching (Open Library, Google Books)
- [x] `toku-cli` — CLI binary
- [ ] `toku-export` — Exporters (CSV, JSON, Markdown, BibTeX)
- [ ] `docs/` — Documentation

## Data Integrity Checklist

- [x] No user data is sent to any server without explicit opt-in
- [x] Import operations are idempotent (re-importing the same file creates no duplicates)
- [x] User edits to metadata are never overwritten by auto-enrichment
- [ ] New fields track provenance (source + timestamp) — N/A for sync ops
- [ ] Export round-trip is preserved (if applicable) — N/A

## Checklist

- [x] I have read [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] `cargo fmt --check` passes
- [x] `cargo clippy --workspace -- -D warnings` passes
- [x] `cargo test --workspace` passes (257 tests)
- [x] I have updated documentation (if applicable)
