### PR TITLE
feat: snapshot compaction and CLI sync command redesign

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Snapshot compaction: `toku sync compact` creates a point-in-time snapshot of the entire library and uploads it to the server, pruning old ops to prevent unbounded op-log growth
+- New-device bootstrap via snapshot: `GET /api/v1/snapshot` downloads the latest snapshot, `POST /api/v1/snapshot` uploads one with automatic op pruning
+- `toku sync init` command for one-step sync setup: registers device, stores credentials, saves sync config to `config.toml`, with optional `--passphrase` for enabling encryption
+- `toku sync status` command showing sync state: server, device, library, pending ops, cursors, encryption status, and registered device count
+- `toku sync disable` command to remove sync configuration while preserving local data
+- Sync config persisted in `config.toml` under `[sync]` section — push, pull, devices, rekey, and compact no longer require `--server` on every invocation
+- Automatic device naming from hostname when `--device-name` is not specified during `toku sync init`
 - Notes and reviews merge: LWW with conflict detection — two devices editing the same note stores a `sync_conflict` for user review, while edits to different notes merge cleanly
 - Review field-level merge: content and rating are tracked independently, so two devices editing different review fields produces no conflict
 - Settings sync: LWW per key for user settings with HLC-based ordering
@@ -71,6 +78,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - macOS app (`toku-apple`) with SwiftUI: sidebar navigation, sortable table and grid views, book detail inspector, Swift Charts statistics dashboard, and drag-and-drop Goodreads CSV import
 - iOS app (iPhone + iPad) with SwiftUI: library cover grid, book detail, barcode scanner (ISBN-13 via camera), quick progress update sheet, statistics glance with Swift Charts, full-text search, Goodreads CSV import, adaptive navigation (TabView on iPhone, NavigationSplitView on iPad), status filter chips, and pull-to-refresh
 - TokuKitUI shared SwiftUI component library (StarRatingView, FlowLayout, MetadataRow, StatCard) for reuse across macOS and iOS apps
+
+### Changed
+
+- `toku sync register` replaced by `toku sync init` with automatic defaults (hostname-based device name, auto-generated library ID)
+- `toku sync push`, `pull`, `devices`, `rekey`, and `compact` no longer require `--server` flag — server URL is read from sync config
+- `toku sync logout` replaced by `toku sync disable` which also clears sync config
+
+### Removed
+
+- `toku sync register` command (replaced by `toku sync init`)
+- `toku sync logout` command (replaced by `toku sync disable`)
+- `--server` flag from push, pull, devices, rekey, and compact subcommands (now read from config)
 
 ## [0.2.1] - 2026-05-30
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1786,6 +1786,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "hostname"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "617aaa3557aef3810a6369d0a99fac8a080891b68bd9f9812a1eeda0c0730cbd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "windows-link 0.2.1",
+]
+
+[[package]]
 name = "html5ever"
 version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4740,6 +4751,7 @@ dependencies = [
  "clap_complete",
  "crossterm",
  "csv",
+ "hostname",
  "keyring",
  "ratatui",
  "reqwest 0.12.28",
@@ -4780,6 +4792,7 @@ dependencies = [
 name = "toku-db"
 version = "0.2.1"
 dependencies = [
+ "base64 0.22.1",
  "chrono",
  "directories",
  "refinery",

--- a/crates/toku-cli/Cargo.toml
+++ b/crates/toku-cli/Cargo.toml
@@ -35,3 +35,4 @@ csv = "1"
 uuid.workspace = true
 rpassword = "5"
 base64 = "0.22"
+hostname = "0.4"

--- a/crates/toku-cli/src/main.rs
+++ b/crates/toku-cli/src/main.rs
@@ -559,59 +559,45 @@ enum ExportTarget {
 
 #[derive(Clone, Subcommand)]
 enum SyncAction {
-    /// Register this device with a sync server
-    Register {
-        /// Sync server URL (e.g. https://sync.example.com)
-        #[arg(long)]
+    /// Set up sync for the first time
+    Init {
+        /// Sync server URL (default: http://localhost:8080)
+        #[arg(long, default_value = "http://localhost:8080")]
         server: String,
 
         /// Library ID (UUID — use the same ID across all devices for one library)
         #[arg(long)]
-        library_id: String,
+        library_id: Option<String>,
 
-        /// Name for this device (e.g. "work-laptop")
+        /// Name for this device (defaults to hostname)
         #[arg(long)]
-        device_name: String,
+        device_name: Option<String>,
+
+        /// Enable client-side encryption (prompts for passphrase)
+        #[arg(long)]
+        passphrase: bool,
     },
+
+    /// Show sync status
+    Status,
+
+    /// Push local changes to the sync server
+    Push,
+
+    /// Pull remote changes from the sync server
+    Pull,
 
     /// List all devices registered to this library
-    Devices {
-        /// Sync server URL
-        #[arg(long)]
-        server: String,
-    },
+    Devices,
 
     /// Deregister another device from the sync server
     Deregister {
-        /// Sync server URL
-        #[arg(long)]
-        server: String,
-
         /// Device ID to deregister
-        #[arg(long)]
         device_id: String,
     },
 
-    /// Remove locally stored sync credentials
-    Logout {
-        /// Sync server URL
-        #[arg(long)]
-        server: String,
-    },
-
-    /// Push local changes to the sync server
-    Push {
-        /// Sync server URL
-        #[arg(long)]
-        server: String,
-    },
-
-    /// Pull remote changes from the sync server
-    Pull {
-        /// Sync server URL
-        #[arg(long)]
-        server: String,
-    },
+    /// Disable sync (local data preserved)
+    Disable,
 
     /// Purge tombstoned books older than the retention period
     Purge {
@@ -621,11 +607,10 @@ enum SyncAction {
     },
 
     /// Change the sync encryption passphrase and re-encrypt all server ops
-    Rekey {
-        /// Sync server URL
-        #[arg(long)]
-        server: String,
-    },
+    Rekey,
+
+    /// Compact the op log by creating a snapshot and pruning old ops
+    Compact,
 }
 
 #[derive(Clone, ValueEnum)]
@@ -2970,19 +2955,83 @@ fn cmd_sync(data_dir: &Path, action: SyncAction, output_format: &OutputFormat) -
         .context("failed to build tokio runtime")?;
 
     let token_store = sync::token_store::TokenStore::new(data_dir);
+    let config = toku_core::TokuConfig::load(data_dir).unwrap_or_default();
+
+    /// Helper: get sync config or error with a helpful message.
+    fn require_sync(config: &toku_core::TokuConfig) -> Result<&toku_core::SyncConfig> {
+        config
+            .sync
+            .as_ref()
+            .ok_or_else(|| anyhow::anyhow!("sync is not configured. Run `toku sync init` first."))
+    }
+
+    /// Helper: get auth token for the configured server.
+    fn require_token(token_store: &sync::token_store::TokenStore, server: &str) -> Result<String> {
+        token_store.load(server)?.ok_or_else(|| {
+            anyhow::anyhow!("no auth token found for {server}. Run `toku sync init` first.")
+        })
+    }
 
     match action {
-        SyncAction::Register {
+        SyncAction::Init {
             server,
             library_id,
             device_name,
+            passphrase,
         } => {
+            let library_id = library_id.unwrap_or_else(|| uuid::Uuid::now_v7().to_string());
+            let device_name = device_name.unwrap_or_else(|| {
+                hostname::get()
+                    .ok()
+                    .and_then(|h| h.into_string().ok())
+                    .unwrap_or_else(|| "unknown-device".to_string())
+            });
+
             let client = sync::client::SyncClient::new(&server)?;
             let resp = rt.block_on(client.register(&library_id, &device_name))?;
 
             token_store
                 .store(&server, &resp.auth_token)
                 .context("failed to store auth token")?;
+
+            let encryption_enabled = if passphrase {
+                eprint!("Encryption passphrase: ");
+                let pass = rpassword::read_password().context("failed to read passphrase")?;
+                if pass.is_empty() {
+                    anyhow::bail!("passphrase cannot be empty");
+                }
+                eprint!("Confirm passphrase: ");
+                let confirm = rpassword::read_password().context("failed to read confirmation")?;
+                if pass != confirm {
+                    anyhow::bail!("passphrases do not match");
+                }
+                let salt = toku_core::SyncKey::generate_salt();
+                let key = toku_core::SyncKey::derive(&pass, &salt)
+                    .map_err(|e| anyhow::anyhow!("key derivation failed: {e}"))?;
+                token_store
+                    .store_sync_key(&server, key.as_exported_bytes())
+                    .context("failed to store sync key")?;
+                true
+            } else {
+                false
+            };
+
+            let db_path = data_dir.join("toku.db");
+            let db = Database::open(&db_path).context("failed to open database")?;
+            let sync_repo = toku_db::SyncRepository::new(&db);
+            sync_repo.get_or_create_device(&device_name)?;
+
+            let mut config = config;
+            config.sync = Some(toku_core::SyncConfig {
+                server: server.clone(),
+                library_id: resp.library_id.clone(),
+                device_id: resp.device_id.clone(),
+                device_name: device_name.clone(),
+                encryption: encryption_enabled,
+            });
+            config
+                .save(data_dir)
+                .map_err(|e| anyhow::anyhow!("failed to save config: {e}"))?;
 
             match output_format {
                 OutputFormat::Json => {
@@ -2991,36 +3040,265 @@ fn cmd_sync(data_dir: &Path, action: SyncAction, output_format: &OutputFormat) -
                         serde_json::to_string_pretty(&serde_json::json!({
                             "device_id": resp.device_id,
                             "library_id": resp.library_id,
+                            "device_name": device_name,
                             "server": server,
+                            "encryption": encryption_enabled,
                         }))?
                     );
                 }
                 OutputFormat::Csv => {
-                    println!("device_id,library_id,server");
-                    println!("{},{},{server}", resp.device_id, resp.library_id);
+                    println!("device_id,library_id,device_name,server,encryption");
+                    println!(
+                        "{},{},{device_name},{server},{encryption_enabled}",
+                        resp.device_id, resp.library_id
+                    );
                 }
                 OutputFormat::Table => {
-                    eprintln!("✓ Registered as \"{}\"", device_name);
-                    eprintln!("  Device ID:  {}", resp.device_id);
-                    eprintln!("  Library ID: {}", resp.library_id);
-                    eprintln!("  Token stored securely");
+                    eprintln!("Sync initialized");
+                    eprintln!("  Server:     {server}");
+                    eprintln!("  Device:     {device_name} ({})", resp.device_id);
+                    eprintln!("  Library:    {}", resp.library_id);
+                    eprintln!(
+                        "  Encryption: {}",
+                        if encryption_enabled {
+                            "enabled"
+                        } else {
+                            "disabled"
+                        }
+                    );
                 }
             }
             Ok(())
         }
 
-        SyncAction::Devices { server } => {
-            let token = token_store.load(&server)?.ok_or_else(|| {
-                anyhow::anyhow!("no auth token found for {server}. Run `toku sync register` first.")
-            })?;
+        SyncAction::Status => {
+            let sync_config = require_sync(&config)?;
+            let server = &sync_config.server;
 
-            let client = sync::client::SyncClient::new(&server)?;
-            let devices = rt.block_on(client.list_devices(&token))?;
+            let db_path = data_dir.join("toku.db");
+            let db = Database::open(&db_path).context("failed to open database")?;
+            let sync_repo = toku_db::SyncRepository::new(&db);
+
+            let pending = sync_repo.count_unpushed_ops()?;
+            let push_cursor = sync_repo.get_cursor("push_cursor")?;
+            let pull_cursor = sync_repo.get_cursor("pull_cursor")?;
+            let device = sync_repo.get_device()?;
+
+            let device_count = token_store
+                .load(server)?
+                .and_then(|token| {
+                    let client = sync::client::SyncClient::new(server).ok()?;
+                    rt.block_on(client.list_devices(&token))
+                        .ok()
+                        .map(|d| d.len())
+                })
+                .unwrap_or(0);
 
             match output_format {
                 OutputFormat::Json => {
-                    println!("{}", serde_json::to_string_pretty(&devices)?);
+                    println!(
+                        "{}",
+                        serde_json::to_string_pretty(&serde_json::json!({
+                            "enabled": true,
+                            "server": server,
+                            "device_id": sync_config.device_id,
+                            "device_name": sync_config.device_name,
+                            "library_id": sync_config.library_id,
+                            "encryption": sync_config.encryption,
+                            "pending_ops": pending,
+                            "push_cursor": push_cursor,
+                            "pull_cursor": pull_cursor,
+                            "device_count": device_count,
+                        }))?
+                    );
                 }
+                OutputFormat::Csv => {
+                    println!("key,value");
+                    println!("enabled,true");
+                    println!("server,{server}");
+                    println!("device,{}", sync_config.device_name);
+                    println!("pending_ops,{pending}");
+                    println!("device_count,{device_count}");
+                }
+                OutputFormat::Table => {
+                    eprintln!("Sync: enabled");
+                    eprintln!("Server: {server}");
+                    if let Some(dev) = &device {
+                        eprintln!("Device: {} ({})", dev.device_name, dev.device_id);
+                    } else {
+                        eprintln!(
+                            "Device: {} ({})",
+                            sync_config.device_name, sync_config.device_id
+                        );
+                    }
+                    eprintln!("Library: {}", sync_config.library_id);
+                    eprintln!("Pending ops: {pending}");
+                    eprintln!(
+                        "Last push cursor: {}",
+                        push_cursor.as_deref().unwrap_or("none")
+                    );
+                    eprintln!(
+                        "Last pull cursor: {}",
+                        pull_cursor.as_deref().unwrap_or("none")
+                    );
+                    eprintln!(
+                        "Encryption: {}",
+                        if sync_config.encryption {
+                            "enabled"
+                        } else {
+                            "disabled"
+                        }
+                    );
+                    if device_count > 0 {
+                        eprintln!("Devices: {device_count} registered");
+                    }
+                }
+            }
+            Ok(())
+        }
+
+        SyncAction::Push => {
+            let sync_config = require_sync(&config)?;
+            let server = &sync_config.server;
+            let token = require_token(&token_store, server)?;
+
+            let db_path = data_dir.join("toku.db");
+            let db = Database::open(&db_path).context("failed to open database")?;
+            let sync_repo = toku_db::SyncRepository::new(&db);
+            let client = sync::client::SyncClient::new(server)?;
+
+            let unpushed = sync_repo.get_unpushed_ops()?;
+            if unpushed.is_empty() {
+                match output_format {
+                    OutputFormat::Json => {
+                        println!(
+                            "{}",
+                            serde_json::to_string_pretty(&serde_json::json!({
+                                "pushed": 0,
+                                "status": "up_to_date",
+                            }))?
+                        );
+                    }
+                    _ => eprintln!("Nothing to push already up to date"),
+                }
+                return Ok(());
+            }
+
+            let total = unpushed.len();
+            let wire_ops: Vec<sync::client::WireOp> =
+                unpushed.iter().map(sync::wire::to_wire).collect();
+
+            let mut total_accepted = 0usize;
+            let mut total_duplicates = 0usize;
+            let mut last_cursor = None;
+
+            for chunk in wire_ops.chunks(1000) {
+                let result = rt.block_on(client.push_ops(&token, chunk))?;
+                total_accepted += result.accepted;
+                total_duplicates += result.duplicates;
+                if result.new_cursor.is_some() {
+                    last_cursor = result.new_cursor;
+                }
+            }
+
+            let op_ids: Vec<uuid::Uuid> = unpushed.iter().map(|op| op.op_id).collect();
+            sync_repo.mark_ops_pushed(&op_ids)?;
+
+            if let Some(ref cursor) = last_cursor {
+                sync_repo.set_cursor("push_cursor", cursor)?;
+            }
+
+            match output_format {
+                OutputFormat::Json => {
+                    println!(
+                        "{}",
+                        serde_json::to_string_pretty(&serde_json::json!({
+                            "pushed": total,
+                            "accepted": total_accepted,
+                            "duplicates": total_duplicates,
+                            "cursor": last_cursor,
+                        }))?
+                    );
+                }
+                OutputFormat::Csv => {
+                    println!("pushed,accepted,duplicates");
+                    println!("{total},{total_accepted},{total_duplicates}");
+                }
+                OutputFormat::Table => {
+                    eprintln!("Pushed {total_accepted} ops ({total_duplicates} duplicates)");
+                }
+            }
+            Ok(())
+        }
+
+        SyncAction::Pull => {
+            let sync_config = require_sync(&config)?;
+            let server = &sync_config.server;
+            let token = require_token(&token_store, server)?;
+
+            let db_path = data_dir.join("toku.db");
+            let db = Database::open(&db_path).context("failed to open database")?;
+            let sync_repo = toku_db::SyncRepository::new(&db);
+            let client = sync::client::SyncClient::new(server)?;
+
+            let mut cursor = sync_repo.get_cursor("pull_cursor")?;
+            let mut total_pulled = 0usize;
+
+            loop {
+                let result = rt.block_on(client.pull_ops(&token, cursor.as_deref()))?;
+                if result.ops.is_empty() {
+                    break;
+                }
+                for wire_op in &result.ops {
+                    let sync_op =
+                        sync::wire::from_wire(wire_op).context("failed to parse remote op")?;
+                    sync_repo.insert_remote_op(&sync_op)?;
+                }
+                total_pulled += result.ops.len();
+                if let Some(new_cursor) = result.cursor {
+                    sync_repo.set_cursor("pull_cursor", &new_cursor)?;
+                    cursor = Some(new_cursor);
+                }
+                if !result.has_more {
+                    break;
+                }
+            }
+
+            match output_format {
+                OutputFormat::Json => {
+                    println!(
+                        "{}",
+                        serde_json::to_string_pretty(&serde_json::json!({
+                            "pulled": total_pulled,
+                            "cursor": cursor,
+                        }))?
+                    );
+                }
+                OutputFormat::Csv => {
+                    println!("pulled,cursor");
+                    println!("{total_pulled},{}", cursor.as_deref().unwrap_or(""));
+                }
+                OutputFormat::Table => {
+                    if total_pulled == 0 {
+                        eprintln!("Nothing to pull already up to date");
+                    } else {
+                        eprintln!("Pulled {total_pulled} ops");
+                    }
+                }
+            }
+            Ok(())
+        }
+
+        SyncAction::Devices => {
+            let sync_config = require_sync(&config)?;
+            let server = &sync_config.server;
+            let token = require_token(&token_store, server)?;
+
+            let client = sync::client::SyncClient::new(server)?;
+            let devices = rt.block_on(client.list_devices(&token))?;
+
+            match output_format {
+                OutputFormat::Json => println!("{}", serde_json::to_string_pretty(&devices)?),
                 OutputFormat::Csv => {
                     println!("device_id,device_name,last_seen,created_at");
                     for d in &devices {
@@ -3055,7 +3333,7 @@ fn cmd_sync(data_dir: &Path, action: SyncAction, output_format: &OutputFormat) -
                         .map(|d| Row {
                             id: d.device_id.clone(),
                             name: d.device_name.clone(),
-                            last_seen: d.last_seen.clone().unwrap_or_else(|| "—".into()),
+                            last_seen: d.last_seen.clone().unwrap_or_else(|| "n/a".into()),
                             created: d.created_at.clone(),
                         })
                         .collect();
@@ -3065,12 +3343,12 @@ fn cmd_sync(data_dir: &Path, action: SyncAction, output_format: &OutputFormat) -
             Ok(())
         }
 
-        SyncAction::Deregister { server, device_id } => {
-            let token = token_store.load(&server)?.ok_or_else(|| {
-                anyhow::anyhow!("no auth token found for {server}. Run `toku sync register` first.")
-            })?;
+        SyncAction::Deregister { device_id } => {
+            let sync_config = require_sync(&config)?;
+            let server = &sync_config.server;
+            let token = require_token(&token_store, server)?;
 
-            let client = sync::client::SyncClient::new(&server)?;
+            let client = sync::client::SyncClient::new(server)?;
             rt.block_on(client.deregister_device(&token, &device_id))?;
 
             match output_format {
@@ -3083,171 +3361,47 @@ fn cmd_sync(data_dir: &Path, action: SyncAction, output_format: &OutputFormat) -
                         }))?
                     );
                 }
-                _ => {
-                    eprintln!("✓ Deregistered device {device_id}");
-                }
+                _ => eprintln!("Deregistered device {device_id}"),
             }
             Ok(())
         }
 
-        SyncAction::Logout { server } => {
-            token_store
-                .delete(&server)
-                .context("failed to remove stored token")?;
-
-            eprintln!("✓ Removed local credentials for {server}");
-            Ok(())
-        }
-
-        SyncAction::Push { server } => {
-            let token = token_store.load(&server)?.ok_or_else(|| {
-                anyhow::anyhow!("no auth token found for {server}. Run `toku sync register` first.")
-            })?;
-
-            let db_path = data_dir.join("toku.db");
-            let db = Database::open(&db_path).context("failed to open database")?;
-            let sync_repo = toku_db::SyncRepository::new(&db);
-            let client = sync::client::SyncClient::new(&server)?;
-
-            let unpushed = sync_repo.get_unpushed_ops()?;
-            if unpushed.is_empty() {
-                match output_format {
-                    OutputFormat::Json => {
-                        println!(
-                            "{}",
-                            serde_json::to_string_pretty(&serde_json::json!({
-                                "pushed": 0,
-                                "status": "up_to_date",
-                            }))?
-                        );
-                    }
-                    _ => {
-                        eprintln!("✓ Nothing to push — already up to date");
-                    }
-                }
+        SyncAction::Disable => {
+            if config.sync.is_none() {
+                eprintln!("Sync is not configured.");
                 return Ok(());
             }
+            let sync_config = config.sync.as_ref().unwrap();
+            let server = &sync_config.server;
+            let _ = token_store.delete(server);
+            let _ = token_store.delete_sync_key(server);
 
-            let total = unpushed.len();
-            let wire_ops: Vec<sync::client::WireOp> =
-                unpushed.iter().map(sync::wire::to_wire).collect();
-
-            // Push in batches of 1000
-            let mut total_accepted = 0usize;
-            let mut total_duplicates = 0usize;
-            let mut last_cursor = None;
-
-            for chunk in wire_ops.chunks(1000) {
-                let result = rt.block_on(client.push_ops(&token, chunk))?;
-                total_accepted += result.accepted;
-                total_duplicates += result.duplicates;
-                if result.new_cursor.is_some() {
-                    last_cursor = result.new_cursor;
-                }
-            }
-
-            // Mark ops as pushed locally
-            let op_ids: Vec<uuid::Uuid> = unpushed.iter().map(|op| op.op_id).collect();
-            sync_repo.mark_ops_pushed(&op_ids)?;
-
-            // Update local push cursor
-            if let Some(ref cursor) = last_cursor {
-                sync_repo.set_cursor("push_cursor", cursor)?;
-            }
+            let mut config = config;
+            config.sync = None;
+            config
+                .save(data_dir)
+                .map_err(|e| anyhow::anyhow!("failed to save config: {e}"))?;
 
             match output_format {
                 OutputFormat::Json => {
                     println!(
                         "{}",
-                        serde_json::to_string_pretty(&serde_json::json!({
-                            "pushed": total,
-                            "accepted": total_accepted,
-                            "duplicates": total_duplicates,
-                            "cursor": last_cursor,
-                        }))?
+                        serde_json::to_string_pretty(&serde_json::json!({ "sync": "disabled" }))?
                     );
                 }
-                OutputFormat::Csv => {
-                    println!("pushed,accepted,duplicates");
-                    println!("{total},{total_accepted},{total_duplicates}");
-                }
-                OutputFormat::Table => {
-                    eprintln!("✓ Pushed {total_accepted} ops ({total_duplicates} duplicates)");
+                _ => {
+                    eprintln!("Sync disabled. Local data preserved.");
+                    eprintln!("  Run `toku sync init` to re-enable.");
                 }
             }
             Ok(())
         }
 
-        SyncAction::Pull { server } => {
-            let token = token_store.load(&server)?.ok_or_else(|| {
-                anyhow::anyhow!("no auth token found for {server}. Run `toku sync register` first.")
-            })?;
-
-            let db_path = data_dir.join("toku.db");
-            let db = Database::open(&db_path).context("failed to open database")?;
-            let sync_repo = toku_db::SyncRepository::new(&db);
-            let client = sync::client::SyncClient::new(&server)?;
-
-            let mut cursor = sync_repo.get_cursor("pull_cursor")?;
-            let mut total_pulled = 0usize;
-
-            loop {
-                let result = rt.block_on(client.pull_ops(&token, cursor.as_deref()))?;
-
-                if result.ops.is_empty() {
-                    break;
-                }
-
-                for wire_op in &result.ops {
-                    let sync_op =
-                        sync::wire::from_wire(wire_op).context("failed to parse remote op")?;
-                    sync_repo.insert_remote_op(&sync_op)?;
-                }
-
-                total_pulled += result.ops.len();
-
-                // Update cursor to the last op we received
-                if let Some(new_cursor) = result.cursor {
-                    sync_repo.set_cursor("pull_cursor", &new_cursor)?;
-                    cursor = Some(new_cursor);
-                }
-
-                if !result.has_more {
-                    break;
-                }
-            }
-
-            match output_format {
-                OutputFormat::Json => {
-                    println!(
-                        "{}",
-                        serde_json::to_string_pretty(&serde_json::json!({
-                            "pulled": total_pulled,
-                            "cursor": cursor,
-                        }))?
-                    );
-                }
-                OutputFormat::Csv => {
-                    println!("pulled,cursor");
-                    println!("{total_pulled},{}", cursor.as_deref().unwrap_or(""));
-                }
-                OutputFormat::Table => {
-                    if total_pulled == 0 {
-                        eprintln!("✓ Nothing to pull — already up to date");
-                    } else {
-                        eprintln!("✓ Pulled {total_pulled} ops");
-                    }
-                }
-            }
-            Ok(())
-        }
         SyncAction::Purge { days } => {
             let db_path = data_dir.join("toku.db");
             let db = Database::open(&db_path).context("failed to open database")?;
             let repo = toku_db::BookRepository::new(&db);
-
             let purged = repo.purge_tombstones(days)?;
-
             match output_format {
                 OutputFormat::Json => {
                     println!(
@@ -3264,21 +3418,21 @@ fn cmd_sync(data_dir: &Path, action: SyncAction, output_format: &OutputFormat) -
                 }
                 OutputFormat::Table => {
                     if purged == 0 {
-                        eprintln!("✓ No tombstones older than {days} days to purge");
+                        eprintln!("No tombstones older than {days} days to purge");
                     } else {
-                        eprintln!("✓ Purged {purged} tombstoned book(s) older than {days} days");
+                        eprintln!("Purged {purged} tombstoned book(s) older than {days} days");
                     }
                 }
             }
             Ok(())
         }
-        SyncAction::Rekey { server } => {
-            let token = token_store.load(&server)?.ok_or_else(|| {
-                anyhow::anyhow!("no auth token found for {server}. Run `toku sync register` first.")
-            })?;
-            let client = sync::client::SyncClient::new(&server)?;
 
-            // Prompt for old passphrase
+        SyncAction::Rekey => {
+            let sync_config = require_sync(&config)?;
+            let server = &sync_config.server;
+            let token = require_token(&token_store, server)?;
+            let client = sync::client::SyncClient::new(server)?;
+
             eprint!("Old passphrase: ");
             let old_passphrase =
                 rpassword::read_password().context("failed to read old passphrase")?;
@@ -3286,7 +3440,6 @@ fn cmd_sync(data_dir: &Path, action: SyncAction, output_format: &OutputFormat) -
                 anyhow::bail!("old passphrase cannot be empty");
             }
 
-            // Prompt for new passphrase (twice)
             eprint!("New passphrase: ");
             let new_passphrase =
                 rpassword::read_password().context("failed to read new passphrase")?;
@@ -3301,51 +3454,41 @@ fn cmd_sync(data_dir: &Path, action: SyncAction, output_format: &OutputFormat) -
             }
 
             rt.block_on(async {
-                // Step 1: Get current salt from server
                 eprintln!("Fetching library salt...");
                 let salt_result = client.get_salt(&token).await?;
-                let old_salt_b64 = salt_result.salt.ok_or_else(|| {
-                    anyhow::anyhow!("library has no salt — encryption was never enabled")
-                })?;
+                let old_salt_b64 = salt_result
+                    .salt
+                    .ok_or_else(|| anyhow::anyhow!("library has no salt"))?;
                 let old_salt_bytes = base64::engine::general_purpose::STANDARD
                     .decode(&old_salt_b64)
                     .context("invalid salt encoding")?;
                 let old_salt: [u8; 16] = old_salt_bytes
                     .try_into()
                     .map_err(|_| anyhow::anyhow!("invalid salt length"))?;
-
-                // Step 2: Derive old key
                 let old_key = toku_core::SyncKey::derive(&old_passphrase, &old_salt)
                     .map_err(|e| anyhow::anyhow!("key derivation failed: {e}"))?;
 
-                // Step 3: Pull all ops from server
                 eprintln!("Pulling all ops from server...");
                 let pull_result = client.pull_all_ops(&token).await?;
                 let total = pull_result.ops.len();
                 eprintln!("  {} ops to re-encrypt", total);
-
                 if total == 0 {
-                    anyhow::bail!("no ops on server — nothing to re-key");
+                    anyhow::bail!("no ops on server");
                 }
 
-                // Step 4: Derive new key with new salt
                 let new_salt = toku_core::SyncKey::generate_salt();
                 let new_key = toku_core::SyncKey::derive(&new_passphrase, &new_salt)
                     .map_err(|e| anyhow::anyhow!("key derivation failed: {e}"))?;
                 let new_salt_b64 = base64::engine::general_purpose::STANDARD.encode(new_salt);
 
-                // Step 5: Decrypt each op with old key, re-encrypt with new key
                 eprintln!("Re-encrypting ops...");
                 let mut re_encrypted_ops = Vec::with_capacity(total);
                 for (i, wire_op) in pull_result.ops.iter().enumerate() {
                     let mut re_wire = wire_op.clone();
-
-                    // Only process encrypted payloads
                     if wire_op.payload.is_object() && wire_op.payload.get("ev").is_some() {
                         let envelope: toku_core::EncryptedEnvelope =
                             serde_json::from_value(wire_op.payload.clone())
                                 .context("invalid encrypted envelope")?;
-
                         let entity_type: toku_core::EntityType = wire_op
                             .entity_type
                             .parse()
@@ -3358,7 +3501,6 @@ fn cmd_sync(data_dir: &Path, action: SyncAction, output_format: &OutputFormat) -
                             .op_type
                             .parse()
                             .map_err(|_| anyhow::anyhow!("invalid op_type"))?;
-
                         let plaintext = toku_core::decrypt_fields(
                             &old_key,
                             &envelope,
@@ -3367,12 +3509,8 @@ fn cmd_sync(data_dir: &Path, action: SyncAction, output_format: &OutputFormat) -
                             &op_type,
                         )
                         .map_err(|e| {
-                            anyhow::anyhow!(
-                                "decryption failed for op {}: {e} (wrong old passphrase?)",
-                                wire_op.op_id
-                            )
+                            anyhow::anyhow!("decryption failed for op {}: {e}", wire_op.op_id)
                         })?;
-
                         let new_envelope = toku_core::encrypt_fields(
                             &new_key,
                             &plaintext,
@@ -3381,35 +3519,87 @@ fn cmd_sync(data_dir: &Path, action: SyncAction, output_format: &OutputFormat) -
                             &op_type,
                         )
                         .map_err(|e| anyhow::anyhow!("re-encryption failed: {e}"))?;
-
                         re_wire.payload = serde_json::to_value(&new_envelope)?;
                     }
-
                     re_encrypted_ops.push(re_wire);
-
-                    // Progress indicator every 100 ops
                     if (i + 1) % 100 == 0 || i + 1 == total {
                         eprint!("\r  {}/{} ops re-encrypted", i + 1, total);
                     }
                 }
                 eprintln!();
 
-                // Step 6: Push re-encrypted ops to server
                 eprintln!("Uploading re-encrypted ops...");
                 let rekey_result = client
                     .rekey(&token, &new_salt_b64, &re_encrypted_ops)
                     .await
-                    .context("rekey request failed — server state unchanged")?;
-
-                // Step 7: Update local keychain with new key
-                token_store.store_sync_key(&server, new_key.as_exported_bytes())?;
-
+                    .context("rekey request failed")?;
+                token_store.store_sync_key(server, new_key.as_exported_bytes())?;
                 eprintln!(
-                    "✓ Re-keyed {} ops with new passphrase",
+                    "Re-keyed {} ops with new passphrase",
                     rekey_result.ops_replaced
                 );
                 Ok(())
             })
+        }
+
+        SyncAction::Compact => {
+            let sync_config = require_sync(&config)?;
+            let server = &sync_config.server;
+            let token = require_token(&token_store, server)?;
+
+            let db_path = data_dir.join("toku.db");
+            let db = Database::open(&db_path).context("failed to open database")?;
+            let sync_repo = toku_db::SyncRepository::new(&db);
+            let snapshot_repo = toku_db::SnapshotRepository::new(&db);
+            let client = sync::client::SyncClient::new(server)?;
+
+            let device = sync_repo.get_device()?.ok_or_else(|| {
+                anyhow::anyhow!("no device identity found. Run `toku sync init` first.")
+            })?;
+            let mut clock = toku_core::HybridClock::new(&device.device_id);
+            let hlc_str = clock.now().to_canonical();
+
+            eprintln!("Creating snapshot...");
+            let snapshot = snapshot_repo
+                .export_snapshot(device.device_id, &hlc_str)
+                .context("failed to export snapshot")?;
+            let snapshot_json =
+                serde_json::to_string(&snapshot).context("failed to serialize snapshot")?;
+            let size_kb = snapshot_json.len() / 1024;
+            eprintln!(
+                "  {} books, {} sessions, {} tags ({} KB)",
+                snapshot.library.books.len(),
+                snapshot.library.sessions.len(),
+                snapshot.library.tags.len(),
+                size_kb
+            );
+
+            eprintln!("Uploading snapshot and pruning old ops...");
+            let result = rt.block_on(async {
+                client
+                    .upload_snapshot(&token, &snapshot_json, &hlc_str)
+                    .await
+            })?;
+
+            match output_format {
+                OutputFormat::Json => {
+                    println!(
+                        "{}",
+                        serde_json::to_string_pretty(&serde_json::json!({
+                            "ops_pruned": result.ops_pruned,
+                            "snapshot_size_bytes": snapshot_json.len(),
+                        }))?
+                    );
+                }
+                OutputFormat::Csv => {
+                    println!("ops_pruned,snapshot_size_bytes");
+                    println!("{},{}", result.ops_pruned, snapshot_json.len());
+                }
+                OutputFormat::Table => {
+                    eprintln!("Snapshot uploaded, {} ops pruned", result.ops_pruned);
+                }
+            }
+            Ok(())
         }
     }
 }

--- a/crates/toku-cli/src/sync/client.rs
+++ b/crates/toku-cli/src/sync/client.rs
@@ -66,6 +66,24 @@ pub struct SaltResult {
     pub salt: Option<String>,
 }
 
+#[derive(Debug, Deserialize)]
+pub struct UploadSnapshotResult {
+    pub ops_pruned: usize,
+    #[allow(dead_code)]
+    pub hlc_at_snapshot: String,
+}
+
+#[derive(Debug, Deserialize)]
+#[allow(dead_code)]
+pub struct DownloadSnapshotResult {
+    pub snapshot_json: String,
+    pub hlc_at_snapshot: String,
+    #[allow(dead_code)]
+    pub created_at: String,
+    #[allow(dead_code)]
+    pub created_by_device: String,
+}
+
 impl SyncClient {
     pub fn new(server_url: &str) -> anyhow::Result<Self> {
         let http = reqwest::Client::builder()
@@ -215,6 +233,51 @@ impl SyncClient {
         }
 
         Ok(resp.json().await?)
+    }
+
+    /// Upload a snapshot to the server and prune old ops.
+    pub async fn upload_snapshot(
+        &self,
+        token: &str,
+        snapshot_json: &str,
+        hlc_at_snapshot: &str,
+    ) -> anyhow::Result<UploadSnapshotResult> {
+        let url = format!("{}/api/v1/snapshot", self.base_url);
+        let resp = self
+            .http
+            .post(&url)
+            .bearer_auth(token)
+            .json(&serde_json::json!({
+                "snapshot_json": snapshot_json,
+                "hlc_at_snapshot": hlc_at_snapshot,
+            }))
+            .send()
+            .await?;
+
+        if !resp.status().is_success() {
+            return Err(extract_error(resp).await);
+        }
+
+        Ok(resp.json().await?)
+    }
+
+    /// Download the latest snapshot from the server.
+    #[allow(dead_code)]
+    pub async fn download_snapshot(
+        &self,
+        token: &str,
+    ) -> anyhow::Result<Option<DownloadSnapshotResult>> {
+        let url = format!("{}/api/v1/snapshot", self.base_url);
+        let resp = self.http.get(&url).bearer_auth(token).send().await?;
+
+        if resp.status() == reqwest::StatusCode::NOT_FOUND {
+            return Ok(None);
+        }
+        if !resp.status().is_success() {
+            return Err(extract_error(resp).await);
+        }
+
+        Ok(Some(resp.json().await?))
     }
 }
 

--- a/crates/toku-core/src/config.rs
+++ b/crates/toku-core/src/config.rs
@@ -14,6 +14,23 @@ pub struct TokuConfig {
     pub color: String,
     /// Primary metadata source (openlibrary, google)
     pub metadata_source: String,
+    /// Sync configuration (optional — absent until `toku sync init`)
+    pub sync: Option<SyncConfig>,
+}
+
+/// Sync configuration stored in `config.toml` under `[sync]`.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct SyncConfig {
+    /// Sync server URL
+    pub server: String,
+    /// Library ID on the server
+    pub library_id: String,
+    /// This device's ID
+    pub device_id: String,
+    /// This device's name
+    pub device_name: String,
+    /// Whether client-side encryption is enabled
+    pub encryption: bool,
 }
 
 impl Default for TokuConfig {
@@ -22,6 +39,7 @@ impl Default for TokuConfig {
             default_format: "table".to_string(),
             color: "auto".to_string(),
             metadata_source: "openlibrary".to_string(),
+            sync: None,
         }
     }
 }
@@ -90,6 +108,7 @@ mod tests {
             default_format: "json".to_string(),
             color: "never".to_string(),
             metadata_source: "google".to_string(),
+            sync: None,
         };
         cfg.save(&dir).expect("save should succeed");
 

--- a/crates/toku-core/src/sync.rs
+++ b/crates/toku-core/src/sync.rs
@@ -480,6 +480,42 @@ impl DeviceIdentity {
 }
 
 // ---------------------------------------------------------------------------
+// Library Snapshot
+// ---------------------------------------------------------------------------
+
+/// A point-in-time snapshot of the entire library state.
+///
+/// Used for snapshot compaction (pruning old ops) and bootstrapping new
+/// devices without replaying the full op history.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LibrarySnapshot {
+    /// Snapshot format version (currently 1).
+    pub version: u16,
+    /// When this snapshot was created.
+    pub created_at: DateTime<Utc>,
+    /// The device that created this snapshot.
+    pub created_by_device: Uuid,
+    /// HLC at the time of snapshot. Ops older than this can be pruned.
+    pub hlc_at_snapshot: String,
+    /// The complete library state.
+    pub library: SnapshotLibrary,
+}
+
+/// The library content within a snapshot.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SnapshotLibrary {
+    pub books: Vec<serde_json::Value>,
+    pub book_authors: Vec<serde_json::Value>,
+    pub sessions: Vec<serde_json::Value>,
+    pub progress: Vec<serde_json::Value>,
+    pub tags: Vec<serde_json::Value>,
+    pub book_tags: Vec<serde_json::Value>,
+    pub notes: Vec<serde_json::Value>,
+    pub reviews: Vec<serde_json::Value>,
+    pub settings: Vec<serde_json::Value>,
+}
+
+// ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
 

--- a/crates/toku-db/Cargo.toml
+++ b/crates/toku-db/Cargo.toml
@@ -17,6 +17,7 @@ serde.workspace = true
 serde_json.workspace = true
 refinery = { version = "0.9", features = ["rusqlite"] }
 directories = "6"
+base64 = "0.22"
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/toku-db/src/lib.rs
+++ b/crates/toku-db/src/lib.rs
@@ -2,10 +2,12 @@ mod database;
 mod error;
 mod merge;
 mod repo;
+mod snapshot;
 mod sync_repo;
 
 pub use database::Database;
 pub use error::DbError;
 pub use merge::MergeEngine;
 pub use repo::BookRepository;
+pub use snapshot::SnapshotRepository;
 pub use sync_repo::SyncRepository;

--- a/crates/toku-db/src/snapshot.rs
+++ b/crates/toku-db/src/snapshot.rs
@@ -1,0 +1,680 @@
+//! Snapshot export and import for sync compaction and new-device bootstrap.
+//!
+//! Export reads the full library state into a [`LibrarySnapshot`].
+//! Import applies a snapshot to the local database, inserting all entities.
+
+use base64::Engine as _;
+use rusqlite::params;
+use toku_core::sync::{LibrarySnapshot, SnapshotLibrary};
+use uuid::Uuid;
+
+use crate::{Database, DbError};
+
+/// Snapshot persistence operations.
+pub struct SnapshotRepository<'a> {
+    db: &'a Database,
+}
+
+impl<'a> SnapshotRepository<'a> {
+    pub fn new(db: &'a Database) -> Self {
+        Self { db }
+    }
+
+    /// Export the full library state as a snapshot.
+    pub fn export_snapshot(
+        &self,
+        device_id: Uuid,
+        hlc_at_snapshot: &str,
+    ) -> Result<LibrarySnapshot, DbError> {
+        let books = self.export_table(
+            "SELECT id, title, subtitle, description, page_count, pub_date,
+             language, format, duration_minutes, cover_hash, work_id, status,
+             rating, created_at, updated_at, deleted_at, deleted_by_device
+             FROM books ORDER BY id",
+            &[
+                "id",
+                "title",
+                "subtitle",
+                "description",
+                "page_count",
+                "pub_date",
+                "language",
+                "format",
+                "duration_minutes",
+                "cover_hash",
+                "work_id",
+                "status",
+                "rating",
+                "created_at",
+                "updated_at",
+                "deleted_at",
+                "deleted_by_device",
+            ],
+        )?;
+
+        let book_authors = self.export_table(
+            "SELECT ba.book_id, ba.author_id, ba.role, ba.position,
+                    a.name, a.sort_name
+             FROM book_authors ba
+             JOIN authors a ON a.id = ba.author_id
+             ORDER BY ba.book_id, ba.position",
+            &[
+                "book_id",
+                "author_id",
+                "role",
+                "position",
+                "author_name",
+                "author_sort_name",
+            ],
+        )?;
+
+        let sessions = self.export_table(
+            "SELECT id, book_id, started_at, finished_at, start_page, end_page,
+             rating, notes, created_at
+             FROM reading_sessions ORDER BY id",
+            &[
+                "id",
+                "book_id",
+                "started_at",
+                "finished_at",
+                "start_page",
+                "end_page",
+                "rating",
+                "notes",
+                "created_at",
+            ],
+        )?;
+
+        let progress = self.export_table(
+            "SELECT id, book_id, session_id, progress_type, value, note,
+             logged_at, created_at
+             FROM reading_progress ORDER BY id",
+            &[
+                "id",
+                "book_id",
+                "session_id",
+                "progress_type",
+                "value",
+                "note",
+                "logged_at",
+                "created_at",
+            ],
+        )?;
+
+        let tags = self.export_table(
+            "SELECT id, name, tag_type, created_at FROM tags ORDER BY id",
+            &["id", "name", "tag_type", "created_at"],
+        )?;
+
+        let book_tags = self.export_table(
+            "SELECT book_id, tag_id FROM book_tags ORDER BY book_id, tag_id",
+            &["book_id", "tag_id"],
+        )?;
+
+        let notes = self.export_table(
+            "SELECT id, book_id, content, deleted_at, deleted_by_device,
+             created_at, updated_at
+             FROM notes ORDER BY id",
+            &[
+                "id",
+                "book_id",
+                "content",
+                "deleted_at",
+                "deleted_by_device",
+                "created_at",
+                "updated_at",
+            ],
+        )?;
+
+        let reviews = self.export_table(
+            "SELECT id, book_id, content, rating, deleted_at, deleted_by_device,
+             created_at, updated_at
+             FROM reviews ORDER BY id",
+            &[
+                "id",
+                "book_id",
+                "content",
+                "rating",
+                "deleted_at",
+                "deleted_by_device",
+                "created_at",
+                "updated_at",
+            ],
+        )?;
+
+        let settings = self.export_table(
+            "SELECT id, key, value, sync_hlc, updated_at FROM user_settings ORDER BY id",
+            &["id", "key", "value", "sync_hlc", "updated_at"],
+        )?;
+
+        Ok(LibrarySnapshot {
+            version: 1,
+            created_at: chrono::Utc::now(),
+            created_by_device: device_id,
+            hlc_at_snapshot: hlc_at_snapshot.to_string(),
+            library: SnapshotLibrary {
+                books,
+                book_authors,
+                sessions,
+                progress,
+                tags,
+                book_tags,
+                notes,
+                reviews,
+                settings,
+            },
+        })
+    }
+
+    /// Apply a snapshot to the local database, inserting all entities.
+    ///
+    /// This is used for new-device bootstrap. The database should be empty
+    /// or the caller should handle conflicts (existing data is not cleared).
+    pub fn apply_snapshot(
+        &self,
+        snapshot: &LibrarySnapshot,
+    ) -> Result<SnapshotApplyResult, DbError> {
+        let tx = self.db.conn.unchecked_transaction()?;
+        let mut result = SnapshotApplyResult::default();
+
+        // Books
+        for book in &snapshot.library.books {
+            let obj = book.as_object().ok_or_else(|| {
+                DbError::InvalidOperation("snapshot book is not an object".into())
+            })?;
+            tx.execute(
+                "INSERT OR IGNORE INTO books
+                 (id, title, subtitle, description, page_count, pub_date,
+                  language, format, duration_minutes, cover_hash, work_id, status,
+                  rating, created_at, updated_at, deleted_at, deleted_by_device)
+                 VALUES (?1,?2,?3,?4,?5,?6,?7,?8,?9,?10,?11,?12,?13,?14,?15,?16,?17)",
+                params![
+                    json_str(obj, "id"),
+                    json_str(obj, "title"),
+                    json_str_opt(obj, "subtitle"),
+                    json_str_opt(obj, "description"),
+                    json_i64_opt(obj, "page_count"),
+                    json_str_opt(obj, "pub_date"),
+                    json_str_opt(obj, "language"),
+                    json_str(obj, "format"),
+                    json_i64_opt(obj, "duration_minutes"),
+                    json_str_opt(obj, "cover_hash"),
+                    json_str_opt(obj, "work_id"),
+                    json_str(obj, "status"),
+                    json_i64_opt(obj, "rating"),
+                    json_str(obj, "created_at"),
+                    json_str(obj, "updated_at"),
+                    json_str_opt(obj, "deleted_at"),
+                    json_str_opt(obj, "deleted_by_device"),
+                ],
+            )?;
+            result.books += 1;
+        }
+
+        // Authors + book_authors
+        for ba in &snapshot.library.book_authors {
+            let obj = ba.as_object().ok_or_else(|| {
+                DbError::InvalidOperation("snapshot book_author is not an object".into())
+            })?;
+            let author_id = json_str(obj, "author_id");
+            let author_name = json_str(obj, "author_name");
+            let sort_name = json_str_opt(obj, "author_sort_name");
+
+            tx.execute(
+                "INSERT OR IGNORE INTO authors (id, name, sort_name) VALUES (?1, ?2, ?3)",
+                params![author_id, author_name, sort_name],
+            )?;
+
+            tx.execute(
+                "INSERT OR IGNORE INTO book_authors (book_id, author_id, role, position)
+                 VALUES (?1, ?2, ?3, ?4)",
+                params![
+                    json_str(obj, "book_id"),
+                    author_id,
+                    json_str(obj, "role"),
+                    json_i64_opt(obj, "position").unwrap_or(0),
+                ],
+            )?;
+        }
+
+        // Sessions
+        for session in &snapshot.library.sessions {
+            let obj = session.as_object().ok_or_else(|| {
+                DbError::InvalidOperation("snapshot session is not an object".into())
+            })?;
+            tx.execute(
+                "INSERT OR IGNORE INTO reading_sessions
+                 (id, book_id, started_at, finished_at, start_page, end_page,
+                  rating, notes, created_at)
+                 VALUES (?1,?2,?3,?4,?5,?6,?7,?8,?9)",
+                params![
+                    json_str(obj, "id"),
+                    json_str(obj, "book_id"),
+                    json_str(obj, "started_at"),
+                    json_str_opt(obj, "finished_at"),
+                    json_i64_opt(obj, "start_page"),
+                    json_i64_opt(obj, "end_page"),
+                    json_i64_opt(obj, "rating"),
+                    json_str_opt(obj, "notes"),
+                    json_str(obj, "created_at"),
+                ],
+            )?;
+            result.sessions += 1;
+        }
+
+        // Progress
+        for prog in &snapshot.library.progress {
+            let obj = prog.as_object().ok_or_else(|| {
+                DbError::InvalidOperation("snapshot progress is not an object".into())
+            })?;
+            tx.execute(
+                "INSERT OR IGNORE INTO reading_progress
+                 (id, book_id, session_id, progress_type, value, note,
+                  logged_at, created_at)
+                 VALUES (?1,?2,?3,?4,?5,?6,?7,?8)",
+                params![
+                    json_str(obj, "id"),
+                    json_str(obj, "book_id"),
+                    json_str_opt(obj, "session_id"),
+                    json_str(obj, "progress_type"),
+                    json_i64_opt(obj, "value").unwrap_or(0),
+                    json_str_opt(obj, "note"),
+                    json_str(obj, "logged_at"),
+                    json_str(obj, "created_at"),
+                ],
+            )?;
+            result.progress += 1;
+        }
+
+        // Tags
+        for tag in &snapshot.library.tags {
+            let obj = tag
+                .as_object()
+                .ok_or_else(|| DbError::InvalidOperation("snapshot tag is not an object".into()))?;
+            tx.execute(
+                "INSERT OR IGNORE INTO tags (id, name, tag_type, created_at)
+                 VALUES (?1, ?2, ?3, ?4)",
+                params![
+                    json_str(obj, "id"),
+                    json_str(obj, "name"),
+                    json_str(obj, "tag_type"),
+                    json_str(obj, "created_at"),
+                ],
+            )?;
+            result.tags += 1;
+        }
+
+        // Book-tag associations
+        for bt in &snapshot.library.book_tags {
+            let obj = bt.as_object().ok_or_else(|| {
+                DbError::InvalidOperation("snapshot book_tag is not an object".into())
+            })?;
+            tx.execute(
+                "INSERT OR IGNORE INTO book_tags (book_id, tag_id) VALUES (?1, ?2)",
+                params![json_str(obj, "book_id"), json_str(obj, "tag_id")],
+            )?;
+        }
+
+        // Notes
+        for note in &snapshot.library.notes {
+            let obj = note.as_object().ok_or_else(|| {
+                DbError::InvalidOperation("snapshot note is not an object".into())
+            })?;
+            tx.execute(
+                "INSERT OR IGNORE INTO notes
+                 (id, book_id, content, deleted_at, deleted_by_device,
+                  created_at, updated_at)
+                 VALUES (?1,?2,?3,?4,?5,?6,?7)",
+                params![
+                    json_str(obj, "id"),
+                    json_str(obj, "book_id"),
+                    json_str(obj, "content"),
+                    json_str_opt(obj, "deleted_at"),
+                    json_str_opt(obj, "deleted_by_device"),
+                    json_str(obj, "created_at"),
+                    json_str(obj, "updated_at"),
+                ],
+            )?;
+            result.notes += 1;
+        }
+
+        // Reviews
+        for review in &snapshot.library.reviews {
+            let obj = review.as_object().ok_or_else(|| {
+                DbError::InvalidOperation("snapshot review is not an object".into())
+            })?;
+            tx.execute(
+                "INSERT OR IGNORE INTO reviews
+                 (id, book_id, content, rating, deleted_at, deleted_by_device,
+                  created_at, updated_at)
+                 VALUES (?1,?2,?3,?4,?5,?6,?7,?8)",
+                params![
+                    json_str(obj, "id"),
+                    json_str(obj, "book_id"),
+                    json_str_opt(obj, "content"),
+                    json_i64_opt(obj, "rating"),
+                    json_str_opt(obj, "deleted_at"),
+                    json_str_opt(obj, "deleted_by_device"),
+                    json_str(obj, "created_at"),
+                    json_str(obj, "updated_at"),
+                ],
+            )?;
+            result.reviews += 1;
+        }
+
+        // Settings
+        for setting in &snapshot.library.settings {
+            let obj = setting.as_object().ok_or_else(|| {
+                DbError::InvalidOperation("snapshot setting is not an object".into())
+            })?;
+            tx.execute(
+                "INSERT OR IGNORE INTO user_settings
+                 (id, key, value, sync_hlc, updated_at)
+                 VALUES (?1, ?2, ?3, ?4, ?5)",
+                params![
+                    json_str(obj, "id"),
+                    json_str(obj, "key"),
+                    json_str(obj, "value"),
+                    json_str_opt(obj, "sync_hlc"),
+                    json_str(obj, "updated_at"),
+                ],
+            )?;
+            result.settings += 1;
+        }
+
+        tx.commit()?;
+        Ok(result)
+    }
+
+    /// Export a table to a vector of JSON objects.
+    fn export_table(&self, sql: &str, columns: &[&str]) -> Result<Vec<serde_json::Value>, DbError> {
+        let mut stmt = self.db.conn.prepare(sql)?;
+        let col_count = columns.len();
+
+        let rows = stmt
+            .query_map([], |row| {
+                let mut map = serde_json::Map::new();
+                for (i, col_name) in columns.iter().enumerate().take(col_count) {
+                    let value: rusqlite::types::Value = row.get(i)?;
+                    map.insert(
+                        col_name.to_string(),
+                        match value {
+                            rusqlite::types::Value::Null => serde_json::Value::Null,
+                            rusqlite::types::Value::Integer(n) => {
+                                serde_json::Value::Number(n.into())
+                            }
+                            rusqlite::types::Value::Real(f) => serde_json::json!(f),
+                            rusqlite::types::Value::Text(s) => serde_json::Value::String(s),
+                            rusqlite::types::Value::Blob(b) => serde_json::Value::String(
+                                base64::engine::general_purpose::STANDARD.encode(b),
+                            ),
+                        },
+                    );
+                }
+                Ok(serde_json::Value::Object(map))
+            })?
+            .collect::<Result<Vec<_>, _>>()?;
+
+        Ok(rows)
+    }
+}
+
+/// Result of applying a snapshot to the local database.
+#[derive(Debug, Default)]
+pub struct SnapshotApplyResult {
+    pub books: usize,
+    pub sessions: usize,
+    pub progress: usize,
+    pub tags: usize,
+    pub notes: usize,
+    pub reviews: usize,
+    pub settings: usize,
+}
+
+// JSON extraction helpers
+fn json_str(obj: &serde_json::Map<String, serde_json::Value>, key: &str) -> Option<String> {
+    obj.get(key).and_then(|v| v.as_str()).map(|s| s.to_string())
+}
+
+fn json_str_opt(obj: &serde_json::Map<String, serde_json::Value>, key: &str) -> Option<String> {
+    obj.get(key)
+        .and_then(|v| if v.is_null() { None } else { v.as_str() })
+        .map(|s| s.to_string())
+}
+
+fn json_i64_opt(obj: &serde_json::Map<String, serde_json::Value>, key: &str) -> Option<i64> {
+    obj.get(key).and_then(|v| v.as_i64())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use toku_core::sync::HybridClock;
+
+    fn setup_db() -> Database {
+        Database::open_in_memory().expect("in-memory DB")
+    }
+
+    fn populate_db(db: &Database) {
+        let now = chrono::Utc::now().to_rfc3339();
+        let book_id = "01972123-abcd-7000-8000-000000000001";
+        let author_id = "01972123-abcd-7000-8000-000000000002";
+        let session_id = "01972123-abcd-7000-8000-000000000003";
+        let tag_id = "01972123-abcd-7000-8000-000000000004";
+        let note_id = "01972123-abcd-7000-8000-000000000005";
+        let review_id = "01972123-abcd-7000-8000-000000000006";
+        let setting_id = "01972123-abcd-7000-8000-000000000007";
+
+        db.conn
+            .execute(
+                "INSERT INTO books (id, title, format, status, rating, created_at, updated_at)
+                 VALUES (?1, 'Dune', 'physical', 'read', 9, ?2, ?2)",
+                params![book_id, now],
+            )
+            .unwrap();
+
+        db.conn
+            .execute(
+                "INSERT INTO authors (id, name, sort_name) VALUES (?1, 'Frank Herbert', 'Herbert, Frank')",
+                params![author_id],
+            )
+            .unwrap();
+
+        db.conn
+            .execute(
+                "INSERT INTO book_authors (book_id, author_id, role, position)
+                 VALUES (?1, ?2, 'author', 0)",
+                params![book_id, author_id],
+            )
+            .unwrap();
+
+        db.conn
+            .execute(
+                "INSERT INTO reading_sessions (id, book_id, started_at, created_at)
+                 VALUES (?1, ?2, ?3, ?3)",
+                params![session_id, book_id, now],
+            )
+            .unwrap();
+
+        db.conn
+            .execute(
+                "INSERT INTO tags (id, name, tag_type, created_at) VALUES (?1, 'sci-fi', 'general', ?2)",
+                params![tag_id, now],
+            )
+            .unwrap();
+
+        db.conn
+            .execute(
+                "INSERT INTO book_tags (book_id, tag_id) VALUES (?1, ?2)",
+                params![book_id, tag_id],
+            )
+            .unwrap();
+
+        db.conn
+            .execute(
+                "INSERT INTO notes (id, book_id, content, created_at, updated_at)
+                 VALUES (?1, ?2, 'Great book', ?3, ?3)",
+                params![note_id, book_id, now],
+            )
+            .unwrap();
+
+        db.conn
+            .execute(
+                "INSERT INTO reviews (id, book_id, content, rating, created_at, updated_at)
+                 VALUES (?1, ?2, 'Masterpiece', 9, ?3, ?3)",
+                params![review_id, book_id, now],
+            )
+            .unwrap();
+
+        db.conn
+            .execute(
+                "INSERT INTO user_settings (id, key, value, updated_at)
+                 VALUES (?1, 'theme', 'dark', ?2)",
+                params![setting_id, now],
+            )
+            .unwrap();
+    }
+
+    #[test]
+    fn export_snapshot_captures_all_entities() {
+        let db = setup_db();
+        populate_db(&db);
+
+        let repo = SnapshotRepository::new(&db);
+        let device = Uuid::now_v7();
+        let mut clock = HybridClock::new(&device);
+        let hlc = clock.now().to_canonical();
+
+        let snapshot = repo.export_snapshot(device, &hlc).unwrap();
+
+        assert_eq!(snapshot.version, 1);
+        assert_eq!(snapshot.created_by_device, device);
+        assert_eq!(snapshot.hlc_at_snapshot, hlc);
+        assert_eq!(snapshot.library.books.len(), 1);
+        assert_eq!(snapshot.library.book_authors.len(), 1);
+        assert_eq!(snapshot.library.sessions.len(), 1);
+        assert_eq!(snapshot.library.tags.len(), 1);
+        assert_eq!(snapshot.library.book_tags.len(), 1);
+        assert_eq!(snapshot.library.notes.len(), 1);
+        assert_eq!(snapshot.library.reviews.len(), 1);
+        assert_eq!(snapshot.library.settings.len(), 1);
+
+        // Verify book content
+        let book = snapshot.library.books[0].as_object().unwrap();
+        assert_eq!(book["title"].as_str().unwrap(), "Dune");
+        assert_eq!(book["rating"].as_i64().unwrap(), 9);
+    }
+
+    #[test]
+    fn snapshot_round_trip() {
+        let source_db = setup_db();
+        populate_db(&source_db);
+
+        let repo = SnapshotRepository::new(&source_db);
+        let device = Uuid::now_v7();
+        let mut clock = HybridClock::new(&device);
+        let hlc = clock.now().to_canonical();
+
+        let snapshot = repo.export_snapshot(device, &hlc).unwrap();
+
+        // Apply to a fresh database
+        let target_db = setup_db();
+        let target_repo = SnapshotRepository::new(&target_db);
+        let result = target_repo.apply_snapshot(&snapshot).unwrap();
+
+        assert_eq!(result.books, 1);
+        assert_eq!(result.sessions, 1);
+        assert_eq!(result.tags, 1);
+        assert_eq!(result.notes, 1);
+        assert_eq!(result.reviews, 1);
+        assert_eq!(result.settings, 1);
+
+        // Verify data survived the round trip
+        let title: String = target_db
+            .conn
+            .query_row("SELECT title FROM books LIMIT 1", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(title, "Dune");
+
+        let author_name: String = target_db
+            .conn
+            .query_row(
+                "SELECT a.name FROM authors a
+                 JOIN book_authors ba ON ba.author_id = a.id LIMIT 1",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(author_name, "Frank Herbert");
+
+        let tag_name: String = target_db
+            .conn
+            .query_row(
+                "SELECT t.name FROM tags t
+                 JOIN book_tags bt ON bt.tag_id = t.id LIMIT 1",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(tag_name, "sci-fi");
+
+        let note_content: String = target_db
+            .conn
+            .query_row("SELECT content FROM notes LIMIT 1", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(note_content, "Great book");
+
+        let setting_val: String = target_db
+            .conn
+            .query_row(
+                "SELECT value FROM user_settings WHERE key = 'theme'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(setting_val, "dark");
+    }
+
+    #[test]
+    fn apply_snapshot_is_idempotent() {
+        let db = setup_db();
+        populate_db(&db);
+
+        let repo = SnapshotRepository::new(&db);
+        let device = Uuid::now_v7();
+        let mut clock = HybridClock::new(&device);
+        let hlc = clock.now().to_canonical();
+        let snapshot = repo.export_snapshot(device, &hlc).unwrap();
+
+        let target_db = setup_db();
+        let target_repo = SnapshotRepository::new(&target_db);
+
+        // Apply twice — second should not fail or duplicate
+        target_repo.apply_snapshot(&snapshot).unwrap();
+        target_repo.apply_snapshot(&snapshot).unwrap();
+
+        let count: i64 = target_db
+            .conn
+            .query_row("SELECT COUNT(*) FROM books", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(count, 1);
+    }
+
+    #[test]
+    fn snapshot_serializes_to_json() {
+        let db = setup_db();
+        populate_db(&db);
+
+        let repo = SnapshotRepository::new(&db);
+        let device = Uuid::now_v7();
+        let mut clock = HybridClock::new(&device);
+        let hlc = clock.now().to_canonical();
+        let snapshot = repo.export_snapshot(device, &hlc).unwrap();
+
+        let json = serde_json::to_string(&snapshot).unwrap();
+        let deserialized: LibrarySnapshot = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(deserialized.version, snapshot.version);
+        assert_eq!(deserialized.library.books.len(), 1);
+    }
+}

--- a/crates/toku-sync/migrations/V3__snapshots.sql
+++ b/crates/toku-sync/migrations/V3__snapshots.sql
@@ -1,0 +1,10 @@
+-- Snapshot storage for compaction and new-device bootstrap.
+CREATE TABLE snapshots (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    library_id TEXT NOT NULL REFERENCES libraries(id),
+    snapshot_json TEXT NOT NULL,
+    hlc_at_snapshot TEXT NOT NULL,
+    created_by_device TEXT NOT NULL,
+    created_at TEXT NOT NULL
+);
+CREATE INDEX idx_snapshots_library ON snapshots(library_id, created_at DESC);

--- a/crates/toku-sync/src/handlers.rs
+++ b/crates/toku-sync/src/handlers.rs
@@ -7,8 +7,9 @@ use crate::auth::{AuthDevice, sha256_hex};
 use crate::db::SyncDatabase;
 use crate::error::SyncError;
 use crate::models::{
-    DeviceResponse, HealthResponse, OpPayload, PullQuery, PullResponse, PushRequest, PushResponse,
-    RegisterRequest, RegisterResponse, RekeyRequest, RekeyResponse,
+    DeviceResponse, DownloadSnapshotResponse, HealthResponse, OpPayload, PullQuery, PullResponse,
+    PushRequest, PushResponse, RegisterRequest, RegisterResponse, RekeyRequest, RekeyResponse,
+    UploadSnapshotRequest, UploadSnapshotResponse,
 };
 
 const MAX_BATCH_SIZE: usize = 1000;
@@ -347,13 +348,104 @@ pub async fn pull_ops(
 
 // ── Snapshot / Salt ─────────────────────────────────────────────────────────
 
-pub async fn snapshot() -> (axum::http::StatusCode, Json<serde_json::Value>) {
-    (
-        axum::http::StatusCode::NOT_IMPLEMENTED,
-        Json(serde_json::json!({
-            "error": "snapshots are not yet implemented"
-        })),
-    )
+// ── Snapshot ────────────────────────────────────────────────────────────────
+
+/// Download the latest snapshot for this library.
+pub async fn download_snapshot(
+    State(db_path): State<PathBuf>,
+    device: AuthDevice,
+) -> Result<Json<DownloadSnapshotResponse>, SyncError> {
+    let resp = tokio::task::spawn_blocking({
+        let db_path = db_path.clone();
+        let library_id = device.library_id.clone();
+        move || -> Result<DownloadSnapshotResponse, SyncError> {
+            let db = SyncDatabase::open_no_migrate(&db_path)?;
+            let row: Option<(String, String, String, String)> = db
+                .conn
+                .query_row(
+                    "SELECT snapshot_json, hlc_at_snapshot, created_at, created_by_device
+                     FROM snapshots
+                     WHERE library_id = ?1
+                     ORDER BY created_at DESC
+                     LIMIT 1",
+                    [&library_id],
+                    |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?)),
+                )
+                .ok();
+
+            match row {
+                Some((snapshot_json, hlc, created_at, device_id)) => Ok(DownloadSnapshotResponse {
+                    snapshot_json,
+                    hlc_at_snapshot: hlc,
+                    created_at,
+                    created_by_device: device_id,
+                }),
+                None => Err(SyncError::NotFound("no snapshot available".into())),
+            }
+        }
+    })
+    .await
+    .map_err(|e| SyncError::Internal(format!("task join error: {e}")))??;
+
+    Ok(Json(resp))
+}
+
+/// Upload a snapshot and prune ops older than the snapshot HLC.
+pub async fn upload_snapshot(
+    State(db_path): State<PathBuf>,
+    device: AuthDevice,
+    Json(req): Json<UploadSnapshotRequest>,
+) -> Result<Json<UploadSnapshotResponse>, SyncError> {
+    if req.snapshot_json.is_empty() {
+        return Err(SyncError::BadRequest("snapshot_json is required".into()));
+    }
+    if req.hlc_at_snapshot.is_empty() {
+        return Err(SyncError::BadRequest("hlc_at_snapshot is required".into()));
+    }
+
+    let resp = tokio::task::spawn_blocking({
+        let db_path = db_path.clone();
+        let library_id = device.library_id.clone();
+        let device_id = device.device_id.clone();
+        let snapshot_json = req.snapshot_json;
+        let hlc = req.hlc_at_snapshot;
+        move || -> Result<UploadSnapshotResponse, SyncError> {
+            let db = SyncDatabase::open_no_migrate(&db_path)?;
+            let tx = db.conn.unchecked_transaction()?;
+
+            // Store the snapshot
+            tx.execute(
+                "INSERT INTO snapshots (library_id, snapshot_json, hlc_at_snapshot, created_by_device, created_at)
+                 VALUES (?1, ?2, ?3, ?4, datetime('now'))",
+                rusqlite::params![library_id, snapshot_json, hlc, device_id],
+            )?;
+
+            // Prune ops older than the snapshot HLC
+            let pruned = tx.execute(
+                "DELETE FROM ops WHERE library_id = ?1 AND hlc <= ?2",
+                rusqlite::params![library_id, hlc],
+            )?;
+
+            // Keep only the latest snapshot per library
+            tx.execute(
+                "DELETE FROM snapshots
+                 WHERE library_id = ?1
+                   AND id != (SELECT id FROM snapshots WHERE library_id = ?1 ORDER BY created_at DESC LIMIT 1)",
+                [&library_id],
+            )?;
+
+            tx.commit()?;
+
+            Ok(UploadSnapshotResponse {
+                ops_pruned: pruned,
+                hlc_at_snapshot: hlc,
+            })
+        }
+    })
+    .await
+    .map_err(|e| SyncError::Internal(format!("task join error: {e}")))??;
+
+    Ok(Json(resp))
 }
 
 /// Get the library salt (needed for key derivation on new devices).

--- a/crates/toku-sync/src/main.rs
+++ b/crates/toku-sync/src/main.rs
@@ -25,7 +25,8 @@ fn build_router(db_path: PathBuf) -> Router {
         .route("/api/v1/pull", get(handlers::pull_ops))
         .route("/api/v1/pull/all", get(handlers::pull_all_ops))
         .route("/api/v1/salt", get(handlers::get_salt))
-        .route("/api/v1/snapshot", get(handlers::snapshot))
+        .route("/api/v1/snapshot", get(handlers::download_snapshot))
+        .route("/api/v1/snapshot", post(handlers::upload_snapshot))
         .route("/api/v1/rekey", post(handlers::rekey))
         .layer(middleware::from_fn_with_state(
             db_path.clone(),
@@ -527,7 +528,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn snapshot_returns_501() {
+    async fn snapshot_download_returns_404_when_none_exists() {
         let db_path = test_db_path();
         let app = build_router(db_path.clone());
 
@@ -567,7 +568,147 @@ mod tests {
             .await
             .unwrap();
 
-        assert_eq!(resp.status(), StatusCode::NOT_IMPLEMENTED);
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+
+        cleanup(&db_path);
+    }
+
+    #[tokio::test]
+    async fn snapshot_upload_and_download_round_trip() {
+        let db_path = test_db_path();
+        let app = build_router(db_path.clone());
+
+        // Register
+        let resp = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/v1/register")
+                    .header("Content-Type", "application/json")
+                    .body(Body::from(
+                        serde_json::to_string(&serde_json::json!({
+                            "library_id": "lib-snap",
+                            "device_name": "dev"
+                        }))
+                        .unwrap(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let register: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        let token = register["auth_token"].as_str().unwrap().to_string();
+
+        // Push some ops first
+        app.clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/v1/push")
+                    .header("Content-Type", "application/json")
+                    .header("Authorization", format!("Bearer {token}"))
+                    .body(Body::from(
+                        serde_json::to_string(&serde_json::json!({
+                            "ops": [
+                                {
+                                    "op_id": "snap-op-1",
+                                    "device_id": "d1",
+                                    "hlc": "2026-01-01T00:00:00.000Z-0001-aaaaaaaaaaaa",
+                                    "entity_type": "book",
+                                    "entity_id": "b1",
+                                    "op_type": "create",
+                                    "payload": {"title": "Dune"}
+                                },
+                                {
+                                    "op_id": "snap-op-2",
+                                    "device_id": "d1",
+                                    "hlc": "2026-01-01T00:00:01.000Z-0001-aaaaaaaaaaaa",
+                                    "entity_type": "book",
+                                    "entity_id": "b1",
+                                    "op_type": "update",
+                                    "payload": {"rating": 9}
+                                }
+                            ]
+                        }))
+                        .unwrap(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        // Upload a snapshot at a HLC that covers the first op
+        let snapshot_hlc = "2026-01-01T00:00:00.500Z-0000-aaaaaaaaaaaa";
+        let resp = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/v1/snapshot")
+                    .header("Content-Type", "application/json")
+                    .header("Authorization", format!("Bearer {token}"))
+                    .body(Body::from(
+                        serde_json::to_string(&serde_json::json!({
+                            "snapshot_json": "{\"version\":1,\"books\":[{\"title\":\"Dune\"}]}",
+                            "hlc_at_snapshot": snapshot_hlc,
+                        }))
+                        .unwrap(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let upload: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        // First op (hlc ...00.000Z) should be pruned, second (...01.000Z) kept
+        assert_eq!(upload["ops_pruned"], 1);
+
+        // Download the snapshot
+        let resp = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri("/api/v1/snapshot")
+                    .header("Authorization", format!("Bearer {token}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let download: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(download["hlc_at_snapshot"], snapshot_hlc);
+        assert!(download["snapshot_json"].as_str().unwrap().contains("Dune"));
+
+        // Verify the first op was pruned — pull/all should only return the second
+        let resp = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri("/api/v1/pull/all")
+                    .header("Authorization", format!("Bearer {token}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let pull: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        let ops = pull["ops"].as_array().unwrap();
+        assert_eq!(ops.len(), 1);
+        assert_eq!(ops[0]["op_id"], "snap-op-2");
 
         cleanup(&db_path);
     }

--- a/crates/toku-sync/src/models.rs
+++ b/crates/toku-sync/src/models.rs
@@ -35,6 +35,12 @@ pub struct RekeyRequest {
     pub ops: Vec<OpPayload>,
 }
 
+#[derive(Debug, Deserialize)]
+pub struct UploadSnapshotRequest {
+    pub snapshot_json: String,
+    pub hlc_at_snapshot: String,
+}
+
 // ── Responses ───────────────────────────────────────────────────────────────
 
 #[derive(Debug, Serialize)]
@@ -81,4 +87,18 @@ pub struct ErrorBody {
 pub struct RekeyResponse {
     pub ops_replaced: usize,
     pub new_salt: String,
+}
+
+#[derive(Debug, Serialize)]
+pub struct UploadSnapshotResponse {
+    pub ops_pruned: usize,
+    pub hlc_at_snapshot: String,
+}
+
+#[derive(Debug, Serialize)]
+pub struct DownloadSnapshotResponse {
+    pub snapshot_json: String,
+    pub hlc_at_snapshot: String,
+    pub created_at: String,
+    pub created_by_device: String,
 }


### PR DESCRIPTION
## Description

Implements snapshot compaction for sync op-log management and redesigns the CLI sync commands for a streamlined user experience.

### What's included

**Snapshot compaction (#73)**
- `LibrarySnapshot` model capturing the full library state (books, authors, sessions, progress, tags, notes, reviews, settings)
- `SnapshotRepository` with `export_snapshot()` and `apply_snapshot()` for local DB snapshot round-trips
- Server-side snapshot storage (`POST /api/v1/snapshot`) with automatic op pruning for ops older than the snapshot HLC
- `GET /api/v1/snapshot` for downloading the latest snapshot (new-device bootstrap)
- `toku sync compact` CLI command to create and upload a snapshot
- 6 new tests (4 snapshot round-trip + 2 server integration)

**CLI sync command redesign (#74)**
- `toku sync init` replaces `register` — one-step setup with automatic device naming (hostname), auto-generated library ID, optional `--passphrase` for encryption, and config persistence to `config.toml`
- `toku sync status` shows sync state: server, device, library, pending ops, cursors, encryption, device count
- `toku sync disable` replaces `logout` — removes sync config and credentials while preserving local data
- All sync commands (`push`, `pull`, `devices`, `rekey`, `compact`) now read server URL from config instead of requiring `--server` on every invocation
- `SyncConfig` added to `config.toml` under `[sync]` section

## Related Issues

Closes #73
Closes #74

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI / infrastructure
- [ ] Other (describe below)

## Crate

- [x] `toku-core` — Domain models, traits, state machine
- [x] `toku-db` — SQLite persistence, migrations, FTS5
- [ ] `toku-import` — Importers (Goodreads, Calibre, StoryGraph)
- [ ] `toku-meta` — Metadata fetching (Open Library, Google Books)
- [x] `toku-cli` — CLI binary
- [ ] `toku-export` — Exporters (CSV, JSON, Markdown, BibTeX)
- [ ] `docs/` — Documentation

## Data Integrity Checklist

- [x] No user data is sent to any server without explicit opt-in
- [x] Import operations are idempotent (re-importing the same file creates no duplicates)
- [x] User edits to metadata are never overwritten by auto-enrichment
- [x] New fields track provenance (source + timestamp)
- [x] Export round-trip is preserved (if applicable)

## Checklist

- [x] I have read [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] `cargo fmt --check` passes
- [x] `cargo clippy --workspace -- -D warnings` passes
- [x] `cargo test --workspace` passes
- [x] I have updated documentation (if applicable)
