### PR TITLE
feat: sync merge rules, client-side encryption, and passphrase re-keying

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Notes and reviews merge: LWW with conflict detection — two devices editing the same note stores a `sync_conflict` for user review, while edits to different notes merge cleanly
+- Review field-level merge: content and rating are tracked independently, so two devices editing different review fields produces no conflict
+- Settings sync: LWW per key for user settings with HLC-based ordering
+- Notes, reviews, and user settings tables (migration V15) with soft delete support for notes and reviews
+- Client-side encryption for sync ops: AES-256-GCM with Argon2id key derivation (m=64MB, t=3, p=1)
+- Encrypted ops envelope per ADR-008: fields JSON is encrypted before leaving the device, server stores opaque blobs
+- AAD (Additional Authenticated Data) binds envelope version, entity type, entity ID, and op type to prevent payload swapping between ops
+- `SyncKey` with zeroize-on-drop for key material protection
+- `SyncOp.encrypt()` and `SyncOp.decrypt()` convenience methods for in-place encryption/decryption
+- `toku sync rekey --server <url>` command to change the sync encryption passphrase and re-encrypt all server-side ops
+- Rekey server endpoint (`POST /api/v1/rekey`): atomically replaces all ops with re-encrypted versions, updates library salt, invalidates all device cursors
+- Push lock during re-keying: server rejects push requests while a rekey is in progress to prevent corruption
+- Salt endpoint (`GET /api/v1/salt`) for clients to fetch the library's current encryption salt
+- Full-library pull endpoint (`GET /api/v1/pull/all`) for re-keying that includes the requesting device's own ops
+- Sync key storage in OS keychain alongside auth tokens
 - Sync data model: `sync_ops`, `sync_cursors`, and `sync_device` tables (migration V12) for local op-log staging
 - Hybrid Logical Clock (HLC) implementation with fixed-width canonical format for causal ordering across devices
 - `SyncRepository` for sync persistence: insert ops, query unpushed, mark pushed, device identity, cursor management

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,14 +9,49 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "aead"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
+dependencies = [
+ "crypto-common 0.1.7",
+ "generic-array",
+]
+
+[[package]]
+name = "aes"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+dependencies = [
+ "cfg-if",
+ "cipher 0.4.4",
+ "cpufeatures 0.2.17",
+]
+
+[[package]]
 name = "aes"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "66bd29a732b644c0431c6140f370d097879203d79b80c94a6747ba0872adaef8"
 dependencies = [
- "cipher",
+ "cipher 0.5.1",
  "cpubits",
  "cpufeatures 0.3.0",
+]
+
+[[package]]
+name = "aes-gcm"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "831010a0f742e1209b3bcea8fab6a8e149051ba6099432c8cb2cc117dec3ead1"
+dependencies = [
+ "aead",
+ "aes 0.8.4",
+ "cipher 0.4.4",
+ "ctr",
+ "ghash",
+ "subtle",
 ]
 
 [[package]]
@@ -113,6 +148,18 @@ name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
+name = "argon2"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c3610892ee6e0cbce8ae2700349fcf8f98adb0dbfbee85aec3c9179d29cc072"
+dependencies = [
+ "base64ct",
+ "blake2",
+ "cpufeatures 0.2.17",
+ "password-hash",
+]
 
 [[package]]
 name = "async-trait"
@@ -226,6 +273,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "base64ct"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
+
+[[package]]
 name = "bit-set"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -253,6 +306,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 dependencies = [
  "serde_core",
+]
+
+[[package]]
+name = "blake2"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
+dependencies = [
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -521,12 +583,22 @@ dependencies = [
 
 [[package]]
 name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common 0.1.7",
+ "inout 0.1.4",
+]
+
+[[package]]
+name = "cipher"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e34d8227fe1ba289043aeb13792056ff80fd6de1a9f49137a5f499de8e8c78ea"
 dependencies = [
  "crypto-common 0.2.1",
- "inout",
+ "inout 0.2.2",
 ]
 
 [[package]]
@@ -756,6 +828,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
+ "rand_core 0.6.4",
  "typenum",
 ]
 
@@ -827,6 +900,15 @@ name = "ctor-proc-macro"
 version = "0.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52560adf09603e58c9a7ee1fe1dcb95a16927b17c127f0ac02d6e768a0e25bc1"
+
+[[package]]
+name = "ctr"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
+dependencies = [
+ "cipher 0.4.4",
+]
 
 [[package]]
 name = "ctutils"
@@ -927,6 +1009,7 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer 0.10.4",
  "crypto-common 0.1.7",
+ "subtle",
 ]
 
 [[package]]
@@ -1477,6 +1560,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ghash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0d8a4362ccb29cb0b265253fb0a2728f592895ee6854fd9bc13f2ffda266ff1"
+dependencies = [
+ "opaque-debug",
+ "polyval",
+]
+
+[[package]]
 name = "gio"
 version = "0.18.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2004,6 +2097,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a588916bfdfd92e71cacef98a63d9b1f0d74d6599980d11894290e7ddefffcf7"
 dependencies = [
  "cfb",
+]
+
+[[package]]
+name = "inout"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+dependencies = [
+ "generic-array",
 ]
 
 [[package]]
@@ -2730,6 +2832,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "opaque-debug"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
+
+[[package]]
 name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2792,6 +2900,17 @@ dependencies = [
  "redox_syscall",
  "smallvec",
  "windows-link 0.2.1",
+]
+
+[[package]]
+name = "password-hash"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "346f04948ba92c43e8469c1ee6736c7563d71012b17d40745260fe106aac2166"
+dependencies = [
+ "base64ct",
+ "rand_core 0.6.4",
+ "subtle",
 ]
 
 [[package]]
@@ -2918,6 +3037,18 @@ dependencies = [
  "fdeflate",
  "flate2",
  "miniz_oxide",
+]
+
+[[package]]
+name = "polyval"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "opaque-debug",
+ "universal-hash",
 ]
 
 [[package]]
@@ -3153,7 +3284,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha",
- "rand_core",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -3163,7 +3294,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.17",
 ]
 
 [[package]]
@@ -3398,6 +3538,16 @@ dependencies = [
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rpassword"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffc936cf8a7ea60c58f030fd36a612a48f440610214dc54bc36431f9ea0c3efb"
+dependencies = [
+ "libc",
+ "winapi",
 ]
 
 [[package]]
@@ -4584,6 +4734,7 @@ name = "toku-cli"
 version = "0.2.1"
 dependencies = [
  "anyhow",
+ "base64 0.22.1",
  "chrono",
  "clap",
  "clap_complete",
@@ -4592,6 +4743,7 @@ dependencies = [
  "keyring",
  "ratatui",
  "reqwest 0.12.28",
+ "rpassword",
  "serde",
  "serde_json",
  "tabled",
@@ -4610,13 +4762,18 @@ dependencies = [
 name = "toku-core"
 version = "0.2.1"
 dependencies = [
+ "aes-gcm",
+ "argon2",
+ "base64 0.22.1",
  "chrono",
+ "getrandom 0.3.4",
  "serde",
  "serde_json",
  "sha2 0.10.9",
  "thiserror 2.0.18",
  "toml 1.1.2+spec-1.1.0",
  "uuid",
+ "zeroize",
 ]
 
 [[package]]
@@ -5077,6 +5234,16 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "universal-hash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
+dependencies = [
+ "crypto-common 0.1.7",
+ "subtle",
+]
 
 [[package]]
 name = "untrusted"
@@ -6154,6 +6321,20 @@ name = "zeroize"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "zerotrie"
@@ -6194,7 +6375,7 @@ version = "8.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d04a6b5381502aa6087c94c669499eb1602eb9c5e8198e534de571f7154809b"
 dependencies = [
- "aes",
+ "aes 0.9.0",
  "bzip2",
  "constant_time_eq",
  "crc32fast",

--- a/crates/toku-cli/Cargo.toml
+++ b/crates/toku-cli/Cargo.toml
@@ -33,3 +33,5 @@ ratatui = "0.29"
 crossterm = "0.28"
 csv = "1"
 uuid.workspace = true
+rpassword = "5"
+base64 = "0.22"

--- a/crates/toku-cli/src/main.rs
+++ b/crates/toku-cli/src/main.rs
@@ -3,6 +3,7 @@ use std::path::{Path, PathBuf};
 use std::str::FromStr;
 
 use anyhow::{Context, Result};
+use base64::Engine as _;
 use clap::{CommandFactory, Parser, Subcommand, ValueEnum};
 use clap_complete::Shell;
 use toku_core::{
@@ -617,6 +618,13 @@ enum SyncAction {
         /// Retention period in days (default: 30)
         #[arg(long, default_value = "30")]
         days: i64,
+    },
+
+    /// Change the sync encryption passphrase and re-encrypt all server ops
+    Rekey {
+        /// Sync server URL
+        #[arg(long)]
+        server: String,
     },
 }
 
@@ -3263,6 +3271,145 @@ fn cmd_sync(data_dir: &Path, action: SyncAction, output_format: &OutputFormat) -
                 }
             }
             Ok(())
+        }
+        SyncAction::Rekey { server } => {
+            let token = token_store.load(&server)?.ok_or_else(|| {
+                anyhow::anyhow!("no auth token found for {server}. Run `toku sync register` first.")
+            })?;
+            let client = sync::client::SyncClient::new(&server)?;
+
+            // Prompt for old passphrase
+            eprint!("Old passphrase: ");
+            let old_passphrase =
+                rpassword::read_password().context("failed to read old passphrase")?;
+            if old_passphrase.is_empty() {
+                anyhow::bail!("old passphrase cannot be empty");
+            }
+
+            // Prompt for new passphrase (twice)
+            eprint!("New passphrase: ");
+            let new_passphrase =
+                rpassword::read_password().context("failed to read new passphrase")?;
+            if new_passphrase.is_empty() {
+                anyhow::bail!("new passphrase cannot be empty");
+            }
+            eprint!("Confirm new passphrase: ");
+            let confirm =
+                rpassword::read_password().context("failed to read passphrase confirmation")?;
+            if new_passphrase != confirm {
+                anyhow::bail!("passphrases do not match");
+            }
+
+            rt.block_on(async {
+                // Step 1: Get current salt from server
+                eprintln!("Fetching library salt...");
+                let salt_result = client.get_salt(&token).await?;
+                let old_salt_b64 = salt_result.salt.ok_or_else(|| {
+                    anyhow::anyhow!("library has no salt — encryption was never enabled")
+                })?;
+                let old_salt_bytes = base64::engine::general_purpose::STANDARD
+                    .decode(&old_salt_b64)
+                    .context("invalid salt encoding")?;
+                let old_salt: [u8; 16] = old_salt_bytes
+                    .try_into()
+                    .map_err(|_| anyhow::anyhow!("invalid salt length"))?;
+
+                // Step 2: Derive old key
+                let old_key = toku_core::SyncKey::derive(&old_passphrase, &old_salt)
+                    .map_err(|e| anyhow::anyhow!("key derivation failed: {e}"))?;
+
+                // Step 3: Pull all ops from server
+                eprintln!("Pulling all ops from server...");
+                let pull_result = client.pull_all_ops(&token).await?;
+                let total = pull_result.ops.len();
+                eprintln!("  {} ops to re-encrypt", total);
+
+                if total == 0 {
+                    anyhow::bail!("no ops on server — nothing to re-key");
+                }
+
+                // Step 4: Derive new key with new salt
+                let new_salt = toku_core::SyncKey::generate_salt();
+                let new_key = toku_core::SyncKey::derive(&new_passphrase, &new_salt)
+                    .map_err(|e| anyhow::anyhow!("key derivation failed: {e}"))?;
+                let new_salt_b64 = base64::engine::general_purpose::STANDARD.encode(new_salt);
+
+                // Step 5: Decrypt each op with old key, re-encrypt with new key
+                eprintln!("Re-encrypting ops...");
+                let mut re_encrypted_ops = Vec::with_capacity(total);
+                for (i, wire_op) in pull_result.ops.iter().enumerate() {
+                    let mut re_wire = wire_op.clone();
+
+                    // Only process encrypted payloads
+                    if wire_op.payload.is_object() && wire_op.payload.get("ev").is_some() {
+                        let envelope: toku_core::EncryptedEnvelope =
+                            serde_json::from_value(wire_op.payload.clone())
+                                .context("invalid encrypted envelope")?;
+
+                        let entity_type: toku_core::EntityType = wire_op
+                            .entity_type
+                            .parse()
+                            .map_err(|_| anyhow::anyhow!("invalid entity_type"))?;
+                        let entity_id: uuid::Uuid = wire_op
+                            .entity_id
+                            .parse()
+                            .map_err(|e| anyhow::anyhow!("invalid entity_id: {e}"))?;
+                        let op_type: toku_core::OpType = wire_op
+                            .op_type
+                            .parse()
+                            .map_err(|_| anyhow::anyhow!("invalid op_type"))?;
+
+                        let plaintext = toku_core::decrypt_fields(
+                            &old_key,
+                            &envelope,
+                            &entity_type,
+                            &entity_id,
+                            &op_type,
+                        )
+                        .map_err(|e| {
+                            anyhow::anyhow!(
+                                "decryption failed for op {}: {e} (wrong old passphrase?)",
+                                wire_op.op_id
+                            )
+                        })?;
+
+                        let new_envelope = toku_core::encrypt_fields(
+                            &new_key,
+                            &plaintext,
+                            &entity_type,
+                            &entity_id,
+                            &op_type,
+                        )
+                        .map_err(|e| anyhow::anyhow!("re-encryption failed: {e}"))?;
+
+                        re_wire.payload = serde_json::to_value(&new_envelope)?;
+                    }
+
+                    re_encrypted_ops.push(re_wire);
+
+                    // Progress indicator every 100 ops
+                    if (i + 1) % 100 == 0 || i + 1 == total {
+                        eprint!("\r  {}/{} ops re-encrypted", i + 1, total);
+                    }
+                }
+                eprintln!();
+
+                // Step 6: Push re-encrypted ops to server
+                eprintln!("Uploading re-encrypted ops...");
+                let rekey_result = client
+                    .rekey(&token, &new_salt_b64, &re_encrypted_ops)
+                    .await
+                    .context("rekey request failed — server state unchanged")?;
+
+                // Step 7: Update local keychain with new key
+                token_store.store_sync_key(&server, new_key.as_exported_bytes())?;
+
+                eprintln!(
+                    "✓ Re-keyed {} ops with new passphrase",
+                    rekey_result.ops_replaced
+                );
+                Ok(())
+            })
         }
     }
 }

--- a/crates/toku-cli/src/sync/client.rs
+++ b/crates/toku-cli/src/sync/client.rs
@@ -54,6 +54,18 @@ struct ErrorBody {
     error: String,
 }
 
+#[derive(Debug, Deserialize)]
+pub struct RekeyResult {
+    pub ops_replaced: usize,
+    #[allow(dead_code)]
+    pub new_salt: String,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct SaltResult {
+    pub salt: Option<String>,
+}
+
 impl SyncClient {
     pub fn new(server_url: &str) -> anyhow::Result<Self> {
         let http = reqwest::Client::builder()
@@ -146,6 +158,57 @@ impl SyncClient {
         }
 
         let resp = self.http.get(&url).bearer_auth(token).send().await?;
+
+        if !resp.status().is_success() {
+            return Err(extract_error(resp).await);
+        }
+
+        Ok(resp.json().await?)
+    }
+
+    /// Pull ALL ops for this library (including own device's).
+    /// Used during re-keying.
+    pub async fn pull_all_ops(&self, token: &str) -> anyhow::Result<PullResult> {
+        let url = format!("{}/api/v1/pull/all", self.base_url);
+        let resp = self.http.get(&url).bearer_auth(token).send().await?;
+
+        if !resp.status().is_success() {
+            return Err(extract_error(resp).await);
+        }
+
+        Ok(resp.json().await?)
+    }
+
+    /// Get the library salt for key derivation.
+    pub async fn get_salt(&self, token: &str) -> anyhow::Result<SaltResult> {
+        let url = format!("{}/api/v1/salt", self.base_url);
+        let resp = self.http.get(&url).bearer_auth(token).send().await?;
+
+        if !resp.status().is_success() {
+            return Err(extract_error(resp).await);
+        }
+
+        Ok(resp.json().await?)
+    }
+
+    /// Submit re-encrypted ops and new salt to the server.
+    pub async fn rekey(
+        &self,
+        token: &str,
+        new_salt: &str,
+        ops: &[WireOp],
+    ) -> anyhow::Result<RekeyResult> {
+        let url = format!("{}/api/v1/rekey", self.base_url);
+        let resp = self
+            .http
+            .post(&url)
+            .bearer_auth(token)
+            .json(&serde_json::json!({
+                "new_salt": new_salt,
+                "ops": ops,
+            }))
+            .send()
+            .await?;
 
         if !resp.status().is_success() {
             return Err(extract_error(resp).await);

--- a/crates/toku-cli/src/sync/token_store.rs
+++ b/crates/toku-cli/src/sync/token_store.rs
@@ -1,6 +1,8 @@
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
+use base64::Engine as _;
+
 /// Stores sync auth tokens using the OS keychain or a local file fallback.
 ///
 /// Tokens are keyed by the normalized server URL.
@@ -9,6 +11,7 @@ pub struct TokenStore {
 }
 
 const KEYRING_SERVICE: &str = "toku-sync";
+const KEYRING_SERVICE_SYNCKEY: &str = "toku-sync-key";
 
 impl TokenStore {
     pub fn new(data_dir: &Path) -> Self {
@@ -67,6 +70,64 @@ impl TokenStore {
 
         // Also remove from file fallback
         self.delete_file(&key)
+    }
+
+    /// Store the derived sync encryption key in the OS keychain.
+    pub fn store_sync_key(&self, server_url: &str, key_bytes: &[u8]) -> anyhow::Result<()> {
+        let key = normalize_url(server_url);
+        let encoded = base64::engine::general_purpose::STANDARD.encode(key_bytes);
+
+        if let Ok(entry) = keyring::Entry::new(KEYRING_SERVICE_SYNCKEY, &key) {
+            match entry.set_password(&encoded) {
+                Ok(()) => return Ok(()),
+                Err(e) => {
+                    eprintln!(
+                        "warning: could not store sync key in OS keychain ({e}), using file fallback"
+                    );
+                }
+            }
+        }
+
+        self.store_file(&format!("{key}:synckey"), &encoded)
+    }
+
+    /// Load the derived sync encryption key from the OS keychain.
+    #[allow(dead_code)]
+    pub fn load_sync_key(&self, server_url: &str) -> anyhow::Result<Option<Vec<u8>>> {
+        use base64::Engine;
+        let key = normalize_url(server_url);
+
+        if let Ok(entry) = keyring::Entry::new(KEYRING_SERVICE_SYNCKEY, &key) {
+            match entry.get_password() {
+                Ok(encoded) => {
+                    let bytes = base64::engine::general_purpose::STANDARD.decode(&encoded)?;
+                    return Ok(Some(bytes));
+                }
+                Err(keyring::Error::NoEntry) => {}
+                Err(_) => {}
+            }
+        }
+
+        // File fallback
+        match self.load_file(&format!("{key}:synckey"))? {
+            Some(encoded) => {
+                let bytes = base64::engine::general_purpose::STANDARD.decode(&encoded)?;
+                Ok(Some(bytes))
+            }
+            None => Ok(None),
+        }
+    }
+
+    /// Delete the stored sync encryption key.
+    #[allow(dead_code)]
+    pub fn delete_sync_key(&self, server_url: &str) -> anyhow::Result<()> {
+        let key = normalize_url(server_url);
+
+        if let Ok(entry) = keyring::Entry::new(KEYRING_SERVICE_SYNCKEY, &key) {
+            let _ = entry.delete_credential();
+        }
+
+        self.delete_file(&format!("{key}:synckey"))
     }
 
     // ── File fallback ───────────────────────────────────────────────────

--- a/crates/toku-cli/src/sync/wire.rs
+++ b/crates/toku-cli/src/sync/wire.rs
@@ -61,6 +61,7 @@ pub fn from_wire(wire: &WireOp) -> anyhow::Result<SyncOp> {
         entity_id,
         op_type,
         fields,
+        encrypted: None,
         checksum: String::new(),
         created_at: chrono::Utc::now(),
     };

--- a/crates/toku-core/Cargo.toml
+++ b/crates/toku-core/Cargo.toml
@@ -15,3 +15,8 @@ serde.workspace = true
 serde_json.workspace = true
 sha2.workspace = true
 toml.workspace = true
+argon2 = "0.5"
+aes-gcm = "0.10"
+base64 = "0.22"
+getrandom = "0.3"
+zeroize = { version = "1", features = ["derive"] }

--- a/crates/toku-core/src/crypto.rs
+++ b/crates/toku-core/src/crypto.rs
@@ -1,0 +1,722 @@
+//! Client-side encryption for sync ops.
+//!
+//! Implements optional AES-256-GCM encryption with Argon2id key derivation,
+//! per ADR-006 and ADR-008. When enabled, the `fields` JSON is encrypted
+//! before leaving the device; the server stores opaque blobs.
+//!
+//! # Key derivation
+//!
+//! Passphrase → Argon2id (m=64MB, t=3, p=1) → 256-bit AES key.
+//! Salt is 128-bit random, generated once per library.
+//!
+//! # Encryption envelope
+//!
+//! Each op's `fields` JSON is encrypted with AES-256-GCM using a random
+//! 96-bit nonce. Additional Authenticated Data (AAD) binds the envelope
+//! version, entity type, entity ID, and op type to prevent payload swapping.
+
+use aes_gcm::aead::{Aead, KeyInit, Payload};
+use aes_gcm::{Aes256Gcm, Nonce};
+use argon2::Argon2;
+use base64::prelude::*;
+use serde::{Deserialize, Serialize};
+use zeroize::{Zeroize, ZeroizeOnDrop};
+
+use crate::TokuError;
+use crate::sync::{EntityType, OpType};
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/// Argon2id memory cost in KiB (64 MB).
+const ARGON2_M_COST: u32 = 65536;
+/// Argon2id time cost (iterations).
+const ARGON2_T_COST: u32 = 3;
+/// Argon2id parallelism.
+const ARGON2_P_COST: u32 = 1;
+
+/// Current encryption envelope version.
+const ENCRYPTION_ENVELOPE_VERSION: u16 = 1;
+
+/// Algorithm identifier for the envelope.
+const ALGORITHM: &str = "aes-256-gcm";
+
+// ---------------------------------------------------------------------------
+// SyncKey
+// ---------------------------------------------------------------------------
+
+/// A 256-bit AES key derived from a user passphrase.
+///
+/// Key material is zeroed on drop to minimize exposure in memory.
+#[derive(Zeroize, ZeroizeOnDrop)]
+pub struct SyncKey([u8; 32]);
+
+impl SyncKey {
+    /// Derive a sync key from a passphrase and salt using Argon2id.
+    ///
+    /// Parameters: m=64MB, t=3, p=1 (per ADR-008).
+    pub fn derive(passphrase: &str, salt: &[u8; 16]) -> Result<Self, TokuError> {
+        let params = argon2::Params::new(ARGON2_M_COST, ARGON2_T_COST, ARGON2_P_COST, Some(32))
+            .map_err(|e| TokuError::Crypto(format!("argon2 params: {e}")))?;
+        let argon2 = Argon2::new(argon2::Algorithm::Argon2id, argon2::Version::V0x13, params);
+
+        let mut key = [0u8; 32];
+        argon2
+            .hash_password_into(passphrase.as_bytes(), salt, &mut key)
+            .map_err(|e| TokuError::Crypto(format!("key derivation failed: {e}")))?;
+
+        Ok(Self(key))
+    }
+
+    /// Generate a random 128-bit salt for key derivation.
+    pub fn generate_salt() -> [u8; 16] {
+        let mut salt = [0u8; 16];
+        getrandom::fill(&mut salt).expect("OS CSPRNG failed");
+        salt
+    }
+
+    /// Access the raw key bytes (internal use only for AES-GCM).
+    fn as_bytes(&self) -> &[u8; 32] {
+        &self.0
+    }
+
+    /// Export the raw key bytes for keychain storage.
+    ///
+    /// The caller is responsible for securely storing these bytes.
+    pub fn as_exported_bytes(&self) -> &[u8] {
+        &self.0
+    }
+}
+
+impl std::fmt::Debug for SyncKey {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("SyncKey([REDACTED])")
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Encrypted Envelope
+// ---------------------------------------------------------------------------
+
+/// An encrypted payload replacing `fields` in a sync op.
+///
+/// Per ADR-008, the envelope contains the algorithm, nonce, ciphertext,
+/// and AAD string that binds the op metadata to the ciphertext.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct EncryptedEnvelope {
+    /// Encryption envelope version (currently 1).
+    pub ev: u16,
+    /// Algorithm identifier (`"aes-256-gcm"`).
+    pub alg: String,
+    /// Base64-encoded 96-bit random nonce.
+    pub nonce: String,
+    /// Base64-encoded encrypted fields JSON.
+    pub ciphertext: String,
+    /// Additional Authenticated Data string bound to the ciphertext.
+    pub aad: String,
+}
+
+// ---------------------------------------------------------------------------
+// Encrypt / Decrypt
+// ---------------------------------------------------------------------------
+
+/// Build the canonical AAD string for an op.
+///
+/// Binds envelope version, entity type, entity ID, and op type to the
+/// ciphertext. This prevents an attacker from swapping encrypted payloads
+/// between ops or changing op metadata without detection.
+pub fn build_aad(
+    envelope_version: u16,
+    entity_type: &EntityType,
+    entity_id: &uuid::Uuid,
+    op_type: &OpType,
+) -> String {
+    format!(
+        "v={},entity_type={},entity_id={},op_type={}",
+        envelope_version,
+        entity_type.as_str(),
+        entity_id,
+        op_type.as_str(),
+    )
+}
+
+/// Encrypt a `fields` JSON value into an [`EncryptedEnvelope`].
+///
+/// Generates a random 96-bit nonce via OS CSPRNG. The AAD binds the
+/// envelope version, entity type, entity ID, and op type.
+pub fn encrypt_fields(
+    key: &SyncKey,
+    fields: &serde_json::Value,
+    entity_type: &EntityType,
+    entity_id: &uuid::Uuid,
+    op_type: &OpType,
+) -> Result<EncryptedEnvelope, TokuError> {
+    let plaintext =
+        serde_json::to_vec(fields).map_err(|e| TokuError::Crypto(format!("serialize: {e}")))?;
+
+    let aad_str = build_aad(ENCRYPTION_ENVELOPE_VERSION, entity_type, entity_id, op_type);
+
+    let cipher = Aes256Gcm::new_from_slice(key.as_bytes())
+        .map_err(|e| TokuError::Crypto(format!("cipher init: {e}")))?;
+
+    let mut nonce_bytes = [0u8; 12];
+    getrandom::fill(&mut nonce_bytes).expect("OS CSPRNG failed");
+    let nonce = Nonce::from_slice(&nonce_bytes);
+
+    let payload = Payload {
+        msg: &plaintext,
+        aad: aad_str.as_bytes(),
+    };
+
+    let ciphertext = cipher
+        .encrypt(nonce, payload)
+        .map_err(|e| TokuError::Crypto(format!("encryption failed: {e}")))?;
+
+    Ok(EncryptedEnvelope {
+        ev: ENCRYPTION_ENVELOPE_VERSION,
+        alg: ALGORITHM.to_string(),
+        nonce: BASE64_STANDARD.encode(nonce_bytes),
+        ciphertext: BASE64_STANDARD.encode(ciphertext),
+        aad: aad_str,
+    })
+}
+
+/// Decrypt an [`EncryptedEnvelope`] back into a `fields` JSON value.
+///
+/// Recomputes the expected AAD from op metadata and verifies it matches
+/// the stored AAD before decryption. This ensures the envelope has not
+/// been tampered with or swapped between ops.
+pub fn decrypt_fields(
+    key: &SyncKey,
+    envelope: &EncryptedEnvelope,
+    entity_type: &EntityType,
+    entity_id: &uuid::Uuid,
+    op_type: &OpType,
+) -> Result<serde_json::Value, TokuError> {
+    // Validate envelope
+    if envelope.ev != ENCRYPTION_ENVELOPE_VERSION {
+        return Err(TokuError::Crypto(format!(
+            "unsupported envelope version: {}",
+            envelope.ev
+        )));
+    }
+    if envelope.alg != ALGORITHM {
+        return Err(TokuError::Crypto(format!(
+            "unsupported algorithm: {}",
+            envelope.alg
+        )));
+    }
+
+    // Recompute AAD and verify it matches
+    let expected_aad = build_aad(envelope.ev, entity_type, entity_id, op_type);
+    if envelope.aad != expected_aad {
+        return Err(TokuError::Crypto(
+            "AAD mismatch: op metadata may have been tampered with".to_string(),
+        ));
+    }
+
+    let nonce_bytes = BASE64_STANDARD
+        .decode(&envelope.nonce)
+        .map_err(|e| TokuError::Crypto(format!("nonce decode: {e}")))?;
+    if nonce_bytes.len() != 12 {
+        return Err(TokuError::Crypto(format!(
+            "invalid nonce length: {} (expected 12)",
+            nonce_bytes.len()
+        )));
+    }
+    let nonce = Nonce::from_slice(&nonce_bytes);
+
+    let ciphertext = BASE64_STANDARD
+        .decode(&envelope.ciphertext)
+        .map_err(|e| TokuError::Crypto(format!("ciphertext decode: {e}")))?;
+
+    let cipher = Aes256Gcm::new_from_slice(key.as_bytes())
+        .map_err(|e| TokuError::Crypto(format!("cipher init: {e}")))?;
+
+    let payload = Payload {
+        msg: &ciphertext,
+        aad: envelope.aad.as_bytes(),
+    };
+
+    let plaintext = cipher.decrypt(nonce, payload).map_err(|_| {
+        TokuError::Crypto("decryption failed (wrong key or tampered data)".to_string())
+    })?;
+
+    serde_json::from_slice(&plaintext)
+        .map_err(|e| TokuError::Crypto(format!("deserialize decrypted fields: {e}")))
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashSet;
+
+    fn test_entity_type() -> EntityType {
+        EntityType::Book
+    }
+
+    fn test_entity_id() -> uuid::Uuid {
+        uuid::Uuid::parse_str("01972123-abcd-7000-8000-000000000001").unwrap()
+    }
+
+    fn test_op_type() -> OpType {
+        OpType::Update
+    }
+
+    fn test_fields() -> serde_json::Value {
+        serde_json::json!({"title": "Dune", "rating": 9})
+    }
+
+    fn test_key_and_salt() -> (SyncKey, [u8; 16]) {
+        let salt: [u8; 16] = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16];
+        let key = SyncKey::derive("test-passphrase", &salt).unwrap();
+        (key, salt)
+    }
+
+    // --- Key derivation ---
+
+    #[test]
+    fn key_derivation_is_stable() {
+        let salt: [u8; 16] = [42; 16];
+        let key1 = SyncKey::derive("my passphrase", &salt).unwrap();
+        let key2 = SyncKey::derive("my passphrase", &salt).unwrap();
+        assert_eq!(
+            key1.0, key2.0,
+            "same passphrase + salt must produce same key"
+        );
+    }
+
+    #[test]
+    fn different_passphrase_different_key() {
+        let salt: [u8; 16] = [42; 16];
+        let key1 = SyncKey::derive("passphrase-a", &salt).unwrap();
+        let key2 = SyncKey::derive("passphrase-b", &salt).unwrap();
+        assert_ne!(key1.0, key2.0);
+    }
+
+    #[test]
+    fn different_salt_different_key() {
+        let salt1: [u8; 16] = [1; 16];
+        let salt2: [u8; 16] = [2; 16];
+        let key1 = SyncKey::derive("same-passphrase", &salt1).unwrap();
+        let key2 = SyncKey::derive("same-passphrase", &salt2).unwrap();
+        assert_ne!(key1.0, key2.0);
+    }
+
+    #[test]
+    fn generate_salt_produces_random_bytes() {
+        let salt1 = SyncKey::generate_salt();
+        let salt2 = SyncKey::generate_salt();
+        assert_ne!(salt1, salt2, "two salts should not be equal");
+    }
+
+    #[test]
+    fn key_debug_does_not_leak() {
+        let (key, _) = test_key_and_salt();
+        let debug = format!("{:?}", key);
+        assert!(debug.contains("REDACTED"));
+        assert!(!debug.contains("0x"));
+    }
+
+    // --- Round-trip encryption/decryption ---
+
+    #[test]
+    fn encrypt_decrypt_round_trip() {
+        let (key, _) = test_key_and_salt();
+        let fields = test_fields();
+
+        let envelope = encrypt_fields(
+            &key,
+            &fields,
+            &test_entity_type(),
+            &test_entity_id(),
+            &test_op_type(),
+        )
+        .unwrap();
+
+        assert_eq!(envelope.ev, 1);
+        assert_eq!(envelope.alg, "aes-256-gcm");
+        assert!(!envelope.nonce.is_empty());
+        assert!(!envelope.ciphertext.is_empty());
+
+        let decrypted = decrypt_fields(
+            &key,
+            &envelope,
+            &test_entity_type(),
+            &test_entity_id(),
+            &test_op_type(),
+        )
+        .unwrap();
+
+        assert_eq!(decrypted, fields);
+    }
+
+    #[test]
+    fn round_trip_with_complex_fields() {
+        let (key, _) = test_key_and_salt();
+        let fields = serde_json::json!({
+            "title": "Les Misérables",
+            "description": "A novel with unicode: 日本語 🎉",
+            "page_count": 1488,
+            "rating": null,
+            "tags": ["classic", "french"],
+        });
+
+        let envelope = encrypt_fields(
+            &key,
+            &fields,
+            &EntityType::Book,
+            &test_entity_id(),
+            &OpType::Create,
+        )
+        .unwrap();
+
+        let decrypted = decrypt_fields(
+            &key,
+            &envelope,
+            &EntityType::Book,
+            &test_entity_id(),
+            &OpType::Create,
+        )
+        .unwrap();
+
+        assert_eq!(decrypted, fields);
+    }
+
+    // --- Wrong key fails ---
+
+    #[test]
+    fn wrong_key_fails_decryption() {
+        let (key, _) = test_key_and_salt();
+        let fields = test_fields();
+
+        let envelope = encrypt_fields(
+            &key,
+            &fields,
+            &test_entity_type(),
+            &test_entity_id(),
+            &test_op_type(),
+        )
+        .unwrap();
+
+        let wrong_salt: [u8; 16] = [99; 16];
+        let wrong_key = SyncKey::derive("wrong-passphrase", &wrong_salt).unwrap();
+
+        let result = decrypt_fields(
+            &wrong_key,
+            &envelope,
+            &test_entity_type(),
+            &test_entity_id(),
+            &test_op_type(),
+        );
+
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(
+            err.contains("decryption failed"),
+            "expected decryption error, got: {err}"
+        );
+    }
+
+    // --- AAD prevents payload swapping ---
+
+    #[test]
+    fn aad_mismatch_entity_type_fails() {
+        let (key, _) = test_key_and_salt();
+        let fields = test_fields();
+
+        let envelope = encrypt_fields(
+            &key,
+            &fields,
+            &EntityType::Book,
+            &test_entity_id(),
+            &test_op_type(),
+        )
+        .unwrap();
+
+        // Try to decrypt as if it were a Session op
+        let result = decrypt_fields(
+            &key,
+            &envelope,
+            &EntityType::Session,
+            &test_entity_id(),
+            &test_op_type(),
+        );
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn aad_mismatch_entity_id_fails() {
+        let (key, _) = test_key_and_salt();
+        let fields = test_fields();
+
+        let envelope = encrypt_fields(
+            &key,
+            &fields,
+            &test_entity_type(),
+            &test_entity_id(),
+            &test_op_type(),
+        )
+        .unwrap();
+
+        let different_id = uuid::Uuid::parse_str("01972123-abcd-7000-8000-999999999999").unwrap();
+        let result = decrypt_fields(
+            &key,
+            &envelope,
+            &test_entity_type(),
+            &different_id,
+            &test_op_type(),
+        );
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn aad_mismatch_op_type_fails() {
+        let (key, _) = test_key_and_salt();
+        let fields = test_fields();
+
+        let envelope = encrypt_fields(
+            &key,
+            &fields,
+            &test_entity_type(),
+            &test_entity_id(),
+            &OpType::Update,
+        )
+        .unwrap();
+
+        let result = decrypt_fields(
+            &key,
+            &envelope,
+            &test_entity_type(),
+            &test_entity_id(),
+            &OpType::Create,
+        );
+        assert!(result.is_err());
+    }
+
+    // --- Nonce uniqueness ---
+
+    #[test]
+    fn nonces_are_unique_across_10000_ops() {
+        let (key, _) = test_key_and_salt();
+        let fields = test_fields();
+        let mut nonces = HashSet::new();
+
+        for _ in 0..10_000 {
+            let envelope = encrypt_fields(
+                &key,
+                &fields,
+                &test_entity_type(),
+                &test_entity_id(),
+                &test_op_type(),
+            )
+            .unwrap();
+            assert!(
+                nonces.insert(envelope.nonce.clone()),
+                "nonce collision detected"
+            );
+        }
+
+        assert_eq!(nonces.len(), 10_000);
+    }
+
+    // --- Ciphertext tampering ---
+
+    #[test]
+    fn tampered_ciphertext_fails() {
+        let (key, _) = test_key_and_salt();
+        let fields = test_fields();
+
+        let mut envelope = encrypt_fields(
+            &key,
+            &fields,
+            &test_entity_type(),
+            &test_entity_id(),
+            &test_op_type(),
+        )
+        .unwrap();
+
+        // Flip one byte in the ciphertext
+        let mut ct_bytes = BASE64_STANDARD.decode(&envelope.ciphertext).unwrap();
+        ct_bytes[0] ^= 0xFF;
+        envelope.ciphertext = BASE64_STANDARD.encode(&ct_bytes);
+
+        let result = decrypt_fields(
+            &key,
+            &envelope,
+            &test_entity_type(),
+            &test_entity_id(),
+            &test_op_type(),
+        );
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn tampered_nonce_fails() {
+        let (key, _) = test_key_and_salt();
+        let fields = test_fields();
+
+        let mut envelope = encrypt_fields(
+            &key,
+            &fields,
+            &test_entity_type(),
+            &test_entity_id(),
+            &test_op_type(),
+        )
+        .unwrap();
+
+        // Flip one byte in the nonce
+        let mut nonce_bytes = BASE64_STANDARD.decode(&envelope.nonce).unwrap();
+        nonce_bytes[0] ^= 0xFF;
+        envelope.nonce = BASE64_STANDARD.encode(&nonce_bytes);
+
+        let result = decrypt_fields(
+            &key,
+            &envelope,
+            &test_entity_type(),
+            &test_entity_id(),
+            &test_op_type(),
+        );
+        assert!(result.is_err());
+    }
+
+    // --- Envelope validation ---
+
+    #[test]
+    fn unsupported_envelope_version_rejected() {
+        let (key, _) = test_key_and_salt();
+        let fields = test_fields();
+
+        let mut envelope = encrypt_fields(
+            &key,
+            &fields,
+            &test_entity_type(),
+            &test_entity_id(),
+            &test_op_type(),
+        )
+        .unwrap();
+
+        envelope.ev = 99;
+        let result = decrypt_fields(
+            &key,
+            &envelope,
+            &test_entity_type(),
+            &test_entity_id(),
+            &test_op_type(),
+        );
+        assert!(result.is_err());
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("unsupported envelope version")
+        );
+    }
+
+    #[test]
+    fn unsupported_algorithm_rejected() {
+        let (key, _) = test_key_and_salt();
+        let fields = test_fields();
+
+        let mut envelope = encrypt_fields(
+            &key,
+            &fields,
+            &test_entity_type(),
+            &test_entity_id(),
+            &test_op_type(),
+        )
+        .unwrap();
+
+        envelope.alg = "chacha20".to_string();
+        let result = decrypt_fields(
+            &key,
+            &envelope,
+            &test_entity_type(),
+            &test_entity_id(),
+            &test_op_type(),
+        );
+        assert!(result.is_err());
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("unsupported algorithm")
+        );
+    }
+
+    #[test]
+    fn invalid_nonce_length_rejected() {
+        let (key, _) = test_key_and_salt();
+        let fields = test_fields();
+
+        let mut envelope = encrypt_fields(
+            &key,
+            &fields,
+            &test_entity_type(),
+            &test_entity_id(),
+            &test_op_type(),
+        )
+        .unwrap();
+
+        // Set nonce to wrong length (8 bytes instead of 12)
+        envelope.nonce = BASE64_STANDARD.encode([0u8; 8]);
+        let result = decrypt_fields(
+            &key,
+            &envelope,
+            &test_entity_type(),
+            &test_entity_id(),
+            &test_op_type(),
+        );
+        assert!(result.is_err());
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("invalid nonce length")
+        );
+    }
+
+    // --- AAD format ---
+
+    #[test]
+    fn aad_format_is_canonical() {
+        let aad = build_aad(1, &EntityType::Book, &test_entity_id(), &OpType::Update);
+        assert_eq!(
+            aad,
+            "v=1,entity_type=book,entity_id=01972123-abcd-7000-8000-000000000001,op_type=update"
+        );
+    }
+
+    // --- All entity types encrypt/decrypt ---
+
+    #[test]
+    fn all_entity_types_round_trip() {
+        let (key, _) = test_key_and_salt();
+        let fields = serde_json::json!({"value": "test"});
+
+        let entity_types = [
+            EntityType::Book,
+            EntityType::Session,
+            EntityType::Progress,
+            EntityType::Tag,
+            EntityType::Note,
+            EntityType::Review,
+            EntityType::Setting,
+        ];
+
+        for et in &entity_types {
+            let envelope =
+                encrypt_fields(&key, &fields, et, &test_entity_id(), &OpType::Create).unwrap();
+
+            let decrypted =
+                decrypt_fields(&key, &envelope, et, &test_entity_id(), &OpType::Create).unwrap();
+
+            assert_eq!(decrypted, fields, "round trip failed for {et}");
+        }
+    }
+}

--- a/crates/toku-core/src/error.rs
+++ b/crates/toku-core/src/error.rs
@@ -50,4 +50,7 @@ pub enum TokuError {
 
     #[error("invalid op type: {0}")]
     InvalidOpType(String),
+
+    #[error("crypto error: {0}")]
+    Crypto(String),
 }

--- a/crates/toku-core/src/lib.rs
+++ b/crates/toku-core/src/lib.rs
@@ -1,5 +1,6 @@
 mod book;
 mod config;
+pub mod crypto;
 mod error;
 pub mod filter;
 mod isbn;
@@ -9,6 +10,7 @@ pub mod sync;
 
 pub use book::*;
 pub use config::*;
+pub use crypto::*;
 pub use error::*;
 pub use filter::*;
 pub use isbn::*;

--- a/crates/toku-core/src/merge.rs
+++ b/crates/toku-core/src/merge.rs
@@ -16,6 +16,11 @@ pub enum MergeOutcome {
     AppliedWithConflicts(Vec<MergeConflict>),
     /// The op was skipped (duplicate, stale, or not applicable).
     Skipped { reason: &'static str },
+    /// The op was skipped, but a conflict was stored for user review.
+    ///
+    /// This happens when the incoming op is older than local state but both
+    /// sides independently modified the same entity (e.g. notes/reviews).
+    SkippedWithConflicts(Vec<MergeConflict>),
     /// The op was rejected (e.g. invalid reading status transition).
     Rejected { reason: String },
 }
@@ -36,5 +41,21 @@ impl MergeOutcome {
     /// Returns `true` if the outcome represents a successful application.
     pub fn was_applied(&self) -> bool {
         matches!(self, Self::Applied | Self::AppliedWithConflicts(_))
+    }
+
+    /// Returns `true` if conflicts were stored (regardless of whether the op was applied).
+    pub fn has_conflicts(&self) -> bool {
+        matches!(
+            self,
+            Self::AppliedWithConflicts(_) | Self::SkippedWithConflicts(_)
+        )
+    }
+
+    /// Returns the stored conflicts, if any.
+    pub fn conflicts(&self) -> &[MergeConflict] {
+        match self {
+            Self::AppliedWithConflicts(c) | Self::SkippedWithConflicts(c) => c,
+            _ => &[],
+        }
     }
 }

--- a/crates/toku-core/src/sync.rs
+++ b/crates/toku-core/src/sync.rs
@@ -7,6 +7,8 @@ use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use uuid::Uuid;
 
+use crate::crypto::EncryptedEnvelope;
+
 // ---------------------------------------------------------------------------
 // HLC Timestamp
 // ---------------------------------------------------------------------------
@@ -328,8 +330,14 @@ pub struct SyncOp {
     pub entity_id: Uuid,
     /// The type of mutation.
     pub op_type: OpType,
-    /// Field-level changes as a canonical JSON object. `None` for deletes.
+    /// Field-level changes as a canonical JSON object. `None` for deletes
+    /// or when encryption is enabled (see `encrypted`).
     pub fields: Option<serde_json::Value>,
+    /// Encrypted fields envelope. Present when client-side encryption is
+    /// enabled; `fields` is `None` in this case. Mutually exclusive with
+    /// `fields` (except for deletes where both may be `None`).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub encrypted: Option<EncryptedEnvelope>,
     /// SHA-256 hash of the canonical op (without the checksum field).
     pub checksum: String,
     /// When this op was created locally.
@@ -355,6 +363,7 @@ impl SyncOp {
             entity_id,
             op_type,
             fields,
+            encrypted: None,
             checksum: String::new(),
             created_at: Utc::now(),
         };
@@ -365,7 +374,8 @@ impl SyncOp {
     /// Compute the SHA-256 checksum of this op's canonical representation.
     ///
     /// The checksum covers all fields except `checksum` itself, serialized
-    /// as a canonical JSON object with sorted keys.
+    /// as a canonical JSON object with sorted keys. When encryption is
+    /// enabled, `encrypted` replaces `fields` in the checksum input.
     pub fn compute_checksum(&self) -> String {
         let mut map = BTreeMap::new();
         map.insert("v", serde_json::json!(self.v));
@@ -375,10 +385,20 @@ impl SyncOp {
         map.insert("entity_type", serde_json::json!(self.entity_type.as_str()));
         map.insert("entity_id", serde_json::json!(self.entity_id.to_string()));
         map.insert("op_type", serde_json::json!(self.op_type.as_str()));
-        map.insert(
-            "fields",
-            self.fields.clone().unwrap_or(serde_json::Value::Null),
-        );
+
+        if let Some(ref enc) = self.encrypted {
+            map.insert(
+                "encrypted",
+                serde_json::to_value(enc).expect("EncryptedEnvelope serialization cannot fail"),
+            );
+            map.insert("fields", serde_json::Value::Null);
+        } else {
+            map.insert(
+                "fields",
+                self.fields.clone().unwrap_or(serde_json::Value::Null),
+            );
+        }
+
         map.insert(
             "created_at",
             serde_json::json!(self.created_at.to_rfc3339()),
@@ -392,6 +412,48 @@ impl SyncOp {
     /// Verify this op's checksum is correct.
     pub fn verify_checksum(&self) -> bool {
         self.checksum == self.compute_checksum()
+    }
+
+    /// Encrypt this op's `fields` in place, replacing them with an
+    /// [`EncryptedEnvelope`]. The checksum is recomputed after encryption.
+    ///
+    /// No-op if `fields` is already `None` (e.g. delete ops).
+    pub fn encrypt(&mut self, key: &crate::crypto::SyncKey) -> Result<(), crate::TokuError> {
+        let Some(ref fields) = self.fields else {
+            return Ok(());
+        };
+        let envelope = crate::crypto::encrypt_fields(
+            key,
+            fields,
+            &self.entity_type,
+            &self.entity_id,
+            &self.op_type,
+        )?;
+        self.encrypted = Some(envelope);
+        self.fields = None;
+        self.checksum = self.compute_checksum();
+        Ok(())
+    }
+
+    /// Decrypt this op's encrypted envelope in place, restoring `fields`.
+    /// The checksum is recomputed after decryption.
+    ///
+    /// No-op if there is no encrypted envelope.
+    pub fn decrypt(&mut self, key: &crate::crypto::SyncKey) -> Result<(), crate::TokuError> {
+        let Some(ref envelope) = self.encrypted else {
+            return Ok(());
+        };
+        let fields = crate::crypto::decrypt_fields(
+            key,
+            envelope,
+            &self.entity_type,
+            &self.entity_id,
+            &self.op_type,
+        )?;
+        self.fields = Some(fields);
+        self.encrypted = None;
+        self.checksum = self.compute_checksum();
+        Ok(())
     }
 }
 

--- a/crates/toku-db/migrations/V15__notes_reviews_settings.sql
+++ b/crates/toku-db/migrations/V15__notes_reviews_settings.sql
@@ -1,0 +1,44 @@
+-- Notes attached to a book (personal annotations).
+CREATE TABLE notes (
+    id TEXT PRIMARY KEY NOT NULL,
+    book_id TEXT NOT NULL REFERENCES books(id),
+    content TEXT NOT NULL,
+    deleted_at TEXT,
+    deleted_by_device TEXT,
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL
+);
+CREATE INDEX idx_notes_book ON notes(book_id);
+
+-- Reviews (a user's review of a book — one per book).
+CREATE TABLE reviews (
+    id TEXT PRIMARY KEY NOT NULL,
+    book_id TEXT NOT NULL REFERENCES books(id),
+    content TEXT,
+    rating INTEGER,
+    deleted_at TEXT,
+    deleted_by_device TEXT,
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL
+);
+CREATE INDEX idx_reviews_book ON reviews(book_id);
+
+-- User settings (key-value, synced via LWW per key).
+CREATE TABLE user_settings (
+    id TEXT PRIMARY KEY NOT NULL,
+    key TEXT NOT NULL UNIQUE,
+    value TEXT NOT NULL,
+    sync_hlc TEXT,
+    updated_at TEXT NOT NULL
+);
+
+-- Per-entity HLC tracking for sync merge of notes, reviews, and other
+-- non-book entities. Tracks which device last wrote each field.
+CREATE TABLE sync_entity_hlc (
+    entity_type TEXT NOT NULL,
+    entity_id TEXT NOT NULL,
+    field_name TEXT NOT NULL,
+    sync_hlc TEXT NOT NULL,
+    device_id TEXT,
+    PRIMARY KEY (entity_type, entity_id, field_name)
+);

--- a/crates/toku-db/src/merge.rs
+++ b/crates/toku-db/src/merge.rs
@@ -9,7 +9,7 @@
 //! - **Setting** — Not yet implemented (no syncable settings table)
 
 use rusqlite::{OptionalExtension, params};
-use toku_core::merge::MergeOutcome;
+use toku_core::merge::{MergeConflict, MergeOutcome};
 use toku_core::sync::{EntityType, OpType, SyncOp};
 use uuid::Uuid;
 
@@ -54,12 +54,9 @@ impl<'a> MergeEngine<'a> {
             EntityType::Session => self.merge_session(op),
             EntityType::Progress => self.merge_progress(op),
             EntityType::Tag => self.merge_tag(op),
-            EntityType::Note | EntityType::Review => Ok(MergeOutcome::Skipped {
-                reason: "note/review merge not yet implemented",
-            }),
-            EntityType::Setting => Ok(MergeOutcome::Skipped {
-                reason: "setting merge not yet implemented",
-            }),
+            EntityType::Note => self.merge_note(op),
+            EntityType::Review => self.merge_review(op),
+            EntityType::Setting => self.merge_setting(op),
             EntityType::Device => Ok(MergeOutcome::Skipped {
                 reason: "device ops handled separately",
             }),
@@ -593,6 +590,469 @@ impl<'a> MergeEngine<'a> {
     }
 
     // -----------------------------------------------------------------------
+    // Note — LWW with conflict detection
+    // -----------------------------------------------------------------------
+
+    fn merge_note(&self, op: &SyncOp) -> Result<MergeOutcome, DbError> {
+        match op.op_type {
+            OpType::Create => self.merge_note_create(op),
+            OpType::Update => self.merge_note_update(op),
+            OpType::Delete => self.merge_note_delete(op),
+        }
+    }
+
+    fn merge_note_create(&self, op: &SyncOp) -> Result<MergeOutcome, DbError> {
+        let note_id = op.entity_id.to_string();
+
+        let exists: bool = self.db.conn.query_row(
+            "SELECT EXISTS(SELECT 1 FROM notes WHERE id = ?1)",
+            params![note_id],
+            |row| row.get(0),
+        )?;
+        if exists {
+            return self.merge_note_update(op);
+        }
+
+        let fields = match &op.fields {
+            Some(v) if v.is_object() => v,
+            _ => {
+                return Ok(MergeOutcome::Rejected {
+                    reason: "note create op missing fields".to_string(),
+                });
+            }
+        };
+        let obj = fields.as_object().unwrap();
+
+        let book_id = obj
+            .get("book_id")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| DbError::InvalidOperation("note missing book_id".to_string()))?;
+        let content = obj.get("content").and_then(|v| v.as_str()).unwrap_or("");
+        let now = op.created_at.to_rfc3339();
+
+        self.db.conn.execute(
+            "INSERT INTO notes (id, book_id, content, created_at, updated_at)
+             VALUES (?1, ?2, ?3, ?4, ?5)",
+            params![note_id, book_id, content, now, now],
+        )?;
+
+        Ok(MergeOutcome::Applied)
+    }
+
+    fn merge_note_update(&self, op: &SyncOp) -> Result<MergeOutcome, DbError> {
+        let note_id = op.entity_id.to_string();
+        let hlc_str = op.hlc.to_canonical();
+        let device_id = op.device_id.to_string();
+
+        // Check note exists and is not deleted
+        let row: Option<(String, bool)> = self
+            .db
+            .conn
+            .query_row(
+                "SELECT content, deleted_at IS NOT NULL FROM notes WHERE id = ?1",
+                params![note_id],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .optional()?;
+
+        let Some((local_content, deleted)) = row else {
+            return Ok(MergeOutcome::Skipped {
+                reason: "note not found",
+            });
+        };
+        if deleted {
+            return Ok(MergeOutcome::Skipped {
+                reason: "note is deleted",
+            });
+        }
+
+        let fields = match &op.fields {
+            Some(v) if v.is_object() => v,
+            _ => {
+                return Ok(MergeOutcome::Skipped {
+                    reason: "update op has no fields",
+                });
+            }
+        };
+        let obj = fields.as_object().unwrap();
+        let new_content = obj.get("content").and_then(|v| v.as_str()).unwrap_or("");
+
+        let (local_hlc, local_device) = self.get_entity_hlc("note", &note_id, "content")?;
+
+        // Determine if this is a genuine conflict (different device edited)
+        let is_conflict = local_hlc.is_some()
+            && local_device.as_deref() != Some(&device_id)
+            && local_content != new_content;
+
+        if let Some(ref lh) = local_hlc
+            && hlc_str <= *lh
+        {
+            // Incoming is older — skip but store conflict if genuine
+            if is_conflict {
+                let conflict = self.store_conflict(
+                    &op.entity_type,
+                    &op.entity_id,
+                    "content",
+                    Some(&local_content),
+                    Some(new_content),
+                    lh,
+                    &hlc_str,
+                )?;
+                return Ok(MergeOutcome::SkippedWithConflicts(vec![conflict]));
+            }
+            return Ok(MergeOutcome::Skipped {
+                reason: "note content is up to date",
+            });
+        }
+
+        let now = chrono::Utc::now().to_rfc3339();
+        self.db.conn.execute(
+            "UPDATE notes SET content = ?1, updated_at = ?2 WHERE id = ?3",
+            params![new_content, now, note_id],
+        )?;
+        self.upsert_entity_hlc("note", &note_id, "content", &hlc_str, &device_id)?;
+
+        if is_conflict {
+            let conflict = self.store_conflict(
+                &op.entity_type,
+                &op.entity_id,
+                "content",
+                Some(&local_content),
+                Some(new_content),
+                local_hlc.as_deref().unwrap_or(""),
+                &hlc_str,
+            )?;
+            return Ok(MergeOutcome::AppliedWithConflicts(vec![conflict]));
+        }
+
+        Ok(MergeOutcome::Applied)
+    }
+
+    fn merge_note_delete(&self, op: &SyncOp) -> Result<MergeOutcome, DbError> {
+        let note_id = op.entity_id.to_string();
+        let hlc_str = op.hlc.to_canonical();
+        let device_id = op.device_id.to_string();
+
+        let count = self.db.conn.execute(
+            "UPDATE notes SET deleted_at = ?1, deleted_by_device = ?2
+             WHERE id = ?3 AND deleted_at IS NULL",
+            params![hlc_str, device_id, note_id],
+        )?;
+
+        if count > 0 {
+            Ok(MergeOutcome::Applied)
+        } else {
+            Ok(MergeOutcome::Skipped {
+                reason: "note not found or already deleted",
+            })
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Review — LWW per field with conflict detection
+    // -----------------------------------------------------------------------
+
+    fn merge_review(&self, op: &SyncOp) -> Result<MergeOutcome, DbError> {
+        match op.op_type {
+            OpType::Create => self.merge_review_create(op),
+            OpType::Update => self.merge_review_update(op),
+            OpType::Delete => self.merge_review_delete(op),
+        }
+    }
+
+    fn merge_review_create(&self, op: &SyncOp) -> Result<MergeOutcome, DbError> {
+        let review_id = op.entity_id.to_string();
+
+        let exists: bool = self.db.conn.query_row(
+            "SELECT EXISTS(SELECT 1 FROM reviews WHERE id = ?1)",
+            params![review_id],
+            |row| row.get(0),
+        )?;
+        if exists {
+            return self.merge_review_update(op);
+        }
+
+        let fields = match &op.fields {
+            Some(v) if v.is_object() => v,
+            _ => {
+                return Ok(MergeOutcome::Rejected {
+                    reason: "review create op missing fields".to_string(),
+                });
+            }
+        };
+        let obj = fields.as_object().unwrap();
+
+        let book_id = obj
+            .get("book_id")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| DbError::InvalidOperation("review missing book_id".to_string()))?;
+        let content = obj.get("content").and_then(|v| v.as_str());
+        let rating = obj.get("rating").and_then(|v| v.as_i64());
+        let now = op.created_at.to_rfc3339();
+
+        self.db.conn.execute(
+            "INSERT INTO reviews (id, book_id, content, rating, created_at, updated_at)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+            params![review_id, book_id, content, rating, now, now],
+        )?;
+
+        Ok(MergeOutcome::Applied)
+    }
+
+    fn merge_review_update(&self, op: &SyncOp) -> Result<MergeOutcome, DbError> {
+        let review_id = op.entity_id.to_string();
+        let hlc_str = op.hlc.to_canonical();
+        let device_id = op.device_id.to_string();
+
+        // Check review exists and is not deleted
+        let row: Option<(Option<String>, Option<i64>, bool)> = self
+            .db
+            .conn
+            .query_row(
+                "SELECT content, rating, deleted_at IS NOT NULL FROM reviews WHERE id = ?1",
+                params![review_id],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+            )
+            .optional()?;
+
+        let Some((local_content, local_rating, deleted)) = row else {
+            return Ok(MergeOutcome::Skipped {
+                reason: "review not found",
+            });
+        };
+        if deleted {
+            return Ok(MergeOutcome::Skipped {
+                reason: "review is deleted",
+            });
+        }
+
+        let fields = match &op.fields {
+            Some(v) if v.is_object() => v,
+            _ => {
+                return Ok(MergeOutcome::Skipped {
+                    reason: "update op has no fields",
+                });
+            }
+        };
+        let obj = fields.as_object().unwrap();
+        let now = chrono::Utc::now().to_rfc3339();
+        let mut applied_any = false;
+        let mut conflicts = Vec::new();
+
+        // Field: content
+        if let Some(new_content_val) = obj.get("content") {
+            let new_content = new_content_val.as_str();
+            let (lh, ld) = self.get_entity_hlc("review", &review_id, "content")?;
+
+            let is_conflict = lh.is_some()
+                && ld.as_deref() != Some(&device_id)
+                && local_content.as_deref() != new_content;
+
+            let should_apply = match &lh {
+                Some(lh) => hlc_str > *lh,
+                None => true,
+            };
+
+            if should_apply {
+                self.db.conn.execute(
+                    "UPDATE reviews SET content = ?1, updated_at = ?2 WHERE id = ?3",
+                    params![new_content, now, review_id],
+                )?;
+                self.upsert_entity_hlc("review", &review_id, "content", &hlc_str, &device_id)?;
+                applied_any = true;
+
+                if is_conflict {
+                    conflicts.push(self.store_conflict(
+                        &op.entity_type,
+                        &op.entity_id,
+                        "content",
+                        local_content.as_deref(),
+                        new_content,
+                        lh.as_deref().unwrap_or(""),
+                        &hlc_str,
+                    )?);
+                }
+            } else if is_conflict {
+                conflicts.push(self.store_conflict(
+                    &op.entity_type,
+                    &op.entity_id,
+                    "content",
+                    local_content.as_deref(),
+                    new_content,
+                    lh.as_deref().unwrap_or(""),
+                    &hlc_str,
+                )?);
+            }
+        }
+
+        // Field: rating
+        if let Some(new_rating_val) = obj.get("rating") {
+            let new_rating = new_rating_val.as_i64();
+            let (lh, ld) = self.get_entity_hlc("review", &review_id, "rating")?;
+
+            let local_rating_str = local_rating.map(|r| r.to_string());
+            let new_rating_str = new_rating.map(|r| r.to_string());
+            let is_conflict = lh.is_some()
+                && ld.as_deref() != Some(&device_id)
+                && local_rating_str != new_rating_str;
+
+            let should_apply = match &lh {
+                Some(lh) => hlc_str > *lh,
+                None => true,
+            };
+
+            if should_apply {
+                self.db.conn.execute(
+                    "UPDATE reviews SET rating = ?1, updated_at = ?2 WHERE id = ?3",
+                    params![new_rating, now, review_id],
+                )?;
+                self.upsert_entity_hlc("review", &review_id, "rating", &hlc_str, &device_id)?;
+                applied_any = true;
+
+                if is_conflict {
+                    conflicts.push(self.store_conflict(
+                        &op.entity_type,
+                        &op.entity_id,
+                        "rating",
+                        local_rating_str.as_deref(),
+                        new_rating_str.as_deref(),
+                        lh.as_deref().unwrap_or(""),
+                        &hlc_str,
+                    )?);
+                }
+            } else if is_conflict {
+                conflicts.push(self.store_conflict(
+                    &op.entity_type,
+                    &op.entity_id,
+                    "rating",
+                    local_rating_str.as_deref(),
+                    new_rating_str.as_deref(),
+                    lh.as_deref().unwrap_or(""),
+                    &hlc_str,
+                )?);
+            }
+        }
+
+        if !conflicts.is_empty() {
+            if applied_any {
+                return Ok(MergeOutcome::AppliedWithConflicts(conflicts));
+            } else {
+                return Ok(MergeOutcome::SkippedWithConflicts(conflicts));
+            }
+        }
+        if applied_any {
+            Ok(MergeOutcome::Applied)
+        } else {
+            Ok(MergeOutcome::Skipped {
+                reason: "all review fields are up to date",
+            })
+        }
+    }
+
+    fn merge_review_delete(&self, op: &SyncOp) -> Result<MergeOutcome, DbError> {
+        let review_id = op.entity_id.to_string();
+        let hlc_str = op.hlc.to_canonical();
+        let device_id = op.device_id.to_string();
+
+        let count = self.db.conn.execute(
+            "UPDATE reviews SET deleted_at = ?1, deleted_by_device = ?2
+             WHERE id = ?3 AND deleted_at IS NULL",
+            params![hlc_str, device_id, review_id],
+        )?;
+
+        if count > 0 {
+            Ok(MergeOutcome::Applied)
+        } else {
+            Ok(MergeOutcome::Skipped {
+                reason: "review not found or already deleted",
+            })
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Setting — LWW per key
+    // -----------------------------------------------------------------------
+
+    fn merge_setting(&self, op: &SyncOp) -> Result<MergeOutcome, DbError> {
+        match op.op_type {
+            OpType::Create => self.merge_setting_upsert(op),
+            OpType::Update => self.merge_setting_upsert(op),
+            OpType::Delete => self.merge_setting_delete(op),
+        }
+    }
+
+    fn merge_setting_upsert(&self, op: &SyncOp) -> Result<MergeOutcome, DbError> {
+        let setting_id = op.entity_id.to_string();
+        let hlc_str = op.hlc.to_canonical();
+
+        let fields = match &op.fields {
+            Some(v) if v.is_object() => v,
+            _ => {
+                return Ok(MergeOutcome::Rejected {
+                    reason: "setting op missing fields".to_string(),
+                });
+            }
+        };
+        let obj = fields.as_object().unwrap();
+
+        let key = obj
+            .get("key")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| DbError::InvalidOperation("setting missing key".to_string()))?;
+        let value = obj
+            .get("value")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| DbError::InvalidOperation("setting missing value".to_string()))?;
+
+        // Check if setting exists and compare HLC
+        let existing: Option<(String, Option<String>)> = self
+            .db
+            .conn
+            .query_row(
+                "SELECT value, sync_hlc FROM user_settings WHERE id = ?1",
+                params![setting_id],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .optional()?;
+
+        if let Some((_, Some(ref lh))) = existing
+            && hlc_str <= *lh
+        {
+            return Ok(MergeOutcome::Skipped {
+                reason: "setting is up to date",
+            });
+        }
+
+        let now = chrono::Utc::now().to_rfc3339();
+        self.db.conn.execute(
+            "INSERT INTO user_settings (id, key, value, sync_hlc, updated_at)
+             VALUES (?1, ?2, ?3, ?4, ?5)
+             ON CONFLICT(id) DO UPDATE SET value = ?3, sync_hlc = ?4, updated_at = ?5
+             WHERE sync_hlc IS NULL OR sync_hlc < ?4",
+            params![setting_id, key, value, hlc_str, now],
+        )?;
+
+        Ok(MergeOutcome::Applied)
+    }
+
+    fn merge_setting_delete(&self, op: &SyncOp) -> Result<MergeOutcome, DbError> {
+        let setting_id = op.entity_id.to_string();
+
+        let count = self.db.conn.execute(
+            "DELETE FROM user_settings WHERE id = ?1",
+            params![setting_id],
+        )?;
+
+        if count > 0 {
+            Ok(MergeOutcome::Applied)
+        } else {
+            Ok(MergeOutcome::Skipped {
+                reason: "setting not found",
+            })
+        }
+    }
+
+    // -----------------------------------------------------------------------
     // Helpers
     // -----------------------------------------------------------------------
 
@@ -606,6 +1066,94 @@ impl<'a> MergeEngine<'a> {
             params![book_id, field_name, hlc],
         )?;
         Ok(())
+    }
+
+    /// Upsert an entity-level HLC record for non-book entities.
+    fn upsert_entity_hlc(
+        &self,
+        entity_type: &str,
+        entity_id: &str,
+        field_name: &str,
+        hlc: &str,
+        device_id: &str,
+    ) -> Result<(), DbError> {
+        self.db.conn.execute(
+            "INSERT INTO sync_entity_hlc (entity_type, entity_id, field_name, sync_hlc, device_id)
+             VALUES (?1, ?2, ?3, ?4, ?5)
+             ON CONFLICT (entity_type, entity_id, field_name) DO UPDATE
+             SET sync_hlc = ?4, device_id = ?5
+             WHERE sync_hlc < ?4",
+            params![entity_type, entity_id, field_name, hlc, device_id],
+        )?;
+        Ok(())
+    }
+
+    /// Get the current HLC and device for an entity field.
+    fn get_entity_hlc(
+        &self,
+        entity_type: &str,
+        entity_id: &str,
+        field_name: &str,
+    ) -> Result<(Option<String>, Option<String>), DbError> {
+        let result: Option<(String, Option<String>)> = self
+            .db
+            .conn
+            .query_row(
+                "SELECT sync_hlc, device_id FROM sync_entity_hlc
+                 WHERE entity_type = ?1 AND entity_id = ?2 AND field_name = ?3",
+                params![entity_type, entity_id, field_name],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .optional()?;
+
+        match result {
+            Some((hlc, device)) => Ok((Some(hlc), device)),
+            None => Ok((None, None)),
+        }
+    }
+
+    /// Store a conflict in the sync_conflicts table for user review.
+    #[allow(clippy::too_many_arguments)]
+    fn store_conflict(
+        &self,
+        entity_type: &EntityType,
+        entity_id: &Uuid,
+        field_name: &str,
+        local_value: Option<&str>,
+        remote_value: Option<&str>,
+        local_hlc: &str,
+        remote_hlc: &str,
+    ) -> Result<MergeConflict, DbError> {
+        let conflict_id = Uuid::now_v7().to_string();
+        let now = chrono::Utc::now().to_rfc3339();
+
+        self.db.conn.execute(
+            "INSERT OR IGNORE INTO sync_conflicts
+             (id, entity_type, entity_id, field_name, local_value, remote_value,
+              local_hlc, remote_hlc, resolved, created_at)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, 0, ?9)",
+            params![
+                conflict_id,
+                entity_type.as_str(),
+                entity_id.to_string(),
+                field_name,
+                local_value,
+                remote_value,
+                local_hlc,
+                remote_hlc,
+                now,
+            ],
+        )?;
+
+        Ok(MergeConflict {
+            entity_type: *entity_type,
+            entity_id: *entity_id,
+            field_name: field_name.to_string(),
+            local_value: local_value.map(|s| s.to_string()),
+            remote_value: remote_value.map(|s| s.to_string()),
+            local_hlc: local_hlc.to_string(),
+            remote_hlc: remote_hlc.to_string(),
+        })
     }
 }
 
@@ -1569,8 +2117,78 @@ mod tests {
         assert_eq!(count, 2);
     }
 
+    // -------------------------------------------------------------------
+    // Note — LWW with conflict detection
+    // -------------------------------------------------------------------
+
+    fn make_note_create(
+        device_id: uuid::Uuid,
+        hlc: HlcTimestamp,
+        note_id: uuid::Uuid,
+        book_id: uuid::Uuid,
+        content: &str,
+    ) -> SyncOp {
+        SyncOp::new(
+            device_id,
+            hlc,
+            EntityType::Note,
+            note_id,
+            OpType::Create,
+            Some(serde_json::json!({
+                "book_id": book_id.to_string(),
+                "content": content,
+            })),
+        )
+    }
+
+    fn make_note_update(
+        device_id: uuid::Uuid,
+        hlc: HlcTimestamp,
+        note_id: uuid::Uuid,
+        content: &str,
+    ) -> SyncOp {
+        SyncOp::new(
+            device_id,
+            hlc,
+            EntityType::Note,
+            note_id,
+            OpType::Update,
+            Some(serde_json::json!({
+                "content": content,
+            })),
+        )
+    }
+
     #[test]
-    fn note_review_merge_skipped_for_now() {
+    fn note_create_inserts_new() {
+        let db = setup_db();
+        let engine = MergeEngine::new(&db);
+        let dev_a = Uuid::now_v7();
+        let mut clock = make_clock(&dev_a);
+        let book_id = Uuid::now_v7();
+        let note_id = Uuid::now_v7();
+
+        let create = make_book_create(dev_a, clock.now(), book_id, "Dune");
+        engine.apply_op(&create).unwrap();
+
+        let op = make_note_create(dev_a, clock.now(), note_id, book_id, "Great book");
+        let result = engine.apply_op(&op).unwrap();
+        assert!(result.was_applied());
+        assert!(!result.has_conflicts());
+
+        let content: String = db
+            .conn
+            .query_row(
+                "SELECT content FROM notes WHERE id = ?1",
+                params![note_id.to_string()],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(content, "Great book");
+    }
+
+    #[test]
+    fn note_create_missing_fields_rejected() {
         let db = setup_db();
         let engine = MergeEngine::new(&db);
         let dev_a = Uuid::now_v7();
@@ -1585,18 +2203,758 @@ mod tests {
             None,
         );
         let result = engine.apply_op(&op).unwrap();
-        assert!(matches!(result, MergeOutcome::Skipped { .. }));
+        assert!(matches!(result, MergeOutcome::Rejected { .. }));
+    }
+
+    #[test]
+    fn note_update_from_same_device_no_conflict() {
+        let db = setup_db();
+        let engine = MergeEngine::new(&db);
+        let dev_a = Uuid::now_v7();
+        let mut clock = make_clock(&dev_a);
+        let book_id = Uuid::now_v7();
+        let note_id = Uuid::now_v7();
+
+        let create = make_book_create(dev_a, clock.now(), book_id, "Dune");
+        engine.apply_op(&create).unwrap();
+
+        let op = make_note_create(dev_a, clock.now(), note_id, book_id, "Draft 1");
+        engine.apply_op(&op).unwrap();
+
+        // Same device updates note — no conflict
+        let update = make_note_update(dev_a, clock.now(), note_id, "Draft 2");
+        let result = engine.apply_op(&update).unwrap();
+        assert!(result.was_applied());
+        assert!(!result.has_conflicts());
+
+        let content: String = db
+            .conn
+            .query_row(
+                "SELECT content FROM notes WHERE id = ?1",
+                params![note_id.to_string()],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(content, "Draft 2");
+    }
+
+    #[test]
+    fn note_two_devices_conflict_detected() {
+        let db = setup_db();
+        let engine = MergeEngine::new(&db);
+        let dev_a = Uuid::now_v7();
+        let dev_b = Uuid::now_v7();
+        let book_id = Uuid::now_v7();
+        let note_id = Uuid::now_v7();
+
+        // Device A creates book and note
+        let hlc_create = HlcTimestamp::new(
+            chrono::DateTime::parse_from_rfc3339("2025-01-01T00:00:00Z")
+                .unwrap()
+                .with_timezone(&chrono::Utc),
+            0,
+            "aaaaaaaaaaaa",
+        );
+        let create = make_book_create(dev_a, hlc_create.clone(), book_id, "Dune");
+        engine.apply_op(&create).unwrap();
+
+        let hlc_note = HlcTimestamp::new(
+            chrono::DateTime::parse_from_rfc3339("2025-02-01T00:00:00Z")
+                .unwrap()
+                .with_timezone(&chrono::Utc),
+            0,
+            "aaaaaaaaaaaa",
+        );
+        let note_create = make_note_create(dev_a, hlc_note, note_id, book_id, "Original");
+        engine.apply_op(&note_create).unwrap();
+
+        // Device A updates note at T1
+        let hlc_a = HlcTimestamp::new(
+            chrono::DateTime::parse_from_rfc3339("2025-06-01T00:00:00Z")
+                .unwrap()
+                .with_timezone(&chrono::Utc),
+            0,
+            "aaaaaaaaaaaa",
+        );
+        let op_a = make_note_update(dev_a, hlc_a, note_id, "Edit from A");
+        engine.apply_op(&op_a).unwrap();
+
+        // Device B updates note at T2 (later) — conflict: both devices edited
+        let hlc_b = HlcTimestamp::new(
+            chrono::DateTime::parse_from_rfc3339("2025-06-01T00:00:01Z")
+                .unwrap()
+                .with_timezone(&chrono::Utc),
+            0,
+            "bbbbbbbbbbbb",
+        );
+        let op_b = make_note_update(dev_b, hlc_b, note_id, "Edit from B");
+        let result = engine.apply_op(&op_b).unwrap();
+
+        // B's edit wins (newer HLC), but conflict is stored
+        assert!(result.was_applied());
+        assert!(result.has_conflicts());
+        let conflicts = result.conflicts();
+        assert_eq!(conflicts.len(), 1);
+        assert_eq!(conflicts[0].field_name, "content");
+        assert_eq!(conflicts[0].local_value.as_deref(), Some("Edit from A"));
+        assert_eq!(conflicts[0].remote_value.as_deref(), Some("Edit from B"));
+
+        // Note content should be B's edit
+        let content: String = db
+            .conn
+            .query_row(
+                "SELECT content FROM notes WHERE id = ?1",
+                params![note_id.to_string()],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(content, "Edit from B");
+
+        // Conflict should be in sync_conflicts table
+        let conflict_count: i64 = db
+            .conn
+            .query_row(
+                "SELECT COUNT(*) FROM sync_conflicts
+                 WHERE entity_type = 'note' AND entity_id = ?1",
+                params![note_id.to_string()],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(conflict_count, 1);
+    }
+
+    #[test]
+    fn note_two_devices_older_edit_skipped_with_conflict() {
+        let db = setup_db();
+        let engine = MergeEngine::new(&db);
+        let dev_a = Uuid::now_v7();
+        let dev_b = Uuid::now_v7();
+        let book_id = Uuid::now_v7();
+        let note_id = Uuid::now_v7();
+
+        // Setup: create book and note
+        let hlc_0 = HlcTimestamp::new(
+            chrono::DateTime::parse_from_rfc3339("2025-01-01T00:00:00Z")
+                .unwrap()
+                .with_timezone(&chrono::Utc),
+            0,
+            "aaaaaaaaaaaa",
+        );
+        let create = make_book_create(dev_a, hlc_0.clone(), book_id, "Dune");
+        engine.apply_op(&create).unwrap();
+        let note_op = make_note_create(dev_a, hlc_0, note_id, book_id, "Original");
+        engine.apply_op(&note_op).unwrap();
+
+        // Device A edits at T2 (later)
+        let hlc_a = HlcTimestamp::new(
+            chrono::DateTime::parse_from_rfc3339("2025-06-01T00:00:01Z")
+                .unwrap()
+                .with_timezone(&chrono::Utc),
+            0,
+            "aaaaaaaaaaaa",
+        );
+        let op_a = make_note_update(dev_a, hlc_a, note_id, "Latest from A");
+        engine.apply_op(&op_a).unwrap();
+
+        // Device B edits at T1 (earlier) — arrives after A's edit
+        let hlc_b = HlcTimestamp::new(
+            chrono::DateTime::parse_from_rfc3339("2025-06-01T00:00:00Z")
+                .unwrap()
+                .with_timezone(&chrono::Utc),
+            0,
+            "bbbbbbbbbbbb",
+        );
+        let op_b = make_note_update(dev_b, hlc_b, note_id, "Older from B");
+        let result = engine.apply_op(&op_b).unwrap();
+
+        // B's edit is skipped (older HLC), but conflict is stored
+        assert!(!result.was_applied());
+        assert!(result.has_conflicts());
+        assert!(matches!(result, MergeOutcome::SkippedWithConflicts(_)));
+
+        // Note content should still be A's edit
+        let content: String = db
+            .conn
+            .query_row(
+                "SELECT content FROM notes WHERE id = ?1",
+                params![note_id.to_string()],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(content, "Latest from A");
+    }
+
+    #[test]
+    fn note_delete_sets_tombstone() {
+        let db = setup_db();
+        let engine = MergeEngine::new(&db);
+        let dev_a = Uuid::now_v7();
+        let mut clock = make_clock(&dev_a);
+        let book_id = Uuid::now_v7();
+        let note_id = Uuid::now_v7();
+
+        let create = make_book_create(dev_a, clock.now(), book_id, "Dune");
+        engine.apply_op(&create).unwrap();
+        let note = make_note_create(dev_a, clock.now(), note_id, book_id, "A note");
+        engine.apply_op(&note).unwrap();
+
+        let del = SyncOp::new(
+            dev_a,
+            clock.now(),
+            EntityType::Note,
+            note_id,
+            OpType::Delete,
+            None,
+        );
+        let result = engine.apply_op(&del).unwrap();
+        assert!(result.was_applied());
+
+        let deleted: bool = db
+            .conn
+            .query_row(
+                "SELECT deleted_at IS NOT NULL FROM notes WHERE id = ?1",
+                params![note_id.to_string()],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert!(deleted);
+    }
+
+    #[test]
+    fn note_update_after_delete_is_skipped() {
+        let db = setup_db();
+        let engine = MergeEngine::new(&db);
+        let dev_a = Uuid::now_v7();
+        let mut clock = make_clock(&dev_a);
+        let book_id = Uuid::now_v7();
+        let note_id = Uuid::now_v7();
+
+        let create = make_book_create(dev_a, clock.now(), book_id, "Dune");
+        engine.apply_op(&create).unwrap();
+        let note = make_note_create(dev_a, clock.now(), note_id, book_id, "A note");
+        engine.apply_op(&note).unwrap();
+
+        let del = SyncOp::new(
+            dev_a,
+            clock.now(),
+            EntityType::Note,
+            note_id,
+            OpType::Delete,
+            None,
+        );
+        engine.apply_op(&del).unwrap();
+
+        let update = make_note_update(dev_a, clock.now(), note_id, "Updated after delete");
+        let result = engine.apply_op(&update).unwrap();
+        assert!(matches!(result, MergeOutcome::Skipped { reason } if reason == "note is deleted"));
+    }
+
+    // -------------------------------------------------------------------
+    // Review — LWW per field with conflict detection
+    // -------------------------------------------------------------------
+
+    #[test]
+    fn review_create_inserts_new() {
+        let db = setup_db();
+        let engine = MergeEngine::new(&db);
+        let dev_a = Uuid::now_v7();
+        let mut clock = make_clock(&dev_a);
+        let book_id = Uuid::now_v7();
+        let review_id = Uuid::now_v7();
+
+        let create = make_book_create(dev_a, clock.now(), book_id, "Dune");
+        engine.apply_op(&create).unwrap();
 
         let op = SyncOp::new(
             dev_a,
             clock.now(),
             EntityType::Review,
-            Uuid::now_v7(),
+            review_id,
+            OpType::Create,
+            Some(serde_json::json!({
+                "book_id": book_id.to_string(),
+                "content": "Amazing book",
+                "rating": 9,
+            })),
+        );
+        let result = engine.apply_op(&op).unwrap();
+        assert!(result.was_applied());
+
+        let (content, rating): (Option<String>, Option<i64>) = db
+            .conn
+            .query_row(
+                "SELECT content, rating FROM reviews WHERE id = ?1",
+                params![review_id.to_string()],
+                |r| Ok((r.get(0)?, r.get(1)?)),
+            )
+            .unwrap();
+        assert_eq!(content.as_deref(), Some("Amazing book"));
+        assert_eq!(rating, Some(9));
+    }
+
+    #[test]
+    fn review_two_devices_different_fields_no_conflict() {
+        let db = setup_db();
+        let engine = MergeEngine::new(&db);
+        let dev_a = Uuid::now_v7();
+        let dev_b = Uuid::now_v7();
+        let book_id = Uuid::now_v7();
+        let review_id = Uuid::now_v7();
+
+        // Create book and review
+        let hlc_0 = HlcTimestamp::new(
+            chrono::DateTime::parse_from_rfc3339("2025-01-01T00:00:00Z")
+                .unwrap()
+                .with_timezone(&chrono::Utc),
+            0,
+            "aaaaaaaaaaaa",
+        );
+        let create = make_book_create(dev_a, hlc_0.clone(), book_id, "Dune");
+        engine.apply_op(&create).unwrap();
+
+        let review_create = SyncOp::new(
+            dev_a,
+            hlc_0,
+            EntityType::Review,
+            review_id,
+            OpType::Create,
+            Some(serde_json::json!({
+                "book_id": book_id.to_string(),
+                "content": "Good",
+                "rating": 7,
+            })),
+        );
+        engine.apply_op(&review_create).unwrap();
+
+        // Device A edits content
+        let hlc_a = HlcTimestamp::new(
+            chrono::DateTime::parse_from_rfc3339("2025-06-01T00:00:00Z")
+                .unwrap()
+                .with_timezone(&chrono::Utc),
+            0,
+            "aaaaaaaaaaaa",
+        );
+        let op_a = SyncOp::new(
+            dev_a,
+            hlc_a,
+            EntityType::Review,
+            review_id,
             OpType::Update,
+            Some(serde_json::json!({"content": "Updated review text"})),
+        );
+        engine.apply_op(&op_a).unwrap();
+
+        // Device B edits rating (different field — no conflict)
+        let hlc_b = HlcTimestamp::new(
+            chrono::DateTime::parse_from_rfc3339("2025-06-01T00:00:01Z")
+                .unwrap()
+                .with_timezone(&chrono::Utc),
+            0,
+            "bbbbbbbbbbbb",
+        );
+        let op_b = SyncOp::new(
+            dev_b,
+            hlc_b,
+            EntityType::Review,
+            review_id,
+            OpType::Update,
+            Some(serde_json::json!({"rating": 9})),
+        );
+        let result = engine.apply_op(&op_b).unwrap();
+        assert!(result.was_applied());
+        assert!(!result.has_conflicts());
+
+        let (content, rating): (Option<String>, Option<i64>) = db
+            .conn
+            .query_row(
+                "SELECT content, rating FROM reviews WHERE id = ?1",
+                params![review_id.to_string()],
+                |r| Ok((r.get(0)?, r.get(1)?)),
+            )
+            .unwrap();
+        assert_eq!(content.as_deref(), Some("Updated review text"));
+        assert_eq!(rating, Some(9));
+    }
+
+    #[test]
+    fn review_two_devices_same_field_conflict_detected() {
+        let db = setup_db();
+        let engine = MergeEngine::new(&db);
+        let dev_a = Uuid::now_v7();
+        let dev_b = Uuid::now_v7();
+        let book_id = Uuid::now_v7();
+        let review_id = Uuid::now_v7();
+
+        let hlc_0 = HlcTimestamp::new(
+            chrono::DateTime::parse_from_rfc3339("2025-01-01T00:00:00Z")
+                .unwrap()
+                .with_timezone(&chrono::Utc),
+            0,
+            "aaaaaaaaaaaa",
+        );
+        let create = make_book_create(dev_a, hlc_0.clone(), book_id, "Dune");
+        engine.apply_op(&create).unwrap();
+
+        let review_create = SyncOp::new(
+            dev_a,
+            hlc_0,
+            EntityType::Review,
+            review_id,
+            OpType::Create,
+            Some(serde_json::json!({
+                "book_id": book_id.to_string(),
+                "content": "Original",
+                "rating": 7,
+            })),
+        );
+        engine.apply_op(&review_create).unwrap();
+
+        // Device A edits content
+        let hlc_a = HlcTimestamp::new(
+            chrono::DateTime::parse_from_rfc3339("2025-06-01T00:00:00Z")
+                .unwrap()
+                .with_timezone(&chrono::Utc),
+            0,
+            "aaaaaaaaaaaa",
+        );
+        let op_a = SyncOp::new(
+            dev_a,
+            hlc_a,
+            EntityType::Review,
+            review_id,
+            OpType::Update,
+            Some(serde_json::json!({"content": "Review from A"})),
+        );
+        engine.apply_op(&op_a).unwrap();
+
+        // Device B also edits content (later HLC — wins, but conflict stored)
+        let hlc_b = HlcTimestamp::new(
+            chrono::DateTime::parse_from_rfc3339("2025-06-01T00:00:01Z")
+                .unwrap()
+                .with_timezone(&chrono::Utc),
+            0,
+            "bbbbbbbbbbbb",
+        );
+        let op_b = SyncOp::new(
+            dev_b,
+            hlc_b,
+            EntityType::Review,
+            review_id,
+            OpType::Update,
+            Some(serde_json::json!({"content": "Review from B"})),
+        );
+        let result = engine.apply_op(&op_b).unwrap();
+
+        assert!(result.was_applied());
+        assert!(result.has_conflicts());
+        let conflicts = result.conflicts();
+        assert_eq!(conflicts.len(), 1);
+        assert_eq!(conflicts[0].field_name, "content");
+
+        let content: String = db
+            .conn
+            .query_row(
+                "SELECT content FROM reviews WHERE id = ?1",
+                params![review_id.to_string()],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(content, "Review from B");
+    }
+
+    #[test]
+    fn review_delete_sets_tombstone() {
+        let db = setup_db();
+        let engine = MergeEngine::new(&db);
+        let dev_a = Uuid::now_v7();
+        let mut clock = make_clock(&dev_a);
+        let book_id = Uuid::now_v7();
+        let review_id = Uuid::now_v7();
+
+        let create = make_book_create(dev_a, clock.now(), book_id, "Dune");
+        engine.apply_op(&create).unwrap();
+
+        let review = SyncOp::new(
+            dev_a,
+            clock.now(),
+            EntityType::Review,
+            review_id,
+            OpType::Create,
+            Some(serde_json::json!({
+                "book_id": book_id.to_string(),
+                "content": "Great",
+            })),
+        );
+        engine.apply_op(&review).unwrap();
+
+        let del = SyncOp::new(
+            dev_a,
+            clock.now(),
+            EntityType::Review,
+            review_id,
+            OpType::Delete,
+            None,
+        );
+        let result = engine.apply_op(&del).unwrap();
+        assert!(result.was_applied());
+
+        let deleted: bool = db
+            .conn
+            .query_row(
+                "SELECT deleted_at IS NOT NULL FROM reviews WHERE id = ?1",
+                params![review_id.to_string()],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert!(deleted);
+    }
+
+    // -------------------------------------------------------------------
+    // Setting — LWW per key
+    // -------------------------------------------------------------------
+
+    #[test]
+    fn setting_create_inserts_new() {
+        let db = setup_db();
+        let engine = MergeEngine::new(&db);
+        let dev_a = Uuid::now_v7();
+        let mut clock = make_clock(&dev_a);
+        let setting_id = Uuid::now_v7();
+
+        let op = SyncOp::new(
+            dev_a,
+            clock.now(),
+            EntityType::Setting,
+            setting_id,
+            OpType::Create,
+            Some(serde_json::json!({
+                "key": "theme",
+                "value": "dark",
+            })),
+        );
+        let result = engine.apply_op(&op).unwrap();
+        assert!(result.was_applied());
+
+        let value: String = db
+            .conn
+            .query_row(
+                "SELECT value FROM user_settings WHERE id = ?1",
+                params![setting_id.to_string()],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(value, "dark");
+    }
+
+    #[test]
+    fn setting_lww_later_wins() {
+        let db = setup_db();
+        let engine = MergeEngine::new(&db);
+        let dev_a = Uuid::now_v7();
+        let dev_b = Uuid::now_v7();
+        let setting_id = Uuid::now_v7();
+
+        // Device A sets theme=dark at T1
+        let hlc_a = HlcTimestamp::new(
+            chrono::DateTime::parse_from_rfc3339("2025-06-01T00:00:00Z")
+                .unwrap()
+                .with_timezone(&chrono::Utc),
+            0,
+            "aaaaaaaaaaaa",
+        );
+        let op_a = SyncOp::new(
+            dev_a,
+            hlc_a,
+            EntityType::Setting,
+            setting_id,
+            OpType::Create,
+            Some(serde_json::json!({"key": "theme", "value": "dark"})),
+        );
+        engine.apply_op(&op_a).unwrap();
+
+        // Device B sets theme=light at T2 (later — wins)
+        let hlc_b = HlcTimestamp::new(
+            chrono::DateTime::parse_from_rfc3339("2025-06-01T00:00:01Z")
+                .unwrap()
+                .with_timezone(&chrono::Utc),
+            0,
+            "bbbbbbbbbbbb",
+        );
+        let op_b = SyncOp::new(
+            dev_b,
+            hlc_b,
+            EntityType::Setting,
+            setting_id,
+            OpType::Update,
+            Some(serde_json::json!({"key": "theme", "value": "light"})),
+        );
+        let result = engine.apply_op(&op_b).unwrap();
+        assert!(result.was_applied());
+
+        let value: String = db
+            .conn
+            .query_row(
+                "SELECT value FROM user_settings WHERE id = ?1",
+                params![setting_id.to_string()],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(value, "light");
+    }
+
+    #[test]
+    fn setting_lww_older_skipped() {
+        let db = setup_db();
+        let engine = MergeEngine::new(&db);
+        let dev_a = Uuid::now_v7();
+        let dev_b = Uuid::now_v7();
+        let setting_id = Uuid::now_v7();
+
+        // Device A sets theme=dark at T2 (later)
+        let hlc_a = HlcTimestamp::new(
+            chrono::DateTime::parse_from_rfc3339("2025-06-01T00:00:01Z")
+                .unwrap()
+                .with_timezone(&chrono::Utc),
+            0,
+            "aaaaaaaaaaaa",
+        );
+        let op_a = SyncOp::new(
+            dev_a,
+            hlc_a,
+            EntityType::Setting,
+            setting_id,
+            OpType::Create,
+            Some(serde_json::json!({"key": "theme", "value": "dark"})),
+        );
+        engine.apply_op(&op_a).unwrap();
+
+        // Device B sets theme=light at T1 (earlier — skipped)
+        let hlc_b = HlcTimestamp::new(
+            chrono::DateTime::parse_from_rfc3339("2025-06-01T00:00:00Z")
+                .unwrap()
+                .with_timezone(&chrono::Utc),
+            0,
+            "bbbbbbbbbbbb",
+        );
+        let op_b = SyncOp::new(
+            dev_b,
+            hlc_b,
+            EntityType::Setting,
+            setting_id,
+            OpType::Update,
+            Some(serde_json::json!({"key": "theme", "value": "light"})),
+        );
+        let result = engine.apply_op(&op_b).unwrap();
+        assert!(matches!(result, MergeOutcome::Skipped { .. }));
+
+        let value: String = db
+            .conn
+            .query_row(
+                "SELECT value FROM user_settings WHERE id = ?1",
+                params![setting_id.to_string()],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(value, "dark");
+    }
+
+    #[test]
+    fn setting_delete_removes() {
+        let db = setup_db();
+        let engine = MergeEngine::new(&db);
+        let dev_a = Uuid::now_v7();
+        let mut clock = make_clock(&dev_a);
+        let setting_id = Uuid::now_v7();
+
+        let create = SyncOp::new(
+            dev_a,
+            clock.now(),
+            EntityType::Setting,
+            setting_id,
+            OpType::Create,
+            Some(serde_json::json!({"key": "theme", "value": "dark"})),
+        );
+        engine.apply_op(&create).unwrap();
+
+        let del = SyncOp::new(
+            dev_a,
+            clock.now(),
+            EntityType::Setting,
+            setting_id,
+            OpType::Delete,
+            None,
+        );
+        let result = engine.apply_op(&del).unwrap();
+        assert!(result.was_applied());
+
+        let count: i64 = db
+            .conn
+            .query_row(
+                "SELECT COUNT(*) FROM user_settings WHERE id = ?1",
+                params![setting_id.to_string()],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(count, 0);
+    }
+
+    #[test]
+    fn setting_missing_fields_rejected() {
+        let db = setup_db();
+        let engine = MergeEngine::new(&db);
+        let dev_a = Uuid::now_v7();
+        let mut clock = make_clock(&dev_a);
+
+        let op = SyncOp::new(
+            dev_a,
+            clock.now(),
+            EntityType::Setting,
+            Uuid::now_v7(),
+            OpType::Create,
             None,
         );
         let result = engine.apply_op(&op).unwrap();
-        assert!(matches!(result, MergeOutcome::Skipped { .. }));
+        assert!(matches!(result, MergeOutcome::Rejected { .. }));
+    }
+
+    // -------------------------------------------------------------------
+    // Two-device note scenarios
+    // -------------------------------------------------------------------
+
+    #[test]
+    fn two_devices_edit_different_notes_no_conflict() {
+        let db = setup_db();
+        let engine = MergeEngine::new(&db);
+        let dev_a = Uuid::now_v7();
+        let dev_b = Uuid::now_v7();
+        let mut clock_a = make_clock(&dev_a);
+        let mut clock_b = make_clock(&dev_b);
+        let book_id = Uuid::now_v7();
+        let note_a = Uuid::now_v7();
+        let note_b = Uuid::now_v7();
+
+        let create = make_book_create(dev_a, clock_a.now(), book_id, "Dune");
+        engine.apply_op(&create).unwrap();
+
+        // Device A creates note A
+        let op_a = make_note_create(dev_a, clock_a.now(), note_a, book_id, "Note A");
+        engine.apply_op(&op_a).unwrap();
+
+        // Device B creates note B (different note — no conflict)
+        let op_b = make_note_create(dev_b, clock_b.now(), note_b, book_id, "Note B");
+        let result = engine.apply_op(&op_b).unwrap();
+        assert!(result.was_applied());
+        assert!(!result.has_conflicts());
+
+        let count: i64 = db
+            .conn
+            .query_row(
+                "SELECT COUNT(*) FROM notes WHERE book_id = ?1",
+                params![book_id.to_string()],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(count, 2);
     }
 
     #[test]

--- a/crates/toku-db/src/sync_repo.rs
+++ b/crates/toku-db/src/sync_repo.rs
@@ -266,6 +266,7 @@ impl SyncOpRow {
             entity_id,
             op_type,
             fields,
+            encrypted: None,
             checksum: self.checksum,
             created_at,
         })

--- a/crates/toku-sync/migrations/V2__rekey.sql
+++ b/crates/toku-sync/migrations/V2__rekey.sql
@@ -1,0 +1,5 @@
+-- Add salt column to libraries for per-library encryption salt.
+ALTER TABLE libraries ADD COLUMN salt TEXT;
+
+-- Rekey lock to prevent concurrent pushes during re-keying.
+ALTER TABLE libraries ADD COLUMN rekey_in_progress INTEGER NOT NULL DEFAULT 0;

--- a/crates/toku-sync/src/handlers.rs
+++ b/crates/toku-sync/src/handlers.rs
@@ -8,7 +8,7 @@ use crate::db::SyncDatabase;
 use crate::error::SyncError;
 use crate::models::{
     DeviceResponse, HealthResponse, OpPayload, PullQuery, PullResponse, PushRequest, PushResponse,
-    RegisterRequest, RegisterResponse,
+    RegisterRequest, RegisterResponse, RekeyRequest, RekeyResponse,
 };
 
 const MAX_BATCH_SIZE: usize = 1000;
@@ -172,6 +172,22 @@ pub async fn push_ops(
         let ops = req.ops;
         move || -> Result<PushResponse, SyncError> {
             let db = SyncDatabase::open_no_migrate(&db_path)?;
+
+            // Reject pushes while a rekey is in progress
+            let locked: bool = db
+                .conn
+                .query_row(
+                    "SELECT rekey_in_progress FROM libraries WHERE id = ?1",
+                    [&library_id],
+                    |row| row.get(0),
+                )
+                .unwrap_or(false);
+            if locked {
+                return Err(SyncError::BadRequest(
+                    "library is being re-keyed; try again shortly".into(),
+                ));
+            }
+
             let tx = db.conn.unchecked_transaction()?;
 
             let mut accepted = 0usize;
@@ -329,7 +345,7 @@ pub async fn pull_ops(
     Ok(Json(resp))
 }
 
-// ── Snapshot / Rekey stubs ──────────────────────────────────────────────────
+// ── Snapshot / Salt ─────────────────────────────────────────────────────────
 
 pub async fn snapshot() -> (axum::http::StatusCode, Json<serde_json::Value>) {
     (
@@ -340,13 +356,164 @@ pub async fn snapshot() -> (axum::http::StatusCode, Json<serde_json::Value>) {
     )
 }
 
-pub async fn rekey() -> (axum::http::StatusCode, Json<serde_json::Value>) {
-    (
-        axum::http::StatusCode::NOT_IMPLEMENTED,
-        Json(serde_json::json!({
-            "error": "re-keying is not yet implemented"
-        })),
-    )
+/// Get the library salt (needed for key derivation on new devices).
+pub async fn get_salt(
+    State(db_path): State<PathBuf>,
+    device: AuthDevice,
+) -> Result<Json<serde_json::Value>, SyncError> {
+    let salt = tokio::task::spawn_blocking({
+        let db_path = db_path.clone();
+        let library_id = device.library_id.clone();
+        move || -> Result<Option<String>, SyncError> {
+            let db = SyncDatabase::open_no_migrate(&db_path)?;
+            let salt: Option<String> = db
+                .conn
+                .query_row(
+                    "SELECT salt FROM libraries WHERE id = ?1",
+                    [&library_id],
+                    |row| row.get(0),
+                )
+                .map_err(|_| SyncError::NotFound("library not found".into()))?;
+            Ok(salt)
+        }
+    })
+    .await
+    .map_err(|e| SyncError::Internal(format!("task join error: {e}")))??;
+
+    Ok(Json(serde_json::json!({ "salt": salt })))
+}
+
+/// Pull ALL ops for this library (including own device's ops).
+/// Used during re-keying when the client needs to decrypt and re-encrypt everything.
+pub async fn pull_all_ops(
+    State(db_path): State<PathBuf>,
+    device: AuthDevice,
+) -> Result<Json<PullResponse>, SyncError> {
+    let resp = tokio::task::spawn_blocking({
+        let db_path = db_path.clone();
+        let library_id = device.library_id.clone();
+        move || -> Result<PullResponse, SyncError> {
+            let db = SyncDatabase::open_no_migrate(&db_path)?;
+            let mut stmt = db.conn.prepare(
+                "SELECT op_id, device_id, hlc, entity_type, entity_id, op_type, payload
+                 FROM ops
+                 WHERE library_id = ?1
+                 ORDER BY hlc, op_id",
+            )?;
+            let ops: Vec<OpPayload> = stmt
+                .query_map([&library_id], row_to_op)?
+                .collect::<Result<Vec<_>, _>>()?;
+
+            Ok(PullResponse {
+                cursor: ops.last().map(|op| op.op_id.clone()),
+                has_more: false,
+                ops,
+            })
+        }
+    })
+    .await
+    .map_err(|e| SyncError::Internal(format!("task join error: {e}")))??;
+
+    Ok(Json(resp))
+}
+
+// ── Rekey ───────────────────────────────────────────────────────────────────
+
+pub async fn rekey(
+    State(db_path): State<PathBuf>,
+    device: AuthDevice,
+    Json(req): Json<RekeyRequest>,
+) -> Result<Json<RekeyResponse>, SyncError> {
+    if req.new_salt.is_empty() {
+        return Err(SyncError::BadRequest("new_salt is required".into()));
+    }
+    if req.ops.is_empty() {
+        return Err(SyncError::BadRequest("ops array is empty".into()));
+    }
+
+    let resp = tokio::task::spawn_blocking({
+        let db_path = db_path.clone();
+        let library_id = device.library_id.clone();
+        let new_salt = req.new_salt;
+        let ops = req.ops;
+        move || -> Result<RekeyResponse, SyncError> {
+            let db = SyncDatabase::open_no_migrate(&db_path)?;
+
+            // Set rekey lock
+            db.conn.execute(
+                "UPDATE libraries SET rekey_in_progress = 1 WHERE id = ?1",
+                [&library_id],
+            )?;
+
+            // Run the replacement in a transaction so failure rolls back
+            let result = (|| -> Result<RekeyResponse, SyncError> {
+                let tx = db.conn.unchecked_transaction()?;
+
+                // Delete all existing ops for this library
+                let deleted: usize = tx.execute(
+                    "DELETE FROM ops WHERE library_id = ?1",
+                    [&library_id],
+                )?;
+                let _ = deleted;
+
+                // Insert the re-encrypted ops
+                let mut inserted = 0usize;
+                for op in &ops {
+                    let payload_str = serde_json::to_string(&op.payload)
+                        .map_err(|e| SyncError::BadRequest(format!("invalid payload: {e}")))?;
+
+                    tx.execute(
+                        "INSERT INTO ops (op_id, library_id, device_id, hlc, entity_type, entity_id, op_type, payload, received_at)
+                         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, datetime('now'))",
+                        rusqlite::params![
+                            op.op_id,
+                            library_id,
+                            op.device_id,
+                            op.hlc,
+                            op.entity_type,
+                            op.entity_id,
+                            op.op_type,
+                            payload_str,
+                        ],
+                    )?;
+                    inserted += 1;
+                }
+
+                // Update salt
+                tx.execute(
+                    "UPDATE libraries SET salt = ?1 WHERE id = ?2",
+                    rusqlite::params![new_salt, library_id],
+                )?;
+
+                // Invalidate all cursors for this library's devices
+                tx.execute(
+                    "DELETE FROM cursors WHERE device_id IN (
+                         SELECT device_id FROM devices WHERE library_id = ?1
+                     )",
+                    [&library_id],
+                )?;
+
+                tx.commit()?;
+
+                Ok(RekeyResponse {
+                    ops_replaced: inserted,
+                    new_salt: new_salt.clone(),
+                })
+            })();
+
+            // Always release the rekey lock, even on failure
+            let _ = db.conn.execute(
+                "UPDATE libraries SET rekey_in_progress = 0 WHERE id = ?1",
+                [&library_id],
+            );
+
+            result
+        }
+    })
+    .await
+    .map_err(|e| SyncError::Internal(format!("task join error: {e}")))??;
+
+    Ok(Json(resp))
 }
 
 // ── Helpers ─────────────────────────────────────────────────────────────────

--- a/crates/toku-sync/src/main.rs
+++ b/crates/toku-sync/src/main.rs
@@ -23,6 +23,8 @@ fn build_router(db_path: PathBuf) -> Router {
         .route("/api/v1/devices/{id}", delete(handlers::delete_device))
         .route("/api/v1/push", post(handlers::push_ops))
         .route("/api/v1/pull", get(handlers::pull_ops))
+        .route("/api/v1/pull/all", get(handlers::pull_all_ops))
+        .route("/api/v1/salt", get(handlers::get_salt))
         .route("/api/v1/snapshot", get(handlers::snapshot))
         .route("/api/v1/rekey", post(handlers::rekey))
         .layer(middleware::from_fn_with_state(
@@ -35,7 +37,7 @@ fn build_router(db_path: PathBuf) -> Router {
         .route("/health", get(handlers::health))
         .route("/api/v1/register", post(handlers::register))
         .merge(authenticated)
-        .layer(DefaultBodyLimit::max(2 * 1024 * 1024)) // 2 MB
+        .layer(DefaultBodyLimit::max(50 * 1024 * 1024)) // 50 MB (rekey may be large)
         .with_state(db_path)
 }
 
@@ -1164,6 +1166,246 @@ mod tests {
         let pull: serde_json::Value = serde_json::from_slice(&body).unwrap();
         assert_eq!(pull["ops"].as_array().unwrap().len(), 0);
         assert_eq!(pull["has_more"], false);
+
+        cleanup(&db_path);
+    }
+
+    #[tokio::test]
+    async fn rekey_replaces_ops_and_updates_salt() {
+        let db_path = test_db_path();
+        let app = build_router(db_path.clone());
+
+        // Register
+        let resp = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/v1/register")
+                    .header("Content-Type", "application/json")
+                    .body(Body::from(
+                        serde_json::to_string(&serde_json::json!({
+                            "library_id": "lib-rekey",
+                            "device_name": "dev"
+                        }))
+                        .unwrap(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let register: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        let token = register["auth_token"].as_str().unwrap().to_string();
+
+        // Push two ops
+        let resp = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/v1/push")
+                    .header("Content-Type", "application/json")
+                    .header("Authorization", format!("Bearer {token}"))
+                    .body(Body::from(
+                        serde_json::to_string(&serde_json::json!({
+                            "ops": [
+                                {
+                                    "op_id": "rk-op-1",
+                                    "device_id": "d1",
+                                    "hlc": "2026-01-01T00:00:00.000Z-0001-d1",
+                                    "entity_type": "book",
+                                    "entity_id": "b1",
+                                    "op_type": "create",
+                                    "payload": {"title": "Dune"}
+                                },
+                                {
+                                    "op_id": "rk-op-2",
+                                    "device_id": "d1",
+                                    "hlc": "2026-01-01T00:00:01.000Z-0001-d1",
+                                    "entity_type": "book",
+                                    "entity_id": "b1",
+                                    "op_type": "update",
+                                    "payload": {"rating": 9}
+                                }
+                            ]
+                        }))
+                        .unwrap(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        // Rekey with "re-encrypted" ops (different payloads simulating re-encryption)
+        let resp = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/v1/rekey")
+                    .header("Content-Type", "application/json")
+                    .header("Authorization", format!("Bearer {token}"))
+                    .body(Body::from(
+                        serde_json::to_string(&serde_json::json!({
+                            "new_salt": "bmV3LXNhbHQ=",
+                            "ops": [
+                                {
+                                    "op_id": "rk-op-1",
+                                    "device_id": "d1",
+                                    "hlc": "2026-01-01T00:00:00.000Z-0001-d1",
+                                    "entity_type": "book",
+                                    "entity_id": "b1",
+                                    "op_type": "create",
+                                    "payload": {"ev": 1, "alg": "aes-256-gcm", "ciphertext": "new-ct-1"}
+                                },
+                                {
+                                    "op_id": "rk-op-2",
+                                    "device_id": "d1",
+                                    "hlc": "2026-01-01T00:00:01.000Z-0001-d1",
+                                    "entity_type": "book",
+                                    "entity_id": "b1",
+                                    "op_type": "update",
+                                    "payload": {"ev": 1, "alg": "aes-256-gcm", "ciphertext": "new-ct-2"}
+                                }
+                            ]
+                        }))
+                        .unwrap(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let rekey: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(rekey["ops_replaced"], 2);
+        assert_eq!(rekey["new_salt"], "bmV3LXNhbHQ=");
+
+        // Verify salt was updated
+        let resp = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri("/api/v1/salt")
+                    .header("Authorization", format!("Bearer {token}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let salt: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(salt["salt"], "bmV3LXNhbHQ=");
+
+        // Verify ops are the re-encrypted versions via pull/all
+        let resp = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri("/api/v1/pull/all")
+                    .header("Authorization", format!("Bearer {token}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let pull: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        let ops = pull["ops"].as_array().unwrap();
+        assert_eq!(ops.len(), 2);
+        // Verify payloads are the re-encrypted versions
+        assert_eq!(ops[0]["payload"]["ciphertext"], "new-ct-1");
+        assert_eq!(ops[1]["payload"]["ciphertext"], "new-ct-2");
+
+        cleanup(&db_path);
+    }
+
+    #[tokio::test]
+    async fn push_blocked_during_rekey() {
+        let db_path = test_db_path();
+        let app = build_router(db_path.clone());
+
+        // Register
+        let resp = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/v1/register")
+                    .header("Content-Type", "application/json")
+                    .body(Body::from(
+                        serde_json::to_string(&serde_json::json!({
+                            "library_id": "lib-lock",
+                            "device_name": "dev"
+                        }))
+                        .unwrap(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let register: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        let token = register["auth_token"].as_str().unwrap().to_string();
+
+        // Manually set rekey lock
+        {
+            let db = SyncDatabase::open_no_migrate(&db_path).unwrap();
+            db.conn
+                .execute(
+                    "UPDATE libraries SET rekey_in_progress = 1 WHERE id = 'lib-lock'",
+                    [],
+                )
+                .unwrap();
+        }
+
+        // Push should be rejected
+        let resp = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/v1/push")
+                    .header("Content-Type", "application/json")
+                    .header("Authorization", format!("Bearer {token}"))
+                    .body(Body::from(
+                        serde_json::to_string(&serde_json::json!({
+                            "ops": [{
+                                "op_id": "blocked-op",
+                                "device_id": "d1",
+                                "hlc": "2026-01-01T00:00:00.000Z-0001-d1",
+                                "entity_type": "book",
+                                "entity_id": "b1",
+                                "op_type": "create",
+                                "payload": {}
+                            }]
+                        }))
+                        .unwrap(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+        let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let err: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert!(err["error"].as_str().unwrap().contains("re-keyed"));
 
         cleanup(&db_path);
     }

--- a/crates/toku-sync/src/models.rs
+++ b/crates/toku-sync/src/models.rs
@@ -29,6 +29,12 @@ pub struct PullQuery {
     pub since: Option<String>,
 }
 
+#[derive(Debug, Deserialize)]
+pub struct RekeyRequest {
+    pub new_salt: String,
+    pub ops: Vec<OpPayload>,
+}
+
 // ── Responses ───────────────────────────────────────────────────────────────
 
 #[derive(Debug, Serialize)]
@@ -69,4 +75,10 @@ pub struct HealthResponse {
 #[derive(Debug, Serialize)]
 pub struct ErrorBody {
     pub error: String,
+}
+
+#[derive(Debug, Serialize)]
+pub struct RekeyResponse {
+    pub ops_replaced: usize,
+    pub new_salt: String,
 }


### PR DESCRIPTION
## Description

Implements the complete sync conflict resolution and encryption layer for Toku's multi-device sync (Phase 7). This PR covers three issues:

### What's included

**Entity-specific merge rules (#69)**
- Notes/reviews merge with LWW and conflict detection — two devices editing the same note stores a `sync_conflict` for user review; edits to different notes merge cleanly
- Reviews use per-field LWW (content and rating tracked independently) to avoid false conflicts
- Settings sync via LWW per key with HLC ordering
- `SkippedWithConflicts` merge outcome for when an incoming op is stale but a conflict record is still stored
- New tables: `notes`, `reviews`, `user_settings`, `sync_entity_hlc` (migration V15)

**Client-side encryption (#71)**
- AES-256-GCM encryption with Argon2id key derivation (m=64MB, t=3, p=1) in a new `toku-core::crypto` module
- Encrypted envelope per ADR-008 with AAD binding entity type, entity ID, and op type to prevent payload swapping
- `SyncKey` with zeroize-on-drop, `SyncOp.encrypt()`/`decrypt()` convenience methods
- `encrypted` field added to `SyncOp` alongside `fields` (mutually exclusive)
- Checksum computation updated to cover `encrypted` when present

**Passphrase rotation (#72)**
- `toku sync rekey --server <url>` CLI command: prompts for old/new passphrase, pulls all ops, decrypts with old key, re-encrypts with new key, atomically replaces on server
- Server-side `POST /api/v1/rekey` endpoint with atomic op replacement, salt update, and cursor invalidation
- Push lock during re-keying prevents concurrent writes
- `GET /api/v1/salt` and `GET /api/v1/pull/all` supporting endpoints
- Sync key storage in OS keychain

## Related Issues

Closes #69
Closes #71
Closes #72

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI / infrastructure
- [ ] Other (describe below)

## Crate

- [x] `toku-core` — Domain models, traits, state machine
- [x] `toku-db` — SQLite persistence, migrations, FTS5
- [ ] `toku-import` — Importers (Goodreads, Calibre, StoryGraph)
- [ ] `toku-meta` — Metadata fetching (Open Library, Google Books)
- [x] `toku-cli` — CLI binary
- [ ] `toku-export` — Exporters (CSV, JSON, Markdown, BibTeX)
- [ ] `docs/` — Documentation

## Data Integrity Checklist

- [x] No user data is sent to any server without explicit opt-in
- [x] Import operations are idempotent (re-importing the same file creates no duplicates)
- [x] User edits to metadata are never overwritten by auto-enrichment
- [x] New fields track provenance (source + timestamp)
- [x] Export round-trip is preserved (if applicable)

## Checklist

- [x] I have read [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] `cargo fmt --check` passes
- [x] `cargo clippy --workspace -- -D warnings` passes
- [x] `cargo test --workspace` passes
- [x] I have updated documentation (if applicable)
