### PR TITLE
feat: add Secret Key generation, Emergency Kit, and recovery docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Account **Secret Key** + **Emergency Kit** for zero-knowledge sync (1Password-style
+  two-secret model). A high-entropy 128-bit Secret Key is generated on-device, formatted
+  for transcription with a `TK` version prefix and a checksum that catches typos
+  (`TK-XXXXXX-XXXXX-XXXXX-XXXXX-XXXXX-CC`). New CLI commands:
+  `toku account secret-key generate` and `toku account emergency-kit`, the latter rendering
+  the kit as plain text, self-contained printable HTML, or PDF. The Secret Key is surfaced
+  once and is never sent to the server. Recovery semantics — including that lost secrets with
+  no local copy mean server data is unrecoverable, and that local SQLite is the ultimate
+  recovery — are documented in `docs/recovery.md`
+
 - SRP-6a authentication for sync libraries: the sync server never sees the user's
   password or Secret Key. Libraries protected with a passphrase use SRP (RFC 5054,
   Group 2048 + SHA-256) so the server stores only a verifier (`v = g^x mod N`).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -568,17 +568,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bstr"
-version = "1.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cee35f73844aa3014bb606320a6c1f010249dbdf43342fe54b5a4f6a8ed4b79"
-dependencies = [
- "memchr",
- "regex-automata",
- "serde_core",
-]
-
-[[package]]
 name = "bumpalo"
 version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2851,12 +2840,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "linked-hash-map"
-version = "0.5.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
-
-[[package]]
 name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2888,23 +2871,6 @@ name = "log"
 version = "0.4.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "953f07c43838f8e6f9758cab68bf5bed85465e7587ebe0b823f1bcd81978ad3a"
-
-[[package]]
-name = "lopdf"
-version = "0.31.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07c8e1b6184b1b32ea5f72f572ebdc40e5da1d2921fa469947ff7c480ad1f85a"
-dependencies = [
- "encoding_rs",
- "flate2",
- "itoa",
- "linked-hash-map",
- "log",
- "md5",
- "pom",
- "time",
- "weezl",
-]
 
 [[package]]
 name = "lru"
@@ -3001,12 +2967,6 @@ dependencies = [
  "quote",
  "syn 2.0.118",
 ]
-
-[[package]]
-name = "md5"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "490cc448043f947bae3cbee9c203358d62dbee0db12107a74be5c30ccfd09771"
 
 [[package]]
 name = "memchr"
@@ -3538,15 +3498,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "owned_ttf_parser"
-version = "0.19.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "706de7e2214113d63a8238d1910463cfce781129a6f263d13fdb09ff64355ba4"
-dependencies = [
- "ttf-parser",
-]
-
-[[package]]
 name = "palette"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3654,6 +3605,18 @@ checksum = "112d82ceb8c5bf524d9af484d4e4970c9fd5a0cc15ba14ad93dccd28873b0629"
 dependencies = [
  "digest 0.11.3",
  "hmac 0.13.0",
+]
+
+[[package]]
+name = "pdf-writer"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ea27c5015ab81753fc61e49f8cde74999346605ee148bb20008ef3d3150e0dc"
+dependencies = [
+ "bitflags 2.13.0",
+ "itoa",
+ "memchr",
+ "ryu",
 ]
 
 [[package]]
@@ -3899,15 +3862,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "pom"
-version = "3.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c972d8f86e943ad532d0b04e8965a749ad1d18bb981a9c7b3ae72fe7fd7744b"
-dependencies = [
- "bstr",
-]
-
-[[package]]
 name = "portable-atomic"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3948,17 +3902,6 @@ name = "precomputed-hash"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
-
-[[package]]
-name = "printpdf"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c30a4cc87c3ca9a98f4970db158a7153f8d1ec8076e005751173c57836380b1d"
-dependencies = [
- "lopdf",
- "owned_ttf_parser",
- "time",
-]
 
 [[package]]
 name = "proc-macro-crate"
@@ -5925,7 +5868,7 @@ dependencies = [
  "csv",
  "hostname",
  "keyring-core",
- "printpdf",
+ "pdf-writer",
  "ratatui",
  "reqwest 0.12.28",
  "rpassword",
@@ -6398,12 +6341,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
-name = "ttf-parser"
-version = "0.19.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49d64318d8311fc2668e48b63969f4343e0a85c4a109aa8460d6672e364b8bd1"
-
-[[package]]
 name = "typed-path"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6861,12 +6798,6 @@ dependencies = [
  "windows",
  "windows-core",
 ]
-
-[[package]]
-name = "weezl"
-version = "0.1.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
 
 [[package]]
 name = "wezterm-bidi"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -568,6 +568,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "bstr"
+version = "1.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cee35f73844aa3014bb606320a6c1f010249dbdf43342fe54b5a4f6a8ed4b79"
+dependencies = [
+ "memchr",
+ "regex-automata",
+ "serde_core",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2840,6 +2851,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "linked-hash-map"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2871,6 +2888,23 @@ name = "log"
 version = "0.4.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "953f07c43838f8e6f9758cab68bf5bed85465e7587ebe0b823f1bcd81978ad3a"
+
+[[package]]
+name = "lopdf"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07c8e1b6184b1b32ea5f72f572ebdc40e5da1d2921fa469947ff7c480ad1f85a"
+dependencies = [
+ "encoding_rs",
+ "flate2",
+ "itoa",
+ "linked-hash-map",
+ "log",
+ "md5",
+ "pom",
+ "time",
+ "weezl",
+]
 
 [[package]]
 name = "lru"
@@ -2967,6 +3001,12 @@ dependencies = [
  "quote",
  "syn 2.0.118",
 ]
+
+[[package]]
+name = "md5"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "490cc448043f947bae3cbee9c203358d62dbee0db12107a74be5c30ccfd09771"
 
 [[package]]
 name = "memchr"
@@ -3498,6 +3538,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "owned_ttf_parser"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "706de7e2214113d63a8238d1910463cfce781129a6f263d13fdb09ff64355ba4"
+dependencies = [
+ "ttf-parser",
+]
+
+[[package]]
 name = "palette"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3850,6 +3899,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "pom"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c972d8f86e943ad532d0b04e8965a749ad1d18bb981a9c7b3ae72fe7fd7744b"
+dependencies = [
+ "bstr",
+]
+
+[[package]]
 name = "portable-atomic"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3890,6 +3948,17 @@ name = "precomputed-hash"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
+
+[[package]]
+name = "printpdf"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c30a4cc87c3ca9a98f4970db158a7153f8d1ec8076e005751173c57836380b1d"
+dependencies = [
+ "lopdf",
+ "owned_ttf_parser",
+ "time",
+]
 
 [[package]]
 name = "proc-macro-crate"
@@ -5856,6 +5925,7 @@ dependencies = [
  "csv",
  "hostname",
  "keyring-core",
+ "printpdf",
  "ratatui",
  "reqwest 0.12.28",
  "rpassword",
@@ -6328,6 +6398,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "ttf-parser"
+version = "0.19.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49d64318d8311fc2668e48b63969f4343e0a85c4a109aa8460d6672e364b8bd1"
+
+[[package]]
 name = "typed-path"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6785,6 +6861,12 @@ dependencies = [
  "windows",
  "windows-core",
 ]
+
+[[package]]
+name = "weezl"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
 
 [[package]]
 name = "wezterm-bidi"

--- a/README.md
+++ b/README.md
@@ -73,6 +73,8 @@ their ever-growing libraries.
 - 🪟 Windows desktop app (Tauri v2) wrapping the web UI in a native window with system tray
 - 🔄 Optional multi-device sync via a self-hostable relay server
   ([deployment guide](docs/sync-server.md)) with end-to-end encryption
+- 🔑 Account Secret Key + printable Emergency Kit for zero-knowledge sync
+  ([recovery guide](docs/recovery.md))
 
 ## Tech Stack
 

--- a/crates/toku-cli/Cargo.toml
+++ b/crates/toku-cli/Cargo.toml
@@ -37,7 +37,7 @@ uuid.workspace = true
 rpassword = "7"
 base64 = "0.22"
 hostname = "0.4"
-printpdf = { version = "0.7", default-features = false }
+pdf-writer = "0.13"
 
 # Platform-native credential stores for the keyring-core ecosystem (keyring 4.x).
 # The umbrella `keyring` crate is intentionally not used: on desktop it pulls in

--- a/crates/toku-cli/Cargo.toml
+++ b/crates/toku-cli/Cargo.toml
@@ -37,6 +37,7 @@ uuid.workspace = true
 rpassword = "7"
 base64 = "0.22"
 hostname = "0.4"
+printpdf = { version = "0.7", default-features = false }
 
 # Platform-native credential stores for the keyring-core ecosystem (keyring 4.x).
 # The umbrella `keyring` crate is intentionally not used: on desktop it pulls in

--- a/crates/toku-cli/src/account.rs
+++ b/crates/toku-cli/src/account.rs
@@ -1,112 +1,168 @@
 //! Account command helpers: rendering the Emergency Kit to PDF.
 //!
 //! The plain-text and HTML renderings live in `toku-core` (pure, WASM/FFI-safe).
-//! PDF generation lives here in the CLI so the heavier `printpdf` dependency
-//! stays out of the core library.
+//! PDF generation lives here in the CLI so the heavier `pdf-writer` dependency
+//! stays out of the core library. `pdf-writer` is a lightweight, well-maintained
+//! crate (no `lopdf` in its dependency tree) used to emit a single-page document
+//! with the standard base-14 fonts — no font embedding required.
 
-use anyhow::{Context, Result};
-use printpdf::{BuiltinFont, IndirectFontRef, Mm, PdfLayerReference};
+use anyhow::Result;
+use pdf_writer::{Content, Finish, Name, Pdf, Rect, Ref, Str};
 use toku_core::{EMERGENCY_KIT_APP_LABEL, EMERGENCY_KIT_WARNING, EmergencyKit};
 
-/// A4 page width in millimetres.
-const PAGE_W: f32 = 210.0;
-/// A4 page height in millimetres.
-const PAGE_H: f32 = 297.0;
-/// Left margin in millimetres.
-const MARGIN_X: f32 = 20.0;
+/// A4 page width in PDF points (1/72 inch).
+const PAGE_W: f32 = 595.28;
+/// A4 page height in PDF points.
+const PAGE_H: f32 = 841.89;
+/// Left margin in PDF points (~20 mm).
+const MARGIN_X: f32 = 56.7;
+
+/// Resource name for the regular (Helvetica) font.
+const FONT_REGULAR: &[u8] = b"F1";
+/// Resource name for the bold (Helvetica-Bold) font.
+const FONT_BOLD: &[u8] = b"F2";
+/// Resource name for the monospace (Courier) font.
+const FONT_MONO: &[u8] = b"F3";
+
+/// Draw a single line of text at the current vertical cursor and advance it.
+///
+/// Positions use absolute text matrices with the PDF bottom-left origin, so
+/// `y` is measured down from the top of the page for readability.
+fn draw_line(content: &mut Content, text: &str, size: f32, font: &[u8], y: &mut f32, gap: f32) {
+    let sanitized = sanitize(text);
+    content.set_font(Name(font), size);
+    content.set_text_matrix([1.0, 0.0, 0.0, 1.0, MARGIN_X, PAGE_H - *y]);
+    content.show(Str(sanitized.as_bytes()));
+    *y += gap;
+}
+
+/// Map text to the printable ASCII range covered by the base-14 fonts'
+/// standard encoding, replacing common typographic characters with ASCII
+/// equivalents and dropping anything else.
+fn sanitize(text: &str) -> String {
+    text.chars()
+        .filter_map(|c| match c {
+            '\u{2014}' | '\u{2013}' => Some('-'),
+            '\u{2018}' | '\u{2019}' => Some('\''),
+            '\u{201C}' | '\u{201D}' => Some('"'),
+            ' ' => Some(' '),
+            c if c.is_ascii_graphic() => Some(c),
+            _ => None,
+        })
+        .collect()
+}
 
 /// Render the Emergency Kit as a single-page A4 PDF and return the bytes.
 pub fn render_pdf(kit: &EmergencyKit) -> Result<Vec<u8>> {
-    let (doc, page, layer) =
-        printpdf::PdfDocument::new("Toku Emergency Kit", Mm(PAGE_W), Mm(PAGE_H), "Layer 1");
-    let regular = doc
-        .add_builtin_font(BuiltinFont::Helvetica)
-        .context("failed to load PDF font")?;
-    let bold = doc
-        .add_builtin_font(BuiltinFont::HelveticaBold)
-        .context("failed to load PDF font")?;
-    let mono = doc
-        .add_builtin_font(BuiltinFont::Courier)
-        .context("failed to load PDF font")?;
+    let mut alloc = Ref::new(1);
+    let catalog_id = alloc.bump();
+    let page_tree_id = alloc.bump();
+    let page_id = alloc.bump();
+    let content_id = alloc.bump();
+    let regular_id = alloc.bump();
+    let bold_id = alloc.bump();
+    let mono_id = alloc.bump();
 
-    let current = doc.get_page(page).get_layer(layer);
+    // Build the page content stream.
+    let mut content = Content::new();
+    content.begin_text();
 
-    // Vertical cursor measured from the top of the page (PDF origin is bottom-left).
-    let mut y = PAGE_H - 25.0;
+    // Vertical cursor measured from the top of the page; `draw_line` advances it.
+    let mut y = 70.0;
 
-    let line = |layer: &PdfLayerReference,
-                text: &str,
-                size: f32,
-                font: &IndirectFontRef,
-                y: &mut f32,
-                gap: f32| {
-        layer.use_text(text, size, Mm(MARGIN_X), Mm(*y), font);
-        *y -= gap;
-    };
-
-    line(
-        &current,
-        &format!("{EMERGENCY_KIT_APP_LABEL} — Emergency Kit"),
+    draw_line(
+        &mut content,
+        &format!("{EMERGENCY_KIT_APP_LABEL} - Emergency Kit"),
         22.0,
-        &bold,
+        FONT_BOLD,
         &mut y,
-        12.0,
+        34.0,
     );
-    line(
-        &current,
+    draw_line(
+        &mut content,
         &format!("Created: {}", kit.created_at.format("%Y-%m-%d %H:%M UTC")),
         10.0,
-        &regular,
+        FONT_REGULAR,
         &mut y,
-        16.0,
+        40.0,
     );
 
-    line(&current, "ACCOUNT", 9.0, &bold, &mut y, 6.0);
-    line(&current, &kit.account_email, 12.0, &regular, &mut y, 14.0);
+    draw_line(&mut content, "ACCOUNT", 9.0, FONT_BOLD, &mut y, 16.0);
+    draw_line(
+        &mut content,
+        &kit.account_email,
+        12.0,
+        FONT_REGULAR,
+        &mut y,
+        34.0,
+    );
 
-    line(&current, "SERVER", 9.0, &bold, &mut y, 6.0);
-    line(
-        &current,
+    draw_line(&mut content, "SERVER", 9.0, FONT_BOLD, &mut y, 16.0);
+    draw_line(
+        &mut content,
         kit.server_url.as_deref().unwrap_or("(not set)"),
         12.0,
-        &regular,
+        FONT_REGULAR,
         &mut y,
-        14.0,
+        34.0,
     );
 
-    line(&current, "SECRET KEY", 9.0, &bold, &mut y, 6.0);
-    line(&current, &kit.secret_key, 16.0, &mono, &mut y, 16.0);
+    draw_line(&mut content, "SECRET KEY", 9.0, FONT_BOLD, &mut y, 16.0);
+    draw_line(&mut content, &kit.secret_key, 15.0, FONT_MONO, &mut y, 40.0);
 
-    line(&current, "PASSWORD", 9.0, &bold, &mut y, 6.0);
-    line(
-        &current,
+    draw_line(&mut content, "PASSWORD", 9.0, FONT_BOLD, &mut y, 16.0);
+    draw_line(
+        &mut content,
         "________________________________________",
         14.0,
-        &mono,
+        FONT_MONO,
         &mut y,
-        5.0,
+        14.0,
     );
-    line(
-        &current,
+    draw_line(
+        &mut content,
         "(write your account password here, by hand)",
         9.0,
-        &regular,
+        FONT_REGULAR,
         &mut y,
-        18.0,
+        44.0,
     );
 
     // Warning, wrapped to a readable width.
-    line(&current, "IMPORTANT", 10.0, &bold, &mut y, 7.0);
+    draw_line(&mut content, "IMPORTANT", 10.0, FONT_BOLD, &mut y, 18.0);
     for wrapped in wrap_text(EMERGENCY_KIT_WARNING, 70) {
-        line(&current, &wrapped, 10.0, &regular, &mut y, 6.0);
+        draw_line(&mut content, &wrapped, 10.0, FONT_REGULAR, &mut y, 16.0);
     }
 
-    let mut buf: Vec<u8> = Vec::new();
+    content.end_text();
+    let content_data = content.finish();
+
+    // Assemble the document structure.
+    let mut pdf = Pdf::new();
+    pdf.catalog(catalog_id).pages(page_tree_id);
+    pdf.pages(page_tree_id).kids([page_id]).count(1);
+
+    let mut page = pdf.page(page_id);
+    page.parent(page_tree_id);
+    page.media_box(Rect::new(0.0, 0.0, PAGE_W, PAGE_H));
+    page.contents(content_id);
     {
-        let mut writer = std::io::BufWriter::new(&mut buf);
-        doc.save(&mut writer).context("failed to serialize PDF")?;
+        let mut resources = page.resources();
+        let mut fonts = resources.fonts();
+        fonts.pair(Name(FONT_REGULAR), regular_id);
+        fonts.pair(Name(FONT_BOLD), bold_id);
+        fonts.pair(Name(FONT_MONO), mono_id);
     }
-    Ok(buf)
+    page.finish();
+
+    // Standard base-14 Type1 fonts; no embedding required.
+    pdf.type1_font(regular_id).base_font(Name(b"Helvetica"));
+    pdf.type1_font(bold_id).base_font(Name(b"Helvetica-Bold"));
+    pdf.type1_font(mono_id).base_font(Name(b"Courier"));
+
+    pdf.stream(content_id, &content_data);
+
+    Ok(pdf.finish())
 }
 
 /// Greedy word-wrap to a maximum number of characters per line.

--- a/crates/toku-cli/src/account.rs
+++ b/crates/toku-cli/src/account.rs
@@ -1,0 +1,158 @@
+//! Account command helpers: rendering the Emergency Kit to PDF.
+//!
+//! The plain-text and HTML renderings live in `toku-core` (pure, WASM/FFI-safe).
+//! PDF generation lives here in the CLI so the heavier `printpdf` dependency
+//! stays out of the core library.
+
+use anyhow::{Context, Result};
+use printpdf::{BuiltinFont, IndirectFontRef, Mm, PdfLayerReference};
+use toku_core::{EMERGENCY_KIT_APP_LABEL, EMERGENCY_KIT_WARNING, EmergencyKit};
+
+/// A4 page width in millimetres.
+const PAGE_W: f32 = 210.0;
+/// A4 page height in millimetres.
+const PAGE_H: f32 = 297.0;
+/// Left margin in millimetres.
+const MARGIN_X: f32 = 20.0;
+
+/// Render the Emergency Kit as a single-page A4 PDF and return the bytes.
+pub fn render_pdf(kit: &EmergencyKit) -> Result<Vec<u8>> {
+    let (doc, page, layer) =
+        printpdf::PdfDocument::new("Toku Emergency Kit", Mm(PAGE_W), Mm(PAGE_H), "Layer 1");
+    let regular = doc
+        .add_builtin_font(BuiltinFont::Helvetica)
+        .context("failed to load PDF font")?;
+    let bold = doc
+        .add_builtin_font(BuiltinFont::HelveticaBold)
+        .context("failed to load PDF font")?;
+    let mono = doc
+        .add_builtin_font(BuiltinFont::Courier)
+        .context("failed to load PDF font")?;
+
+    let current = doc.get_page(page).get_layer(layer);
+
+    // Vertical cursor measured from the top of the page (PDF origin is bottom-left).
+    let mut y = PAGE_H - 25.0;
+
+    let line = |layer: &PdfLayerReference,
+                text: &str,
+                size: f32,
+                font: &IndirectFontRef,
+                y: &mut f32,
+                gap: f32| {
+        layer.use_text(text, size, Mm(MARGIN_X), Mm(*y), font);
+        *y -= gap;
+    };
+
+    line(
+        &current,
+        &format!("{EMERGENCY_KIT_APP_LABEL} — Emergency Kit"),
+        22.0,
+        &bold,
+        &mut y,
+        12.0,
+    );
+    line(
+        &current,
+        &format!("Created: {}", kit.created_at.format("%Y-%m-%d %H:%M UTC")),
+        10.0,
+        &regular,
+        &mut y,
+        16.0,
+    );
+
+    line(&current, "ACCOUNT", 9.0, &bold, &mut y, 6.0);
+    line(&current, &kit.account_email, 12.0, &regular, &mut y, 14.0);
+
+    line(&current, "SERVER", 9.0, &bold, &mut y, 6.0);
+    line(
+        &current,
+        kit.server_url.as_deref().unwrap_or("(not set)"),
+        12.0,
+        &regular,
+        &mut y,
+        14.0,
+    );
+
+    line(&current, "SECRET KEY", 9.0, &bold, &mut y, 6.0);
+    line(&current, &kit.secret_key, 16.0, &mono, &mut y, 16.0);
+
+    line(&current, "PASSWORD", 9.0, &bold, &mut y, 6.0);
+    line(
+        &current,
+        "________________________________________",
+        14.0,
+        &mono,
+        &mut y,
+        5.0,
+    );
+    line(
+        &current,
+        "(write your account password here, by hand)",
+        9.0,
+        &regular,
+        &mut y,
+        18.0,
+    );
+
+    // Warning, wrapped to a readable width.
+    line(&current, "IMPORTANT", 10.0, &bold, &mut y, 7.0);
+    for wrapped in wrap_text(EMERGENCY_KIT_WARNING, 70) {
+        line(&current, &wrapped, 10.0, &regular, &mut y, 6.0);
+    }
+
+    let mut buf: Vec<u8> = Vec::new();
+    {
+        let mut writer = std::io::BufWriter::new(&mut buf);
+        doc.save(&mut writer).context("failed to serialize PDF")?;
+    }
+    Ok(buf)
+}
+
+/// Greedy word-wrap to a maximum number of characters per line.
+fn wrap_text(text: &str, max_chars: usize) -> Vec<String> {
+    let mut lines = Vec::new();
+    let mut current = String::new();
+    for word in text.split_whitespace() {
+        if current.is_empty() {
+            current.push_str(word);
+        } else if current.len() + 1 + word.len() <= max_chars {
+            current.push(' ');
+            current.push_str(word);
+        } else {
+            lines.push(std::mem::take(&mut current));
+            current.push_str(word);
+        }
+    }
+    if !current.is_empty() {
+        lines.push(current);
+    }
+    lines
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn kit() -> EmergencyKit {
+        EmergencyKit::new(
+            "reader@example.com",
+            Some("https://toku.example.com".to_string()),
+            "TK-ABCDEF-GHIJK-LMNOP-QRSTU-VWXYZ-23",
+        )
+    }
+
+    #[test]
+    fn render_pdf_produces_pdf_bytes() {
+        let bytes = render_pdf(&kit()).unwrap();
+        assert!(bytes.starts_with(b"%PDF"), "output should be a PDF");
+        assert!(bytes.len() > 500, "PDF should have content");
+    }
+
+    #[test]
+    fn wrap_text_respects_width() {
+        let wrapped = wrap_text("the quick brown fox jumps over", 10);
+        assert!(wrapped.iter().all(|l| l.len() <= 10 || !l.contains(' ')));
+        assert!(wrapped.len() > 1);
+    }
+}

--- a/crates/toku-cli/src/main.rs
+++ b/crates/toku-cli/src/main.rs
@@ -13,6 +13,7 @@ use toku_core::{
 };
 use toku_db::{BookRepository, Database};
 
+mod account;
 mod import_ui;
 mod sync;
 mod tui;
@@ -254,6 +255,12 @@ enum Commands {
     Sync {
         #[command(subcommand)]
         action: SyncAction,
+    },
+
+    /// Manage account secrets (Secret Key, Emergency Kit)
+    Account {
+        #[command(subcommand)]
+        action: AccountAction,
     },
 }
 
@@ -620,6 +627,58 @@ enum SyncAction {
 }
 
 #[derive(Clone, Subcommand)]
+enum AccountAction {
+    /// Manage your account Secret Key
+    SecretKey {
+        #[command(subcommand)]
+        action: SecretKeyAction,
+    },
+
+    /// Generate and render an Emergency Kit (account details + Secret Key)
+    EmergencyKit {
+        /// Account email / identifier
+        #[arg(long)]
+        email: Option<String>,
+
+        /// Sync server URL
+        #[arg(long)]
+        server: Option<String>,
+
+        /// Use an existing Secret Key (otherwise a fresh one is generated)
+        #[arg(long)]
+        secret_key: Option<String>,
+
+        /// Kit output format
+        #[arg(long, value_enum, default_value = "text")]
+        kit_format: KitFormat,
+
+        /// Write the kit to a file instead of stdout (required for PDF)
+        #[arg(long, short)]
+        out: Option<PathBuf>,
+    },
+}
+
+#[derive(Clone, Subcommand)]
+enum SecretKeyAction {
+    /// Generate a new Secret Key
+    Generate {
+        /// Write the formatted Secret Key to a file instead of stdout
+        #[arg(long, short)]
+        out: Option<PathBuf>,
+    },
+}
+
+#[derive(Clone, Copy, Debug, ValueEnum)]
+enum KitFormat {
+    /// Plain text
+    Text,
+    /// Printable, self-contained HTML
+    Html,
+    /// PDF document
+    Pdf,
+}
+
+#[derive(Clone, Subcommand)]
 enum ConflictAction {
     /// List unresolved conflicts (default when no subcommand is given)
     List,
@@ -704,6 +763,9 @@ fn main() -> Result<()> {
         }
         Commands::Sync { action } => {
             return cmd_sync(&data_dir, action.clone(), &cli.format);
+        }
+        Commands::Account { action } => {
+            return cmd_account(action.clone());
         }
         _ => {}
     }
@@ -796,7 +858,8 @@ fn main() -> Result<()> {
         Commands::Config { .. }
         | Commands::Completions { .. }
         | Commands::Serve { .. }
-        | Commands::Sync { .. } => {
+        | Commands::Sync { .. }
+        | Commands::Account { .. } => {
             unreachable!()
         }
     }
@@ -2998,6 +3061,120 @@ fn cmd_shelf(
             Ok(())
         }
     }
+}
+
+/// Generate a Secret Key and/or an Emergency Kit. Standalone for now — full
+/// account signup/login (SRP) lands in a later change.
+fn cmd_account(action: AccountAction) -> Result<()> {
+    match action {
+        AccountAction::SecretKey {
+            action: SecretKeyAction::Generate { out },
+        } => {
+            let key = toku_core::SecretKey::generate()
+                .map_err(|e| anyhow::anyhow!("failed to generate secret key: {e}"))?;
+            let formatted = key.format();
+
+            match out {
+                Some(path) => {
+                    std::fs::write(&path, format!("{formatted}\n"))
+                        .with_context(|| format!("failed to write {}", path.display()))?;
+                    eprintln!("Secret Key written to {}", path.display());
+                }
+                None => {
+                    println!("{formatted}");
+                }
+            }
+
+            eprintln!();
+            eprintln!("⚠  This is your account Secret Key. It is shown once.");
+            eprintln!("   Store it offline (an Emergency Kit is the easiest way).");
+            eprintln!("   It cannot be recovered — there is no server-side copy.");
+            Ok(())
+        }
+
+        AccountAction::EmergencyKit {
+            email,
+            server,
+            secret_key,
+            kit_format,
+            out,
+        } => {
+            // Resolve the Secret Key: validate a provided one, or generate fresh.
+            let (formatted_key, generated) = match secret_key {
+                Some(raw) => {
+                    let parsed = toku_core::SecretKey::parse(&raw)
+                        .map_err(|e| anyhow::anyhow!("invalid secret key: {e}"))?;
+                    (parsed.format(), false)
+                }
+                None => {
+                    let key = toku_core::SecretKey::generate()
+                        .map_err(|e| anyhow::anyhow!("failed to generate secret key: {e}"))?;
+                    (key.format(), true)
+                }
+            };
+
+            // Resolve account email (prompt if missing).
+            let email = match email {
+                Some(e) => e,
+                None => prompt_line("Account email: ")?,
+            };
+            let server = server.filter(|s| !s.trim().is_empty());
+
+            let kit = toku_core::EmergencyKit::new(email, server, formatted_key.clone());
+
+            match kit_format {
+                KitFormat::Text => write_kit_bytes(out.as_deref(), kit.to_text().as_bytes())?,
+                KitFormat::Html => write_kit_bytes(out.as_deref(), kit.to_html().as_bytes())?,
+                KitFormat::Pdf => {
+                    let path = out.as_deref().ok_or_else(|| {
+                        anyhow::anyhow!("--out <FILE> is required for PDF output")
+                    })?;
+                    let bytes = account::render_pdf(&kit)?;
+                    std::fs::write(path, &bytes)
+                        .with_context(|| format!("failed to write {}", path.display()))?;
+                    eprintln!("Emergency Kit (PDF) written to {}", path.display());
+                }
+            }
+
+            if generated {
+                eprintln!();
+                eprintln!("⚠  A new Secret Key was generated and embedded in this kit.");
+                eprintln!("   Print or store the kit offline now — the key is shown once");
+                eprintln!("   and cannot be recovered from the server.");
+            }
+            Ok(())
+        }
+    }
+}
+
+/// Write kit bytes to a file, or to stdout when no path is given.
+fn write_kit_bytes(out: Option<&Path>, bytes: &[u8]) -> Result<()> {
+    use std::io::Write as _;
+    match out {
+        Some(path) => {
+            std::fs::write(path, bytes)
+                .with_context(|| format!("failed to write {}", path.display()))?;
+            eprintln!("Emergency Kit written to {}", path.display());
+        }
+        None => {
+            std::io::stdout()
+                .write_all(bytes)
+                .context("failed to write to stdout")?;
+        }
+    }
+    Ok(())
+}
+
+/// Read a single line of input from the terminal, trimming the trailing newline.
+fn prompt_line(prompt: &str) -> Result<String> {
+    use std::io::Write as _;
+    eprint!("{prompt}");
+    std::io::stderr().flush().ok();
+    let mut buf = String::new();
+    std::io::stdin()
+        .read_line(&mut buf)
+        .context("failed to read input")?;
+    Ok(buf.trim().to_string())
 }
 
 fn cmd_sync(data_dir: &Path, action: SyncAction, output_format: &OutputFormat) -> Result<()> {

--- a/crates/toku-core/src/crypto.rs
+++ b/crates/toku-core/src/crypto.rs
@@ -28,6 +28,9 @@ use crate::sync::{EntityType, OpType};
 mod key_hierarchy;
 pub use key_hierarchy::*;
 
+mod secret_key;
+pub use secret_key::*;
+
 // ---------------------------------------------------------------------------
 // Constants
 // ---------------------------------------------------------------------------

--- a/crates/toku-core/src/crypto/secret_key.rs
+++ b/crates/toku-core/src/crypto/secret_key.rs
@@ -1,0 +1,334 @@
+//! Account Secret Key: generation, formatting, and checksum-validated parsing.
+//!
+//! The Secret Key is the high-entropy second factor in Toku's 1Password-style
+//! two-secret auth model (see ADR-010). It is generated **on the device** at
+//! account creation, surfaced exactly once via the Emergency Kit, and combined
+//! with the account password to derive the master unlock key
+//! ([`super::AccountKeys`]). The server never sees it and there is **no**
+//! server-side escrow.
+//!
+//! # Format
+//!
+//! ```text
+//! TK-XXXXXX-XXXXX-XXXXX-XXXXX-XXXXX-CC
+//! └┬┘ └────────── 26 base32 chars ──────────┘ └┬┘
+//!  version           128-bit entropy          checksum
+//! ```
+//!
+//! - `TK` is a human-readable version prefix.
+//! - 16 random bytes (128-bit entropy) are encoded as 26 RFC 4648 base32
+//!   characters (`A–Z`, `2–7`) and grouped `6-5-5-5-5` for readability.
+//! - The final `CC` group is a 10-bit checksum (2 base32 chars) derived from the
+//!   entropy. Parsing recomputes it so single-character typos and adjacent
+//!   transpositions are caught before the key is used.
+//!
+//! The decoded 16 entropy bytes are what feed [`super::AccountKeys::create`] and
+//! [`super::AccountKeys::unlock_data_key`].
+
+use sha2::{Digest, Sha256};
+use zeroize::{Zeroize, ZeroizeOnDrop};
+
+use crate::TokuError;
+
+/// Number of entropy bytes (128-bit).
+const SECRET_KEY_BYTES: usize = 16;
+/// Human-readable version prefix.
+const VERSION_PREFIX: &str = "TK";
+/// RFC 4648 base32 alphabet (no padding), uppercase and unambiguous.
+const BASE32_ALPHABET: &[u8; 32] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZ234567";
+/// Base32 characters needed to encode 16 bytes (`ceil(128 / 5)`).
+const ENTROPY_CHARS: usize = 26;
+/// Base32 characters in the checksum group (10 bits).
+const CHECKSUM_CHARS: usize = 2;
+/// Domain separation tag for the checksum hash.
+const CHECKSUM_DOMAIN: &[u8] = b"toku/secret-key/checksum/v1";
+
+/// A 128-bit account Secret Key.
+///
+/// The raw entropy is zeroized on drop. Use [`SecretKey::format`] (or the
+/// [`std::fmt::Display`] impl) to render the transcribable string, and
+/// [`SecretKey::parse`] to validate user-entered input.
+#[derive(Clone, Zeroize, ZeroizeOnDrop, PartialEq, Eq)]
+pub struct SecretKey([u8; SECRET_KEY_BYTES]);
+
+impl SecretKey {
+    /// Generate a fresh Secret Key from the operating system CSPRNG.
+    pub fn generate() -> Result<Self, TokuError> {
+        let mut bytes = [0u8; SECRET_KEY_BYTES];
+        getrandom::fill(&mut bytes)
+            .map_err(|e| TokuError::Crypto(format!("os rng failed for secret key: {e}")))?;
+        Ok(Self(bytes))
+    }
+
+    /// Reconstruct a Secret Key from raw 16-byte entropy.
+    pub fn from_bytes(bytes: [u8; SECRET_KEY_BYTES]) -> Self {
+        Self(bytes)
+    }
+
+    /// The raw 16 entropy bytes, suitable for [`super::AccountKeys::create`].
+    pub fn as_bytes(&self) -> &[u8; SECRET_KEY_BYTES] {
+        &self.0
+    }
+
+    /// Render the formatted, transcribable Secret Key string
+    /// (e.g. `TK-ABCDEF-GHIJK-LMNOP-QRSTU-VWXYZ-23`).
+    pub fn format(&self) -> String {
+        let entropy = encode_base32(&self.0);
+        let checksum = checksum_chars(&self.0);
+
+        // Grouping: 6-5-5-5-5 over the 26 entropy chars, then the checksum.
+        let groups = [
+            &entropy[0..6],
+            &entropy[6..11],
+            &entropy[11..16],
+            &entropy[16..21],
+            &entropy[21..26],
+        ];
+        format!("{VERSION_PREFIX}-{}-{checksum}", groups.join("-"))
+    }
+
+    /// Parse and validate a user-entered Secret Key string.
+    ///
+    /// Input is normalized (uppercased, whitespace and hyphens removed), then
+    /// the version prefix, length, alphabet, canonical base32 encoding, and
+    /// checksum are all validated. A checksum mismatch (typo) is rejected.
+    pub fn parse(input: &str) -> Result<Self, TokuError> {
+        let normalized: String = input
+            .chars()
+            .filter(|c| !c.is_whitespace() && *c != '-')
+            .map(|c| c.to_ascii_uppercase())
+            .collect();
+
+        let body = normalized.strip_prefix(VERSION_PREFIX).ok_or_else(|| {
+            TokuError::Crypto(format!("secret key must start with '{VERSION_PREFIX}-'"))
+        })?;
+
+        let expected_len = ENTROPY_CHARS + CHECKSUM_CHARS;
+        if body.len() != expected_len {
+            return Err(TokuError::Crypto(format!(
+                "secret key has {} characters, expected {expected_len}",
+                body.len()
+            )));
+        }
+
+        if let Some(bad) = body.bytes().find(|b| !BASE32_ALPHABET.contains(b)) {
+            return Err(TokuError::Crypto(format!(
+                "secret key contains invalid character '{}'",
+                bad as char
+            )));
+        }
+
+        let (entropy_chars, checksum_chars) = body.split_at(ENTROPY_CHARS);
+        let bytes = decode_base32(entropy_chars)?;
+
+        if checksum_chars != checksum_chars_str(&bytes) {
+            return Err(TokuError::Crypto(
+                "secret key checksum mismatch (check for typos)".to_string(),
+            ));
+        }
+
+        Ok(Self(bytes))
+    }
+}
+
+impl std::fmt::Display for SecretKey {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.format())
+    }
+}
+
+impl std::fmt::Debug for SecretKey {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("SecretKey([REDACTED])")
+    }
+}
+
+/// Encode bytes as RFC 4648 base32 without padding (uppercase).
+fn encode_base32(input: &[u8]) -> String {
+    let mut out = String::with_capacity(input.len().div_ceil(5) * 8);
+    let mut buffer: u32 = 0;
+    let mut bits: u32 = 0;
+    for &byte in input {
+        buffer = (buffer << 8) | u32::from(byte);
+        bits += 8;
+        while bits >= 5 {
+            bits -= 5;
+            let idx = ((buffer >> bits) & 0x1f) as usize;
+            out.push(BASE32_ALPHABET[idx] as char);
+        }
+    }
+    if bits > 0 {
+        let idx = ((buffer << (5 - bits)) & 0x1f) as usize;
+        out.push(BASE32_ALPHABET[idx] as char);
+    }
+    out
+}
+
+/// Decode canonical RFC 4648 base32 (no padding) into 16 bytes.
+///
+/// Rejects non-canonical encodings (non-zero trailing bits), which catches a
+/// further class of transcription errors.
+fn decode_base32(input: &str) -> Result<[u8; SECRET_KEY_BYTES], TokuError> {
+    let mut out = Vec::with_capacity(SECRET_KEY_BYTES);
+    let mut buffer: u32 = 0;
+    let mut bits: u32 = 0;
+    for ch in input.bytes() {
+        let value = BASE32_ALPHABET
+            .iter()
+            .position(|&a| a == ch)
+            .ok_or_else(|| TokuError::Crypto("secret key contains invalid character".to_string()))?
+            as u32;
+        buffer = (buffer << 5) | value;
+        bits += 5;
+        if bits >= 8 {
+            bits -= 8;
+            out.push(((buffer >> bits) & 0xff) as u8);
+        }
+    }
+    if bits > 0 && (buffer & ((1 << bits) - 1)) != 0 {
+        return Err(TokuError::Crypto(
+            "secret key is not canonically encoded".to_string(),
+        ));
+    }
+    out.try_into()
+        .map_err(|_| TokuError::Crypto("secret key has wrong decoded length".to_string()))
+}
+
+/// Compute the 10-bit checksum for the entropy and return it as two base32 chars.
+fn checksum_chars(entropy: &[u8; SECRET_KEY_BYTES]) -> String {
+    checksum_chars_str(entropy)
+}
+
+fn checksum_chars_str(entropy: &[u8; SECRET_KEY_BYTES]) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(CHECKSUM_DOMAIN);
+    hasher.update(entropy);
+    let digest = hasher.finalize();
+    // Top 10 bits of the digest -> two 5-bit base32 symbols.
+    let value = (u16::from(digest[0]) << 8 | u16::from(digest[1])) >> 6;
+    let c1 = BASE32_ALPHABET[((value >> 5) & 0x1f) as usize] as char;
+    let c2 = BASE32_ALPHABET[(value & 0x1f) as usize] as char;
+    format!("{c1}{c2}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::crypto::AccountKeys;
+
+    #[test]
+    fn generate_produces_valid_parseable_key() {
+        let key = SecretKey::generate().unwrap();
+        let formatted = key.format();
+        let parsed = SecretKey::parse(&formatted).unwrap();
+        assert_eq!(key.as_bytes(), parsed.as_bytes());
+    }
+
+    #[test]
+    fn formatted_key_has_expected_shape() {
+        let key = SecretKey::from_bytes([0u8; 16]);
+        let formatted = key.format();
+        assert!(formatted.starts_with("TK-"));
+        let groups: Vec<&str> = formatted.split('-').collect();
+        // TK + 5 entropy groups + 1 checksum group
+        assert_eq!(groups.len(), 7);
+        assert_eq!(groups[0], "TK");
+        assert_eq!(groups[1].len(), 6);
+        for g in &groups[2..6] {
+            assert_eq!(g.len(), 5);
+        }
+        assert_eq!(groups[6].len(), 2);
+    }
+
+    #[test]
+    fn parse_is_case_and_whitespace_insensitive() {
+        let key = SecretKey::generate().unwrap();
+        let formatted = key.format();
+        let messy = format!("  {}  ", formatted.to_lowercase().replace('-', " "));
+        let parsed = SecretKey::parse(&messy).unwrap();
+        assert_eq!(key.as_bytes(), parsed.as_bytes());
+    }
+
+    #[test]
+    fn as_bytes_is_16_bytes() {
+        let key = SecretKey::generate().unwrap();
+        assert_eq!(key.as_bytes().len(), 16);
+    }
+
+    #[test]
+    fn checksum_rejects_single_char_typo() {
+        let key = SecretKey::from_bytes([7u8; 16]);
+        let formatted = key.format();
+        // Flip one character in the entropy section.
+        let mut chars: Vec<char> = formatted.chars().collect();
+        let pos = 4; // inside the first entropy group
+        chars[pos] = if chars[pos] == 'A' { 'B' } else { 'A' };
+        let typo: String = chars.into_iter().collect();
+        assert!(SecretKey::parse(&typo).is_err());
+    }
+
+    #[test]
+    fn checksum_rejects_adjacent_transposition() {
+        // Find a key whose first two entropy chars differ, then swap them.
+        let mut formatted = String::new();
+        for seed in 0u8..255 {
+            let f = SecretKey::from_bytes([seed; 16]).format();
+            let body: Vec<char> = f.chars().collect();
+            // index 3,4 are the first two entropy chars (after "TK-")
+            if body[3] != body[4] {
+                formatted = f;
+                break;
+            }
+        }
+        assert!(!formatted.is_empty());
+        let mut chars: Vec<char> = formatted.chars().collect();
+        chars.swap(3, 4);
+        let swapped: String = chars.into_iter().collect();
+        assert!(SecretKey::parse(&swapped).is_err());
+    }
+
+    #[test]
+    fn parse_rejects_missing_prefix() {
+        let key = SecretKey::generate().unwrap();
+        let without_prefix = key.format().replacen("TK-", "", 1);
+        assert!(SecretKey::parse(&without_prefix).is_err());
+    }
+
+    #[test]
+    fn parse_rejects_wrong_length() {
+        assert!(SecretKey::parse("TK-AAAAA").is_err());
+        assert!(SecretKey::parse("TK-AAAAAA-BBBBB-CCCCC-DDDDD-EEEEE-FF-EXTRA").is_err());
+    }
+
+    #[test]
+    fn parse_rejects_invalid_character() {
+        // '0', '1', '8', '9' are not in the base32 alphabet.
+        let key = SecretKey::generate().unwrap();
+        let bad = key.format().replacen(|c: char| c.is_alphabetic(), "0", 1);
+        assert!(SecretKey::parse(&bad).is_err());
+    }
+
+    #[test]
+    fn secret_key_unlocks_account_keys_end_to_end() {
+        let secret = SecretKey::generate().unwrap();
+        let (account_keys, data_key) =
+            AccountKeys::create("correct horse battery staple", secret.as_bytes()).unwrap();
+
+        // Re-parse the formatted key (simulating a new device) and unlock.
+        let reparsed = SecretKey::parse(&secret.format()).unwrap();
+        let unlocked = account_keys
+            .unlock_data_key("correct horse battery staple", reparsed.as_bytes())
+            .unwrap();
+        assert_eq!(
+            data_key.as_exported_bytes(),
+            unlocked.as_exported_bytes(),
+            "re-parsed secret key must unlock the same data key"
+        );
+    }
+
+    #[test]
+    fn debug_is_redacted() {
+        let key = SecretKey::generate().unwrap();
+        assert_eq!(format!("{key:?}"), "SecretKey([REDACTED])");
+    }
+}

--- a/crates/toku-core/src/emergency_kit.rs
+++ b/crates/toku-core/src/emergency_kit.rs
@@ -1,0 +1,251 @@
+//! The Emergency Kit: the printable artifact that captures a user's account
+//! details and their Secret Key.
+//!
+//! The Secret Key is surfaced **exactly once**, at account creation, and is
+//! never recoverable from the server (see ADR-010 and `docs/recovery.md`). The
+//! Emergency Kit is the user's offline record of it.
+//!
+//! This module is pure (no I/O): it renders the kit to plain text and to a
+//! self-contained, print-friendly HTML document. Binary formats such as PDF are
+//! rendered by the consuming application (the CLI) so `toku-core` stays
+//! WASM/FFI-friendly and dependency-light.
+
+use chrono::{DateTime, Utc};
+
+/// The application label printed on the kit (e.g. on the header).
+pub const EMERGENCY_KIT_APP_LABEL: &str = "Toku";
+
+/// The standard warning printed on every Emergency Kit.
+pub const EMERGENCY_KIT_WARNING: &str = "Store this somewhere safe and offline. Your Secret Key cannot be recovered. \
+If you lose it and have no local copy of your library, your server data is unrecoverable. \
+There is no server-side recovery and no password reset that bypasses the Secret Key.";
+
+/// A rendered Emergency Kit.
+///
+/// Construct with [`EmergencyKit::new`], then render with [`EmergencyKit::to_text`]
+/// or [`EmergencyKit::to_html`].
+#[derive(Debug, Clone)]
+pub struct EmergencyKit {
+    /// The account email / identifier.
+    pub account_email: String,
+    /// The sync server URL, if the account is tied to a specific server.
+    pub server_url: Option<String>,
+    /// The formatted Secret Key (e.g. `TK-...`). See [`super::SecretKey::format`].
+    pub secret_key: String,
+    /// When the kit was generated.
+    pub created_at: DateTime<Utc>,
+}
+
+impl EmergencyKit {
+    /// Create a new Emergency Kit, stamped at the current time.
+    pub fn new(
+        account_email: impl Into<String>,
+        server_url: Option<String>,
+        secret_key: impl Into<String>,
+    ) -> Self {
+        Self {
+            account_email: account_email.into(),
+            server_url,
+            secret_key: secret_key.into(),
+            created_at: Utc::now(),
+        }
+    }
+
+    /// Override the creation timestamp (useful for deterministic rendering/tests).
+    pub fn with_created_at(mut self, created_at: DateTime<Utc>) -> Self {
+        self.created_at = created_at;
+        self
+    }
+
+    fn server_display(&self) -> &str {
+        self.server_url.as_deref().unwrap_or("(not set)")
+    }
+
+    fn created_display(&self) -> String {
+        self.created_at.format("%Y-%m-%d %H:%M UTC").to_string()
+    }
+
+    /// Render the kit as plain text suitable for a terminal or `.txt` file.
+    pub fn to_text(&self) -> String {
+        format!(
+            "\
+============================================================
+  {label} — EMERGENCY KIT
+============================================================
+
+  Created:   {created}
+
+  Account:   {email}
+  Server:    {server}
+
+  Secret Key:
+      {secret_key}
+
+  Password:
+      ______________________________________________
+      (write your account password here, by hand)
+
+------------------------------------------------------------
+  {warning}
+============================================================
+",
+            label = EMERGENCY_KIT_APP_LABEL,
+            created = self.created_display(),
+            email = self.account_email,
+            server = self.server_display(),
+            secret_key = self.secret_key,
+            warning = EMERGENCY_KIT_WARNING,
+        )
+    }
+
+    /// Render the kit as a self-contained, print-friendly HTML document.
+    ///
+    /// The output inlines all styling so it can be opened in any browser and
+    /// printed (or "printed to PDF") without external assets.
+    pub fn to_html(&self) -> String {
+        format!(
+            "<!DOCTYPE html>\n\
+<html lang=\"en\">\n\
+<head>\n\
+<meta charset=\"utf-8\">\n\
+<meta name=\"viewport\" content=\"width=device-width, initial-scale=1\">\n\
+<title>{label} — Emergency Kit</title>\n\
+<style>\n\
+  :root {{ color-scheme: light; }}\n\
+  * {{ box-sizing: border-box; }}\n\
+  body {{ font-family: -apple-system, Segoe UI, Roboto, Helvetica, Arial, sans-serif;\n\
+         color: #1a1a1a; background: #fff; margin: 0; padding: 2rem; }}\n\
+  .kit {{ max-width: 40rem; margin: 0 auto; border: 2px solid #1a1a1a;\n\
+          border-radius: 12px; padding: 2rem; }}\n\
+  h1 {{ font-size: 1.5rem; margin: 0 0 0.25rem; }}\n\
+  .created {{ color: #555; font-size: 0.85rem; margin-bottom: 1.5rem; }}\n\
+  .row {{ margin-bottom: 1.25rem; }}\n\
+  .label {{ font-size: 0.75rem; text-transform: uppercase; letter-spacing: 0.05em;\n\
+            color: #555; margin-bottom: 0.25rem; }}\n\
+  .value {{ font-size: 1rem; }}\n\
+  .secret {{ font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;\n\
+             font-size: 1.25rem; font-weight: 700; letter-spacing: 0.04em;\n\
+             padding: 0.75rem 1rem; background: #f4f4f5; border-radius: 8px;\n\
+             word-break: break-all; }}\n\
+  .password-line {{ border-bottom: 1px solid #1a1a1a; height: 1.75rem; }}\n\
+  .password-hint {{ color: #555; font-size: 0.8rem; margin-top: 0.25rem; }}\n\
+  .warning {{ margin-top: 1.5rem; padding: 1rem; border: 2px solid #b00020;\n\
+              border-radius: 8px; color: #b00020; font-weight: 600;\n\
+              font-size: 0.9rem; line-height: 1.45; }}\n\
+  @media print {{ body {{ padding: 0; }} .kit {{ border-color: #000; }} }}\n\
+</style>\n\
+</head>\n\
+<body>\n\
+  <div class=\"kit\">\n\
+    <h1>{label} — Emergency Kit</h1>\n\
+    <div class=\"created\">Created: {created}</div>\n\
+    <div class=\"row\">\n\
+      <div class=\"label\">Account</div>\n\
+      <div class=\"value\">{email}</div>\n\
+    </div>\n\
+    <div class=\"row\">\n\
+      <div class=\"label\">Server</div>\n\
+      <div class=\"value\">{server}</div>\n\
+    </div>\n\
+    <div class=\"row\">\n\
+      <div class=\"label\">Secret Key</div>\n\
+      <div class=\"secret\">{secret_key}</div>\n\
+    </div>\n\
+    <div class=\"row\">\n\
+      <div class=\"label\">Password</div>\n\
+      <div class=\"password-line\"></div>\n\
+      <div class=\"password-hint\">Write your account password here, by hand.</div>\n\
+    </div>\n\
+    <div class=\"warning\">{warning}</div>\n\
+  </div>\n\
+</body>\n\
+</html>\n",
+            label = EMERGENCY_KIT_APP_LABEL,
+            created = self.created_display(),
+            email = html_escape(&self.account_email),
+            server = html_escape(self.server_display()),
+            secret_key = html_escape(&self.secret_key),
+            warning = html_escape(EMERGENCY_KIT_WARNING),
+        )
+    }
+}
+
+/// Minimal HTML escaping for the small set of user-supplied fields.
+fn html_escape(input: &str) -> String {
+    let mut out = String::with_capacity(input.len());
+    for c in input.chars() {
+        match c {
+            '&' => out.push_str("&amp;"),
+            '<' => out.push_str("&lt;"),
+            '>' => out.push_str("&gt;"),
+            '"' => out.push_str("&quot;"),
+            '\'' => out.push_str("&#39;"),
+            _ => out.push(c),
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample() -> EmergencyKit {
+        EmergencyKit::new(
+            "reader@example.com",
+            Some("https://toku.example.com".to_string()),
+            "TK-ABCDEF-GHIJK-LMNOP-QRSTU-VWXYZ-23",
+        )
+        .with_created_at(
+            DateTime::parse_from_rfc3339("2026-01-02T03:04:05Z")
+                .unwrap()
+                .with_timezone(&Utc),
+        )
+    }
+
+    #[test]
+    fn text_contains_required_fields() {
+        let text = sample().to_text();
+        assert!(text.contains("reader@example.com"));
+        assert!(text.contains("https://toku.example.com"));
+        assert!(text.contains("TK-ABCDEF-GHIJK-LMNOP-QRSTU-VWXYZ-23"));
+        assert!(text.contains("2026-01-02 03:04 UTC"));
+    }
+
+    #[test]
+    fn text_has_password_placeholder_and_warning() {
+        let text = sample().to_text();
+        assert!(text.to_lowercase().contains("password"));
+        assert!(text.contains("write your account password"));
+        assert!(text.contains("cannot be recovered"));
+    }
+
+    #[test]
+    fn html_contains_required_fields_and_warning() {
+        let html = sample().to_html();
+        assert!(html.starts_with("<!DOCTYPE html>"));
+        assert!(html.contains("reader@example.com"));
+        assert!(html.contains("TK-ABCDEF-GHIJK-LMNOP-QRSTU-VWXYZ-23"));
+        assert!(html.contains("cannot be recovered"));
+        assert!(html.to_lowercase().contains("password"));
+    }
+
+    #[test]
+    fn html_escapes_user_fields() {
+        let kit = EmergencyKit::new(
+            "a<b>&\"'@x.com",
+            None,
+            "TK-ABCDEF-GHIJK-LMNOP-QRSTU-VWXYZ-23",
+        );
+        let html = kit.to_html();
+        assert!(html.contains("a&lt;b&gt;&amp;&quot;&#39;@x.com"));
+        assert!(!html.contains("a<b>&\"'@x.com"));
+    }
+
+    #[test]
+    fn missing_server_renders_placeholder() {
+        let kit = EmergencyKit::new("x@y.com", None, "TK-ABCDEF-GHIJK-LMNOP-QRSTU-VWXYZ-23");
+        assert!(kit.to_text().contains("(not set)"));
+        assert!(kit.to_html().contains("(not set)"));
+    }
+}

--- a/crates/toku-core/src/lib.rs
+++ b/crates/toku-core/src/lib.rs
@@ -1,6 +1,7 @@
 mod book;
 mod config;
 pub mod crypto;
+mod emergency_kit;
 mod error;
 pub mod filter;
 mod isbn;
@@ -11,6 +12,7 @@ pub mod sync;
 pub use book::*;
 pub use config::*;
 pub use crypto::*;
+pub use emergency_kit::*;
 pub use error::*;
 pub use filter::*;
 pub use isbn::*;

--- a/docs/adr/010-self-host-auth.md
+++ b/docs/adr/010-self-host-auth.md
@@ -51,9 +51,10 @@ trust model of the server, and the encryption posture.
 Users authenticate with two secrets that are never transmitted to the server:
 
 1. **Account password** — chosen by the user, memorable.
-2. **Secret Key** — a high-entropy random value (128-bit, base32-encoded,
-   formatted as `TK-XXXXX-XXXXX-XXXXX-XXXXX-XXXXX` for readability) generated
-   on the user's device at sign-up.
+2. **Secret Key** — a high-entropy random value (128-bit, base32-encoded with a `TK`
+   version prefix, grouped for readability and ending in a 2-character checksum, e.g.
+   `TK-XXXXXX-XXXXX-XXXXX-XXXXX-XXXXX-CC`) generated on the user's device at sign-up.
+   The checksum lets typos be caught before the key is used. See `docs/recovery.md`.
 
 Authentication uses **SRP (Secure Remote Password, RFC 5054)**. The SRP verifier stored on
 the server is derived from both the password and the Secret Key:
@@ -104,7 +105,9 @@ ciphertext. It **cannot** derive any plaintext data from these.
 ### Emergency Kit and Recovery
 
 - The Secret Key is surfaced **once** during account creation and presented as an
-  **Emergency Kit** — a printable/downloadable document the user keeps offline.
+  **Emergency Kit** — a printable/downloadable document the user keeps offline. Toku
+  renders it as plain text, self-contained printable HTML, or PDF
+  (`toku account emergency-kit`). See `docs/recovery.md`.
 - Losing the Secret Key with no local device means the server data is **unrecoverable**.
   This is documented clearly and intentionally: there is no server-side recovery path.
 - **Recovery path**: any local SQLite copy of the library is the recovery. `toku export backup`

--- a/docs/recovery.md
+++ b/docs/recovery.md
@@ -1,0 +1,89 @@
+# Recovery & the Secret Key
+
+Toku's optional self-hosted sync uses a **zero-knowledge** design (see
+[ADR-010](adr/010-self-host-auth.md)). This document explains, in plain terms, **what can
+and cannot be recovered**, and how the **Secret Key** and **Emergency Kit** fit in.
+
+> **Local-first first.** None of this applies to single-device, offline use. Your library
+> lives in a local SQLite database and works with no account, no server, and no network.
+> The material below only concerns the *optional* hosted sync feature.
+
+## The two secrets
+
+Hosted sync authenticates you with **two** secrets that never leave your device:
+
+1. **Account password** — chosen by you, memorable.
+2. **Secret Key** — a 128-bit, high-entropy value generated **on your device**. It is
+   formatted for transcription:
+
+   ```text
+   TK-XXXXXX-XXXXX-XXXXX-XXXXX-XXXXX-CC
+   ```
+
+   - `TK` is a version prefix.
+   - The middle groups encode 128 bits of entropy in base32 (`A–Z`, `2–7`).
+   - The final two characters are a **checksum**, so a single mistyped or swapped
+     character is detected when you enter the key.
+
+Your encryption keys are derived from **both** secrets. The server only ever stores an SRP
+verifier and encrypted (wrapped) key material — it **cannot** derive your password, your
+Secret Key, or any key that decrypts your data.
+
+## The Emergency Kit
+
+Because the Secret Key is generated on your device and never sent to the server, it is shown
+**exactly once**. The **Emergency Kit** is your offline record of it — a one-page document
+containing your account email, the server, the Secret Key, and a blank line to write your
+password by hand.
+
+Generate one with the CLI:
+
+```sh
+# Generate just a Secret Key (shown once)
+toku account secret-key generate
+
+# Render an Emergency Kit (generates a fresh Secret Key unless --secret-key is given)
+toku account emergency-kit --email you@example.com --server https://toku.example.com \
+  --kit-format text                       # plain text to stdout
+toku account emergency-kit --email you@example.com --kit-format html --out kit.html
+toku account emergency-kit --email you@example.com --kit-format pdf  --out kit.pdf
+```
+
+Print it or store it somewhere safe and **offline** (a safe, a password manager's secure
+notes, a locked drawer). Do not store it as the only copy on the same device whose data it
+protects.
+
+## What can and cannot be recovered
+
+| Situation | Recoverable? | How |
+|---|---|---|
+| You forget your **password** but still have a logged-in device | Yes | Re-authenticate on that device, then change the password (re-wraps your keys). |
+| You lose your **Secret Key** but still have a logged-in device | Yes | The device already holds the unwrapped keys; export a backup and/or generate a new Emergency Kit. |
+| You lose **both** secrets but still have a local copy of the library | Yes (data only) | Your local SQLite database is the recovery. `toku export backup` produces a portable archive. The server account itself is not recoverable. |
+| You lose the **Secret Key** and have **no** local device/copy | **No** | Server data is **unrecoverable**. There is no server-side escrow and no reset that bypasses the Secret Key. |
+
+### Why there is no "reset"
+
+A password reset that recovered your data would mean the server could decrypt your data —
+which would defeat the zero-knowledge guarantee. Toku deliberately has **no server-side key
+escrow**. This is the same trade-off as 1Password's Secret Key: stronger privacy in exchange
+for personal responsibility over the Secret Key.
+
+## Device enrollment
+
+A new device is enrolled by entering your **account email + password + Secret Key**. The
+device performs SRP authentication, derives the account unlock key, and unwraps your keys
+locally. The server never receives the secrets and cannot enroll a device on its own.
+
+## The ultimate safety net: local-first
+
+Your **local SQLite library is always the ultimate recovery.** Even if the server is gone,
+your account is locked out, or every secret is lost, any device that holds a copy of the
+library still has your data in an open, portable format:
+
+```sh
+toku export backup   # canonical, portable ZIP archive of your library
+```
+
+Keep at least one offline backup. Combined with your Emergency Kit, that is everything you
+need to recover from any single loss.


### PR DESCRIPTION
## Description

Implements the **Secret Key**, **Emergency Kit**, and recovery semantics for Toku's
1Password-style zero-knowledge sync (issue #118, part of the #114 self-host epic). The key
hierarchy (#116) and SRP auth (#117) already landed; this adds the on-device Secret Key
generation, the human-transcribable format with a typo-catching checksum, the printable
Emergency Kit, and clear documentation of what is (and isn't) recoverable.

### What's included

- **`toku-core` — `SecretKey`** (`crypto/secret_key.rs`): a 128-bit, on-device Secret Key
  with `generate`, `format`/`Display`, and a checksum-validating `parse`. Format is
  `TK-XXXXXX-XXXXX-XXXXX-XXXXX-XXXXX-CC` (RFC 4648 base32 + 2-char checksum that detects
  single-character typos and adjacent transpositions). Returns the raw 16 entropy bytes for
  the existing `AccountKeys` hierarchy. Pure, WASM/FFI-safe; zeroized on drop.
- **`toku-core` — `EmergencyKit`** (`emergency_kit.rs`): renders the kit to plain text and a
  self-contained, print-friendly HTML document (account, server, Secret Key, blank password
  line, "cannot be recovered" warning). Pure, no I/O.
- **`toku-cli` — `toku account` commands**: `secret-key generate` and `emergency-kit`
  (`--kit-format text|html|pdf`, `--out`, `--email`, `--server`, `--secret-key`), each with
  one-time "store offline / unrecoverable" messaging. PDF rendering uses `printpdf` and lives
  in the CLI so `toku-core` stays dependency-light.
- **Docs**: new `docs/recovery.md` (recovery semantics, no server-side escrow, local SQLite as
  the ultimate recovery), refined Secret Key format in ADR-010, plus README + CHANGELOG.

## Related Issues

Closes #118. Part of #114. Builds on #116 and #117.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI / infrastructure
- [ ] Other (describe below)

## Crate

- [x] `toku-core` — Domain models, traits, state machine
- [ ] `toku-db` — SQLite persistence, migrations, FTS5
- [ ] `toku-import` — Importers (Goodreads, Calibre, StoryGraph)
- [ ] `toku-meta` — Metadata fetching (Open Library, Google Books)
- [x] `toku-cli` — CLI binary
- [ ] `toku-export` — Exporters (CSV, JSON, Markdown, BibTeX)
- [x] `docs/` — Documentation

## Data Integrity Checklist

- [x] No user data is sent to any server without explicit opt-in
- [ ] Import operations are idempotent (re-importing the same file creates no duplicates)
- [ ] User edits to metadata are never overwritten by auto-enrichment
- [ ] New fields track provenance (source + timestamp)
- [ ] Export round-trip is preserved (if applicable)

> The Secret Key is generated on-device and is never transmitted. There is no server-side
> escrow; lost secrets with no local copy mean server data is unrecoverable, while the local
> SQLite library remains the ultimate recovery (`docs/recovery.md`).

## Checklist

- [x] I have read [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] `cargo fmt --check` passes
- [x] `cargo clippy --workspace -- -D warnings` passes
- [x] `cargo test --workspace` passes
- [x] I have updated documentation (if applicable)
