### PR TITLE
chore: group Dependabot updates into single PRs per ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,10 @@ updates:
       - "ci"
       - "dependencies"
     open-pull-requests-limit: 5
+    groups:
+      github-actions:
+        patterns:
+          - "*"
 
   # Rust (Cargo)
   - package-ecosystem: "cargo"
@@ -25,3 +29,7 @@ updates:
     labels:
       - "dependencies"
     open-pull-requests-limit: 10
+    groups:
+      cargo:
+        patterns:
+          - "*"


### PR DESCRIPTION
## Why

Dependabot currently opens a separate PR for each dependency update, which creates noise and review overhead. Grouping updates per ecosystem consolidates them into a single PR, making routine dependency maintenance faster to review and merge.

## What

Adds a `groups:` block to each `updates:` entry in `.github/dependabot.yml`:

- **github-actions** — all actions bundled into one grouped PR (`patterns: ["*"]`)
- **cargo** — all Rust crate updates bundled into one grouped PR (`patterns: ["*"]`)

All existing keys (schedule, commit-message prefix, labels, open-pull-requests-limit) are preserved exactly. The only change is the added grouping configuration.

## Notes

Config-only change; no application code affected. Grouping behavior takes effect on the next Dependabot run.