### PR TITLE
feat: add user accounts, admin roles, and multi-user schema to toku-sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Passwordless libraries continue to use the existing static bearer-token path
   unchanged — full backward compatibility
 
+- User accounts, admin roles, and multi-user schema in the sync server
+  (Immich-style self-hosting). A new `users` model stores SRP credentials and
+  wrapped key material; accounts sign up via `POST /api/v1/account/signup` and log
+  in with `POST /api/v1/account/challenge` + `POST /api/v1/account/verify`
+  (user-scoped session tokens). The **first account** on a fresh instance becomes
+  the administrator; subsequent self-registration is **closed by default** — the
+  instance is invite/admin-gated. Admin endpoints let an administrator list users
+  (`GET /api/v1/admin/users`), enable/disable accounts
+  (`POST /api/v1/admin/users/{id}/status`, with guards against disabling yourself or
+  the last admin), and toggle open registration (`GET`/`PUT /api/v1/admin/registration`).
+  Libraries and devices gain a nullable owner (`user_id`), stamped when an
+  authenticated user enrolls; legacy unowned rows remain valid. Honors "no social
+  features": the only multi-user surface is administration, never cross-user data
+  access
+
 - Multi-device sync integration test harness (`toku-sync/tests/`): a reusable
   `TestServer` (real in-process Axum relay on a random port) and `SimulatedDevice`
   (real client + database + merge engine + deterministic HLC), plus 10 end-to-end

--- a/crates/toku-sync/migrations/V5__users_and_admin.sql
+++ b/crates/toku-sync/migrations/V5__users_and_admin.sql
@@ -1,0 +1,68 @@
+-- User accounts, admin roles, and multi-user schema (issue #119).
+--
+-- Additive and backward-compatible: the existing library-level SRP relay
+-- (V4) is left untouched. This migration introduces *users* as the SRP
+-- principal for account-level authentication, an instance-level registration
+-- gate, and ownership links from libraries/devices to users.
+
+-- Real user accounts. The server stores only the SRP verifier + salt (it never
+-- sees the password or Secret Key — see #117) and opaque wrapped key material
+-- (see #116). It cannot derive any plaintext data from these columns.
+CREATE TABLE users (
+    id                   TEXT    PRIMARY KEY,            -- uuid v7
+    email                TEXT    NOT NULL UNIQUE,        -- account handle / login
+    srp_salt             TEXT    NOT NULL,               -- hex-encoded SRP salt
+    srp_verifier         TEXT    NOT NULL,               -- hex-encoded SRP verifier (g^x mod N)
+    wrapped_private_key  TEXT,                           -- opaque wrapped account private key (#116)
+    account_public_key   TEXT,                           -- account public key (#116)
+    kdf_params           TEXT,                           -- versioned KDF params blob (#116)
+    role                 TEXT    NOT NULL DEFAULT 'user'
+                                 CHECK (role IN ('admin', 'user')),
+    status               TEXT    NOT NULL DEFAULT 'active'
+                                 CHECK (status IN ('active', 'disabled')),
+    failed_attempts      INTEGER NOT NULL DEFAULT 0,
+    locked_until         TEXT,                           -- ISO-8601 datetime; NULL = not locked
+    created_at           TEXT    NOT NULL
+);
+
+-- Instance-wide configuration. Single row (id = 1). Self-registration is
+-- CLOSED by default — the instance is invite/admin-gated like Immich. The
+-- first account created on a fresh instance bootstraps as the admin regardless
+-- of this flag.
+CREATE TABLE instance_config (
+    id                 INTEGER PRIMARY KEY CHECK (id = 1),
+    registration_open  INTEGER NOT NULL DEFAULT 0,       -- 0 = closed, 1 = open
+    created_at         TEXT    NOT NULL,
+    updated_at         TEXT    NOT NULL
+);
+INSERT OR IGNORE INTO instance_config (id, registration_open, created_at, updated_at)
+VALUES (1, 0, datetime('now'), datetime('now'));
+
+-- Ephemeral SRP server challenges for *user* logins (single-use, 5-min TTL).
+-- Kept separate from the library-scoped `srp_challenges` so the existing relay
+-- auth path is undisturbed.
+CREATE TABLE user_srp_challenges (
+    challenge_id             TEXT PRIMARY KEY,
+    user_id                  TEXT NOT NULL REFERENCES users(id),
+    server_ephemeral_secret  TEXT NOT NULL,  -- hex-encoded b
+    client_public_a          TEXT NOT NULL,  -- hex-encoded A (needed for verify)
+    created_at               TEXT NOT NULL
+);
+CREATE INDEX idx_user_srp_challenges_created ON user_srp_challenges(created_at);
+
+-- Short-lived session tokens issued after successful user SRP verification.
+-- Distinct from the device-scoped `sessions` table; user sessions authenticate
+-- account/admin endpoints, not device sync traffic.
+CREATE TABLE user_sessions (
+    session_token_hash  TEXT    PRIMARY KEY,
+    user_id             TEXT    NOT NULL REFERENCES users(id),
+    expires_at          TEXT    NOT NULL,   -- ISO-8601 UTC datetime
+    created_at          TEXT    NOT NULL
+);
+CREATE INDEX idx_user_sessions_expires ON user_sessions(expires_at);
+
+-- Ownership links. Nullable for backward compatibility: pre-existing libraries
+-- and devices registered under the open relay model remain valid (unowned).
+-- New writes by an authenticated user stamp ownership.
+ALTER TABLE libraries ADD COLUMN user_id TEXT REFERENCES users(id);
+ALTER TABLE devices ADD COLUMN user_id TEXT REFERENCES users(id);

--- a/crates/toku-sync/src/auth.rs
+++ b/crates/toku-sync/src/auth.rs
@@ -37,8 +37,9 @@ use srp::ServerG2048;
 use crate::db::SyncDatabase;
 use crate::error::SyncError;
 use crate::models::{
-    EnrollRequest, EnrollResponse, SrpChallengeRequest, SrpChallengeResponse, SrpVerifyRequest,
-    SrpVerifyResponse,
+    AccountChallengeRequest, AccountChallengeResponse, AccountVerifyRequest, AccountVerifyResponse,
+    EnrollRequest, EnrollResponse, SignupRequest, SignupResponse, SrpChallengeRequest,
+    SrpChallengeResponse, SrpVerifyRequest, SrpVerifyResponse,
 };
 
 /// Maximum failed login attempts before account lockout.
@@ -64,6 +65,33 @@ impl<S: Send + Sync> FromRequestParts<S> for AuthDevice {
         parts
             .extensions
             .get::<AuthDevice>()
+            .cloned()
+            .ok_or(SyncError::Unauthorized)
+    }
+}
+
+/// Authenticated user identity, injected by [`require_user_auth`].
+#[derive(Debug, Clone)]
+pub struct AuthUser {
+    pub user_id: String,
+    pub email: String,
+    pub role: String,
+}
+
+impl AuthUser {
+    /// True when the user holds the `admin` role.
+    pub fn is_admin(&self) -> bool {
+        self.role == "admin"
+    }
+}
+
+impl<S: Send + Sync> FromRequestParts<S> for AuthUser {
+    type Rejection = SyncError;
+
+    async fn from_request_parts(parts: &mut Parts, _state: &S) -> Result<Self, Self::Rejection> {
+        parts
+            .extensions
+            .get::<AuthUser>()
             .cloned()
             .ok_or(SyncError::Unauthorized)
     }
@@ -171,6 +199,86 @@ pub async fn require_auth(
     Ok(next.run(req).await)
 }
 
+/// Resolve an optional user-session token to an active user id.
+///
+/// `token` is the raw bearer value (already stripped of the `Bearer ` prefix).
+/// Returns `None` when absent, expired, or the user is not active. Used to
+/// *opt-in* stamp ownership on library/device creation without breaking the
+/// legacy unauthenticated relay paths.
+pub fn resolve_user_owner(db: &SyncDatabase, token: Option<&str>) -> Option<String> {
+    let token = token?;
+    let token_hash = sha256_hex(token);
+    db.conn
+        .query_row(
+            "SELECT u.id FROM user_sessions s
+             JOIN users u ON u.id = s.user_id
+             WHERE s.session_token_hash = ?1
+               AND s.expires_at > datetime('now')
+               AND u.status = 'active'",
+            [&token_hash],
+            |row| row.get::<_, String>(0),
+        )
+        .ok()
+}
+
+// ── User-session auth middleware ─────────────────────────────────────────────
+
+/// Middleware that validates a user-session Bearer token and injects [`AuthUser`].
+///
+/// Resolves the token against `user_sessions`, loads the owning user, and
+/// rejects disabled accounts. Used to gate account/admin endpoints.
+pub async fn require_user_auth(
+    State(db_path): State<PathBuf>,
+    mut req: Request,
+    next: Next,
+) -> Result<Response, SyncError> {
+    let header = req
+        .headers()
+        .get(AUTHORIZATION)
+        .and_then(|v| v.to_str().ok())
+        .ok_or(SyncError::Unauthorized)?;
+
+    let token = header
+        .strip_prefix("Bearer ")
+        .ok_or(SyncError::Unauthorized)?;
+
+    let token_hash = sha256_hex(token);
+
+    let user = tokio::task::spawn_blocking({
+        let db_path = db_path.clone();
+        move || -> Result<AuthUser, SyncError> {
+            let db = SyncDatabase::open_no_migrate(&db_path)?;
+            let (user_id, email, role, status): (String, String, String, String) = db
+                .conn
+                .query_row(
+                    "SELECT u.id, u.email, u.role, u.status
+                     FROM user_sessions s
+                     JOIN users u ON u.id = s.user_id
+                     WHERE s.session_token_hash = ?1
+                       AND s.expires_at > datetime('now')",
+                    [&token_hash],
+                    |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?)),
+                )
+                .map_err(|_| SyncError::Unauthorized)?;
+
+            if status != "active" {
+                return Err(SyncError::Forbidden("account is disabled".into()));
+            }
+
+            Ok(AuthUser {
+                user_id,
+                email,
+                role,
+            })
+        }
+    })
+    .await
+    .map_err(|e| SyncError::Internal(format!("task join error: {e}")))??;
+
+    req.extensions_mut().insert(user);
+    Ok(next.run(req).await)
+}
+
 // ── SRP handlers ─────────────────────────────────────────────────────────────
 
 /// `POST /api/v1/auth/enroll`
@@ -183,6 +291,7 @@ pub async fn require_auth(
 /// Fails if the library already has an SRP account to prevent takeover attacks.
 pub async fn srp_enroll(
     State(db_path): State<PathBuf>,
+    headers: axum::http::HeaderMap,
     Json(req): Json<EnrollRequest>,
 ) -> Result<Json<EnrollResponse>, SyncError> {
     if req.library_id.is_empty() {
@@ -199,6 +308,13 @@ pub async fn srp_enroll(
 
     let device_id = uuid::Uuid::now_v7().to_string();
 
+    // Optional user-session bearer for ownership stamping (issue #119).
+    let owner_token = headers
+        .get(AUTHORIZATION)
+        .and_then(|v| v.to_str().ok())
+        .and_then(|v| v.strip_prefix("Bearer "))
+        .map(|t| t.to_string());
+
     let resp = tokio::task::spawn_blocking({
         let db_path = db_path.clone();
         let library_id = req.library_id.clone();
@@ -207,6 +323,7 @@ pub async fn srp_enroll(
         let srp_salt = req.srp_salt.clone();
         let srp_verifier = req.srp_verifier.clone();
         let encryption_salt = req.encryption_salt.clone();
+        let owner_token = owner_token.clone();
         move || -> Result<EnrollResponse, SyncError> {
             let db = SyncDatabase::open_no_migrate(&db_path)?;
 
@@ -257,6 +374,19 @@ pub async fn srp_enroll(
                  VALUES (?1, ?2, ?3, '', datetime('now'))",
                 rusqlite::params![device_id, library_id, device_name],
             )?;
+
+            // Ownership stamping (issue #119): if a valid user-session bearer is
+            // present, mark the new library + device as owned by that user.
+            if let Some(owner_id) = resolve_user_owner(&db, owner_token.as_deref()) {
+                db.conn.execute(
+                    "UPDATE libraries SET user_id = ?1 WHERE id = ?2 AND user_id IS NULL",
+                    rusqlite::params![owner_id, library_id],
+                )?;
+                db.conn.execute(
+                    "UPDATE devices SET user_id = ?1 WHERE device_id = ?2",
+                    rusqlite::params![owner_id, device_id],
+                )?;
+            }
 
             Ok(EnrollResponse {
                 device_id,
@@ -631,6 +761,468 @@ fn record_failure_and_err(
             .execute(
                 "UPDATE accounts SET failed_attempts = ?1 WHERE library_id = ?2",
                 rusqlite::params![new_count, library_id],
+            )
+            .ok();
+        Err(SyncError::Unauthorized)
+    }
+}
+
+// ── User account handlers (issue #119) ───────────────────────────────────────
+
+/// Validate an email handle: non-empty, contains `@`, no surrounding whitespace.
+fn validate_email(email: &str) -> Result<(), SyncError> {
+    let trimmed = email.trim();
+    if trimmed.is_empty() || trimmed != email {
+        return Err(SyncError::BadRequest("email is required".into()));
+    }
+    if !email.contains('@') || email.len() > 320 {
+        return Err(SyncError::BadRequest("email is invalid".into()));
+    }
+    Ok(())
+}
+
+/// `POST /api/v1/account/signup`
+///
+/// Create a user account using SRP-6a. The first account on a fresh instance
+/// bootstraps as the `admin` (regardless of the registration flag). Subsequent
+/// signups are rejected unless an admin has opened registration. The client
+/// uploads only the SRP verifier + salt and opaque wrapped key material — the
+/// server never sees the password or Secret Key.
+pub async fn account_signup(
+    State(db_path): State<PathBuf>,
+    Json(req): Json<SignupRequest>,
+) -> Result<Json<SignupResponse>, SyncError> {
+    validate_email(&req.email)?;
+    hex::decode(&req.srp_salt)
+        .map_err(|_| SyncError::BadRequest("srp_salt must be hex-encoded".into()))?;
+    hex::decode(&req.srp_verifier)
+        .map_err(|_| SyncError::BadRequest("srp_verifier must be hex-encoded".into()))?;
+
+    let user_id = uuid::Uuid::now_v7().to_string();
+
+    let resp = tokio::task::spawn_blocking({
+        let db_path = db_path.clone();
+        let user_id = user_id.clone();
+        let email = req.email.clone();
+        let srp_salt = req.srp_salt.clone();
+        let srp_verifier = req.srp_verifier.clone();
+        let wrapped_private_key = req.wrapped_private_key.clone();
+        let account_public_key = req.account_public_key.clone();
+        let kdf_params = req.kdf_params.clone();
+        move || -> Result<SignupResponse, SyncError> {
+            let db = SyncDatabase::open_no_migrate(&db_path)?;
+
+            // First-run bootstrap: the first account is always allowed and
+            // becomes the admin. Counting + insert run in one transaction so
+            // two concurrent first signups can't both become admin.
+            let tx_guard = db.conn.unchecked_transaction()?;
+
+            let existing_users: i64 =
+                tx_guard.query_row("SELECT COUNT(*) FROM users", [], |row| row.get(0))?;
+
+            let role = if existing_users == 0 {
+                "admin"
+            } else {
+                // Subsequent signups require open registration.
+                let registration_open: i64 = tx_guard
+                    .query_row(
+                        "SELECT registration_open FROM instance_config WHERE id = 1",
+                        [],
+                        |row| row.get(0),
+                    )
+                    .unwrap_or(0);
+                if registration_open == 0 {
+                    return Err(SyncError::Forbidden(
+                        "registration is closed; ask an administrator for an invite".into(),
+                    ));
+                }
+                "user"
+            };
+
+            // Reject duplicate emails with a clear 409.
+            let email_taken: i64 = tx_guard.query_row(
+                "SELECT COUNT(*) FROM users WHERE email = ?1",
+                [&email],
+                |row| row.get(0),
+            )?;
+            if email_taken > 0 {
+                return Err(SyncError::Conflict("email is already registered".into()));
+            }
+
+            tx_guard.execute(
+                "INSERT INTO users
+                 (id, email, srp_salt, srp_verifier, wrapped_private_key,
+                  account_public_key, kdf_params, role, status, created_at)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, 'active', datetime('now'))",
+                rusqlite::params![
+                    user_id,
+                    email,
+                    srp_salt,
+                    srp_verifier,
+                    wrapped_private_key,
+                    account_public_key,
+                    kdf_params,
+                    role,
+                ],
+            )?;
+
+            tx_guard.commit()?;
+
+            Ok(SignupResponse {
+                user_id,
+                email,
+                role: role.to_string(),
+            })
+        }
+    })
+    .await
+    .map_err(|e| SyncError::Internal(format!("task join error: {e}")))??;
+
+    Ok(Json(resp))
+}
+
+/// `POST /api/v1/account/challenge`
+///
+/// Start a user SRP-6a login. Mirrors [`srp_challenge`] but keyed to the user's
+/// email and backed by the `user_srp_challenges` table.
+pub async fn account_challenge(
+    State(db_path): State<PathBuf>,
+    Json(req): Json<AccountChallengeRequest>,
+) -> Result<Json<AccountChallengeResponse>, SyncError> {
+    if req.email.is_empty() {
+        return Err(SyncError::BadRequest("email is required".into()));
+    }
+    let a_pub_bytes = hex::decode(&req.client_public_a)
+        .map_err(|_| SyncError::BadRequest("client_public_a must be hex-encoded".into()))?;
+    if a_pub_bytes.is_empty() || a_pub_bytes.iter().all(|&b| b == 0) {
+        return Err(SyncError::BadRequest(
+            "client_public_a must be a non-zero group element".into(),
+        ));
+    }
+
+    let challenge_id = uuid::Uuid::now_v7().to_string();
+    let client_public_a_hex = req.client_public_a.clone();
+
+    let resp = tokio::task::spawn_blocking({
+        let db_path = db_path.clone();
+        let email = req.email.clone();
+        let challenge_id = challenge_id.clone();
+        move || -> Result<AccountChallengeResponse, SyncError> {
+            let db = SyncDatabase::open_no_migrate(&db_path)?;
+
+            // SRP identity is the account email. Load credentials by email.
+            let (user_id, srp_salt_hex, srp_verifier_hex, status, locked_until): (
+                String,
+                String,
+                String,
+                String,
+                Option<String>,
+            ) = db
+                .conn
+                .query_row(
+                    "SELECT id, srp_salt, srp_verifier, status, locked_until
+                     FROM users WHERE email = ?1",
+                    [&email],
+                    |row| {
+                        Ok((
+                            row.get(0)?,
+                            row.get(1)?,
+                            row.get(2)?,
+                            row.get(3)?,
+                            row.get(4)?,
+                        ))
+                    },
+                )
+                .map_err(|_| SyncError::Unauthorized)?;
+
+            if status != "active" {
+                return Err(SyncError::Forbidden("account is disabled".into()));
+            }
+
+            if let Some(until) = locked_until {
+                let still_locked: bool = db
+                    .conn
+                    .query_row("SELECT ?1 > datetime('now')", [&until], |row| row.get(0))
+                    .unwrap_or(false);
+                if still_locked {
+                    return Err(SyncError::AccountLocked { until });
+                }
+            }
+
+            let verifier_bytes = hex::decode(&srp_verifier_hex)
+                .map_err(|_| SyncError::Internal("stored verifier is corrupt".into()))?;
+
+            let mut b = [0u8; 48];
+            rand::RngExt::fill(&mut rand::rng(), &mut b);
+
+            let server = ServerG2048::<Sha256>::new();
+            let b_pub_bytes = server.compute_public_ephemeral(&b, &verifier_bytes);
+
+            let server_ephemeral_hex = hex::encode(b);
+            let b_pub_hex = hex::encode(&b_pub_bytes);
+
+            db.conn.execute(
+                "INSERT INTO user_srp_challenges
+                 (challenge_id, user_id, server_ephemeral_secret, client_public_a, created_at)
+                 VALUES (?1, ?2, ?3, ?4, datetime('now'))",
+                rusqlite::params![
+                    challenge_id,
+                    user_id,
+                    server_ephemeral_hex,
+                    client_public_a_hex
+                ],
+            )?;
+
+            let _ = db.conn.execute(
+                "DELETE FROM user_srp_challenges
+                 WHERE created_at < datetime('now', ?1)",
+                [format!("-{CHALLENGE_TTL_SECS} seconds")],
+            );
+
+            Ok(AccountChallengeResponse {
+                challenge_id,
+                server_public_b: b_pub_hex,
+                srp_salt: srp_salt_hex,
+            })
+        }
+    })
+    .await
+    .map_err(|e| SyncError::Internal(format!("task join error: {e}")))??;
+
+    Ok(Json(resp))
+}
+
+/// `POST /api/v1/account/verify`
+///
+/// Complete a user SRP-6a login and issue a user-session token. Mirrors
+/// [`srp_verify`] but operates on `users` / `user_sessions`.
+pub async fn account_verify(
+    State(db_path): State<PathBuf>,
+    Json(req): Json<AccountVerifyRequest>,
+) -> Result<Json<AccountVerifyResponse>, SyncError> {
+    if req.challenge_id.is_empty() {
+        return Err(SyncError::BadRequest("challenge_id is required".into()));
+    }
+    let m1_bytes = hex::decode(&req.client_proof_m1)
+        .map_err(|_| SyncError::BadRequest("client_proof_m1 must be hex-encoded".into()))?;
+    if m1_bytes.is_empty() {
+        return Err(SyncError::BadRequest("client_proof_m1 is empty".into()));
+    }
+
+    let session_token = generate_token();
+    let token_hash = sha256_hex(&session_token);
+
+    let resp = tokio::task::spawn_blocking({
+        let db_path = db_path.clone();
+        let challenge_id = req.challenge_id.clone();
+        let session_token = session_token.clone();
+        let token_hash = token_hash.clone();
+        move || -> Result<AccountVerifyResponse, SyncError> {
+            let db = SyncDatabase::open_no_migrate(&db_path)?;
+
+            let (user_id, server_ephemeral_hex, client_public_a_hex, created_at): (
+                String,
+                String,
+                String,
+                String,
+            ) = db
+                .conn
+                .query_row(
+                    "SELECT user_id, server_ephemeral_secret, client_public_a, created_at
+                     FROM user_srp_challenges WHERE challenge_id = ?1",
+                    [&challenge_id],
+                    |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?)),
+                )
+                .map_err(|_| SyncError::BadRequest("challenge not found or already used".into()))?;
+
+            let expired: bool = db
+                .conn
+                .query_row(
+                    "SELECT ?1 < datetime('now', ?2)",
+                    rusqlite::params![created_at, format!("-{CHALLENGE_TTL_SECS} seconds")],
+                    |row| row.get(0),
+                )
+                .unwrap_or(true);
+            if expired {
+                let _ = db.conn.execute(
+                    "DELETE FROM user_srp_challenges WHERE challenge_id = ?1",
+                    [&challenge_id],
+                );
+                return Err(SyncError::BadRequest(
+                    "challenge has expired; request a new one".into(),
+                ));
+            }
+
+            let (email, srp_salt_hex, srp_verifier_hex, role, status, failed_attempts, locked_until): (
+                String,
+                String,
+                String,
+                String,
+                String,
+                i64,
+                Option<String>,
+            ) = db
+                .conn
+                .query_row(
+                    "SELECT email, srp_salt, srp_verifier, role, status, failed_attempts, locked_until
+                     FROM users WHERE id = ?1",
+                    [&user_id],
+                    |row| {
+                        Ok((
+                            row.get(0)?,
+                            row.get(1)?,
+                            row.get(2)?,
+                            row.get(3)?,
+                            row.get(4)?,
+                            row.get(5)?,
+                            row.get(6)?,
+                        ))
+                    },
+                )
+                .map_err(|_| SyncError::Internal("user disappeared".into()))?;
+
+            if status != "active" {
+                return Err(SyncError::Forbidden("account is disabled".into()));
+            }
+
+            if let Some(ref until) = locked_until {
+                let still_locked: bool = db
+                    .conn
+                    .query_row("SELECT ?1 > datetime('now')", [until], |row| row.get(0))
+                    .unwrap_or(false);
+                if still_locked {
+                    return Err(SyncError::AccountLocked {
+                        until: until.clone(),
+                    });
+                }
+            }
+
+            let salt_bytes = hex::decode(&srp_salt_hex)
+                .map_err(|_| SyncError::Internal("stored salt is corrupt".into()))?;
+            let verifier_bytes = hex::decode(&srp_verifier_hex)
+                .map_err(|_| SyncError::Internal("stored verifier is corrupt".into()))?;
+            let b_bytes = hex::decode(&server_ephemeral_hex)
+                .map_err(|_| SyncError::Internal("stored server ephemeral is corrupt".into()))?;
+            let a_pub_bytes = hex::decode(&client_public_a_hex)
+                .map_err(|_| SyncError::Internal("stored client_public_a is corrupt".into()))?;
+
+            // Single-use: always delete the challenge.
+            let _ = db.conn.execute(
+                "DELETE FROM user_srp_challenges WHERE challenge_id = ?1",
+                [&challenge_id],
+            );
+
+            // SRP identity is the account email (stable input the client knows
+            // at signup and login time).
+            let server = ServerG2048::<Sha256>::new();
+            let server_verifier = match server.process_reply(
+                email.as_bytes(),
+                &salt_bytes,
+                &b_bytes,
+                &verifier_bytes,
+                &a_pub_bytes,
+            ) {
+                Ok(v) => v,
+                Err(_) => {
+                    record_user_failure(&db, &user_id, failed_attempts)?;
+                    return Err(SyncError::Unauthorized);
+                }
+            };
+
+            if server_verifier.verify_client(&m1_bytes).is_err() {
+                return record_user_failure_and_err(&db, &user_id, failed_attempts);
+            }
+
+            let m2_hex = hex::encode(server_verifier.proof());
+
+            let _ = db.conn.execute(
+                "UPDATE users SET failed_attempts = 0, locked_until = NULL WHERE id = ?1",
+                [&user_id],
+            );
+
+            let expires_at: String = db
+                .conn
+                .query_row(
+                    "SELECT datetime('now', ?1)",
+                    [format!("+{SESSION_TTL_HOURS} hours")],
+                    |row| row.get(0),
+                )
+                .map_err(|e| SyncError::Internal(format!("datetime query failed: {e}")))?;
+
+            db.conn.execute(
+                "INSERT INTO user_sessions
+                 (session_token_hash, user_id, expires_at, created_at)
+                 VALUES (?1, ?2, ?3, datetime('now'))",
+                rusqlite::params![token_hash, user_id, expires_at],
+            )?;
+
+            let _ = email; // email reserved for future audit logging
+            Ok(AccountVerifyResponse {
+                session_token,
+                server_proof_m2: m2_hex,
+                expires_at,
+                user_id,
+                role,
+            })
+        }
+    })
+    .await
+    .map_err(|e| SyncError::Internal(format!("task join error: {e}")))??;
+
+    Ok(Json(resp))
+}
+
+/// Increment a user's failed-attempt counter; lock the account at the threshold.
+fn record_user_failure(
+    db: &SyncDatabase,
+    user_id: &str,
+    current_attempts: i64,
+) -> Result<(), SyncError> {
+    let new_count = current_attempts + 1;
+    if new_count >= MAX_FAILED_ATTEMPTS {
+        db.conn.execute(
+            "UPDATE users SET failed_attempts = ?1, locked_until = datetime('now', ?2)
+             WHERE id = ?3",
+            rusqlite::params![new_count, format!("+{LOCKOUT_MINUTES} minutes"), user_id],
+        )?;
+    } else {
+        db.conn.execute(
+            "UPDATE users SET failed_attempts = ?1 WHERE id = ?2",
+            rusqlite::params![new_count, user_id],
+        )?;
+    }
+    Ok(())
+}
+
+/// Increment the counter and return the appropriate error for a failed login.
+fn record_user_failure_and_err(
+    db: &SyncDatabase,
+    user_id: &str,
+    current_attempts: i64,
+) -> Result<AccountVerifyResponse, SyncError> {
+    let new_count = current_attempts + 1;
+    if new_count >= MAX_FAILED_ATTEMPTS {
+        db.conn
+            .execute(
+                "UPDATE users SET failed_attempts = ?1, locked_until = datetime('now', ?2)
+                 WHERE id = ?3",
+                rusqlite::params![new_count, format!("+{LOCKOUT_MINUTES} minutes"), user_id],
+            )
+            .ok();
+        let until: String = db
+            .conn
+            .query_row(
+                "SELECT locked_until FROM users WHERE id = ?1",
+                [user_id],
+                |row| row.get(0),
+            )
+            .unwrap_or_else(|_| "unknown".into());
+        Err(SyncError::AccountLocked { until })
+    } else {
+        db.conn
+            .execute(
+                "UPDATE users SET failed_attempts = ?1 WHERE id = ?2",
+                rusqlite::params![new_count, user_id],
             )
             .ok();
         Err(SyncError::Unauthorized)

--- a/crates/toku-sync/src/error.rs
+++ b/crates/toku-sync/src/error.rs
@@ -23,6 +23,9 @@ pub enum SyncError {
     #[error("bad request: {0}")]
     BadRequest(String),
 
+    #[error("conflict: {0}")]
+    Conflict(String),
+
     #[error("too many failed authentication attempts; retry after {retry_after}")]
     RateLimited { retry_after: String },
 
@@ -42,6 +45,7 @@ impl IntoResponse for SyncError {
             SyncError::Unauthorized => StatusCode::UNAUTHORIZED,
             SyncError::Forbidden(_) => StatusCode::FORBIDDEN,
             SyncError::BadRequest(_) => StatusCode::BAD_REQUEST,
+            SyncError::Conflict(_) => StatusCode::CONFLICT,
             SyncError::RateLimited { .. } => StatusCode::TOO_MANY_REQUESTS,
             SyncError::AccountLocked { .. } => StatusCode::from_u16(423).unwrap(),
             SyncError::Internal(_) => StatusCode::INTERNAL_SERVER_ERROR,

--- a/crates/toku-sync/src/handlers.rs
+++ b/crates/toku-sync/src/handlers.rs
@@ -3,13 +3,14 @@ use std::path::PathBuf;
 use axum::Json;
 use axum::extract::{Path, Query, State};
 
-use crate::auth::{AuthDevice, generate_token, sha256_hex};
+use crate::auth::{AuthDevice, AuthUser, generate_token, sha256_hex};
 use crate::db::SyncDatabase;
 use crate::error::SyncError;
 use crate::models::{
     DeviceResponse, DownloadSnapshotResponse, HealthResponse, OpPayload, PullQuery, PullResponse,
-    PushRequest, PushResponse, RegisterRequest, RegisterResponse, RekeyRequest, RekeyResponse,
-    UploadSnapshotRequest, UploadSnapshotResponse,
+    PushRequest, PushResponse, RegisterRequest, RegisterResponse, RegistrationConfigResponse,
+    RekeyRequest, RekeyResponse, SetRegistrationRequest, SetUserStatusRequest,
+    UploadSnapshotRequest, UploadSnapshotResponse, UserListResponse, UserSummary,
 };
 
 const MAX_BATCH_SIZE: usize = 1000;
@@ -75,7 +76,7 @@ pub async fn register(
             // For SRP libraries: validate the session token (must match the library).
             // Keep the session hash so we can rebind it after the device row is created.
             let srp_session_hash: Option<String> = if is_srp_library {
-                let session_token = bearer_token.ok_or(SyncError::Unauthorized)?;
+                let session_token = bearer_token.clone().ok_or(SyncError::Unauthorized)?;
                 let session_hash = sha256_hex(&session_token);
                 let auth_library_id: String = db
                     .conn
@@ -122,6 +123,20 @@ pub async fn register(
                  VALUES (?1, ?2, ?3, ?4, datetime('now'))",
                 rusqlite::params![device_id, library_id, device_name, token_hash_to_store],
             )?;
+
+            // Ownership stamping (issue #119): if a valid user-session bearer is
+            // present, mark the library + device as owned by that user. Legacy
+            // unauthenticated registrations leave user_id NULL (unowned).
+            if let Some(owner_id) = crate::auth::resolve_user_owner(&db, bearer_token.as_deref()) {
+                db.conn.execute(
+                    "UPDATE libraries SET user_id = ?1 WHERE id = ?2 AND user_id IS NULL",
+                    rusqlite::params![owner_id, library_id],
+                )?;
+                db.conn.execute(
+                    "UPDATE devices SET user_id = ?1 WHERE device_id = ?2",
+                    rusqlite::params![owner_id, device_id],
+                )?;
+            }
 
             // Rebind the session to the newly-created device. The FK constraint on
             // sessions.device_id requires the device row to exist first.
@@ -700,4 +715,200 @@ fn row_to_op(row: &rusqlite::Row) -> rusqlite::Result<OpPayload> {
         op_type: row.get(5)?,
         payload,
     })
+}
+
+// ── Admin (issue #119) ───────────────────────────────────────────────────────
+
+/// Reject non-admin callers. Admin endpoints honor "no social features": the
+/// only multi-user surface is administration, never cross-user data access.
+fn require_admin(user: &AuthUser) -> Result<(), SyncError> {
+    if user.is_admin() {
+        Ok(())
+    } else {
+        Err(SyncError::Forbidden("admin role required".into()))
+    }
+}
+
+/// `GET /api/v1/admin/users` — list all accounts (admin only).
+///
+/// Returns only non-sensitive fields; SRP verifiers and wrapped key material are
+/// never exposed.
+pub async fn list_users(
+    State(db_path): State<PathBuf>,
+    user: AuthUser,
+) -> Result<Json<UserListResponse>, SyncError> {
+    require_admin(&user)?;
+
+    let users = tokio::task::spawn_blocking({
+        let db_path = db_path.clone();
+        move || -> Result<Vec<UserSummary>, SyncError> {
+            let db = SyncDatabase::open_no_migrate(&db_path)?;
+            let mut stmt = db.conn.prepare(
+                "SELECT id, email, role, status, created_at
+                 FROM users ORDER BY created_at",
+            )?;
+            let rows = stmt
+                .query_map([], |row| {
+                    Ok(UserSummary {
+                        id: row.get(0)?,
+                        email: row.get(1)?,
+                        role: row.get(2)?,
+                        status: row.get(3)?,
+                        created_at: row.get(4)?,
+                    })
+                })?
+                .collect::<Result<Vec<_>, _>>()?;
+            Ok(rows)
+        }
+    })
+    .await
+    .map_err(|e| SyncError::Internal(format!("task join error: {e}")))??;
+
+    Ok(Json(UserListResponse { users }))
+}
+
+/// `POST /api/v1/admin/users/{id}/status` — enable/disable a user (admin only).
+///
+/// Guards: an admin cannot disable their own account, and the last remaining
+/// admin cannot be disabled (so the instance always has at least one admin).
+/// Disabling a user invalidates their active sessions.
+pub async fn set_user_status(
+    State(db_path): State<PathBuf>,
+    user: AuthUser,
+    Path(target_id): Path<String>,
+    Json(req): Json<SetUserStatusRequest>,
+) -> Result<Json<UserSummary>, SyncError> {
+    require_admin(&user)?;
+
+    let new_status = match req.status.as_str() {
+        "active" | "disabled" => req.status.clone(),
+        _ => {
+            return Err(SyncError::BadRequest(
+                "status must be 'active' or 'disabled'".into(),
+            ));
+        }
+    };
+
+    if new_status == "disabled" && target_id == user.user_id {
+        return Err(SyncError::Forbidden(
+            "you cannot disable your own account".into(),
+        ));
+    }
+
+    let summary = tokio::task::spawn_blocking({
+        let db_path = db_path.clone();
+        let target_id = target_id.clone();
+        move || -> Result<UserSummary, SyncError> {
+            let db = SyncDatabase::open_no_migrate(&db_path)?;
+
+            // Load the target (404 if absent).
+            let (email, role, current_status, created_at): (String, String, String, String) = db
+                .conn
+                .query_row(
+                    "SELECT email, role, status, created_at FROM users WHERE id = ?1",
+                    [&target_id],
+                    |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?)),
+                )
+                .map_err(|_| SyncError::NotFound(format!("user {target_id} not found")))?;
+
+            // Don't disable the last active admin.
+            if new_status == "disabled" && role == "admin" {
+                let other_active_admins: i64 = db.conn.query_row(
+                    "SELECT COUNT(*) FROM users
+                     WHERE role = 'admin' AND status = 'active' AND id != ?1",
+                    [&target_id],
+                    |row| row.get(0),
+                )?;
+                if other_active_admins == 0 {
+                    return Err(SyncError::Forbidden(
+                        "cannot disable the last remaining admin".into(),
+                    ));
+                }
+            }
+
+            if new_status != current_status {
+                db.conn.execute(
+                    "UPDATE users SET status = ?1 WHERE id = ?2",
+                    rusqlite::params![new_status, target_id],
+                )?;
+                // Revoke active sessions when disabling.
+                if new_status == "disabled" {
+                    db.conn
+                        .execute("DELETE FROM user_sessions WHERE user_id = ?1", [&target_id])?;
+                }
+            }
+
+            Ok(UserSummary {
+                id: target_id,
+                email,
+                role,
+                status: new_status,
+                created_at,
+            })
+        }
+    })
+    .await
+    .map_err(|e| SyncError::Internal(format!("task join error: {e}")))??;
+
+    Ok(Json(summary))
+}
+
+/// `GET /api/v1/admin/registration` — read the open-registration flag (admin only).
+pub async fn get_registration(
+    State(db_path): State<PathBuf>,
+    user: AuthUser,
+) -> Result<Json<RegistrationConfigResponse>, SyncError> {
+    require_admin(&user)?;
+
+    let open = tokio::task::spawn_blocking({
+        let db_path = db_path.clone();
+        move || -> Result<bool, SyncError> {
+            let db = SyncDatabase::open_no_migrate(&db_path)?;
+            let flag: i64 = db
+                .conn
+                .query_row(
+                    "SELECT registration_open FROM instance_config WHERE id = 1",
+                    [],
+                    |row| row.get(0),
+                )
+                .unwrap_or(0);
+            Ok(flag != 0)
+        }
+    })
+    .await
+    .map_err(|e| SyncError::Internal(format!("task join error: {e}")))??;
+
+    Ok(Json(RegistrationConfigResponse {
+        registration_open: open,
+    }))
+}
+
+/// `PUT /api/v1/admin/registration` — open/close self-registration (admin only).
+pub async fn set_registration(
+    State(db_path): State<PathBuf>,
+    user: AuthUser,
+    Json(req): Json<SetRegistrationRequest>,
+) -> Result<Json<RegistrationConfigResponse>, SyncError> {
+    require_admin(&user)?;
+
+    let open = req.open;
+    tokio::task::spawn_blocking({
+        let db_path = db_path.clone();
+        move || -> Result<(), SyncError> {
+            let db = SyncDatabase::open_no_migrate(&db_path)?;
+            db.conn.execute(
+                "UPDATE instance_config
+                 SET registration_open = ?1, updated_at = datetime('now')
+                 WHERE id = 1",
+                [i64::from(open)],
+            )?;
+            Ok(())
+        }
+    })
+    .await
+    .map_err(|e| SyncError::Internal(format!("task join error: {e}")))??;
+
+    Ok(Json(RegistrationConfigResponse {
+        registration_open: open,
+    }))
 }

--- a/crates/toku-sync/src/lib.rs
+++ b/crates/toku-sync/src/lib.rs
@@ -40,6 +40,22 @@ pub fn build_router(db_path: PathBuf) -> Router {
             auth::require_auth,
         ));
 
+    // Account/admin routes requiring a *user* session (issue #119).
+    let user_authenticated = Router::new()
+        .route("/api/v1/admin/users", get(handlers::list_users))
+        .route(
+            "/api/v1/admin/users/{id}/status",
+            post(handlers::set_user_status),
+        )
+        .route(
+            "/api/v1/admin/registration",
+            get(handlers::get_registration).put(handlers::set_registration),
+        )
+        .layer(middleware::from_fn_with_state(
+            db_path.clone(),
+            auth::require_user_auth,
+        ));
+
     // Public routes (unauthenticated)
     Router::new()
         .route("/health", get(handlers::health))
@@ -49,7 +65,12 @@ pub fn build_router(db_path: PathBuf) -> Router {
         .route("/api/v1/auth/enroll", post(auth::srp_enroll))
         .route("/api/v1/auth/challenge", post(auth::srp_challenge))
         .route("/api/v1/auth/verify", post(auth::srp_verify))
+        // User account (SRP) endpoints
+        .route("/api/v1/account/signup", post(auth::account_signup))
+        .route("/api/v1/account/challenge", post(auth::account_challenge))
+        .route("/api/v1/account/verify", post(auth::account_verify))
         .merge(authenticated)
+        .merge(user_authenticated)
         .layer(DefaultBodyLimit::max(50 * 1024 * 1024)) // 50 MB (rekey may be large)
         .layer(TraceLayer::new_for_http())
         .with_state(db_path)

--- a/crates/toku-sync/src/models.rs
+++ b/crates/toku-sync/src/models.rs
@@ -169,3 +169,104 @@ pub struct DownloadSnapshotResponse {
     pub created_at: String,
     pub created_by_device: String,
 }
+
+// ── User accounts & admin (issue #119) ───────────────────────────────────────
+
+/// `POST /api/v1/account/signup` — create a user account.
+///
+/// The client computes the SRP verifier locally from `(Secret Key + password)`
+/// and uploads only the verifier + salt (never the secrets). Wrapped key
+/// material from the key hierarchy (#116) is stored opaquely.
+#[derive(Debug, Deserialize)]
+pub struct SignupRequest {
+    pub email: String,
+    /// Hex-encoded SRP salt used to compute the verifier.
+    pub srp_salt: String,
+    /// Hex-encoded SRP verifier `v = g^x mod N`.
+    pub srp_verifier: String,
+    /// Opaque wrapped account private key (AES-256-GCM under the unlock key).
+    #[serde(default)]
+    pub wrapped_private_key: Option<String>,
+    /// Account public key (X25519).
+    #[serde(default)]
+    pub account_public_key: Option<String>,
+    /// Versioned KDF parameter blob.
+    #[serde(default)]
+    pub kdf_params: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct SignupResponse {
+    pub user_id: String,
+    pub email: String,
+    pub role: String,
+}
+
+/// `POST /api/v1/account/challenge` — start a user SRP login.
+#[derive(Debug, Deserialize)]
+pub struct AccountChallengeRequest {
+    pub email: String,
+    /// Hex-encoded client public ephemeral A (`g^a mod N`).
+    pub client_public_a: String,
+}
+
+#[derive(Debug, Serialize)]
+pub struct AccountChallengeResponse {
+    pub challenge_id: String,
+    /// Hex-encoded server public ephemeral B.
+    pub server_public_b: String,
+    /// Hex-encoded SRP salt stored at signup.
+    pub srp_salt: String,
+}
+
+/// `POST /api/v1/account/verify` — complete a user SRP login.
+#[derive(Debug, Deserialize)]
+pub struct AccountVerifyRequest {
+    pub challenge_id: String,
+    /// Hex-encoded client proof M1.
+    pub client_proof_m1: String,
+}
+
+#[derive(Debug, Serialize)]
+pub struct AccountVerifyResponse {
+    /// User session bearer token — store securely, use for account/admin calls.
+    pub session_token: String,
+    /// Hex-encoded server proof M2. The client MUST verify this.
+    pub server_proof_m2: String,
+    pub expires_at: String,
+    pub user_id: String,
+    pub role: String,
+}
+
+/// A single user, as exposed to admins. Never includes verifier/key material.
+#[derive(Debug, Serialize)]
+pub struct UserSummary {
+    pub id: String,
+    pub email: String,
+    pub role: String,
+    pub status: String,
+    pub created_at: String,
+}
+
+#[derive(Debug, Serialize)]
+pub struct UserListResponse {
+    pub users: Vec<UserSummary>,
+}
+
+/// `POST /api/v1/admin/users/{id}/status` — enable/disable a user.
+#[derive(Debug, Deserialize)]
+pub struct SetUserStatusRequest {
+    /// `"active"` or `"disabled"`.
+    pub status: String,
+}
+
+/// `GET/PUT /api/v1/admin/registration` — read/toggle open registration.
+#[derive(Debug, Serialize)]
+pub struct RegistrationConfigResponse {
+    pub registration_open: bool,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct SetRegistrationRequest {
+    pub open: bool,
+}

--- a/crates/toku-sync/tests/harness/mod.rs
+++ b/crates/toku-sync/tests/harness/mod.rs
@@ -93,6 +93,11 @@ impl TestServer {
     pub fn base_url(&self) -> &str {
         &self.base_url
     }
+
+    /// Path to the server's SQLite database (for white-box assertions).
+    pub fn db_path(&self) -> std::path::PathBuf {
+        self._tempdir.path().join("server.db")
+    }
 }
 
 /// A simulated Toku device with its own local database, registered against a

--- a/crates/toku-sync/tests/user_accounts.rs
+++ b/crates/toku-sync/tests/user_accounts.rs
@@ -1,0 +1,464 @@
+//! User accounts, admin, and multi-user schema integration tests (issue #119).
+//!
+//! Covers:
+//! (a) First-run bootstrap: the first signup becomes the admin even when
+//!     registration is closed.
+//! (b) Closed registration rejects a second signup; opening it lets a plain user
+//!     register.
+//! (c) Duplicate email is rejected with 409.
+//! (d) User SRP login end-to-end (challenge + verify) issues a session; wrong
+//!     password is rejected with 401; lockout after 5 failures (HTTP 423).
+//! (e) Admin authorization: admin can list users; a plain user gets 403;
+//!     unauthenticated gets 401.
+//! (f) Disabling a user blocks their login; an admin cannot disable themselves
+//!     or the last remaining admin.
+//! (g) Security: no plaintext password lands in users/challenges/sessions.
+
+mod harness;
+
+use harness::TestServer;
+use sha2::{Digest, Sha256};
+use srp::ClientG2048;
+
+// ── HTTP helpers ─────────────────────────────────────────────────────────────
+
+fn rt() -> tokio::runtime::Runtime {
+    tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("build rt")
+}
+
+/// POST JSON, no auth. Returns (status, parsed body).
+fn post_json(url: &str, body: &serde_json::Value) -> (u16, serde_json::Value) {
+    rt().block_on(async {
+        let resp = reqwest::Client::new()
+            .post(url)
+            .json(body)
+            .send()
+            .await
+            .expect("send request");
+        let status = resp.status().as_u16();
+        let val: serde_json::Value = resp.json().await.unwrap_or(serde_json::Value::Null);
+        (status, val)
+    })
+}
+
+/// POST JSON with a bearer token. Returns (status, parsed body).
+fn post_json_auth(url: &str, bearer: &str, body: &serde_json::Value) -> (u16, serde_json::Value) {
+    rt().block_on(async {
+        let resp = reqwest::Client::new()
+            .post(url)
+            .bearer_auth(bearer)
+            .json(body)
+            .send()
+            .await
+            .expect("send request");
+        let status = resp.status().as_u16();
+        let val: serde_json::Value = resp.json().await.unwrap_or(serde_json::Value::Null);
+        (status, val)
+    })
+}
+
+/// PUT JSON with a bearer token. Returns (status, parsed body).
+fn put_json_auth(url: &str, bearer: &str, body: &serde_json::Value) -> (u16, serde_json::Value) {
+    rt().block_on(async {
+        let resp = reqwest::Client::new()
+            .put(url)
+            .bearer_auth(bearer)
+            .json(body)
+            .send()
+            .await
+            .expect("send request");
+        let status = resp.status().as_u16();
+        let val: serde_json::Value = resp.json().await.unwrap_or(serde_json::Value::Null);
+        (status, val)
+    })
+}
+
+/// GET with optional bearer token. Returns (status, parsed body).
+fn get_json(url: &str, bearer: Option<&str>) -> (u16, serde_json::Value) {
+    rt().block_on(async {
+        let mut req = reqwest::Client::new().get(url);
+        if let Some(token) = bearer {
+            req = req.bearer_auth(token);
+        }
+        let resp = req.send().await.expect("send request");
+        let status = resp.status().as_u16();
+        let val: serde_json::Value = resp.json().await.unwrap_or(serde_json::Value::Null);
+        (status, val)
+    })
+}
+
+// ── SRP helpers ──────────────────────────────────────────────────────────────
+
+/// Deterministic 16-byte salt derived from the email (so the test client and
+/// server agree). Real clients use CSPRNG output.
+fn salt_for(email: &str) -> Vec<u8> {
+    let digest = Sha256::digest(format!("salt:{email}").as_bytes());
+    digest[..16].to_vec()
+}
+
+/// Compute the hex-encoded SRP verifier for an account, using the email as the
+/// SRP identity (matching the server).
+fn verifier_hex(email: &str, password: &str, salt: &[u8]) -> String {
+    let client = ClientG2048::<Sha256>::new();
+    let v = client.compute_verifier(email.as_bytes(), password.as_bytes(), salt);
+    hex::encode(v)
+}
+
+/// Sign up an account. Returns (status, body).
+fn signup(server: &TestServer, email: &str, password: &str) -> (u16, serde_json::Value) {
+    signup_auth(server, email, password, None)
+}
+
+/// Sign up an account, optionally presenting a user-session bearer.
+fn signup_auth(
+    server: &TestServer,
+    email: &str,
+    password: &str,
+    bearer: Option<&str>,
+) -> (u16, serde_json::Value) {
+    let salt = salt_for(email);
+    let body = serde_json::json!({
+        "email": email,
+        "srp_salt": hex::encode(&salt),
+        "srp_verifier": verifier_hex(email, password, &salt),
+    });
+    let url = format!("{}/api/v1/account/signup", server.base_url());
+    match bearer {
+        Some(token) => post_json_auth(&url, token, &body),
+        None => post_json(&url, &body),
+    }
+}
+
+/// Run a full user SRP login (challenge + verify). Returns (status, verify body).
+fn login(server: &TestServer, email: &str, password: &str) -> (u16, serde_json::Value) {
+    use rand::RngExt;
+    let client = ClientG2048::<Sha256>::new();
+
+    let mut a = [0u8; 48];
+    rand::rng().fill(&mut a);
+    let a_pub = client.compute_public_ephemeral(&a);
+
+    // Challenge
+    let (status, challenge) = post_json(
+        &format!("{}/api/v1/account/challenge", server.base_url()),
+        &serde_json::json!({ "email": email, "client_public_a": hex::encode(&a_pub) }),
+    );
+    if status != 200 {
+        return (status, challenge);
+    }
+    let challenge_id = challenge["challenge_id"].as_str().expect("challenge_id");
+    let server_b =
+        hex::decode(challenge["server_public_b"].as_str().expect("b")).expect("decode b");
+    let salt = hex::decode(challenge["srp_salt"].as_str().expect("salt")).expect("decode salt");
+
+    let verifier = client
+        .process_reply(&a, email.as_bytes(), password.as_bytes(), &salt, &server_b)
+        .expect("process_reply");
+    let m1 = hex::encode(verifier.proof());
+
+    // Verify
+    let (status, body) = post_json(
+        &format!("{}/api/v1/account/verify", server.base_url()),
+        &serde_json::json!({ "challenge_id": challenge_id, "client_proof_m1": m1 }),
+    );
+
+    // When the login succeeds, confirm the server proof so we exercise the full
+    // mutual-auth handshake the same way a real client would.
+    if status == 200 {
+        let m2 = hex::decode(body["server_proof_m2"].as_str().expect("m2")).expect("decode m2");
+        verifier
+            .verify_server(&m2)
+            .expect("server proof M2 must verify");
+    }
+    (status, body)
+}
+
+/// Convenience: sign up + log in, returning the session token.
+fn signup_and_token(server: &TestServer, email: &str, password: &str) -> String {
+    let (status, _) = signup(server, email, password);
+    assert_eq!(status, 200, "signup should succeed");
+    let (status, body) = login(server, email, password);
+    assert_eq!(status, 200, "login should succeed");
+    body["session_token"]
+        .as_str()
+        .expect("session_token")
+        .to_string()
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+/// (a) The first account on a fresh instance becomes the admin even though
+/// registration is closed by default.
+#[test]
+fn first_signup_bootstraps_admin() {
+    let server = TestServer::start();
+
+    let (status, body) = signup(&server, "admin@example.com", "correct horse");
+    assert_eq!(status, 200, "first signup must succeed (bootstrap)");
+    assert_eq!(body["role"], "admin", "first account must be admin");
+}
+
+/// (b) With registration closed, a second signup is rejected; after an admin
+/// opens registration, a plain user can sign up as role `user`.
+#[test]
+fn closed_registration_then_open() {
+    let server = TestServer::start();
+    let admin_token = signup_and_token(&server, "admin@example.com", "admin pass");
+
+    // Second signup blocked while closed.
+    let (status, _) = signup(&server, "bob@example.com", "bob pass");
+    assert_eq!(status, 403, "self-registration must be closed by default");
+
+    // Admin reads the flag (false), then opens it.
+    let (status, cfg) = get_json(
+        &format!("{}/api/v1/admin/registration", server.base_url()),
+        Some(&admin_token),
+    );
+    assert_eq!(status, 200);
+    assert_eq!(cfg["registration_open"], false);
+
+    let (status, cfg) = put_json_auth(
+        &format!("{}/api/v1/admin/registration", server.base_url()),
+        &admin_token,
+        &serde_json::json!({ "open": true }),
+    );
+    assert_eq!(status, 200);
+    assert_eq!(cfg["registration_open"], true);
+
+    // Now Bob can register, as a plain user.
+    let (status, body) = signup(&server, "bob@example.com", "bob pass");
+    assert_eq!(status, 200, "signup must succeed once registration is open");
+    assert_eq!(body["role"], "user", "non-first accounts are plain users");
+}
+
+/// (c) Duplicate email is rejected with 409.
+#[test]
+fn duplicate_email_conflicts() {
+    let server = TestServer::start();
+    let admin_token = signup_and_token(&server, "admin@example.com", "admin pass");
+    put_json_auth(
+        &format!("{}/api/v1/admin/registration", server.base_url()),
+        &admin_token,
+        &serde_json::json!({ "open": true }),
+    );
+
+    let (status, _) = signup(&server, "dupe@example.com", "pw one");
+    assert_eq!(status, 200);
+    let (status, _) = signup(&server, "dupe@example.com", "pw two");
+    assert_eq!(status, 409, "duplicate email must conflict");
+}
+
+/// (d) Wrong password is rejected with 401; the correct password still works.
+#[test]
+fn wrong_password_rejected() {
+    let server = TestServer::start();
+    signup(&server, "admin@example.com", "right pass");
+
+    let (status, _) = login(&server, "admin@example.com", "WRONG pass");
+    assert_eq!(status, 401, "wrong password must be unauthorized");
+
+    let (status, _) = login(&server, "admin@example.com", "right pass");
+    assert_eq!(status, 200, "correct password must authenticate");
+}
+
+/// (d) Five consecutive failed logins lock the account (HTTP 423).
+#[test]
+fn lockout_after_five_failures() {
+    let server = TestServer::start();
+    signup(&server, "admin@example.com", "right pass");
+
+    for _ in 0..5 {
+        let (status, _) = login(&server, "admin@example.com", "bad pass");
+        assert!(
+            status == 401 || status == 423,
+            "expected 401/423, got {status}"
+        );
+    }
+
+    // Even the correct password is now locked out.
+    let (status, _) = login(&server, "admin@example.com", "right pass");
+    assert_eq!(status, 423, "account must be locked after 5 failures");
+}
+
+/// (e) Admin can list users; a plain user is forbidden; unauthenticated is 401.
+#[test]
+fn admin_authorization() {
+    let server = TestServer::start();
+    let admin_token = signup_and_token(&server, "admin@example.com", "admin pass");
+    put_json_auth(
+        &format!("{}/api/v1/admin/registration", server.base_url()),
+        &admin_token,
+        &serde_json::json!({ "open": true }),
+    );
+    let user_token = signup_and_token(&server, "bob@example.com", "bob pass");
+
+    let url = format!("{}/api/v1/admin/users", server.base_url());
+
+    // Unauthenticated → 401.
+    let (status, _) = get_json(&url, None);
+    assert_eq!(status, 401);
+
+    // Plain user → 403.
+    let (status, _) = get_json(&url, Some(&user_token));
+    assert_eq!(status, 403, "non-admin must be forbidden");
+
+    // Admin → 200 with both users, no secret material leaked.
+    let (status, body) = get_json(&url, Some(&admin_token));
+    assert_eq!(status, 200);
+    let users = body["users"].as_array().expect("users array");
+    assert_eq!(users.len(), 2);
+    let raw = body.to_string();
+    assert!(
+        !raw.contains("srp_verifier") && !raw.contains("srp_salt"),
+        "admin user list must not expose SRP material"
+    );
+}
+
+/// (f) Disabling a user blocks their login and revokes existing sessions; an
+/// admin cannot disable themselves or the last remaining admin.
+#[test]
+fn disable_user_and_guards() {
+    let server = TestServer::start();
+    let admin_token = signup_and_token(&server, "admin@example.com", "admin pass");
+    put_json_auth(
+        &format!("{}/api/v1/admin/registration", server.base_url()),
+        &admin_token,
+        &serde_json::json!({ "open": true }),
+    );
+    let bob_token = signup_and_token(&server, "bob@example.com", "bob pass");
+
+    // Find Bob's id from the admin listing.
+    let (_, body) = get_json(
+        &format!("{}/api/v1/admin/users", server.base_url()),
+        Some(&admin_token),
+    );
+    let users = body["users"].as_array().unwrap();
+    let bob = users
+        .iter()
+        .find(|u| u["email"] == "bob@example.com")
+        .expect("bob in list");
+    let bob_id = bob["id"].as_str().unwrap().to_string();
+    let admin_id = users
+        .iter()
+        .find(|u| u["email"] == "admin@example.com")
+        .unwrap()["id"]
+        .as_str()
+        .unwrap()
+        .to_string();
+
+    // Admin cannot disable self.
+    let (status, _) = post_json_auth(
+        &format!("{}/api/v1/admin/users/{admin_id}/status", server.base_url()),
+        &admin_token,
+        &serde_json::json!({ "status": "disabled" }),
+    );
+    assert_eq!(status, 403, "admin must not disable own account");
+
+    // The lone admin cannot be disabled even by id.
+    // (Bob is a plain user, so admin is the last admin.)
+    // Disable Bob — allowed.
+    let (status, body) = post_json_auth(
+        &format!("{}/api/v1/admin/users/{bob_id}/status", server.base_url()),
+        &admin_token,
+        &serde_json::json!({ "status": "disabled" }),
+    );
+    assert_eq!(status, 200);
+    assert_eq!(body["status"], "disabled");
+
+    // Bob's existing session is now revoked.
+    let (status, _) = get_json(
+        &format!("{}/api/v1/admin/users", server.base_url()),
+        Some(&bob_token),
+    );
+    assert_eq!(status, 401, "disabled user's session must be revoked");
+
+    // Bob can no longer log in.
+    let (status, _) = login(&server, "bob@example.com", "bob pass");
+    assert_eq!(status, 403, "disabled user cannot log in");
+
+    // Re-enable Bob; login works again.
+    let (status, _) = post_json_auth(
+        &format!("{}/api/v1/admin/users/{bob_id}/status", server.base_url()),
+        &admin_token,
+        &serde_json::json!({ "status": "active" }),
+    );
+    assert_eq!(status, 200);
+    let (status, _) = login(&server, "bob@example.com", "bob pass");
+    assert_eq!(status, 200, "re-enabled user can log in");
+}
+
+/// The last remaining admin cannot be disabled (instance keeps an admin).
+#[test]
+fn cannot_disable_last_admin() {
+    let server = TestServer::start();
+    let admin_token = signup_and_token(&server, "admin@example.com", "admin pass");
+
+    let (_, body) = get_json(
+        &format!("{}/api/v1/admin/users", server.base_url()),
+        Some(&admin_token),
+    );
+    let admin_id = body["users"][0]["id"].as_str().unwrap().to_string();
+
+    let (status, _) = post_json_auth(
+        &format!("{}/api/v1/admin/users/{admin_id}/status", server.base_url()),
+        &admin_token,
+        &serde_json::json!({ "status": "disabled" }),
+    );
+    // Self-disable guard fires first (admin is disabling itself), which also
+    // protects the last-admin invariant.
+    assert_eq!(status, 403);
+}
+
+/// (g) The server never persists the plaintext password in any auth table.
+#[test]
+fn no_plaintext_password_stored() {
+    let server = TestServer::start();
+    let password = "super secret pw 123";
+    signup(&server, "admin@example.com", password);
+    login(&server, "admin@example.com", password);
+
+    // Open the server DB directly and scan the auth tables.
+    let db =
+        toku_sync::db::SyncDatabase::open_no_migrate(&server.db_path()).expect("open server db");
+
+    let scan = |table: &str, cols: &[&str]| {
+        let select = cols.join(", ");
+        let mut stmt = db
+            .conn
+            .prepare(&format!("SELECT {select} FROM {table}"))
+            .expect("prepare");
+        let n = cols.len();
+        let rows = stmt
+            .query_map([], move |row| {
+                let mut joined = String::new();
+                for i in 0..n {
+                    let v: Option<String> = row.get(i)?;
+                    joined.push_str(&v.unwrap_or_default());
+                    joined.push('\u{1f}');
+                }
+                Ok(joined)
+            })
+            .expect("query")
+            .collect::<Result<Vec<_>, _>>()
+            .expect("collect");
+        for r in rows {
+            assert!(
+                !r.contains(password),
+                "plaintext password leaked into {table}"
+            );
+        }
+    };
+
+    scan(
+        "users",
+        &["email", "srp_salt", "srp_verifier", "wrapped_private_key"],
+    );
+    scan(
+        "user_srp_challenges",
+        &["server_ephemeral_secret", "client_public_a"],
+    );
+    scan("user_sessions", &["session_token_hash"]);
+}


### PR DESCRIPTION
## Description

Adds **user accounts, admin roles, and a multi-user schema** to `toku-sync`,
the next step toward Immich-style self-hosting (epic #114, ADR-010). The change
is additive and backward compatible: the existing library-level SRP relay and
passwordless paths are untouched.

### What's included

- **New `V5` migration** (idempotent): a `users` table (email, SRP salt/verifier,
  wrapped key material, `role` admin/user, `status` active/disabled, rate-limit
  fields); an `instance_config` singleton with **registration closed by default**;
  separate `user_srp_challenges` and `user_sessions` tables; and nullable
  `user_id` owner columns on `libraries` and `devices`.
- **User accounts via SRP**: `POST /api/v1/account/signup`, `/account/challenge`,
  and `/account/verify` — full user-level SRP-6a login reusing the existing
  primitives, issuing user-scoped session tokens (24h TTL). The **first account on
  a fresh instance becomes the admin**; later self-registration is rejected (403)
  while closed, and duplicate emails conflict (409). Five failed logins lock the
  account for 15 minutes (423).
- **Admin endpoints** (admin-only): list users (`GET /api/v1/admin/users`),
  enable/disable accounts (`POST /api/v1/admin/users/{id}/status`, with guards
  against disabling yourself or the last remaining admin, and session revocation
  on disable), and read/toggle open registration
  (`GET`/`PUT /api/v1/admin/registration`).
- **Ownership stamping**: when an authenticated user enrolls/registers, the new
  library and device are stamped with their `user_id`; legacy unowned rows stay
  valid. Honors "no social features" — the only multi-user surface is
  administration, never cross-user data access.
- **Tests**: new `tests/user_accounts.rs` (9 cases) covering bootstrap,
  closed→open registration, duplicate email, full SRP login, wrong-password and
  lockout, admin authorization, disable + guards, and a white-box check that no
  plaintext password is persisted.

## Related Issues

Closes #119. Part of #114 (depends on #116, #117). Device-enrollment rewiring and
closing open registration remain in #120.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI / infrastructure
- [ ] Other (describe below)

## Crate

- [x] `toku-sync` — Sync relay server (migrations, models, auth, handlers)

## Data Integrity Checklist

- [x] No user data is sent to any server without explicit opt-in (sync/accounts are opt-in; server stores only SRP verifiers and wrapped key material)
- [ ] Import operations are idempotent — N/A
- [ ] User edits to metadata are never overwritten by auto-enrichment — N/A
- [ ] New fields track provenance (source + timestamp) — N/A
- [ ] Export round-trip is preserved — N/A

## Checklist

- [x] I have read [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] `cargo fmt --check` passes
- [x] `cargo clippy --workspace -- -D warnings` passes
- [x] `cargo test --workspace` passes
- [x] I have updated documentation (CHANGELOG.md)
