### PR TITLE
feat: add sync conflict resolution UI for CLI and web

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Sync conflict resolution UI (CLI + web): `toku sync conflicts` lists unresolved note/review conflicts, `toku sync conflicts show <id>` shows the local/remote diff, and `resolve <id> --keep local|remote` / `resolve-all --keep local|remote` resolve them. Resolving writes the chosen value to the entity, marks the conflict resolved, and emits a propagating sync op. `toku sync status` now reports the unresolved conflict count
+- Web conflicts page (`/conflicts`): side-by-side local/remote diff cards with one-click keep-local / keep-remote buttons and bulk resolve actions, plus a sync status indicator in the dashboard header (shown only when sync is configured) that links to the conflicts page and highlights when conflicts are pending
 - Native client sync (FFI + Swift): the iOS and macOS apps can now configure sync, push, pull, and view sync status/devices directly. New `toku_sync_init/push/pull/status/devices` C FFI functions expose the sync client to Swift, backed by a shared `toku-sync-client` crate extracted from the CLI so both surfaces reuse one implementation
 - `SyncSettingsView` in the Apple apps (shared via `TokuKitUI`): set up sync against a server, enable optional end-to-end encryption, run "Sync Now"/push/pull, and view pending changes and registered devices — reachable from macOS Settings and the iOS Sync screen
 - Automatic sync-on-launch in the Apple apps: when sync is configured, the iOS and macOS apps run a best-effort push/pull once on launch and refresh the library and stats if remote changes were applied; failures are silent (non-blocking)

--- a/crates/toku-cli/src/main.rs
+++ b/crates/toku-cli/src/main.rs
@@ -611,6 +611,58 @@ enum SyncAction {
 
     /// Compact the op log by creating a snapshot and pruning old ops
     Compact,
+
+    /// Review and resolve sync conflicts (note/review edits that collided across devices)
+    Conflicts {
+        #[command(subcommand)]
+        action: Option<ConflictAction>,
+    },
+}
+
+#[derive(Clone, Subcommand)]
+enum ConflictAction {
+    /// List unresolved conflicts (default when no subcommand is given)
+    List,
+
+    /// Show the local/remote diff for a single conflict
+    Show {
+        /// Conflict ID
+        id: String,
+    },
+
+    /// Resolve a single conflict by keeping the local or remote value
+    Resolve {
+        /// Conflict ID
+        id: String,
+
+        /// Which side to keep
+        #[arg(long, value_enum)]
+        keep: KeepArg,
+    },
+
+    /// Resolve every unresolved conflict the same way
+    ResolveAll {
+        /// Which side to keep
+        #[arg(long, value_enum)]
+        keep: KeepArg,
+    },
+}
+
+#[derive(Clone, Copy, ValueEnum)]
+enum KeepArg {
+    /// Keep this device's local value
+    Local,
+    /// Keep the incoming remote value
+    Remote,
+}
+
+impl From<KeepArg> for toku_db::ConflictKeep {
+    fn from(value: KeepArg) -> Self {
+        match value {
+            KeepArg::Local => toku_db::ConflictKeep::Local,
+            KeepArg::Remote => toku_db::ConflictKeep::Remote,
+        }
+    }
 }
 
 #[derive(Clone, ValueEnum)]
@@ -3066,6 +3118,7 @@ fn cmd_sync(data_dir: &Path, action: SyncAction, output_format: &OutputFormat) -
                             "push_cursor": status.push_cursor,
                             "pull_cursor": status.pull_cursor,
                             "device_count": status.device_count,
+                            "unresolved_conflicts": status.unresolved_conflicts,
                         }))?
                     );
                 }
@@ -3076,6 +3129,7 @@ fn cmd_sync(data_dir: &Path, action: SyncAction, output_format: &OutputFormat) -
                     println!("device,{}", status.device_name);
                     println!("pending_ops,{}", status.pending_ops);
                     println!("device_count,{}", status.device_count);
+                    println!("unresolved_conflicts,{}", status.unresolved_conflicts);
                 }
                 OutputFormat::Table => {
                     eprintln!("Sync: enabled");
@@ -3101,6 +3155,14 @@ fn cmd_sync(data_dir: &Path, action: SyncAction, output_format: &OutputFormat) -
                     );
                     if status.device_count > 0 {
                         eprintln!("Devices: {} registered", status.device_count);
+                    }
+                    if status.unresolved_conflicts > 0 {
+                        eprintln!(
+                            "Conflicts: {} unresolved (run `toku sync conflicts`)",
+                            status.unresolved_conflicts
+                        );
+                    } else {
+                        eprintln!("Conflicts: none");
                     }
                 }
             }
@@ -3490,6 +3552,169 @@ fn cmd_sync(data_dir: &Path, action: SyncAction, output_format: &OutputFormat) -
                 }
                 OutputFormat::Table => {
                     eprintln!("Snapshot uploaded, {} ops pruned", result.ops_pruned);
+                }
+            }
+            Ok(())
+        }
+
+        SyncAction::Conflicts { action } => {
+            let action = action.unwrap_or(ConflictAction::List);
+            cmd_sync_conflicts(data_dir, action, output_format)
+        }
+    }
+}
+
+fn conflict_to_json(c: &toku_db::SyncConflict) -> serde_json::Value {
+    serde_json::json!({
+        "id": c.id,
+        "entity_type": c.entity_type,
+        "entity_id": c.entity_id,
+        "field_name": c.field_name,
+        "local_value": c.local_value,
+        "remote_value": c.remote_value,
+        "local_hlc": c.local_hlc,
+        "remote_hlc": c.remote_hlc,
+        "created_at": c.created_at,
+    })
+}
+
+fn print_conflict_human(c: &toku_db::SyncConflict) {
+    let field = c.field_name.as_deref().unwrap_or("");
+    let local = c.local_value.as_deref().unwrap_or("(none)");
+    let remote = c.remote_value.as_deref().unwrap_or("(none)");
+    eprintln!("Conflict {}", c.id);
+    eprintln!("  Entity: {} {} ({field})", c.entity_type, c.entity_id);
+    eprintln!("  Local  [{}]: {local}", c.local_hlc);
+    eprintln!("  Remote [{}]: {remote}", c.remote_hlc);
+    eprintln!(
+        "  Resolve: toku sync conflicts resolve {} --keep local|remote",
+        c.id
+    );
+}
+
+fn cmd_sync_conflicts(
+    data_dir: &Path,
+    action: ConflictAction,
+    output_format: &OutputFormat,
+) -> Result<()> {
+    match action {
+        ConflictAction::List => {
+            let conflicts = sync::orchestrator::conflicts(data_dir)?;
+            match output_format {
+                OutputFormat::Json => {
+                    let arr: Vec<_> = conflicts.iter().map(conflict_to_json).collect();
+                    println!("{}", serde_json::to_string_pretty(&arr)?);
+                }
+                OutputFormat::Csv => {
+                    println!("id,entity_type,entity_id,field_name,local_value,remote_value");
+                    for c in &conflicts {
+                        println!(
+                            "{},{},{},{},{},{}",
+                            c.id,
+                            c.entity_type,
+                            c.entity_id,
+                            c.field_name.as_deref().unwrap_or(""),
+                            c.local_value.as_deref().unwrap_or(""),
+                            c.remote_value.as_deref().unwrap_or("")
+                        );
+                    }
+                }
+                OutputFormat::Table => {
+                    if conflicts.is_empty() {
+                        eprintln!("No unresolved conflicts.");
+                    } else {
+                        eprintln!("{} unresolved conflict(s):\n", conflicts.len());
+                        for c in &conflicts {
+                            print_conflict_human(c);
+                            eprintln!();
+                        }
+                    }
+                }
+            }
+            Ok(())
+        }
+
+        ConflictAction::Show { id } => {
+            let conflict = sync::orchestrator::conflict(data_dir, &id)?
+                .ok_or_else(|| anyhow::anyhow!("no conflict found with id {id}"))?;
+            match output_format {
+                OutputFormat::Json => {
+                    println!(
+                        "{}",
+                        serde_json::to_string_pretty(&conflict_to_json(&conflict))?
+                    );
+                }
+                OutputFormat::Csv => {
+                    println!("id,entity_type,entity_id,field_name,local_value,remote_value");
+                    println!(
+                        "{},{},{},{},{},{}",
+                        conflict.id,
+                        conflict.entity_type,
+                        conflict.entity_id,
+                        conflict.field_name.as_deref().unwrap_or(""),
+                        conflict.local_value.as_deref().unwrap_or(""),
+                        conflict.remote_value.as_deref().unwrap_or("")
+                    );
+                }
+                OutputFormat::Table => {
+                    print_conflict_human(&conflict);
+                }
+            }
+            Ok(())
+        }
+
+        ConflictAction::Resolve { id, keep } => {
+            let resolved = sync::orchestrator::resolve_conflict(data_dir, &id, keep.into())?;
+            if !resolved {
+                anyhow::bail!("no unresolved conflict found with id {id}");
+            }
+            let kept = match keep {
+                KeepArg::Local => "local",
+                KeepArg::Remote => "remote",
+            };
+            match output_format {
+                OutputFormat::Json => {
+                    println!(
+                        "{}",
+                        serde_json::to_string_pretty(&serde_json::json!({
+                            "resolved": id,
+                            "kept": kept,
+                        }))?
+                    );
+                }
+                OutputFormat::Csv => {
+                    println!("resolved,kept");
+                    println!("{id},{kept}");
+                }
+                OutputFormat::Table => {
+                    eprintln!("Resolved conflict {id} (kept {kept}).");
+                }
+            }
+            Ok(())
+        }
+
+        ConflictAction::ResolveAll { keep } => {
+            let count = sync::orchestrator::resolve_all_conflicts(data_dir, keep.into())?;
+            let kept = match keep {
+                KeepArg::Local => "local",
+                KeepArg::Remote => "remote",
+            };
+            match output_format {
+                OutputFormat::Json => {
+                    println!(
+                        "{}",
+                        serde_json::to_string_pretty(&serde_json::json!({
+                            "resolved_count": count,
+                            "kept": kept,
+                        }))?
+                    );
+                }
+                OutputFormat::Csv => {
+                    println!("resolved_count,kept");
+                    println!("{count},{kept}");
+                }
+                OutputFormat::Table => {
+                    eprintln!("Resolved {count} conflict(s) (kept {kept}).");
                 }
             }
             Ok(())

--- a/crates/toku-db/src/lib.rs
+++ b/crates/toku-db/src/lib.rs
@@ -10,4 +10,4 @@ pub use error::DbError;
 pub use merge::MergeEngine;
 pub use repo::BookRepository;
 pub use snapshot::SnapshotRepository;
-pub use sync_repo::SyncRepository;
+pub use sync_repo::{ConflictKeep, SyncConflict, SyncRepository};

--- a/crates/toku-db/src/sync_repo.rs
+++ b/crates/toku-db/src/sync_repo.rs
@@ -1,8 +1,49 @@
+use std::str::FromStr;
+
 use rusqlite::{OptionalExtension, params};
-use toku_core::{DeviceIdentity, EntityType, HlcTimestamp, OpType, SyncOp};
+use toku_core::{DeviceIdentity, EntityType, HlcTimestamp, HybridClock, OpType, SyncOp};
 use uuid::Uuid;
 
 use crate::{Database, DbError};
+
+/// Which side of a sync conflict to keep when resolving.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ConflictKeep {
+    /// Keep this device's local value.
+    Local,
+    /// Keep the incoming remote value.
+    Remote,
+}
+
+/// A stored sync conflict awaiting user review.
+///
+/// Mirrors a row of the `sync_conflicts` table. Conflicts are only produced for
+/// note and review edits that collide across devices (all other entity types
+/// merge silently).
+#[derive(Debug, Clone)]
+pub struct SyncConflict {
+    pub id: String,
+    pub entity_type: String,
+    pub entity_id: String,
+    pub field_name: Option<String>,
+    pub local_value: Option<String>,
+    pub remote_value: Option<String>,
+    pub local_hlc: String,
+    pub remote_hlc: String,
+    pub resolved: bool,
+    pub resolved_at: Option<String>,
+    pub created_at: String,
+}
+
+impl SyncConflict {
+    /// The value that would remain if the given side is kept.
+    pub fn kept_value(&self, keep: ConflictKeep) -> Option<&str> {
+        match keep {
+            ConflictKeep::Local => self.local_value.as_deref(),
+            ConflictKeep::Remote => self.remote_value.as_deref(),
+        }
+    }
+}
 
 /// Sync persistence operations: ops, cursors, and device identity.
 pub struct SyncRepository<'a> {
@@ -211,6 +252,205 @@ impl<'a> SyncRepository<'a> {
             |row| row.get(0),
         )?;
         Ok(count)
+    }
+
+    // -----------------------------------------------------------------------
+    // Conflicts
+    // -----------------------------------------------------------------------
+
+    /// List all unresolved sync conflicts, oldest first.
+    pub fn list_unresolved_conflicts(&self) -> Result<Vec<SyncConflict>, DbError> {
+        let mut stmt = self.db.conn.prepare(
+            "SELECT id, entity_type, entity_id, field_name, local_value, remote_value,
+                    local_hlc, remote_hlc, resolved, resolved_at, created_at
+             FROM sync_conflicts
+             WHERE resolved = 0
+             ORDER BY created_at ASC",
+        )?;
+        let conflicts = stmt
+            .query_map([], Self::map_conflict_row)?
+            .collect::<Result<Vec<_>, _>>()?;
+        Ok(conflicts)
+    }
+
+    /// Fetch a single conflict by id.
+    pub fn get_conflict(&self, id: &str) -> Result<Option<SyncConflict>, DbError> {
+        let conflict = self
+            .db
+            .conn
+            .query_row(
+                "SELECT id, entity_type, entity_id, field_name, local_value, remote_value,
+                        local_hlc, remote_hlc, resolved, resolved_at, created_at
+                 FROM sync_conflicts WHERE id = ?1",
+                params![id],
+                Self::map_conflict_row,
+            )
+            .optional()?;
+        Ok(conflict)
+    }
+
+    /// Count unresolved conflicts.
+    pub fn count_unresolved_conflicts(&self) -> Result<i64, DbError> {
+        let count: i64 = self.db.conn.query_row(
+            "SELECT COUNT(*) FROM sync_conflicts WHERE resolved = 0",
+            [],
+            |row| row.get(0),
+        )?;
+        Ok(count)
+    }
+
+    /// Resolve a single conflict by keeping the local or remote value.
+    ///
+    /// Applies the chosen value to the underlying note/review entity, bumps the
+    /// per-field HLC, emits a new sync op so the resolution propagates to other
+    /// devices, and marks the conflict resolved. A no-op (returns `false`) if the
+    /// conflict is missing or already resolved.
+    pub fn resolve_conflict(&self, id: &str, keep: ConflictKeep) -> Result<bool, DbError> {
+        let Some(conflict) = self.get_conflict(id)? else {
+            return Ok(false);
+        };
+        if conflict.resolved {
+            return Ok(false);
+        }
+
+        self.apply_resolution(&conflict, keep)?;
+
+        let now = chrono::Utc::now().to_rfc3339();
+        self.db.conn.execute(
+            "UPDATE sync_conflicts SET resolved = 1, resolved_at = ?1 WHERE id = ?2",
+            params![now, id],
+        )?;
+        Ok(true)
+    }
+
+    /// Resolve every unresolved conflict with the same choice. Returns the count resolved.
+    pub fn resolve_all_conflicts(&self, keep: ConflictKeep) -> Result<usize, DbError> {
+        let conflicts = self.list_unresolved_conflicts()?;
+        let mut resolved = 0;
+        for conflict in &conflicts {
+            self.apply_resolution(conflict, keep)?;
+            resolved += 1;
+        }
+        if resolved > 0 {
+            let now = chrono::Utc::now().to_rfc3339();
+            self.db.conn.execute(
+                "UPDATE sync_conflicts SET resolved = 1, resolved_at = ?1 WHERE resolved = 0",
+                params![now],
+            )?;
+        }
+        Ok(resolved)
+    }
+
+    /// Write the chosen value into the live entity, bump its HLC, and emit a
+    /// propagating sync op. Best-effort: if no device identity exists yet, the
+    /// entity value is still updated but no op is generated.
+    fn apply_resolution(&self, conflict: &SyncConflict, keep: ConflictKeep) -> Result<(), DbError> {
+        let field = conflict.field_name.as_deref().ok_or_else(|| {
+            DbError::InvalidOperation("conflict has no field to resolve".to_string())
+        })?;
+        let value = conflict.kept_value(keep);
+
+        let entity_type = EntityType::from_str(&conflict.entity_type)
+            .map_err(|_| DbError::InvalidOperation("unknown conflict entity type".to_string()))?;
+        let entity_uuid = Uuid::parse_str(&conflict.entity_id)
+            .map_err(|e| DbError::InvalidOperation(e.to_string()))?;
+
+        let device = self.get_device()?;
+        let (hlc_canonical, device_id_str) = match &device {
+            Some(identity) => {
+                let mut clock = HybridClock::new(&identity.device_id);
+                (clock.now().to_canonical(), identity.device_id.to_string())
+            }
+            None => (String::new(), String::new()),
+        };
+
+        let now = chrono::Utc::now().to_rfc3339();
+
+        // Build the fields payload for the propagating op (typed per field).
+        let field_value = match (entity_type, field) {
+            (EntityType::Review, "rating") => match value {
+                Some(v) => serde_json::json!(v.parse::<i64>().ok()),
+                None => serde_json::Value::Null,
+            },
+            _ => match value {
+                Some(v) => serde_json::json!(v),
+                None => serde_json::Value::Null,
+            },
+        };
+
+        match (entity_type, field) {
+            (EntityType::Note, "content") => {
+                self.db.conn.execute(
+                    "UPDATE notes SET content = ?1, updated_at = ?2 WHERE id = ?3",
+                    params![value.unwrap_or(""), now, conflict.entity_id],
+                )?;
+            }
+            (EntityType::Review, "content") => {
+                self.db.conn.execute(
+                    "UPDATE reviews SET content = ?1, updated_at = ?2 WHERE id = ?3",
+                    params![value, now, conflict.entity_id],
+                )?;
+            }
+            (EntityType::Review, "rating") => {
+                let rating: Option<i64> = value.and_then(|v| v.parse().ok());
+                self.db.conn.execute(
+                    "UPDATE reviews SET rating = ?1, updated_at = ?2 WHERE id = ?3",
+                    params![rating, now, conflict.entity_id],
+                )?;
+            }
+            _ => {
+                return Err(DbError::InvalidOperation(format!(
+                    "cannot resolve conflict for {}.{field}",
+                    conflict.entity_type
+                )));
+            }
+        }
+
+        if let Some(identity) = device {
+            self.db.conn.execute(
+                "INSERT INTO sync_entity_hlc (entity_type, entity_id, field_name, sync_hlc, device_id)
+                 VALUES (?1, ?2, ?3, ?4, ?5)
+                 ON CONFLICT (entity_type, entity_id, field_name)
+                 DO UPDATE SET sync_hlc = ?4, device_id = ?5",
+                params![
+                    conflict.entity_type,
+                    conflict.entity_id,
+                    field,
+                    hlc_canonical,
+                    device_id_str
+                ],
+            )?;
+
+            let hlc = HlcTimestamp::from_str(&hlc_canonical)
+                .map_err(|e| DbError::InvalidOperation(e.to_string()))?;
+            let op = SyncOp::new(
+                identity.device_id,
+                hlc,
+                entity_type,
+                entity_uuid,
+                OpType::Update,
+                Some(serde_json::json!({ field: field_value })),
+            );
+            self.insert_op(&op)?;
+        }
+
+        Ok(())
+    }
+
+    fn map_conflict_row(row: &rusqlite::Row) -> rusqlite::Result<SyncConflict> {
+        Ok(SyncConflict {
+            id: row.get(0)?,
+            entity_type: row.get(1)?,
+            entity_id: row.get(2)?,
+            field_name: row.get(3)?,
+            local_value: row.get(4)?,
+            remote_value: row.get(5)?,
+            local_hlc: row.get(6)?,
+            remote_hlc: row.get(7)?,
+            resolved: row.get::<_, i64>(8)? != 0,
+            resolved_at: row.get(9)?,
+            created_at: row.get(10)?,
+        })
     }
 }
 
@@ -449,5 +689,167 @@ mod tests {
             .query_row("SELECT COUNT(*) FROM sync_device", [], |row| row.get(0))
             .unwrap();
         assert_eq!(count, 0);
+    }
+
+    // ── Conflict tests ──────────────────────────────────────────────
+
+    fn seed_book_and_note(db: &Database, note_id: &str, content: &str) {
+        let now = "2026-06-15T10:00:00Z";
+        db.conn
+            .execute(
+                "INSERT INTO books (id, title, created_at, updated_at)
+                 VALUES (?1, 'Dune', ?2, ?2)",
+                params!["01972123-aaaa-7000-8000-000000000abc", now],
+            )
+            .unwrap();
+        db.conn
+            .execute(
+                "INSERT INTO notes (id, book_id, content, created_at, updated_at)
+                 VALUES (?1, ?2, ?3, ?4, ?4)",
+                params![
+                    note_id,
+                    "01972123-aaaa-7000-8000-000000000abc",
+                    content,
+                    now
+                ],
+            )
+            .unwrap();
+    }
+
+    fn insert_conflict(
+        db: &Database,
+        id: &str,
+        entity_id: &str,
+        local: &str,
+        remote: &str,
+        resolved: bool,
+    ) {
+        db.conn
+            .execute(
+                "INSERT INTO sync_conflicts
+                 (id, entity_type, entity_id, field_name, local_value, remote_value,
+                  local_hlc, remote_hlc, resolved, created_at)
+                 VALUES (?1, 'note', ?2, 'content', ?3, ?4, ?5, ?6, ?7,
+                         '2026-06-15T10:30:00Z')",
+                params![
+                    id,
+                    entity_id,
+                    local,
+                    remote,
+                    format!("hlc-a-{id}"),
+                    format!("hlc-b-{id}"),
+                    resolved as i64
+                ],
+            )
+            .unwrap();
+    }
+
+    #[test]
+    fn list_and_count_unresolved_conflicts() {
+        let db = test_db();
+        let repo = SyncRepository::new(&db);
+        let note_id = Uuid::now_v7().to_string();
+        seed_book_and_note(&db, &note_id, "remote text");
+
+        insert_conflict(&db, "c1", &note_id, "local text", "remote text", false);
+        insert_conflict(&db, "c2", &note_id, "old local", "old remote", true);
+
+        let unresolved = repo.list_unresolved_conflicts().unwrap();
+        assert_eq!(unresolved.len(), 1);
+        assert_eq!(unresolved[0].id, "c1");
+        assert_eq!(repo.count_unresolved_conflicts().unwrap(), 1);
+    }
+
+    #[test]
+    fn resolve_conflict_keep_local_updates_note_and_emits_op() {
+        let db = test_db();
+        let repo = SyncRepository::new(&db);
+        repo.get_or_create_device("test-device").unwrap();
+
+        let note_id = Uuid::now_v7().to_string();
+        seed_book_and_note(&db, &note_id, "remote text");
+        insert_conflict(&db, "c1", &note_id, "local text", "remote text", false);
+
+        let resolved = repo.resolve_conflict("c1", ConflictKeep::Local).unwrap();
+        assert!(resolved);
+
+        // Note content reverted to the kept local value.
+        let content: String = db
+            .conn
+            .query_row(
+                "SELECT content FROM notes WHERE id = ?1",
+                params![note_id],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(content, "local text");
+
+        // Conflict marked resolved and excluded from listings.
+        assert_eq!(repo.count_unresolved_conflicts().unwrap(), 0);
+        let conflict = repo.get_conflict("c1").unwrap().unwrap();
+        assert!(conflict.resolved);
+        assert!(conflict.resolved_at.is_some());
+
+        // A propagating op was emitted.
+        let ops = repo.get_unpushed_ops().unwrap();
+        assert_eq!(ops.len(), 1);
+        assert_eq!(ops[0].entity_type, EntityType::Note);
+        assert_eq!(ops[0].op_type, OpType::Update);
+    }
+
+    #[test]
+    fn resolve_conflict_keep_remote_keeps_remote_value() {
+        let db = test_db();
+        let repo = SyncRepository::new(&db);
+        repo.get_or_create_device("test-device").unwrap();
+
+        let note_id = Uuid::now_v7().to_string();
+        seed_book_and_note(&db, &note_id, "remote text");
+        insert_conflict(&db, "c1", &note_id, "local text", "remote text", false);
+
+        assert!(repo.resolve_conflict("c1", ConflictKeep::Remote).unwrap());
+
+        let content: String = db
+            .conn
+            .query_row(
+                "SELECT content FROM notes WHERE id = ?1",
+                params![note_id],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(content, "remote text");
+    }
+
+    #[test]
+    fn resolve_all_conflicts_resolves_every_unresolved() {
+        let db = test_db();
+        let repo = SyncRepository::new(&db);
+        repo.get_or_create_device("test-device").unwrap();
+
+        let note_id = Uuid::now_v7().to_string();
+        seed_book_and_note(&db, &note_id, "remote text");
+        insert_conflict(&db, "c1", &note_id, "local 1", "remote 1", false);
+        insert_conflict(&db, "c2", &note_id, "local 2", "remote 2", false);
+
+        let count = repo.resolve_all_conflicts(ConflictKeep::Local).unwrap();
+        assert_eq!(count, 2);
+        assert_eq!(repo.count_unresolved_conflicts().unwrap(), 0);
+    }
+
+    #[test]
+    fn resolve_missing_or_resolved_conflict_is_noop() {
+        let db = test_db();
+        let repo = SyncRepository::new(&db);
+
+        assert!(
+            !repo
+                .resolve_conflict("missing", ConflictKeep::Local)
+                .unwrap()
+        );
+
+        let note_id = Uuid::now_v7().to_string();
+        seed_book_and_note(&db, &note_id, "x");
+        insert_conflict(&db, "c1", &note_id, "a", "b", true);
+        assert!(!repo.resolve_conflict("c1", ConflictKeep::Local).unwrap());
     }
 }

--- a/crates/toku-sync-client/src/orchestrator.rs
+++ b/crates/toku-sync-client/src/orchestrator.rs
@@ -9,7 +9,7 @@ use std::path::Path;
 
 use anyhow::Context;
 use serde::Serialize;
-use toku_db::{Database, SyncRepository};
+use toku_db::{ConflictKeep, Database, SyncConflict, SyncRepository};
 
 use crate::client::{DeviceInfo, SyncClient, WireOp};
 use crate::token_store::TokenStore;
@@ -57,6 +57,7 @@ pub struct StatusOutcome {
     pub push_cursor: Option<String>,
     pub pull_cursor: Option<String>,
     pub device_count: usize,
+    pub unresolved_conflicts: usize,
 }
 
 fn build_runtime() -> anyhow::Result<tokio::runtime::Runtime> {
@@ -258,6 +259,7 @@ pub fn status(data_dir: &Path) -> anyhow::Result<StatusOutcome> {
     let pending = sync_repo.count_unpushed_ops()?;
     let push_cursor = sync_repo.get_cursor("push_cursor")?;
     let pull_cursor = sync_repo.get_cursor("pull_cursor")?;
+    let unresolved_conflicts = sync_repo.count_unresolved_conflicts()? as usize;
 
     let device_count = token_store
         .load(&server)?
@@ -280,6 +282,7 @@ pub fn status(data_dir: &Path) -> anyhow::Result<StatusOutcome> {
         push_cursor,
         pull_cursor,
         device_count,
+        unresolved_conflicts,
     })
 }
 
@@ -295,6 +298,35 @@ pub fn devices(data_dir: &Path) -> anyhow::Result<Vec<DeviceInfo>> {
     let client = SyncClient::new(server)?;
     let devices = rt.block_on(client.list_devices(&token))?;
     Ok(devices)
+}
+
+/// List all unresolved sync conflicts awaiting user review.
+pub fn conflicts(data_dir: &Path) -> anyhow::Result<Vec<SyncConflict>> {
+    let db = open_db(data_dir)?;
+    let sync_repo = SyncRepository::new(&db);
+    Ok(sync_repo.list_unresolved_conflicts()?)
+}
+
+/// Fetch a single conflict by id.
+pub fn conflict(data_dir: &Path, id: &str) -> anyhow::Result<Option<SyncConflict>> {
+    let db = open_db(data_dir)?;
+    let sync_repo = SyncRepository::new(&db);
+    Ok(sync_repo.get_conflict(id)?)
+}
+
+/// Resolve a single conflict, keeping the local or remote value.
+/// Returns `false` if the conflict is missing or already resolved.
+pub fn resolve_conflict(data_dir: &Path, id: &str, keep: ConflictKeep) -> anyhow::Result<bool> {
+    let db = open_db(data_dir)?;
+    let sync_repo = SyncRepository::new(&db);
+    Ok(sync_repo.resolve_conflict(id, keep)?)
+}
+
+/// Resolve every unresolved conflict with the same choice. Returns the count resolved.
+pub fn resolve_all_conflicts(data_dir: &Path, keep: ConflictKeep) -> anyhow::Result<usize> {
+    let db = open_db(data_dir)?;
+    let sync_repo = SyncRepository::new(&db);
+    Ok(sync_repo.resolve_all_conflicts(keep)?)
 }
 
 /// The default device name, derived from the host name.

--- a/crates/toku-web/src/conflicts_handlers.rs
+++ b/crates/toku-web/src/conflicts_handlers.rs
@@ -1,0 +1,73 @@
+//! Axum route handlers for the sync conflicts page.
+
+use axum::extract::{Form, Path, State};
+use axum::response::{Html, Redirect};
+use toku_db::{ConflictKeep, Database, SyncRepository};
+
+use crate::AppState;
+use crate::error::WebError;
+use crate::views;
+
+#[derive(serde::Deserialize)]
+pub struct ResolveForm {
+    pub keep: String,
+}
+
+fn parse_keep(value: &str) -> Result<ConflictKeep, WebError> {
+    match value {
+        "local" => Ok(ConflictKeep::Local),
+        "remote" => Ok(ConflictKeep::Remote),
+        other => Err(WebError::Internal(format!("invalid keep value: {other}"))),
+    }
+}
+
+/// `GET /conflicts` — list unresolved sync conflicts with resolution actions.
+pub async fn conflicts_page(State(state): State<AppState>) -> Result<Html<String>, WebError> {
+    let db_path = state.db_path.clone();
+
+    let conflicts = tokio::task::spawn_blocking(move || {
+        let db = Database::open_no_migrate(&db_path)?;
+        SyncRepository::new(&db).list_unresolved_conflicts()
+    })
+    .await
+    .map_err(|e| WebError::Internal(e.to_string()))??;
+
+    Ok(Html(views::conflicts_page(&conflicts).into_string()))
+}
+
+/// `POST /conflicts/resolve/{id}` — resolve one conflict, then redirect back.
+pub async fn resolve_conflict(
+    State(state): State<AppState>,
+    Path(id): Path<String>,
+    Form(form): Form<ResolveForm>,
+) -> Result<Redirect, WebError> {
+    let keep = parse_keep(&form.keep)?;
+    let db_path = state.db_path.clone();
+
+    tokio::task::spawn_blocking(move || {
+        let db = Database::open(&db_path)?;
+        SyncRepository::new(&db).resolve_conflict(&id, keep)
+    })
+    .await
+    .map_err(|e| WebError::Internal(e.to_string()))??;
+
+    Ok(Redirect::to("/conflicts"))
+}
+
+/// `POST /conflicts/resolve-all` — batch resolve every conflict, then redirect.
+pub async fn resolve_all_conflicts(
+    State(state): State<AppState>,
+    Form(form): Form<ResolveForm>,
+) -> Result<Redirect, WebError> {
+    let keep = parse_keep(&form.keep)?;
+    let db_path = state.db_path.clone();
+
+    tokio::task::spawn_blocking(move || {
+        let db = Database::open(&db_path)?;
+        SyncRepository::new(&db).resolve_all_conflicts(keep)
+    })
+    .await
+    .map_err(|e| WebError::Internal(e.to_string()))??;
+
+    Ok(Redirect::to("/conflicts"))
+}

--- a/crates/toku-web/src/lib.rs
+++ b/crates/toku-web/src/lib.rs
@@ -11,12 +11,14 @@ use axum::Router;
 use axum::routing::{get, post};
 
 mod charts;
+mod conflicts_handlers;
 mod error;
 mod handlers;
 pub mod import_handlers;
 mod import_views;
 pub mod library_handlers;
 mod library_views;
+mod sync_status;
 mod views;
 
 pub use error::WebError;
@@ -37,6 +39,11 @@ pub fn build_router(db_path: PathBuf, temp_dir: PathBuf) -> Router {
         .unwrap_or_else(|| std::path::Path::new("."))
         .join("covers");
 
+    // Record the data dir so the header sync badge can read sync state.
+    if let Some(data_dir) = db_path.parent() {
+        sync_status::set_data_dir(data_dir.to_path_buf());
+    }
+
     let state = AppState {
         db_path,
         import_sessions: Arc::new(Mutex::new(HashMap::new())),
@@ -56,6 +63,16 @@ pub fn build_router(db_path: PathBuf, temp_dir: PathBuf) -> Router {
         .route("/stats", get(handlers::stats_dashboard))
         .route("/stats/wrap/{year}", get(handlers::yearly_wrap))
         .route("/api/stats", get(handlers::stats_json))
+        // Sync conflicts
+        .route("/conflicts", get(conflicts_handlers::conflicts_page))
+        .route(
+            "/conflicts/resolve/{id}",
+            post(conflicts_handlers::resolve_conflict),
+        )
+        .route(
+            "/conflicts/resolve-all",
+            post(conflicts_handlers::resolve_all_conflicts),
+        )
         // Import wizard
         .route("/import", get(import_handlers::import_page))
         .route("/import/upload", post(import_handlers::upload_csv))

--- a/crates/toku-web/src/library_views.rs
+++ b/crates/toku-web/src/library_views.rs
@@ -29,6 +29,7 @@ fn base(title: &str, content: Markup) -> Markup {
                             a.nav-link href="/stats" { "Dashboard" }
                             " "
                             a.nav-link href="/import" { "Import" }
+                            (crate::sync_status::header_badge())
                         }
                     }
                 }
@@ -713,6 +714,13 @@ a:hover { text-decoration: underline; }
 .logo { font-size: 1.25rem; font-weight: 700; color: var(--text); text-decoration: none; }
 .nav-link { color: var(--accent); text-decoration: none; font-weight: 500; }
 .nav-link:hover { text-decoration: underline; }
+.sync-indicator {
+    margin-left: 0.75rem; padding: 0.2rem 0.6rem; border-radius: 999px;
+    font-size: 0.8rem; font-weight: 600; text-decoration: none; border: 1px solid var(--border);
+}
+.sync-indicator-ok { color: var(--text-secondary); }
+.sync-indicator-alert { color: #fff; background: #dc2626; border-color: #dc2626; }
+.sync-indicator:hover { text-decoration: none; opacity: 0.9; }
 
 /* Footer */
 .site-footer { text-align: center; padding: 2rem 1rem; color: var(--text-secondary); font-size: 0.85rem; }

--- a/crates/toku-web/src/sync_status.rs
+++ b/crates/toku-web/src/sync_status.rs
@@ -1,0 +1,78 @@
+//! Shared sync status indicator for the dashboard header.
+//!
+//! The header is rendered by two separate `base()` layouts that have no access
+//! to request state, so the data directory is stashed in a process-wide
+//! `OnceLock` at server startup and read lazily when rendering the badge.
+
+use std::path::PathBuf;
+use std::sync::OnceLock;
+
+use maud::{Markup, html};
+use toku_db::{Database, SyncRepository};
+
+static DATA_DIR: OnceLock<PathBuf> = OnceLock::new();
+
+/// Record the data directory so the header badge can read sync state.
+pub fn set_data_dir(dir: PathBuf) {
+    let _ = DATA_DIR.set(dir);
+}
+
+/// Current sync state for the header indicator.
+pub struct SyncIndicator {
+    pub configured: bool,
+    pub conflicts: usize,
+}
+
+/// Compute the current sync indicator state (best-effort; never errors).
+pub fn current() -> SyncIndicator {
+    let Some(dir) = DATA_DIR.get() else {
+        return SyncIndicator {
+            configured: false,
+            conflicts: 0,
+        };
+    };
+
+    let config = toku_core::TokuConfig::load(dir).unwrap_or_default();
+    if config.sync.is_none() {
+        return SyncIndicator {
+            configured: false,
+            conflicts: 0,
+        };
+    }
+
+    let conflicts = Database::open_no_migrate(&dir.join("toku.db"))
+        .ok()
+        .and_then(|db| SyncRepository::new(&db).count_unresolved_conflicts().ok())
+        .unwrap_or(0)
+        .max(0) as usize;
+
+    SyncIndicator {
+        configured: true,
+        conflicts,
+    }
+}
+
+/// Render the header sync badge, or nothing when sync is not configured.
+pub fn header_badge() -> Markup {
+    let indicator = current();
+    if !indicator.configured {
+        return html! {};
+    }
+
+    let (class, label) = if indicator.conflicts > 0 {
+        (
+            "sync-indicator sync-indicator-alert",
+            format!(
+                "⚠ {} conflict{}",
+                indicator.conflicts,
+                if indicator.conflicts == 1 { "" } else { "s" }
+            ),
+        )
+    } else {
+        ("sync-indicator sync-indicator-ok", "✓ Synced".to_string())
+    };
+
+    html! {
+        a class=(class) href="/conflicts" title="Sync status" { (label) }
+    }
+}

--- a/crates/toku-web/src/views.rs
+++ b/crates/toku-web/src/views.rs
@@ -2,6 +2,7 @@
 
 use maud::{DOCTYPE, Markup, PreEscaped, html};
 use toku_core::ReadingStats;
+use toku_db::SyncConflict;
 
 use crate::charts;
 
@@ -28,12 +29,86 @@ fn base(title: &str, content: Markup) -> Markup {
                             a.nav-link href="/stats" { "Dashboard" }
                             " "
                             a.nav-link href="/import" { "Import" }
+                            (crate::sync_status::header_badge())
                         }
                     }
                 }
                 main { (content) }
                 footer.site-footer {
                     p { "Toku — your private reading tracker" }
+                }
+            }
+        }
+    }
+}
+
+/// Render the sync conflicts page.
+pub fn conflicts_page(conflicts: &[SyncConflict]) -> Markup {
+    let content = html! {
+        div.dashboard-header {
+            h1 { "Sync Conflicts" }
+        }
+
+        @if conflicts.is_empty() {
+            div.conflict-empty {
+                p { "🎉 No unresolved conflicts." }
+                p.muted { "When two devices edit the same note or review, the earlier version is kept here for review." }
+            }
+        } @else {
+            div.conflict-toolbar {
+                p { (conflicts.len()) " unresolved conflict" @if conflicts.len() != 1 { "s" } "." }
+                div.conflict-bulk {
+                    form method="post" action="/conflicts/resolve-all" {
+                        input type="hidden" name="keep" value="local";
+                        button.btn.btn-secondary type="submit" { "Keep all local" }
+                    }
+                    form method="post" action="/conflicts/resolve-all" {
+                        input type="hidden" name="keep" value="remote";
+                        button.btn.btn-secondary type="submit" { "Keep all remote" }
+                    }
+                }
+            }
+
+            @for c in conflicts {
+                (conflict_card(c))
+            }
+        }
+    };
+    base("Sync Conflicts", content)
+}
+
+fn conflict_card(c: &SyncConflict) -> Markup {
+    let field = c.field_name.as_deref().unwrap_or("value");
+    let local = c.local_value.as_deref().unwrap_or("(empty)");
+    let remote = c.remote_value.as_deref().unwrap_or("(empty)");
+    let resolve_action = format!("/conflicts/resolve/{}", c.id);
+
+    html! {
+        div.conflict-card {
+            div.conflict-card-head {
+                span.conflict-entity { (c.entity_type) " · " (field) }
+                span.conflict-id { (c.entity_id) }
+            }
+            div.conflict-sides {
+                div.conflict-side {
+                    div.conflict-side-head { "Local" }
+                    div.conflict-hlc { (c.local_hlc) }
+                    pre.conflict-value { (local) }
+                }
+                div.conflict-side {
+                    div.conflict-side-head { "Remote" }
+                    div.conflict-hlc { (c.remote_hlc) }
+                    pre.conflict-value { (remote) }
+                }
+            }
+            div.conflict-actions {
+                form method="post" action=(resolve_action) {
+                    input type="hidden" name="keep" value="local";
+                    button.btn.btn-primary type="submit" { "Keep local" }
+                }
+                form method="post" action=(resolve_action) {
+                    input type="hidden" name="keep" value="remote";
+                    button.btn.btn-primary type="submit" { "Keep remote" }
                 }
             }
         }
@@ -691,11 +766,76 @@ main {
 }
 .wrap-footer a:hover { text-decoration: underline; }
 
+/* Sync indicator (header badge) */
+.sync-indicator {
+    margin-left: 0.75rem;
+    padding: 0.2rem 0.6rem;
+    border-radius: 999px;
+    font-size: 0.8rem;
+    font-weight: 600;
+    text-decoration: none;
+    border: 1px solid var(--border);
+}
+.sync-indicator-ok { color: var(--text-secondary); }
+.sync-indicator-alert {
+    color: #fff;
+    background: #dc2626;
+    border-color: #dc2626;
+}
+.sync-indicator:hover { text-decoration: none; opacity: 0.9; }
+
+/* Buttons */
+.btn {
+    display: inline-block; padding: 0.5rem 1.25rem; border-radius: 6px;
+    font-size: 0.9rem; font-weight: 500; cursor: pointer; text-decoration: none;
+    border: 1px solid var(--border); background: var(--bg-card); color: var(--text);
+    transition: background 0.15s, border-color 0.15s;
+}
+.btn:hover { border-color: var(--accent); color: var(--accent); }
+.btn-primary { background: var(--accent); color: #fff; border-color: var(--accent); }
+.btn-primary:hover { background: var(--accent-hover); }
+.btn-secondary { margin-left: 0.5rem; }
+
+/* Conflicts page */
+.conflict-empty {
+    background: var(--bg-card); border: 1px solid var(--border);
+    border-radius: 10px; padding: 2rem; text-align: center; margin-top: 1.5rem;
+}
+.conflict-empty .muted { color: var(--text-secondary); font-size: 0.9rem; margin-top: 0.5rem; }
+.conflict-toolbar {
+    display: flex; align-items: center; justify-content: space-between;
+    flex-wrap: wrap; gap: 0.75rem; margin: 1.5rem 0;
+}
+.conflict-bulk { display: flex; }
+.conflict-bulk form { display: inline; }
+.conflict-card {
+    background: var(--bg-card); border: 1px solid var(--border);
+    border-radius: 10px; padding: 1.25rem; margin-bottom: 1.25rem;
+}
+.conflict-card-head {
+    display: flex; justify-content: space-between; align-items: baseline;
+    flex-wrap: wrap; gap: 0.5rem; margin-bottom: 1rem;
+}
+.conflict-entity { font-weight: 600; }
+.conflict-id { color: var(--text-secondary); font-size: 0.8rem; font-family: monospace; }
+.conflict-sides { display: grid; grid-template-columns: 1fr 1fr; gap: 1rem; }
+.conflict-side {
+    border: 1px solid var(--border); border-radius: 8px; padding: 0.75rem;
+    background: var(--bg);
+}
+.conflict-side-head { font-weight: 600; font-size: 0.85rem; text-transform: uppercase; letter-spacing: 0.04em; }
+.conflict-hlc { color: var(--text-secondary); font-size: 0.75rem; font-family: monospace; margin: 0.25rem 0 0.5rem; }
+.conflict-value { white-space: pre-wrap; word-break: break-word; font-family: inherit; font-size: 0.9rem; margin: 0; }
+.conflict-actions { display: flex; gap: 0.5rem; margin-top: 1rem; }
+.conflict-actions form { display: inline; }
+.conflict-actions .btn-primary { margin-left: 0; }
+
 /* Responsive */
 @media (max-width: 640px) {
     .dashboard-header { flex-direction: column; }
     .metrics { grid-template-columns: repeat(2, 1fr); }
     .charts-row { grid-template-columns: 1fr; }
     .streak-cards { flex-direction: column; }
+    .conflict-sides { grid-template-columns: 1fr; }
 }
 "#;


### PR DESCRIPTION
## Description

Adds the conflict resolution UI for sync (CLI + web), closing the loop on note/review edits that collide across devices. The detection/storage half already existed (the `sync_conflicts` table and merge-engine conflict capture); this PR adds the surfaces to **review and resolve** those conflicts. Resolving a conflict writes the chosen value back to the entity, bumps the per-field HLC, emits a propagating sync op so the choice reaches other devices, and marks the conflict resolved (excluding it from future listings).

### What's included

- **toku-db** — `SyncConflict` model + `ConflictKeep` enum and `SyncRepository` methods: `list_unresolved_conflicts`, `get_conflict`, `count_unresolved_conflicts`, `resolve_conflict`, `resolve_all_conflicts`. Notes (`content`) and reviews (`content`, `rating`) are the only conflict-producing entities. Includes new unit tests.
- **toku-sync-client** — `unresolved_conflicts` added to `StatusOutcome`, plus orchestrator helpers (`conflicts`, `conflict`, `resolve_conflict`, `resolve_all_conflicts`).
- **toku-cli** — `toku sync conflicts [list | show <id> | resolve <id> --keep local|remote | resolve-all --keep local|remote]` with `table|json|csv` output; conflict count added to `toku sync status`.
- **toku-web** — `/conflicts` page with side-by-side local/remote diff cards, one-click keep-local / keep-remote buttons, and bulk resolve; a sync status indicator in the dashboard header (shown only when sync is configured) that links to the page and highlights when conflicts are pending.

## Related Issues

Closes #75. Follow-up for an inline manual-merge editor tracked in #129.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI / infrastructure
- [ ] Other (describe below)

## Crate

- [ ] `toku-core` — Domain models, traits, state machine
- [x] `toku-db` — SQLite persistence, migrations, FTS5
- [ ] `toku-import` — Importers (Goodreads, Calibre, StoryGraph)
- [ ] `toku-meta` — Metadata fetching (Open Library, Google Books)
- [x] `toku-cli` — CLI binary
- [ ] `toku-export` — Exporters (CSV, JSON, Markdown, BibTeX)
- [ ] `docs/` — Documentation

(Also touches `toku-sync-client` and `toku-web`.)

## Data Integrity Checklist

- [x] No user data is sent to any server without explicit opt-in
- [ ] Import operations are idempotent (re-importing the same file creates no duplicates)
- [x] User edits to metadata are never overwritten by auto-enrichment
- [ ] New fields track provenance (source + timestamp)
- [ ] Export round-trip is preserved (if applicable)

## Checklist

- [ ] I have read [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] `cargo fmt --check` passes
- [x] `cargo clippy --workspace -- -D warnings` passes
- [x] `cargo test --workspace` passes
- [x] I have updated documentation (if applicable)
