### PR TITLE
docs: document toku sync commands in ADR-003

### DIFF
--- a/docs/adr/003-cli-design.md
+++ b/docs/adr/003-cli-design.md
@@ -44,6 +44,37 @@ toku config [--edit]
 > for all user-defined book groupings. `ReadingStatus` remains a separate
 > per-book state machine.
 
+### Sync subcommands (Phase 7)
+
+Sync is opt-in and additive — every command above works fully offline. The
+`toku sync` namespace manages multi-device synchronization. See ADR-006
+(sync strategy) and ADR-008 (wire protocol) for the underlying design.
+
+```sh
+toku sync init [--server <url>] [--library-id <uuid>] [--device-name <name>] [--passphrase]
+toku sync status                                   # Show sync state, pending ops, devices, conflicts
+toku sync push                                     # Push local changes to the sync server
+toku sync pull                                     # Pull remote changes from the sync server
+toku sync devices                                  # List devices registered to this library
+toku sync deregister <device-id>                   # Deregister another device from the server
+toku sync disable                                  # Disable sync (local data preserved)
+toku sync purge [--days <n>]                        # Purge tombstoned books past the retention period (default 30)
+toku sync rekey                                    # Change the encryption passphrase and re-encrypt server ops
+toku sync compact                                  # Snapshot + prune the op log
+toku sync conflicts                                # List unresolved conflicts (notes/reviews)
+toku sync conflicts show <id>                      # Show the local/remote diff for a conflict
+toku sync conflicts resolve <id> --keep local|remote
+toku sync conflicts resolve-all --keep local|remote
+```
+
+> **Note**: `toku sync init` defaults the server to `http://localhost:8080`.
+> The `--library-id` must match across all devices for a single library; omit it
+> on the first device to generate one. `--passphrase` enables client-side
+> encryption (interactive, hidden input). Only note and review edits can produce
+> user-visible conflicts; all other entities merge silently per ADR-006's
+> entity-specific rules. Like every other command, sync subcommands respect
+> `--format table|json|csv` and `NO_COLOR`.
+
 ## Rationale
 
 - clap v4 is the Rust CLI standard — well-documented, actively maintained, generates


### PR DESCRIPTION
## Description

Updates ADR-003 (CLI Design) to document the `toku sync` command hierarchy
added in Phase 7, so the ADR remains the canonical CLI command reference.

### What's included

- New **Sync subcommands (Phase 7)** section in the Command Hierarchy of
  `docs/adr/003-cli-design.md`.
- Documents the full `toku sync` namespace as actually implemented in
  `crates/toku-cli/src/main.rs` (`SyncAction` / `ConflictAction`):
  `init`, `status`, `push`, `pull`, `devices`, `deregister`, `disable`,
  `purge`, `rekey`, `compact`, and `conflicts [show | resolve | resolve-all]`.
- A clarifying note covering opt-in/offline-first behavior, `init` flags
  (`--server`, `--library-id`, `--device-name`, `--passphrase`), the fact that
  only note/review edits produce user-visible conflicts, and that sync
  commands respect `--format` and `NO_COLOR` like the rest of the CLI.
- Cross-references ADR-006 (sync strategy) and ADR-008 (wire protocol).

Reflects the implemented CLI rather than the issue's literal proposal: uses
`sync deregister <device-id>` (not `devices remove`) and includes
`sync purge [--days]`.

## Related Issues

Closes #80

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI / infrastructure
- [ ] Other (describe below)

## Crate

- [x] `docs/` — Documentation

## Data Integrity Checklist

<!-- Not applicable — documentation-only change, no code or data paths touched. -->

- [ ] No user data is sent to any server without explicit opt-in
- [ ] Import operations are idempotent (re-importing the same file creates no duplicates)
- [ ] User edits to metadata are never overwritten by auto-enrichment
- [ ] New fields track provenance (source + timestamp)
- [ ] Export round-trip is preserved (if applicable)

## Checklist

- [ ] I have read [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] `cargo fmt --check` passes (N/A — docs only)
- [x] `cargo clippy --workspace -- -D warnings` passes (N/A — docs only)
- [x] `cargo test --workspace` passes (N/A — docs only)
- [x] I have updated documentation (if applicable)
