### PR TITLE
docs: add ADR-010 superseding ADR-006/008 with self-host + zero-knowledge auth model

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -302,63 +302,39 @@ client:
 - No concept of "revoking" a device's data — if a device is lost, the user changes
   their sync passphrase, which re-encrypts all server-side data with a new key.
 
-#### Encryption: lighter than Pildora, still private
+#### Encryption and authentication — superseded by ADR-010
 
-Book data is personal but not health-critical. Toku does **not** need Pildora's
+> **⚠️ This section reflects the original ADR-006 design (optional encryption,
+> unauthenticated relay) and has been superseded.** See
+> [ADR-010](adr/010-self-host-auth.md) for the current model: self-hosted server with
+> mandatory zero-knowledge E2E encryption and 1Password-style two-secret SRP
+> authentication.
+
+~~Book data is personal but not health-critical. Toku does **not** need Pildora's
 zero-knowledge architecture (SRP, vault hierarchy, per-item keys, asymmetric key
-exchange). Instead:
+exchange). Instead:~~
 
-**Optional symmetric encryption with a user passphrase.**
+**Current model (ADR-010)**: mandatory zero-knowledge E2E with 1Password-style SRP auth.
 
-- The user sets a sync passphrase during setup: `toku sync init --passphrase`.
-- A key is derived from the passphrase using **Argon2id** (memory-hard KDF).
-- All ops are encrypted client-side with **AES-256-GCM** before upload.
-- The server stores only opaque encrypted blobs + unencrypted metadata (op ID, device ID, timestamp, entity type — not entity content).
-- The server **cannot** read book titles, ratings, notes, or any content.
+- **Two secrets**: account password + high-entropy Secret Key generated on the device
+  at sign-up. Neither is ever sent to the server.
+- **SRP authentication**: server stores only an SRP verifier; it cannot derive the
+  password, Secret Key, or any encryption key.
+- **Key hierarchy**: (Secret Key + password) → Argon2id → Account Unlock Key → wraps
+  Account Key Pair → wraps Library Encryption Key. The server stores only encrypted blobs.
+- **Mandatory encryption for hosted mode**: there is no plaintext fallback.
+- **Emergency Kit**: Secret Key is surfaced once at registration. Losing it with no local
+  device means server data is unrecoverable. Local SQLite is the recovery path.
 
-**What the server CAN see** (metadata leakage — accepted trade-off):
-
-- How many books are in the library (op count)
-- When sync happens (timestamps)
-- Which devices sync (device IDs)
-- Entity types being synced (book, session, shelf — but not content)
-
-**What the server CANNOT see**:
-
-- Book titles, authors, ISBNs
-- Ratings, reviews, notes
-- Reading progress
-- Shelf names, tag names
-- Any content field
-
-**This is NOT zero-knowledge** — the server knows *that* you have books, but not *which* books. For a personal book manager, this is a reasonable trade-off. Users who want stronger privacy can self-host the server.
-
-**Key lifecycle** (kept simple):
-
-- **Setup**: User picks a passphrase → Argon2id → encryption key stored in OS keychain.
-- **New device**: User enters their passphrase on the new device. No key exchange protocol — the passphrase IS the shared secret.
-- **Passphrase change**: Client pulls all ops, re-encrypts with new key, pushes a re-encrypted snapshot. Old ops are purged.
-- **Forgotten passphrase**: **Data on the server is unrecoverable.** The local SQLite on any device is the recovery path. This is documented clearly: "Your passphrase is your key. We cannot recover it."
-- **No passphrase (opt-out)**: If the user skips encryption, ops are stored as plaintext
-  JSON on the server. Self-hosters may prefer this for simplicity.
-
-**Comparison to Pildora**:
-
-| Concern | Pildora (health data) | Toku (book data) |
-|---------|----------------------|------------------|
-| Threat model | Server compromise exposes medications | Server compromise exposes reading list |
-| Encryption | Mandatory E2E, zero-knowledge, per-vault keys | Optional symmetric, single passphrase |
-| Key exchange | SRP + asymmetric wrapping | Passphrase-based (symmetric only) |
-| Key hierarchy | Master → Vault → Item | Single derived key |
-| Sharing | Encrypted vault sharing with roles | No sharing (personal tool) |
-| Recovery | Recovery key + emergency access | Local SQLite is the recovery |
-| Server knowledge | Nothing — can't even see metadata structure | Knows op count, timestamps, entity types |
-| Complexity | ~3 months of crypto engineering | ~2–3 weeks for a working sync |
+**What the server can and cannot see** remains the same as before: op count, timestamps,
+device IDs, entity types — but never content. ADR-010 makes this a hard guarantee rather
+than a user-configurable option.
 
 #### Deployment options
 
-- **Self-hosted (recommended)**: Docker image, single binary, SQLite backend. Run on a
-  VPS, NAS, or Raspberry Pi. `docker run -p 8080:8080 kafkade/toku-sync`.
+- **Self-hosted (recommended)**: Docker image + docker-compose, single binary, SQLite
+  backend. First-run admin onboarding. Run on a VPS, NAS, or Raspberry Pi.
+  `docker compose up kafkade/toku-sync`.
 - **Managed (future, maybe)**: A hosted instance at `sync.toku.dev` for users who don't
   want to self-host. Free tier for small libraries. This is optional and deferred — the
   self-hosted path must work first.
@@ -368,7 +344,7 @@ Rejected sync alternatives:
 - **cr-sqlite**: Elegant but experimental. iOS/WASM support is unproven. Kept as a research branch — if it matures, it could replace the op-log approach for native clients. Not the roadmap bet.
 - **File-based sync (iCloud/Dropbox)**: SQLite files + cloud sync = corruption risk. Documented as a manual backup workflow, not a sync strategy.
 - **Turso/libSQL**: Adds a mandatory cloud dependency. Conflicts with local-first.
-- **Full zero-knowledge (Pildora model)**: Overkill for book data. 3x the engineering effort for marginal privacy gain.
+- **Optional-only encryption (original ADR-006 model)**: Replaced by ADR-010 — unauthenticated relay is not viable for a self-hosted server facing the public internet.
 
 #### Sync protocol — technical summary
 
@@ -789,9 +765,11 @@ File management lives in a new `toku-files` crate that depends on `toku-core` an
 
 ### 7.5 — Self-Hosted Sync Server 🔴
 
-- Deferred to Phase 7. Changeset-based REST sync is the chosen approach (see ADR-006).
-- Axum server with REST API + Docker deployment.
-- All data optionally encrypted at rest on server (client-side encryption).
+- Deferred to Phase 7. See ADR-010 for the current architecture decision.
+- Immich-style self-hostable Docker image with first-run admin onboarding, real user
+  accounts, and 1Password-style two-secret SRP authentication.
+- Mandatory zero-knowledge E2E encryption — no plaintext mode for hosted sync.
+- Axum server with REST API (op-log wire protocol from ADR-008 retained).
 - cr-sqlite kept as a research alternative if it matures for iOS/WASM.
 
 ---
@@ -1398,14 +1376,14 @@ Before committing to the architecture, validate:
 **Theme**: "My library everywhere."
 **Goal**: Opt-in multi-device sync via a lightweight changeset-based REST API. Users can sync between CLI, iOS, macOS, web, and Windows — without sacrificing the local-first guarantee. Sync is additive: a user who never enables sync loses nothing.
 
-**Architecture**: See Section 2.5 (Sync Strategy) and ADR-006 for the full design. Summary: append-only op-log synced over REST with optional client-side symmetric encryption (Argon2id + AES-256-GCM).
+**Architecture**: See Section 2.5 (Sync Strategy) and ADR-010 for the current design. Summary: append-only op-log synced over REST with mandatory zero-knowledge E2E encryption (AES-256-GCM), 1Password-style SRP authentication, and Immich-style self-hosted Docker deployment.
 
 **Deliverables** (5):
 
 1. **Sync data model + op-log**: Local `sync_ops` table with Hybrid Logical Clock (HLC) timestamps, op IDs (UUID v7), entity type/ID, and encrypted-or-plaintext payload. Every mutation writes to both the domain table and the op-log in a single transaction.
 2. **Sync server (`toku-sync` crate)**: Axum REST API for push/pull/snapshot/device management. Thin relay — stores ops and cursors, does not interpret content. Deployable as a Docker image (`kafkade/toku-sync`).
 3. **Push/pull protocol with entity-specific merge rules**: Push sends new ops since last cursor. Pull receives ops and applies entity-specific merge: LWW per field for books, append-only for reading sessions, monotonic for progress, LWW with conflict detection for notes/reviews. Soft deletes with 30-day tombstone retention.
-4. **Optional client-side encryption**: Passphrase → Argon2id → AES-256-GCM. Key stored in OS keychain. Server stores opaque blobs. Passphrase change triggers re-keying (pull, re-encrypt, push snapshot, purge old ops).
+4. **Mandatory client-side E2E encryption + SRP auth**: Mandatory for hosted mode — no plaintext fallback. 1Password-style two-secret SRP (password + Secret Key). Key hierarchy: (Secret Key + password) → Argon2id → unlock key → wraps key pair → wraps library key. Emergency Kit generated at account creation.
 5. **CLI sync commands + device management**: `toku sync init`, `toku sync push`, `toku sync pull`, `toku sync status`, `toku sync devices`. Device registration with UUID + human-readable name.
 
 **Acceptance criteria**:
@@ -1526,7 +1504,7 @@ Phase 3: Analytics & Polish (1.0)
         │       └─── Phase 6: File Management (independent of web)
         │
         └─── Phase 7: Sync (depends on stable schema)
-                │     Changeset REST API, see ADR-006
+                │     Self-hosted server, see ADR-010
                 └─── Phase 8: Moonshots
 ```
 
@@ -1688,7 +1666,7 @@ The name must satisfy:
 | 5 | Metadata source | Open Library / Google Books / ISBNdb / Multi-source | **Open Library primary + Google Books fallback** — both free | Decided |
 | 6 | Work vs edition model | Full FRBR / Book=Edition / Deferred | **Book=Edition for MVP, Work grouping Phase 3** — pragmatic | Decided |
 | 7 | Rating scale | 5-star / 10-point / 5-star with halves | **0–10 integer (displayed as 5★ with halves)** — Goodreads-compatible | Decided |
-| 8 | Sync strategy | File copy / REST server / CRDTs / SQLite replication | **Changeset-based REST sync with optional symmetric encryption** — lighter than Pildora's ZK, privacy-respecting | Deferred (Phase 7) |
+| 8 | Sync strategy | File copy / REST server / CRDTs / SQLite replication | **Self-hosted server (Immich-style) with mandatory zero-knowledge E2E encryption and 1Password-style two-secret SRP auth** — see ADR-010 (supersedes ADR-006/008) | Deferred (Phase 7) |
 | 9 | License | MIT / Apache 2.0 / GPL / Dual | **MIT** — maximum contributor friendliness | Decided |
 | 10 | Web framework | Axum+HTMX / Leptos / SvelteKit / Next.js | **Axum + maud** — server-rendered HTML, inline SVG charts, no client-side framework (see ADR-007) | Decided |
 | 11 | Cover storage | Filesystem / Database blobs / Content-addressed | **Filesystem, content-addressed (SHA-256)** — keeps DB small | Decided |

--- a/docs/adr/006-sync-strategy.md
+++ b/docs/adr/006-sync-strategy.md
@@ -1,9 +1,15 @@
 # ADR-006: Sync Strategy — Changeset-Based REST with Optional Encryption
 
-**Status**: Accepted (implementation deferred to Phase 7)
+**Status**: Superseded by ADR-010
 **Date**: 2026-04-26
-**Decision**: Multi-device sync via a lightweight changeset-based REST API with optional
-client-side symmetric encryption. Lighter than Pildora's zero-knowledge model.
+**Superseded by**: [ADR-010](010-self-host-auth.md) (2026-06-26) — the unauthenticated
+relay model and optional encryption were replaced with a self-hosted server using mandatory
+zero-knowledge E2E encryption and 1Password-style SRP authentication. See ADR-010 for the
+rationale and the revised threat model.
+
+**Original decision** (archived): Multi-device sync via a lightweight changeset-based REST
+API with optional client-side symmetric encryption. Lighter than Pildora's zero-knowledge
+model.
 
 ## Context
 

--- a/docs/adr/008-sync-wire-protocol.md
+++ b/docs/adr/008-sync-wire-protocol.md
@@ -1,9 +1,16 @@
 # ADR-008: Sync Wire Protocol — Op-Log Format, HLC, and Encryption Envelope
 
-**Status**: Accepted (implementation in Phase 7)
+**Status**: Superseded by ADR-010
 **Date**: 2026-05-31
-**Decision**: Define the sync wire protocol using UUID v7 op IDs, Hybrid Logical Clocks
-for ordering, a versioned JSON op envelope, and an optional AES-256-GCM encryption layer.
+**Superseded by**: [ADR-010](010-self-host-auth.md) (2026-06-26) — the wire protocol
+technical details (op-log format, HLC, cursor contract, batch limits, snapshots, rate
+limiting) are retained, but the authentication model and encryption posture have changed:
+registration is now SRP-authenticated, and op encryption is mandatory for hosted mode.
+See ADR-010 for the revised auth layer and threat model.
+
+**Original decision** (archived): Define the sync wire protocol using UUID v7 op IDs,
+Hybrid Logical Clocks for ordering, a versioned JSON op envelope, and an optional
+AES-256-GCM encryption layer.
 
 ## Context
 

--- a/docs/adr/010-self-host-auth.md
+++ b/docs/adr/010-self-host-auth.md
@@ -1,0 +1,231 @@
+# ADR-010: Self-Hosted Server with Mandatory Zero-Knowledge Encryption and 1Password-Style SRP Authentication
+
+**Status**: Accepted
+**Date**: 2026-06-26
+**Supersedes**: ADR-006, ADR-008
+**Issue**: #114 (Epic), #115 (this ADR)
+
+## Context
+
+ADR-006 chose **optional** symmetric encryption (single passphrase → Argon2id → AES-256-GCM)
+and an **unauthenticated relay** server, explicitly rejecting zero-knowledge and SRP as
+"overkill for book data." ADR-008 defined the wire protocol in that context.
+
+Epic #114 (Immich-style self-hosting with 1Password-style auth) surfaced a fundamental
+security gap: the current design has **open registration** — anyone who knows or guesses a
+`library_id` can register a device and pull all ops. This is not a theoretical risk; it is
+a design flaw that makes self-hosting unsafe.
+
+Three factors have changed since ADR-006 was written:
+
+1. **Self-hosting implies real users.** A Docker image deployed on a VPS faces the public
+   internet. An unauthenticated relay is not viable; we need real accounts and credentials.
+2. **The "overkill" cost estimate was overstated.** ADR-006 estimated ~3 months for a
+   Pildora-style system. Modern Rust crates (`srp`, `argon2`, `aes-gcm`, `p256`, `rand`)
+   reduce implementation complexity significantly. The 1Password model, applied to a simpler
+   single-user personal tool, is meaningfully cheaper than the full Pildora vault-sharing
+   hierarchy.
+3. **User data ownership is a non-negotiable.** Mandatory zero-knowledge E2E is a stronger
+   guarantee than optional encryption — it removes the server as a potential trust boundary.
+
+## Decision
+
+### Overview
+
+Replace the unauthenticated optional-encryption relay with an **Immich-style self-hostable
+server** that uses:
+
+- **1Password-style two-secret SRP authentication**: account password + device-generated
+  Secret Key. The server never sees either secret.
+- **Mandatory zero-knowledge E2E encryption** for all hosted/sync operations. There is no
+  plaintext mode for synced data.
+- **Real user accounts** with first-run admin onboarding, device management, and
+  authenticated sessions.
+
+The wire protocol defined in ADR-008 (op-log, HLC, UUID v7, cursor contract, batch limits,
+snapshots, rate limiting) is **retained**. What changes is the authentication layer, the
+trust model of the server, and the encryption posture.
+
+### Two-Secret Authentication Model
+
+Users authenticate with two secrets that are never transmitted to the server:
+
+1. **Account password** — chosen by the user, memorable.
+2. **Secret Key** — a high-entropy random value (128-bit, base32-encoded,
+   formatted as `TK-XXXXX-XXXXX-XXXXX-XXXXX-XXXXX` for readability) generated
+   on the user's device at sign-up.
+
+Authentication uses **SRP (Secure Remote Password, RFC 5054)**. The SRP verifier stored on
+the server is derived from both the password and the Secret Key:
+
+```text
+verifier_input = hash(Secret Key || account_password)
+SRP verifier   = srp::generate_verifier(verifier_input)
+```
+
+The server stores only the SRP verifier — it cannot derive the password, the Secret Key,
+or any encryption key from it.
+
+### Key Hierarchy
+
+```text
+Secret Key + Account Password
+          │
+          ▼ Argon2id (m=64 MB, t=3, p=1, salt=per-account)
+          │
+    Account Unlock Key (256-bit)
+          │
+          ├─── wraps ──► Account Key Pair (X25519 ECDH)
+          │                     │
+          │                     └─ public key stored on server
+          │                        private key stored encrypted on server
+          │
+          └─── per-library ──► Library Encryption Key (AES-256-GCM)
+                                      │
+                                      └─ wraps all sync op fields
+                                         one key per library
+                                         stored encrypted under account key pair
+```
+
+Concretely:
+
+- **Account Unlock Key**: derived from (Secret Key + password) via Argon2id. Only exists
+  ephemerally in memory during an authenticated session.
+- **Account Key Pair**: asymmetric keypair (X25519). Private key is wrapped (AES-256-GCM)
+  with the Account Unlock Key and stored on the server. The server stores the ciphertext
+  but cannot unwrap it.
+- **Library Key**: per-library AES-256-GCM key, generated at library creation. Wrapped
+  with the account's public key and stored on the server. The client unwraps it using the
+  private key after authentication.
+
+The server stores: SRP verifier, wrapped private key ciphertext, wrapped library key
+ciphertext. It **cannot** derive any plaintext data from these.
+
+### Emergency Kit and Recovery
+
+- The Secret Key is surfaced **once** during account creation and presented as an
+  **Emergency Kit** — a printable/downloadable document the user keeps offline.
+- Losing the Secret Key with no local device means the server data is **unrecoverable**.
+  This is documented clearly and intentionally: there is no server-side recovery path.
+- **Recovery path**: any local SQLite copy of the library is the recovery. `toku export backup`
+  creates a portable archive. Local-first is the safety net.
+- **Password change**: user re-authenticates with current secrets, derives new Account Unlock
+  Key, re-wraps the private key with the new unlock key, pushes the new wrapped blob.
+  The Library Key itself does not change; only the wrapper changes.
+
+### Device Enrollment
+
+New devices are enrolled by entering the Secret Key:
+
+1. User installs Toku on a new device and points it at the server URL.
+2. User enters their account email + password + Secret Key.
+3. Client performs SRP auth, derives the Account Unlock Key, unwraps the private key,
+   decrypts the Library Key.
+4. Device generates a device keypair, sends the device public key to the server.
+5. Server records the new device. Future ops from this device are authenticated.
+
+There is **no server-side key escrow**. The server cannot enroll devices without the user's
+Secret Key.
+
+### Local-First Non-Negotiable Preserved
+
+| Mode | Account Required? | Server Required? | Network Required? |
+|------|-------------------|------------------|-------------------|
+| Single-device offline | No | No | No |
+| Manual backup/restore | No | No | No |
+| Multi-device sync (hosted) | Yes | Yes | At sync time |
+
+Single-device, offline-only usage is unchanged. Toku is installed, the local SQLite is
+the library, and no account exists. The sync/hosted layer is entirely opt-in.
+
+### Wire Protocol Changes from ADR-008
+
+The op-log format, HLC semantics, cursor contract, batch limits (1000 ops), snapshot format,
+and rate limiting are **retained** from ADR-008.
+
+The following change:
+
+| Area | ADR-008 | ADR-010 |
+|------|---------|---------|
+| Registration | `POST /sync/register` unauthenticated | SRP auth flow + device enrollment; see #120 |
+| Session auth | None (library_id + device_id header) | SRP session token; all routes require auth |
+| `fields` encryption | Optional (`encrypted` envelope or plaintext) | Mandatory for hosted mode; `encrypted` envelope always present |
+| Server trust model | Dumb relay — may store plaintext | Zero-knowledge — stores only encrypted blobs |
+| Auth endpoint | None | `POST /auth/login` (SRP exchange); `POST /auth/enroll` (new device) |
+
+### Revised Threat Model
+
+| Threat | Old model (ADR-006/008) | New model (ADR-010) |
+|--------|-------------------------|---------------------|
+| Server compromise | Attacker reads plaintext ops (if no passphrase) or encrypted blobs | Attacker gets only encrypted blobs, SRP verifiers, wrapped keys — cannot read any data |
+| Network interception | Password sent in plaintext (or no auth at all) | SRP: password/Secret Key never cross the wire |
+| Unauthorized device registration | Anyone with a `library_id` can register | Requires Secret Key — no server-side path exists |
+| Credential brute-force | No server-side credential | SRP verifier is memory-hard (Argon2id); Secret Key adds 128 bits of entropy |
+| Lost device | Deregister device; all data still readable if encryption was optional | Deregister device; Library Key unreachable from deregistered device's key |
+| Passphrase/key forgotten | Server data unrecoverable; local SQLite is recovery | Same: local SQLite is recovery |
+
+### Trade-Offs vs ADR-006 / ADR-008
+
+| Aspect | ADR-006/008 (old) | ADR-010 (new) | Δ |
+|--------|-------------------|---------------|---|
+| Encryption posture | Optional | Mandatory for hosted mode | Stronger |
+| Server auth | Unauthenticated relay | SRP two-secret | Stronger |
+| Key complexity | Single derived key | 3-layer hierarchy | Higher |
+| Server knowledge | Op count + entity types (if encrypted) | Same, enforced | Same |
+| Engineering cost | ~2–3 weeks | ~3 months (epic #114 sub-issues) | Higher |
+| User onboarding friction | None | Emergency Kit + Secret Key | Higher |
+| Recovery story | Local SQLite (same) | Local SQLite (same) | Same |
+| Rationale | Book data < health data | Self-hosting = real attack surface | Justified |
+
+### Why This Cost Is Now Justified
+
+The prior "2–3 weeks" estimate assumed no auth, no accounts, and optional crypto. As
+soon as we add self-hosting with Docker and a public-internet server, we need:
+
+- Real user accounts (no unauthenticated access to anyone's library)
+- Credential security (passwords that can be verified without storing them)
+- Cryptographic guarantees that server operators cannot read user data
+
+These are not optional extras — they are the minimum bar for a self-hosted tool that stores
+personal data. The "overkill" judgment in ADR-006 was correct for a local-only tool, but
+incorrect for a networked self-hosted server.
+
+## Consequences
+
+- **toku-core**: New `crypto` module for key hierarchy (KDF, key wrapping, ECDH).
+  See #116.
+- **toku-sync**: New auth layer (SRP), user accounts table, device enrollment flow,
+  mandatory encryption enforcement. See #117, #119, #120, #121.
+- **toku-cli**: Account signup/login/device enrollment UX, Emergency Kit prompt, Secret
+  Key management. See #123.
+- **toku-web**: Authenticated sessions via SRP-derived session token, login UI. See #122.
+- **Deployment**: Docker image + docker-compose + first-run onboarding. See #124.
+- **Security review**: Full threat model audit before Phase 7 merge. See #125.
+- **Migration**: Path from the open relay model (existing users, if any). See #126.
+- **Wire format compatibility**: ADR-008 op-log format is retained; existing op data can
+  be re-encrypted and migrated. See #126.
+
+## Sub-Issues
+
+| Issue | Scope |
+|-------|-------|
+| #116 | Key hierarchy in `toku-core` |
+| #117 | SRP authentication (server/client) |
+| #118 | Secret Key generation + Emergency Kit |
+| #119 | User accounts, admin, multi-user schema in `toku-sync` |
+| #120 | Authenticated device enrollment |
+| #121 | Mandatory E2E encryption for hosted mode |
+| #122 | `toku-web` login + session auth |
+| #123 | CLI account/enrollment UX |
+| #124 | Docker image + docker-compose + deployment docs |
+| #125 | Threat model security review |
+| #126 | Migration from open relay model |
+
+## Alternatives Considered
+
+| Option | Rejected Because |
+|--------|-----------------|
+| Keep optional encryption, add HTTP Basic Auth | Does not address server-compromise threat; Basic Auth over TLS is weaker than SRP |
+| OIDC/OAuth2 (delegate to external IdP) | Adds mandatory external dependency; breaks offline onboarding; does not solve E2E key hierarchy |
+| Keep ADR-006/008 for self-hosted, add ZK only for managed | Inconsistent security model; self-hosted users deserve the same guarantees |
+| Full Pildora model (vault sharing, per-item keys) | No sharing feature exists; per-item keys are unnecessary complexity for a personal tool |


### PR DESCRIPTION
## Description

Write ADR-010 to record the decision to supersede ADR-006 (Sync Strategy) and ADR-008 (Sync Wire Protocol) with a self-hosted server architecture using mandatory zero-knowledge E2E encryption and 1Password-style two-secret SRP authentication (part of epic #114).

### What's included

- **`docs/adr/010-self-host-auth.md`** (new) — Full decision record covering:
  - Immich-style self-hostable Docker server with real user accounts and first-run onboarding
  - 1Password-style two-secret SRP auth: account password + device-generated Secret Key; neither is ever transmitted to the server
  - Mandatory zero-knowledge E2E encryption for all hosted/sync operations — no plaintext fallback
  - Key hierarchy: (Secret Key + password) → Argon2id → Account Unlock Key → wraps Account Key Pair → wraps Library Key
  - Emergency Kit model (Secret Key surfaced once at registration); local SQLite is the recovery path
  - Local-first non-negotiable explicitly preserved: single-device offline requires no account or server
  - Wire protocol delta from ADR-008 (op-log, HLC, cursors, batch limits retained; auth layer and encryption posture changed)
  - Revised threat model table and trade-offs vs ADR-006/008
  - Cross-references to all implementation sub-issues (#116–#126)
- **`docs/adr/006-sync-strategy.md`** — Status updated to **Superseded by ADR-010** with link and archived-decision note
- **`docs/adr/008-sync-wire-protocol.md`** — Status updated to **Superseded by ADR-010** with link and archived-decision note
- **`ROADMAP.md`** — §2.5 encryption subsection flagged superseded and updated to summarise the new model; §7.5 self-host blurb updated; Phase 7 deliverable #4 updated from "optional encryption" to "mandatory E2E + SRP auth"; decisions table row 8 updated to reference ADR-010; dependency graph updated

## Related Issues

Closes #115
Part of #114

## Type of Change

- [x] Documentation update

## Crate

- [x] `docs/` — Documentation

## Data Integrity Checklist

- [x] No user data is sent to any server without explicit opt-in
- [x] Import operations are idempotent (re-importing the same file creates no duplicates)
- [x] User edits to metadata are never overwritten by auto-enrichment
- [x] New fields track provenance (source + timestamp)
- [x] Export round-trip is preserved (if applicable)

## Checklist

- [x] I have read [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] `cargo fmt --check` passes
- [x] `cargo clippy --workspace -- -D warnings` passes
- [x] `cargo test --workspace` passes
- [x] I have updated documentation (if applicable)
