### PR TITLE
feat: Docker deployment for self-hosted toku-sync server

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,42 @@
+# Keep the Docker build context small and the image reproducible.
+
+# Rust build artifacts
+/target/
+**/*.rs.bk
+
+# Native apps (not a cargo member; not needed to build toku-sync)
+/toku-apple/
+
+# Tauri auto-generated schemas
+/crates/toku-desktop/gen/
+
+# Swift / SwiftPM build artifacts
+.build/
+.swiftpm/
+
+# Git / CI metadata
+.git/
+.github/
+
+# IDE
+.idea/
+.vscode/
+*.swp
+*.swo
+*~
+
+# OS
+.DS_Store
+Thumbs.db
+
+# Local data / secrets
+*.db
+*.db-journal
+*.db-wal
+covers/
+.env
+
+# Docs and misc (not needed for the build)
+docs/
+*.md
+docker-compose.yml

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,68 @@
+name: Docker
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Image tag to publish (defaults to 'latest' + short sha)"
+        required: false
+        type: string
+
+concurrency:
+  group: docker-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  packages: write
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository_owner }}/toku-sync
+
+jobs:
+  build-and-push:
+    name: Build and push multi-arch image
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract image metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=raw,value=latest,enable=${{ github.ref_type == 'tag' }}
+            type=raw,value=${{ inputs.tag }},enable=${{ inputs.tag != '' }}
+            type=sha
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: crates/toku-sync/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Docker deployment for the self-hosted `toku-sync` server: a multi-stage, multi-arch
+  (`linux/amd64` + `linux/arm64`, incl. Raspberry Pi) image published to
+  `ghcr.io/kafkade/toku-sync`, plus a root `docker-compose.yml`, a built-in container health check
+  (`toku-sync healthcheck`), and a `docs/sync-server.md` deployment guide covering Docker Compose
+  and Caddy/nginx HTTPS reverse-proxy setup
+- Structured logging for `toku-sync` via `tracing`/`tracing-subscriber` with per-request tracing;
+  configurable through `--log-level` / `TOKU_SYNC_LOG_LEVEL` (and `RUST_LOG`)
 - Sync conflict resolution UI (CLI + web): `toku sync conflicts` lists unresolved note/review conflicts, `toku sync conflicts show <id>` shows the local/remote diff, and `resolve <id> --keep local|remote` / `resolve-all --keep local|remote` resolve them. Resolving writes the chosen value to the entity, marks the conflict resolved, and emits a propagating sync op. `toku sync status` now reports the unresolved conflict count
 - Web conflicts page (`/conflicts`): side-by-side local/remote diff cards with one-click keep-local / keep-remote buttons and bulk resolve actions, plus a sync status indicator in the dashboard header (shown only when sync is configured) that links to the conflicts page and highlights when conflicts are pending
 - Native client sync (FFI + Swift): the iOS and macOS apps can now configure sync, push, pull, and view sync status/devices directly. New `toku_sync_init/push/pull/status/devices` C FFI functions expose the sync client to Swift, backed by a shared `toku-sync-client` crate extracted from the CLI so both surfaces reuse one implementation

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2864,6 +2864,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
 name = "matchit"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3035,6 +3044,15 @@ checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
 dependencies = [
  "memchr",
  "minimal-lexical",
+]
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4812,6 +4830,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "shlex"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5526,6 +5553,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "time"
 version = "0.3.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5804,6 +5840,9 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tower",
+ "tower-http",
+ "tracing",
+ "tracing-subscriber",
  "uuid",
 ]
 
@@ -6009,6 +6048,7 @@ dependencies = [
  "tower",
  "tower-layer",
  "tower-service",
+ "tracing",
  "url",
 ]
 
@@ -6054,6 +6094,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]
@@ -6266,6 +6336,12 @@ dependencies = [
  "serde_core",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "vcpkg"

--- a/README.md
+++ b/README.md
@@ -71,6 +71,8 @@ their ever-growing libraries.
 - 🍎 macOS app (SwiftUI) with sidebar navigation, sortable table/grid views, and Swift Charts
 - 📱 iOS app (iPhone + iPad) with cover grid, barcode scanner, and reading progress updates
 - 🪟 Windows desktop app (Tauri v2) wrapping the web UI in a native window with system tray
+- 🔄 Optional multi-device sync via a self-hostable relay server
+  ([deployment guide](docs/sync-server.md)) with end-to-end encryption
 
 ## Tech Stack
 

--- a/crates/toku-sync/Cargo.toml
+++ b/crates/toku-sync/Cargo.toml
@@ -25,6 +25,9 @@ serde_json.workspace = true
 sha2.workspace = true
 thiserror.workspace = true
 tokio = { workspace = true, features = ["rt-multi-thread", "net", "signal"] }
+tower-http = { version = "0.6", features = ["trace"] }
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 uuid.workspace = true
 
 [dev-dependencies]

--- a/crates/toku-sync/Dockerfile
+++ b/crates/toku-sync/Dockerfile
@@ -1,0 +1,78 @@
+# syntax=docker/dockerfile:1
+
+# Multi-stage build for the toku-sync relay server.
+#
+# Build context must be the repository root, e.g.:
+#   docker build -f crates/toku-sync/Dockerfile -t toku-sync .
+#
+# The builder cross-compiles a static musl binary on the *native* build platform
+# (no QEMU for the Rust compile), then copies it into a minimal distroless image.
+# Supports linux/amd64 and linux/arm64 (e.g. Raspberry Pi).
+
+# ── Builder ───────────────────────────────────────────────────────────────────
+FROM --platform=$BUILDPLATFORM rust:1.88-bookworm AS builder
+
+# Provided automatically by buildx.
+ARG TARGETARCH
+
+# Map the Docker target arch to a Rust musl target and install the cross
+# toolchain needed to link a static binary for it.
+RUN set -eux; \
+    case "$TARGETARCH" in \
+        amd64) RUST_TARGET="x86_64-unknown-linux-musl"; GCC_PKG="gcc-x86-64-linux-gnu" ;; \
+        arm64) RUST_TARGET="aarch64-unknown-linux-musl"; GCC_PKG="gcc-aarch64-linux-gnu" ;; \
+        *) echo "unsupported TARGETARCH: $TARGETARCH" >&2; exit 1 ;; \
+    esac; \
+    echo "$RUST_TARGET" > /rust_target; \
+    apt-get update; \
+    apt-get install -y --no-install-recommends musl-tools "$GCC_PKG"; \
+    rm -rf /var/lib/apt/lists/*; \
+    rustup target add "$RUST_TARGET"
+
+WORKDIR /build
+
+# Copy the whole workspace (build context = repo root). The .dockerignore keeps
+# this small by excluding target/, the native apps, etc.
+COPY . .
+
+# Tell cargo/cc which linker to use for the aarch64 musl target.
+ENV CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER=aarch64-linux-gnu-gcc \
+    CC_aarch64_unknown_linux_musl=aarch64-linux-gnu-gcc
+
+RUN --mount=type=cache,target=/usr/local/cargo/registry \
+    set -eux; \
+    RUST_TARGET="$(cat /rust_target)"; \
+    cargo build --release --locked -p toku-sync --target "$RUST_TARGET"; \
+    cp "target/$RUST_TARGET/release/toku-sync" /toku-sync
+
+# Pre-create the data dir owned by the runtime's non-root uid so a freshly
+# created named volume mounted at /data inherits writable ownership.
+RUN mkdir -p /data && chown 65532:65532 /data
+
+# ── Runtime ───────────────────────────────────────────────────────────────────
+# distroless static: tiny, no shell, runs as non-root, ships CA certs + /etc/passwd.
+FROM gcr.io/distroless/static-debian12:nonroot
+
+LABEL org.opencontainers.image.title="toku-sync" \
+      org.opencontainers.image.description="Sync relay server for the Toku personal book manager" \
+      org.opencontainers.image.source="https://github.com/kafkade/toku" \
+      org.opencontainers.image.licenses="MIT"
+
+COPY --from=builder /toku-sync /toku-sync
+COPY --from=builder --chown=65532:65532 /data /data
+
+# Container defaults (overridable). The binary's own default data dir is
+# ./toku-sync-data; in the image we point it at the mounted volume.
+ENV TOKU_SYNC_DATA_DIR=/data \
+    TOKU_SYNC_PORT=8080 \
+    TOKU_SYNC_BIND=0.0.0.0 \
+    TOKU_SYNC_LOG_LEVEL=info
+
+EXPOSE 8080
+VOLUME ["/data"]
+
+# Runs as the distroless "nonroot" user (uid 65532).
+HEALTHCHECK --interval=30s --timeout=5s --start-period=5s --retries=3 \
+    CMD ["/toku-sync", "healthcheck"]
+
+ENTRYPOINT ["/toku-sync"]

--- a/crates/toku-sync/src/config.rs
+++ b/crates/toku-sync/src/config.rs
@@ -15,6 +15,10 @@ pub struct Config {
     /// Directory for server data (SQLite database)
     #[arg(long, default_value = "./toku-sync-data", env = "TOKU_SYNC_DATA_DIR")]
     pub data_dir: String,
+
+    /// Log verbosity (error, warn, info, debug, trace). Overridden by `RUST_LOG` if set.
+    #[arg(long, default_value = "info", env = "TOKU_SYNC_LOG_LEVEL")]
+    pub log_level: String,
 }
 
 impl Config {

--- a/crates/toku-sync/src/main.rs
+++ b/crates/toku-sync/src/main.rs
@@ -12,6 +12,7 @@ use axum::extract::DefaultBodyLimit;
 use axum::middleware;
 use axum::routing::{delete, get, post};
 use clap::Parser;
+use tower_http::trace::TraceLayer;
 
 use crate::config::Config;
 use crate::db::SyncDatabase;
@@ -39,12 +40,21 @@ fn build_router(db_path: PathBuf) -> Router {
         .route("/api/v1/register", post(handlers::register))
         .merge(authenticated)
         .layer(DefaultBodyLimit::max(50 * 1024 * 1024)) // 50 MB (rekey may be large)
+        .layer(TraceLayer::new_for_http())
         .with_state(db_path)
 }
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
+    // Lightweight health-check mode for container orchestration. Runs before the
+    // full config is parsed so it works on shell-less images (distroless/scratch):
+    //   `toku-sync healthcheck` exits 0 if GET /health returns 200, else 1.
+    if std::env::args().nth(1).as_deref() == Some("healthcheck") {
+        std::process::exit(run_healthcheck());
+    }
+
     let config = Config::parse();
+    init_tracing(&config.log_level);
     let db_path = config.db_path();
 
     // Run migrations once at startup
@@ -55,7 +65,7 @@ async fn main() -> anyhow::Result<()> {
     let addr = config.bind_addr();
 
     let listener = tokio::net::TcpListener::bind(&addr).await?;
-    eprintln!("toku-sync listening on http://{addr}");
+    tracing::info!("toku-sync listening on http://{addr}");
 
     axum::serve(listener, app)
         .with_graceful_shutdown(shutdown_signal())
@@ -64,11 +74,59 @@ async fn main() -> anyhow::Result<()> {
     Ok(())
 }
 
+/// Initialise the tracing subscriber. `RUST_LOG` takes precedence; otherwise the
+/// configured log level (from `--log-level` / `TOKU_SYNC_LOG_LEVEL`) is used.
+fn init_tracing(log_level: &str) {
+    use tracing_subscriber::EnvFilter;
+
+    let filter = EnvFilter::try_from_default_env()
+        .or_else(|_| EnvFilter::try_new(log_level))
+        .unwrap_or_else(|_| EnvFilter::new("info"));
+
+    tracing_subscriber::fmt().with_env_filter(filter).init();
+}
+
+/// Perform a minimal HTTP `GET /health` against the local server using only the
+/// standard library (no extra runtime deps), so it runs on a `scratch` image.
+/// Returns a process exit code: 0 = healthy, 1 = unhealthy.
+fn run_healthcheck() -> i32 {
+    use std::io::{Read, Write};
+    use std::net::TcpStream;
+    use std::time::Duration;
+
+    let port = std::env::var("TOKU_SYNC_PORT").unwrap_or_else(|_| "8080".to_string());
+    let addr = format!("127.0.0.1:{port}");
+
+    let result = (|| -> std::io::Result<bool> {
+        let mut stream = TcpStream::connect(&addr)?;
+        stream.set_read_timeout(Some(Duration::from_secs(5)))?;
+        stream.set_write_timeout(Some(Duration::from_secs(5)))?;
+        stream
+            .write_all(b"GET /health HTTP/1.0\r\nHost: localhost\r\nConnection: close\r\n\r\n")?;
+
+        let mut response = String::new();
+        stream.read_to_string(&mut response)?;
+        Ok(response.starts_with("HTTP/1.0 200") || response.starts_with("HTTP/1.1 200"))
+    })();
+
+    match result {
+        Ok(true) => 0,
+        Ok(false) => {
+            eprintln!("healthcheck: server at {addr} did not return 200");
+            1
+        }
+        Err(e) => {
+            eprintln!("healthcheck: failed to reach {addr}: {e}");
+            1
+        }
+    }
+}
+
 async fn shutdown_signal() {
     tokio::signal::ctrl_c()
         .await
         .expect("failed to listen for ctrl+c");
-    eprintln!("\nshutting down...");
+    tracing::info!("shutting down");
 }
 
 #[cfg(test)]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,26 @@
+# Self-hosted toku-sync relay server.
+# Quick start:  docker compose up -d
+# See docs/sync-server.md for full deployment + reverse-proxy (HTTPS) instructions.
+
+services:
+  toku-sync:
+    image: ghcr.io/kafkade/toku-sync:latest
+    container_name: toku-sync
+    restart: unless-stopped
+    ports:
+      - "8080:8080"
+    volumes:
+      - toku-sync-data:/data
+    environment:
+      - TOKU_SYNC_DATA_DIR=/data
+      - TOKU_SYNC_PORT=8080
+      - TOKU_SYNC_LOG_LEVEL=info
+    healthcheck:
+      test: ["CMD", "/toku-sync", "healthcheck"]
+      interval: 30s
+      timeout: 5s
+      start_period: 5s
+      retries: 3
+
+volumes:
+  toku-sync-data:

--- a/docs/sync-server.md
+++ b/docs/sync-server.md
@@ -1,0 +1,197 @@
+# Self-hosting the Toku sync server
+
+`toku-sync` is the optional relay server that lets you sync your Toku library across multiple
+devices. It is a small, single-binary HTTP service backed by SQLite. It stores **only** sync
+operations (which are end-to-end encrypted when you enable a passphrase) — it never needs access
+to your decrypted library.
+
+Syncing is entirely opt-in. Toku works fully offline without ever running this server. See
+[ADR-006](./adr/006-sync-strategy.md) and [ADR-008](./adr/008-sync-wire-protocol.md) for the
+design.
+
+This guide covers deploying the server with Docker.
+
+## Quick start
+
+### Docker
+
+```bash
+docker run -d \
+  --name toku-sync \
+  -p 8080:8080 \
+  -v toku-sync-data:/data \
+  ghcr.io/kafkade/toku-sync:latest
+```
+
+The server is now listening on `http://localhost:8080`. Check it:
+
+```bash
+curl http://localhost:8080/health
+# {"status":"ok","version":"0.2.1"}
+```
+
+### Docker Compose
+
+A ready-to-use [`docker-compose.yml`](../docker-compose.yml) is provided in the repository root:
+
+```yaml
+services:
+  toku-sync:
+    image: ghcr.io/kafkade/toku-sync:latest
+    container_name: toku-sync
+    restart: unless-stopped
+    ports:
+      - "8080:8080"
+    volumes:
+      - toku-sync-data:/data
+    environment:
+      - TOKU_SYNC_DATA_DIR=/data
+      - TOKU_SYNC_PORT=8080
+      - TOKU_SYNC_LOG_LEVEL=info
+    healthcheck:
+      test: ["CMD", "/toku-sync", "healthcheck"]
+      interval: 30s
+      timeout: 5s
+      start_period: 5s
+      retries: 3
+
+volumes:
+  toku-sync-data:
+```
+
+Start it with:
+
+```bash
+docker compose up -d
+```
+
+## Connecting a client
+
+Once the server is reachable, point your Toku CLI at it:
+
+```bash
+toku sync init --server https://sync.example.com --passphrase "your-secret-passphrase"
+toku sync push
+toku sync pull
+```
+
+The passphrase enables end-to-end encryption — the server stores only opaque encrypted blobs.
+Use the same passphrase on every device. See `toku sync --help` for the full command set.
+
+## Configuration
+
+The server is configured entirely through environment variables (or equivalent CLI flags).
+
+| Env variable | Default | Description |
+|--------------|---------|-------------|
+| `TOKU_SYNC_PORT` | `8080` | Port to listen on |
+| `TOKU_SYNC_BIND` | `0.0.0.0` | Address to bind to |
+| `TOKU_SYNC_DATA_DIR` | `/data` (image) | Directory for the SQLite database |
+| `TOKU_SYNC_LOG_LEVEL` | `info` | Log verbosity: `error`, `warn`, `info`, `debug`, `trace` |
+
+`RUST_LOG` is also honoured and takes precedence over `TOKU_SYNC_LOG_LEVEL` if set, allowing
+per-module filters (e.g. `RUST_LOG=toku_sync=debug,tower_http=debug`).
+
+> The container image defaults `TOKU_SYNC_DATA_DIR` to `/data`. When running the binary directly
+> (outside Docker) the default is `./toku-sync-data`.
+
+## Data persistence
+
+All server state lives in a single SQLite database at `$TOKU_SYNC_DATA_DIR/sync.db`. Mounting a
+volume at `/data` (as shown above) ensures data survives container restarts, recreation, and image
+upgrades.
+
+To back up the server, stop the container and copy the volume's contents, or copy `sync.db` while
+the server is stopped:
+
+```bash
+docker run --rm -v toku-sync-data:/data -v "$PWD:/backup" busybox \
+  cp /data/sync.db /backup/sync.db.bak
+```
+
+> The image runs as a non-root user (uid `65532`). A freshly created **named** volume inherits the
+> correct ownership automatically. If you use a **bind mount** instead, make sure the host directory
+> is writable by uid `65532` (e.g. `sudo chown 65532:65532 ./data`).
+
+## Health checks
+
+The image ships a built-in health check used by Docker/Compose and any orchestrator:
+
+```bash
+docker inspect --format '{{.State.Health.Status}}' toku-sync
+# healthy
+```
+
+It runs `toku-sync healthcheck`, which performs a `GET /health` against the local port and exits
+non-zero if the server is not responding. You can also poll `GET /health` directly from an external
+monitor or Kubernetes liveness/readiness probe.
+
+## Multi-architecture support
+
+The image is published for both `linux/amd64` and `linux/arm64`, so it runs on regular x86 servers
+as well as ARM devices such as a Raspberry Pi (64-bit OS required). Docker automatically pulls the
+correct variant for your platform; no extra flags are needed.
+
+## HTTPS with a reverse proxy
+
+The server speaks plain HTTP. For internet-facing deployments, terminate TLS with a reverse proxy.
+Sync credentials are sent as bearer tokens, so **HTTPS is strongly recommended** for any
+non-localhost access.
+
+### Caddy
+
+Caddy obtains and renews Let's Encrypt certificates automatically. A minimal `Caddyfile`:
+
+```caddyfile
+sync.example.com {
+    reverse_proxy localhost:8080
+}
+```
+
+```bash
+caddy run --config Caddyfile
+```
+
+### nginx
+
+```nginx
+server {
+    listen 443 ssl;
+    server_name sync.example.com;
+
+    ssl_certificate     /etc/letsencrypt/live/sync.example.com/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/sync.example.com/privkey.pem;
+
+    # Snapshots can be large; allow big request bodies (matches the server's 50 MB limit).
+    client_max_body_size 50m;
+
+    location / {
+        proxy_pass         http://127.0.0.1:8080;
+        proxy_set_header   Host              $host;
+        proxy_set_header   X-Real-IP         $remote_addr;
+        proxy_set_header   X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header   X-Forwarded-Proto $scheme;
+    }
+}
+```
+
+Obtain certificates with [certbot](https://certbot.eff.org/) (`certbot --nginx`) or your preferred
+ACME client, then reload nginx.
+
+## Building the image locally
+
+You can build the image yourself from the repository root (build context must be the repo root):
+
+```bash
+docker build -f crates/toku-sync/Dockerfile -t toku-sync .
+docker run -d -p 8080:8080 -v toku-sync-data:/data toku-sync
+```
+
+For a multi-arch build, use Buildx:
+
+```bash
+docker buildx build \
+  --platform linux/amd64,linux/arm64 \
+  -f crates/toku-sync/Dockerfile \
+  -t toku-sync .
+```


### PR DESCRIPTION
## Description

Packages the `toku-sync` relay server as a Docker image so it can be self-hosted with a single `docker run` / `docker compose up`, per issue #77.

**What's included**

- **Dockerfile** (`crates/toku-sync/Dockerfile`): multi-stage build that cross-compiles a static musl binary on the native build platform (no QEMU for the Rust compile) into a minimal `distroless/static:nonroot` runtime image. Sets sane env defaults, `EXPOSE 8080`, a `/data` volume, and a `HEALTHCHECK`.
- **Multi-arch CI** (`.github/workflows/docker.yml`): builds and pushes `linux/amd64` + `linux/arm64` (Raspberry Pi) images to `ghcr.io/kafkade/toku-sync` on `v*` tags and via manual dispatch, using `GITHUB_TOKEN` (no extra secrets) and GHA layer caching.
- **Built-in health check**: new hidden `toku-sync healthcheck` subcommand performs a `GET /health` using only the standard library, so it works on the shell-less distroless image and integrates with container orchestration.
- **Structured logging**: wired up `tracing`/`tracing-subscriber` with per-request tracing, configurable via `--log-level` / `TOKU_SYNC_LOG_LEVEL` (and `RUST_LOG`), replacing the previous `eprintln!` calls.
- **`docker-compose.yml`** at the repo root, plus **`docs/sync-server.md`** covering Docker/Compose deployment, env vars, persistence, multi-arch/Raspberry Pi notes, and Caddy/nginx HTTPS reverse-proxy configuration. README links the guide.

> Note: this adds a new `Docker` workflow and does not rename or remove the `Validate` gate, so no `kafkade/github-infra` change is required.

## Related Issues

Closes #77

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [x] CI / infrastructure
- [ ] Other (describe below)

## Crate

- [x] Other: `toku-sync` — sync relay server (Docker packaging, logging, health check)
- [x] `docs/` — Documentation

## Data Integrity Checklist

- [x] No user data is sent to any server without explicit opt-in
- [ ] Import operations are idempotent (re-importing the same file creates no duplicates)
- [ ] User edits to metadata are never overwritten by auto-enrichment
- [ ] New fields track provenance (source + timestamp)
- [ ] Export round-trip is preserved (if applicable)

## Checklist

- [x] I have read [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] `cargo fmt --check` passes
- [x] `cargo clippy --workspace -- -D warnings` passes
- [x] `cargo test --workspace` passes
- [x] I have updated documentation (if applicable)
