### PR TITLE
feat: authenticated, Secret-Key-gated device enrollment for sync server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -142,9 +142,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - iOS app (iPhone + iPad) with SwiftUI: library cover grid, book detail, barcode scanner (ISBN-13 via camera), quick progress update sheet, statistics glance with Swift Charts, full-text search, Goodreads CSV import, adaptive navigation (TabView on iPhone, NavigationSplitView on iPad), status filter chips, and pull-to-refresh
 - TokuKitUI shared SwiftUI component library (StarRatingView, FlowLayout, MetadataRow, StatCard) for reuse across macOS and iOS apps
 - 1Password-style account key hierarchy primitives in `toku-core` for hosted sync: two-secret unlock key derivation (password + Secret Key), wrapped account private keys, wrapped library data keys, and versioned serialized key-material formats for future migrations
+- Authenticated, Secret-Key-gated device enrollment for the sync server: new devices
+  are enrolled through an authenticated account session (which already proves
+  possession of the password + Secret Key via SRP) at `POST /api/v1/devices/enroll`,
+  rather than via open registration. Devices and libraries are scoped to the
+  authenticated account, so a user can only enroll into libraries they own. Account
+  holders can list and remove their own devices with
+  `GET /api/v1/account/devices` and `DELETE /api/v1/account/devices/{id}`
+- Optional trusted-device approval flow for sync (off by default, Immich-style
+  opt-in): when enabled, a newly enrolled device on a library that already has an
+  active device is held in a `pending` state and issued no session token until an
+  existing trusted device approves it via `POST /api/v1/devices/{id}/approval`;
+  the approved device then claims its token from `POST /api/v1/devices/{id}/session`.
+  Rejected devices are denied. Administrators toggle the requirement with
+  `GET`/`PUT /api/v1/admin/device-approvals`
 
 ### Changed
 
+- Sync device registration is now gated once an instance has accounts: the legacy
+  unauthenticated `POST /api/v1/register` path is rejected with 403 as soon as the
+  first user account exists, so account-managed instances enroll devices only
+  through the authenticated flow. Fresh, accountless instances (passwordless and
+  library-SRP relays) are unaffected
+- Sync session validation now requires an `active` device: a session token belonging
+  to a `pending` or `rejected` device is rejected even if the session row still exists
 - `toku sync register` replaced by `toku sync init` with automatic defaults (hostname-based device name, auto-generated library ID)
 - `toku sync push`, `pull`, `devices`, `rekey`, and `compact` no longer require `--server` flag — server URL is read from sync config
 - `toku sync logout` replaced by `toku sync disable` which also clears sync config

--- a/crates/toku-sync/migrations/V6__device_enrollment.sql
+++ b/crates/toku-sync/migrations/V6__device_enrollment.sql
@@ -1,0 +1,26 @@
+-- Authenticated, Secret-Key-gated device enrollment (issue #120).
+--
+-- Builds on the account layer (V5): device enrollment is now gated behind an
+-- authenticated account session (which already proves possession of the
+-- password + Secret Key via SRP). This migration adds the device lifecycle
+-- state needed for an optional trusted-device approval flow and an instance
+-- toggle to enable it.
+--
+-- Additive and backward-compatible: existing device rows default to 'active',
+-- so the legacy passwordless / library-SRP relay paths are undisturbed.
+
+-- Device lifecycle status. 'pending' devices have been enrolled by an
+-- authenticated account but await approval from an existing trusted device
+-- before they are issued a session token; 'rejected' devices were denied.
+ALTER TABLE devices ADD COLUMN status TEXT NOT NULL DEFAULT 'active'
+    CHECK (status IN ('active', 'pending', 'rejected'));
+
+-- Optional device public key (X25519) uploaded at enrollment (ADR-010 step 4).
+-- Nullable for backward compatibility and for relay-only deployments.
+ALTER TABLE devices ADD COLUMN device_public_key TEXT;
+
+-- When enabled, a newly enrolled device on a library that already has an active
+-- device is held in 'pending' until an existing trusted device (the account
+-- owner) approves it. Off by default (Immich-style opt-in).
+ALTER TABLE instance_config
+    ADD COLUMN device_approvals_required INTEGER NOT NULL DEFAULT 0;

--- a/crates/toku-sync/src/auth.rs
+++ b/crates/toku-sync/src/auth.rs
@@ -146,12 +146,16 @@ pub async fn require_auth(
         move || -> Result<AuthDevice, SyncError> {
             let db = SyncDatabase::open_no_migrate(&db_path)?;
 
-            // 1. Check the sessions table (SRP-issued, short-lived).
+            // 1. Check the sessions table (SRP-issued, short-lived). Only
+            //    active devices may authenticate — a rejected/pending device
+            //    (issue #120) is denied even if a stale session row lingers.
             let session = db.conn.query_row(
                 "SELECT s.device_id, s.library_id
                  FROM sessions s
+                 JOIN devices d ON d.device_id = s.device_id
                  WHERE s.session_token_hash = ?1
-                   AND s.expires_at > datetime('now')",
+                   AND s.expires_at > datetime('now')
+                   AND d.status = 'active'",
                 [&token_hash],
                 |row| {
                     Ok(AuthDevice {
@@ -173,7 +177,7 @@ pub async fn require_auth(
                 .conn
                 .query_row(
                     "SELECT device_id, library_id
-                     FROM devices WHERE auth_token_hash = ?1",
+                     FROM devices WHERE auth_token_hash = ?1 AND status = 'active'",
                     [&token_hash],
                     |row| {
                         Ok(AuthDevice {

--- a/crates/toku-sync/src/handlers.rs
+++ b/crates/toku-sync/src/handlers.rs
@@ -7,10 +7,13 @@ use crate::auth::{AuthDevice, AuthUser, generate_token, sha256_hex};
 use crate::db::SyncDatabase;
 use crate::error::SyncError;
 use crate::models::{
-    DeviceResponse, DownloadSnapshotResponse, HealthResponse, OpPayload, PullQuery, PullResponse,
+    AccountDeviceListResponse, AccountDeviceSummary, DeviceApprovalRequest,
+    DeviceApprovalsConfigResponse, DeviceResponse, DeviceSessionResponse, DownloadSnapshotResponse,
+    EnrollDeviceRequest, EnrollDeviceResponse, HealthResponse, OpPayload, PullQuery, PullResponse,
     PushRequest, PushResponse, RegisterRequest, RegisterResponse, RegistrationConfigResponse,
-    RekeyRequest, RekeyResponse, SetRegistrationRequest, SetUserStatusRequest,
-    UploadSnapshotRequest, UploadSnapshotResponse, UserListResponse, UserSummary,
+    RekeyRequest, RekeyResponse, SetDeviceApprovalsRequest, SetRegistrationRequest,
+    SetUserStatusRequest, UploadSnapshotRequest, UploadSnapshotResponse, UserListResponse,
+    UserSummary,
 };
 
 const MAX_BATCH_SIZE: usize = 1000;
@@ -96,6 +99,32 @@ pub async fn register(
             } else {
                 None
             };
+
+            // Hard-gate open registration on account-managed instances (issue #120).
+            //
+            // Once any account exists the instance is "managed": the legacy
+            // unauthenticated relay path (non-SRP library, no session) is closed
+            // so that guessing a `library_id` no longer grants access. Callers
+            // must enroll through POST /api/v1/devices/enroll instead. SRP-session
+            // adds (validated above) and user-session-authenticated adds still
+            // work; zero-account (bootstrap / offline-relay) instances are
+            // unaffected, preserving the legacy passwordless flow.
+            if !is_srp_library {
+                let account_managed: bool = db
+                    .conn
+                    .query_row("SELECT COUNT(*) FROM users", [], |row| row.get::<_, i64>(0))
+                    .unwrap_or(0)
+                    > 0;
+                if account_managed
+                    && crate::auth::resolve_user_owner(&db, bearer_token.as_deref()).is_none()
+                {
+                    return Err(SyncError::Forbidden(
+                        "open device registration is disabled on this account-managed instance; \
+                         authenticate and enroll via POST /api/v1/devices/enroll"
+                            .into(),
+                    ));
+                }
+            }
 
             // Auto-create library if it doesn't exist.
             db.conn.execute(
@@ -231,6 +260,407 @@ pub async fn delete_device(
             db.conn
                 .execute("DELETE FROM cursors WHERE device_id = ?1", [&target_id])?;
 
+            Ok(())
+        }
+    })
+    .await
+    .map_err(|e| SyncError::Internal(format!("task join error: {e}")))??;
+
+    Ok(Json(serde_json::json!({ "deleted": true })))
+}
+
+// ── Authenticated device enrollment (issue #120) ─────────────────────────────
+
+/// Device session token TTL (hours). Mirrors the SRP session TTL.
+const DEVICE_SESSION_TTL_HOURS: i64 = 24;
+
+/// Insert a fresh device session token row and return `(token, expires_at)`.
+/// Runs inside a blocking task with an open connection.
+fn issue_device_session(
+    db: &SyncDatabase,
+    device_id: &str,
+    library_id: &str,
+) -> Result<(String, String), SyncError> {
+    let token = generate_token();
+    let token_hash = sha256_hex(&token);
+    let expires_at: String = db
+        .conn
+        .query_row(
+            "SELECT datetime('now', ?1)",
+            [format!("+{DEVICE_SESSION_TTL_HOURS} hours")],
+            |row| row.get(0),
+        )
+        .map_err(|e| SyncError::Internal(format!("datetime query failed: {e}")))?;
+    db.conn.execute(
+        "INSERT INTO sessions
+         (session_token_hash, device_id, library_id, expires_at, created_at)
+         VALUES (?1, ?2, ?3, ?4, datetime('now'))",
+        rusqlite::params![token_hash, device_id, library_id, expires_at],
+    )?;
+    Ok((token, expires_at))
+}
+
+/// `POST /api/v1/devices/enroll`
+///
+/// Enroll a device under the authenticated account. Requires a user-session
+/// bearer (issued by the account SRP flow, which already proves possession of
+/// the password + Secret Key). The device is bound to a library the user owns —
+/// no library is auto-created for an unauthenticated caller.
+///
+/// When the instance requires device approvals and the target library already
+/// has an active device, the new device is recorded as `pending` (no token) and
+/// must be approved by an existing trusted device before it can sync.
+pub async fn enroll_device(
+    State(db_path): State<PathBuf>,
+    user: AuthUser,
+    Json(req): Json<EnrollDeviceRequest>,
+) -> Result<Json<EnrollDeviceResponse>, SyncError> {
+    if req.device_name.is_empty() {
+        return Err(SyncError::BadRequest("device_name is required".into()));
+    }
+
+    let device_id = uuid::Uuid::now_v7().to_string();
+
+    let resp = tokio::task::spawn_blocking({
+        let db_path = db_path.clone();
+        let user_id = user.user_id.clone();
+        let device_id = device_id.clone();
+        let requested_library = req.library_id.clone();
+        let device_name = req.device_name.clone();
+        let encryption_salt = req.encryption_salt.clone();
+        let device_public_key = req.device_public_key.clone();
+        move || -> Result<EnrollDeviceResponse, SyncError> {
+            let db = SyncDatabase::open_no_migrate(&db_path)?;
+            let tx = db.conn.unchecked_transaction()?;
+
+            // Resolve the target library, enforcing ownership.
+            let library_id = match requested_library {
+                Some(lib) if !lib.is_empty() => {
+                    let owner: Option<Option<String>> = tx
+                        .query_row(
+                            "SELECT user_id FROM libraries WHERE id = ?1",
+                            [&lib],
+                            |row| row.get::<_, Option<String>>(0),
+                        )
+                        .ok();
+                    match owner {
+                        // Existing library: must be owned by this user.
+                        Some(Some(owner_id)) if owner_id == user_id => lib,
+                        Some(_) => {
+                            return Err(SyncError::Forbidden(
+                                "you are not authorized to enroll into this library".into(),
+                            ));
+                        }
+                        // Library does not exist yet: create it owned by the user.
+                        None => {
+                            tx.execute(
+                                "INSERT INTO libraries (id, created_at, user_id)
+                                 VALUES (?1, datetime('now'), ?2)",
+                                rusqlite::params![lib, user_id],
+                            )?;
+                            lib
+                        }
+                    }
+                }
+                // No library specified: mint a fresh one owned by the user.
+                _ => {
+                    let lib = uuid::Uuid::now_v7().to_string();
+                    tx.execute(
+                        "INSERT INTO libraries (id, created_at, user_id)
+                         VALUES (?1, datetime('now'), ?2)",
+                        rusqlite::params![lib, user_id],
+                    )?;
+                    lib
+                }
+            };
+
+            // Establish the library salt on first encrypted enrollment.
+            if let Some(ref salt) = encryption_salt {
+                tx.execute(
+                    "UPDATE libraries SET salt = ?1 WHERE id = ?2 AND salt IS NULL",
+                    rusqlite::params![salt, library_id],
+                )?;
+            }
+
+            // Decide whether this device needs approval. Approval only applies
+            // when the toggle is on AND the library already has an active device
+            // (the first device cannot be approved by anyone).
+            let approvals_required: bool = tx
+                .query_row(
+                    "SELECT device_approvals_required FROM instance_config WHERE id = 1",
+                    [],
+                    |row| row.get::<_, i64>(0),
+                )
+                .unwrap_or(0)
+                > 0;
+            let active_devices: i64 = tx.query_row(
+                "SELECT COUNT(*) FROM devices WHERE library_id = ?1 AND status = 'active'",
+                [&library_id],
+                |row| row.get(0),
+            )?;
+            let status = if approvals_required && active_devices > 0 {
+                "pending"
+            } else {
+                "active"
+            };
+
+            // SRP/account libraries don't use static auth tokens.
+            tx.execute(
+                "INSERT INTO devices
+                 (device_id, library_id, device_name, auth_token_hash, user_id,
+                  status, device_public_key, created_at)
+                 VALUES (?1, ?2, ?3, '', ?4, ?5, ?6, datetime('now'))",
+                rusqlite::params![
+                    device_id,
+                    library_id,
+                    device_name,
+                    user_id,
+                    status,
+                    device_public_key,
+                ],
+            )?;
+
+            let (session_token, expires_at) = if status == "active" {
+                let (token, exp) = issue_device_session(&db, &device_id, &library_id)?;
+                (Some(token), Some(exp))
+            } else {
+                (None, None)
+            };
+
+            tx.commit()?;
+
+            Ok(EnrollDeviceResponse {
+                device_id,
+                library_id,
+                status: status.to_string(),
+                session_token,
+                expires_at,
+            })
+        }
+    })
+    .await
+    .map_err(|e| SyncError::Internal(format!("task join error: {e}")))??;
+
+    Ok(Json(resp))
+}
+
+/// `POST /api/v1/devices/{id}/approval`
+///
+/// Approve or reject a `pending` device. Scoped strictly to the authenticated
+/// user: only devices the user owns can be acted on. Approving flips the device
+/// to `active` (it can then mint a session token); rejecting marks it `rejected`
+/// and revokes any sessions.
+pub async fn approve_device(
+    State(db_path): State<PathBuf>,
+    user: AuthUser,
+    Path(target_id): Path<String>,
+    Json(req): Json<DeviceApprovalRequest>,
+) -> Result<Json<AccountDeviceSummary>, SyncError> {
+    let approve = match req.decision.as_str() {
+        "approve" => true,
+        "reject" => false,
+        _ => {
+            return Err(SyncError::BadRequest(
+                "decision must be 'approve' or 'reject'".into(),
+            ));
+        }
+    };
+
+    let summary = tokio::task::spawn_blocking({
+        let db_path = db_path.clone();
+        let user_id = user.user_id.clone();
+        let target_id = target_id.clone();
+        move || -> Result<AccountDeviceSummary, SyncError> {
+            let db = SyncDatabase::open_no_migrate(&db_path)?;
+
+            // Load the device, scoped to the authenticated owner.
+            let (library_id, device_name, status, last_seen, created_at): (
+                String,
+                String,
+                String,
+                Option<String>,
+                String,
+            ) = db
+                .conn
+                .query_row(
+                    "SELECT library_id, device_name, status, last_seen, created_at
+                     FROM devices WHERE device_id = ?1 AND user_id = ?2",
+                    rusqlite::params![target_id, user_id],
+                    |row| {
+                        Ok((
+                            row.get(0)?,
+                            row.get(1)?,
+                            row.get(2)?,
+                            row.get(3)?,
+                            row.get(4)?,
+                        ))
+                    },
+                )
+                .map_err(|_| SyncError::NotFound(format!("device {target_id} not found")))?;
+
+            if status != "pending" {
+                return Err(SyncError::Conflict(format!(
+                    "device is '{status}', not pending approval"
+                )));
+            }
+
+            let new_status = if approve { "active" } else { "rejected" };
+            db.conn.execute(
+                "UPDATE devices SET status = ?1 WHERE device_id = ?2",
+                rusqlite::params![new_status, target_id],
+            )?;
+            if !approve {
+                // Defensive: drop any sessions for a rejected device.
+                db.conn
+                    .execute("DELETE FROM sessions WHERE device_id = ?1", [&target_id])?;
+            }
+
+            Ok(AccountDeviceSummary {
+                device_id: target_id,
+                library_id,
+                device_name,
+                status: new_status.to_string(),
+                last_seen,
+                created_at,
+            })
+        }
+    })
+    .await
+    .map_err(|e| SyncError::Internal(format!("task join error: {e}")))??;
+
+    Ok(Json(summary))
+}
+
+/// `POST /api/v1/devices/{id}/session`
+///
+/// Mint a device session token for an `active` device owned by the authenticated
+/// user. Used by a previously `pending` device to obtain its token after
+/// approval, and as a refresh path for an existing device.
+pub async fn create_device_session(
+    State(db_path): State<PathBuf>,
+    user: AuthUser,
+    Path(target_id): Path<String>,
+) -> Result<Json<DeviceSessionResponse>, SyncError> {
+    let resp = tokio::task::spawn_blocking({
+        let db_path = db_path.clone();
+        let user_id = user.user_id.clone();
+        let target_id = target_id.clone();
+        move || -> Result<DeviceSessionResponse, SyncError> {
+            let db = SyncDatabase::open_no_migrate(&db_path)?;
+
+            let (library_id, status): (String, String) = db
+                .conn
+                .query_row(
+                    "SELECT library_id, status FROM devices
+                     WHERE device_id = ?1 AND user_id = ?2",
+                    rusqlite::params![target_id, user_id],
+                    |row| Ok((row.get(0)?, row.get(1)?)),
+                )
+                .map_err(|_| SyncError::NotFound(format!("device {target_id} not found")))?;
+
+            match status.as_str() {
+                "active" => {}
+                "pending" => {
+                    return Err(SyncError::Forbidden(
+                        "device is pending approval by an existing trusted device".into(),
+                    ));
+                }
+                _ => {
+                    return Err(SyncError::Forbidden(
+                        "device enrollment was rejected".into(),
+                    ));
+                }
+            }
+
+            let (session_token, expires_at) = issue_device_session(&db, &target_id, &library_id)?;
+
+            Ok(DeviceSessionResponse {
+                device_id: target_id,
+                library_id,
+                session_token,
+                expires_at,
+            })
+        }
+    })
+    .await
+    .map_err(|e| SyncError::Internal(format!("task join error: {e}")))??;
+
+    Ok(Json(resp))
+}
+
+/// `GET /api/v1/account/devices`
+///
+/// List the devices owned by the authenticated user, across all of their
+/// libraries. Strictly user-scoped — never exposes another account's devices.
+pub async fn list_account_devices(
+    State(db_path): State<PathBuf>,
+    user: AuthUser,
+) -> Result<Json<AccountDeviceListResponse>, SyncError> {
+    let devices = tokio::task::spawn_blocking({
+        let db_path = db_path.clone();
+        let user_id = user.user_id.clone();
+        move || -> Result<Vec<AccountDeviceSummary>, SyncError> {
+            let db = SyncDatabase::open_no_migrate(&db_path)?;
+            let mut stmt = db.conn.prepare(
+                "SELECT device_id, library_id, device_name, status, last_seen, created_at
+                 FROM devices WHERE user_id = ?1 ORDER BY created_at",
+            )?;
+            let rows = stmt
+                .query_map([&user_id], |row| {
+                    Ok(AccountDeviceSummary {
+                        device_id: row.get(0)?,
+                        library_id: row.get(1)?,
+                        device_name: row.get(2)?,
+                        status: row.get(3)?,
+                        last_seen: row.get(4)?,
+                        created_at: row.get(5)?,
+                    })
+                })?
+                .collect::<Result<Vec<_>, _>>()?;
+            Ok(rows)
+        }
+    })
+    .await
+    .map_err(|e| SyncError::Internal(format!("task join error: {e}")))??;
+
+    Ok(Json(AccountDeviceListResponse { devices }))
+}
+
+/// `DELETE /api/v1/account/devices/{id}`
+///
+/// Deregister a device owned by the authenticated user. Cleans up the device's
+/// sessions and cursors. Strictly user-scoped.
+pub async fn delete_account_device(
+    State(db_path): State<PathBuf>,
+    user: AuthUser,
+    Path(target_id): Path<String>,
+) -> Result<Json<serde_json::Value>, SyncError> {
+    tokio::task::spawn_blocking({
+        let db_path = db_path.clone();
+        let user_id = user.user_id.clone();
+        let target_id = target_id.clone();
+        move || -> Result<(), SyncError> {
+            let db = SyncDatabase::open_no_migrate(&db_path)?;
+
+            // Confirm ownership first (404 if absent or owned by someone else),
+            // then remove child rows before the device to satisfy FK constraints.
+            let owned: i64 = db.conn.query_row(
+                "SELECT COUNT(*) FROM devices WHERE device_id = ?1 AND user_id = ?2",
+                rusqlite::params![target_id, user_id],
+                |row| row.get(0),
+            )?;
+            if owned == 0 {
+                return Err(SyncError::NotFound(format!("device {target_id} not found")));
+            }
+
+            db.conn
+                .execute("DELETE FROM sessions WHERE device_id = ?1", [&target_id])?;
+            db.conn
+                .execute("DELETE FROM cursors WHERE device_id = ?1", [&target_id])?;
+            db.conn.execute(
+                "DELETE FROM devices WHERE device_id = ?1 AND user_id = ?2",
+                rusqlite::params![target_id, user_id],
+            )?;
             Ok(())
         }
     })
@@ -910,5 +1340,67 @@ pub async fn set_registration(
 
     Ok(Json(RegistrationConfigResponse {
         registration_open: open,
+    }))
+}
+
+/// `GET /api/v1/admin/device-approvals` — read the device-approval gate (admin only).
+pub async fn get_device_approvals(
+    State(db_path): State<PathBuf>,
+    user: AuthUser,
+) -> Result<Json<DeviceApprovalsConfigResponse>, SyncError> {
+    require_admin(&user)?;
+
+    let required = tokio::task::spawn_blocking({
+        let db_path = db_path.clone();
+        move || -> Result<bool, SyncError> {
+            let db = SyncDatabase::open_no_migrate(&db_path)?;
+            let flag: i64 = db
+                .conn
+                .query_row(
+                    "SELECT device_approvals_required FROM instance_config WHERE id = 1",
+                    [],
+                    |row| row.get(0),
+                )
+                .unwrap_or(0);
+            Ok(flag != 0)
+        }
+    })
+    .await
+    .map_err(|e| SyncError::Internal(format!("task join error: {e}")))??;
+
+    Ok(Json(DeviceApprovalsConfigResponse {
+        device_approvals_required: required,
+    }))
+}
+
+/// `PUT /api/v1/admin/device-approvals` — enable/disable the device-approval
+/// gate (admin only). When enabled, a newly enrolled device joining a library
+/// that already has an active device is held `pending` until approved.
+pub async fn set_device_approvals(
+    State(db_path): State<PathBuf>,
+    user: AuthUser,
+    Json(req): Json<SetDeviceApprovalsRequest>,
+) -> Result<Json<DeviceApprovalsConfigResponse>, SyncError> {
+    require_admin(&user)?;
+
+    let required = req.required;
+    tokio::task::spawn_blocking({
+        let db_path = db_path.clone();
+        move || -> Result<(), SyncError> {
+            let db = SyncDatabase::open_no_migrate(&db_path)?;
+            db.conn.execute(
+                "UPDATE instance_config
+                 SET device_approvals_required = ?1, updated_at = datetime('now')
+                 WHERE id = 1",
+                [i64::from(required)],
+            )?;
+            Ok(())
+        }
+    })
+    .await
+    .map_err(|e| SyncError::Internal(format!("task join error: {e}")))??;
+
+    Ok(Json(DeviceApprovalsConfigResponse {
+        device_approvals_required: required,
     }))
 }

--- a/crates/toku-sync/src/lib.rs
+++ b/crates/toku-sync/src/lib.rs
@@ -40,7 +40,7 @@ pub fn build_router(db_path: PathBuf) -> Router {
             auth::require_auth,
         ));
 
-    // Account/admin routes requiring a *user* session (issue #119).
+    // Account/admin routes requiring a *user* session (issues #119, #120).
     let user_authenticated = Router::new()
         .route("/api/v1/admin/users", get(handlers::list_users))
         .route(
@@ -50,6 +50,28 @@ pub fn build_router(db_path: PathBuf) -> Router {
         .route(
             "/api/v1/admin/registration",
             get(handlers::get_registration).put(handlers::set_registration),
+        )
+        .route(
+            "/api/v1/admin/device-approvals",
+            get(handlers::get_device_approvals).put(handlers::set_device_approvals),
+        )
+        // Authenticated, Secret-Key-gated device enrollment (issue #120).
+        .route("/api/v1/devices/enroll", post(handlers::enroll_device))
+        .route(
+            "/api/v1/devices/{id}/approval",
+            post(handlers::approve_device),
+        )
+        .route(
+            "/api/v1/devices/{id}/session",
+            post(handlers::create_device_session),
+        )
+        .route(
+            "/api/v1/account/devices",
+            get(handlers::list_account_devices),
+        )
+        .route(
+            "/api/v1/account/devices/{id}",
+            delete(handlers::delete_account_device),
         )
         .layer(middleware::from_fn_with_state(
             db_path.clone(),

--- a/crates/toku-sync/src/main.rs
+++ b/crates/toku-sync/src/main.rs
@@ -547,6 +547,50 @@ mod tests {
         cleanup(&db_path);
     }
 
+    /// Issue #120: once an account exists the instance is "account-managed" and
+    /// the legacy open `register` path is hard-gated — guessing a `library_id`
+    /// no longer auto-creates a library or hands out a token.
+    #[tokio::test]
+    async fn register_rejected_on_account_managed_instance() {
+        let db_path = test_db_path();
+
+        // Simulate an account-managed instance by inserting a user directly.
+        {
+            let db = SyncDatabase::open_no_migrate(&db_path).unwrap();
+            db.conn
+                .execute(
+                    "INSERT INTO users
+                     (id, email, srp_salt, srp_verifier, role, status, created_at)
+                     VALUES (?1, 'admin@example.com', 'aa', 'bb', 'admin', 'active', datetime('now'))",
+                    [uuid::Uuid::now_v7().to_string()],
+                )
+                .unwrap();
+        }
+
+        let app = build_router(db_path.clone());
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/v1/register")
+                    .header("Content-Type", "application/json")
+                    .body(Body::from(
+                        serde_json::to_string(&serde_json::json!({
+                            "library_id": "victim-lib",
+                            "device_name": "attacker"
+                        }))
+                        .unwrap(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+
+        cleanup(&db_path);
+    }
+
     #[tokio::test]
     async fn snapshot_download_returns_404_when_none_exists() {
         let db_path = test_db_path();

--- a/crates/toku-sync/src/models.rs
+++ b/crates/toku-sync/src/models.rs
@@ -270,3 +270,86 @@ pub struct RegistrationConfigResponse {
 pub struct SetRegistrationRequest {
     pub open: bool,
 }
+
+/// `GET/PUT /api/v1/admin/device-approvals` — read/toggle the device-approval gate.
+#[derive(Debug, Serialize)]
+pub struct DeviceApprovalsConfigResponse {
+    pub device_approvals_required: bool,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct SetDeviceApprovalsRequest {
+    pub required: bool,
+}
+
+// ── Authenticated device enrollment (issue #120) ─────────────────────────────
+
+/// `POST /api/v1/devices/enroll` — enroll a device under the authenticated user.
+///
+/// The caller must present a user-session bearer (obtained via the account SRP
+/// flow, which already proves possession of password + Secret Key). The device
+/// is bound to the user's library; no library is auto-created for an
+/// unauthenticated caller.
+#[derive(Debug, Deserialize)]
+pub struct EnrollDeviceRequest {
+    /// Target library. Omit to create a fresh library owned by the user; when
+    /// supplied it must be a library the authenticated user owns (or one that
+    /// does not exist yet, in which case it is created owned by the user).
+    #[serde(default)]
+    pub library_id: Option<String>,
+    pub device_name: String,
+    /// Optional base64-encoded library key-derivation salt; first writer wins.
+    #[serde(default)]
+    pub encryption_salt: Option<String>,
+    /// Optional hex/base64 device public key (X25519); stored opaquely.
+    #[serde(default)]
+    pub device_public_key: Option<String>,
+}
+
+/// Response to `POST /api/v1/devices/enroll`.
+///
+/// When the device is immediately `active`, `session_token` + `expires_at` are
+/// populated and the device can sync right away. When `status` is `pending`
+/// (approval flow), both are `None` until an existing trusted device approves
+/// it, after which the device mints a token via `POST /devices/{id}/session`.
+#[derive(Debug, Serialize)]
+pub struct EnrollDeviceResponse {
+    pub device_id: String,
+    pub library_id: String,
+    pub status: String,
+    pub session_token: Option<String>,
+    pub expires_at: Option<String>,
+}
+
+/// `POST /api/v1/devices/{id}/approval` — approve or reject a pending device.
+#[derive(Debug, Deserialize)]
+pub struct DeviceApprovalRequest {
+    /// `"approve"` or `"reject"`.
+    pub decision: String,
+}
+
+/// Response to `POST /api/v1/devices/{id}/session` — a freshly minted device
+/// session token for an approved (active) device.
+#[derive(Debug, Serialize)]
+pub struct DeviceSessionResponse {
+    pub device_id: String,
+    pub library_id: String,
+    pub session_token: String,
+    pub expires_at: String,
+}
+
+/// A device as exposed to its owning account. Never includes token material.
+#[derive(Debug, Serialize)]
+pub struct AccountDeviceSummary {
+    pub device_id: String,
+    pub library_id: String,
+    pub device_name: String,
+    pub status: String,
+    pub last_seen: Option<String>,
+    pub created_at: String,
+}
+
+#[derive(Debug, Serialize)]
+pub struct AccountDeviceListResponse {
+    pub devices: Vec<AccountDeviceSummary>,
+}

--- a/crates/toku-sync/tests/device_enrollment.rs
+++ b/crates/toku-sync/tests/device_enrollment.rs
@@ -1,0 +1,473 @@
+//! Authenticated, Secret-Key-gated device enrollment integration tests (issue #120).
+//!
+//! Covers:
+//! (a) Open `register` stays available on a fresh (zero-account) instance, but is
+//!     hard-gated (403) once an account exists — guessing a `library_id` no longer
+//!     grants access.
+//! (b) Device enrollment requires a valid account session (401 without one).
+//! (c) A successful enrollment binds the device to the user's library and issues a
+//!     device session token that can push/pull.
+//! (d) Enrolling into another user's library is forbidden (403).
+//! (e) Optional approval flow: a second device on a library with approvals enabled
+//!     is held `pending`, cannot mint a session, and only syncs after an existing
+//!     trusted device (the account owner) approves it; rejection blocks it.
+//! (f) Account-scoped device listing/deregistration never crosses user boundaries.
+
+mod harness;
+
+use harness::TestServer;
+use sha2::{Digest, Sha256};
+use srp::ClientG2048;
+
+// ── HTTP helpers ─────────────────────────────────────────────────────────────
+
+fn rt() -> tokio::runtime::Runtime {
+    tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("build rt")
+}
+
+fn post_json(url: &str, body: &serde_json::Value) -> (u16, serde_json::Value) {
+    rt().block_on(async {
+        let resp = reqwest::Client::new()
+            .post(url)
+            .json(body)
+            .send()
+            .await
+            .expect("send request");
+        let status = resp.status().as_u16();
+        let val: serde_json::Value = resp.json().await.unwrap_or(serde_json::Value::Null);
+        (status, val)
+    })
+}
+
+fn post_json_auth(url: &str, bearer: &str, body: &serde_json::Value) -> (u16, serde_json::Value) {
+    rt().block_on(async {
+        let resp = reqwest::Client::new()
+            .post(url)
+            .bearer_auth(bearer)
+            .json(body)
+            .send()
+            .await
+            .expect("send request");
+        let status = resp.status().as_u16();
+        let val: serde_json::Value = resp.json().await.unwrap_or(serde_json::Value::Null);
+        (status, val)
+    })
+}
+
+fn put_json_auth(url: &str, bearer: &str, body: &serde_json::Value) -> (u16, serde_json::Value) {
+    rt().block_on(async {
+        let resp = reqwest::Client::new()
+            .put(url)
+            .bearer_auth(bearer)
+            .json(body)
+            .send()
+            .await
+            .expect("send request");
+        let status = resp.status().as_u16();
+        let val: serde_json::Value = resp.json().await.unwrap_or(serde_json::Value::Null);
+        (status, val)
+    })
+}
+
+/// GET with an optional bearer token.
+fn get_json(url: &str, bearer: Option<&str>) -> (u16, serde_json::Value) {
+    rt().block_on(async {
+        let mut req = reqwest::Client::new().get(url);
+        if let Some(token) = bearer {
+            req = req.bearer_auth(token);
+        }
+        let resp = req.send().await.expect("send request");
+        let status = resp.status().as_u16();
+        let val: serde_json::Value = resp.json().await.unwrap_or(serde_json::Value::Null);
+        (status, val)
+    })
+}
+
+/// DELETE with an optional bearer token.
+fn delete_json(url: &str, bearer: Option<&str>) -> (u16, serde_json::Value) {
+    rt().block_on(async {
+        let mut req = reqwest::Client::new().delete(url);
+        if let Some(token) = bearer {
+            req = req.bearer_auth(token);
+        }
+        let resp = req.send().await.expect("send request");
+        let status = resp.status().as_u16();
+        let val: serde_json::Value = resp.json().await.unwrap_or(serde_json::Value::Null);
+        (status, val)
+    })
+}
+
+// ── Account SRP helpers (mirror the server's email-keyed SRP) ─────────────────
+
+fn salt_for(email: &str) -> Vec<u8> {
+    Sha256::digest(format!("salt:{email}").as_bytes())[..16].to_vec()
+}
+
+fn verifier_hex(email: &str, password: &str, salt: &[u8]) -> String {
+    let client = ClientG2048::<Sha256>::new();
+    hex::encode(client.compute_verifier(email.as_bytes(), password.as_bytes(), salt))
+}
+
+/// Sign up an account (no auth). Returns (status, body).
+fn signup(server: &TestServer, email: &str, password: &str) -> (u16, serde_json::Value) {
+    let salt = salt_for(email);
+    let body = serde_json::json!({
+        "email": email,
+        "srp_salt": hex::encode(&salt),
+        "srp_verifier": verifier_hex(email, password, &salt),
+    });
+    post_json(
+        &format!("{}/api/v1/account/signup", server.base_url()),
+        &body,
+    )
+}
+
+/// Full account SRP login. Returns the user-session token.
+fn login_token(server: &TestServer, email: &str, password: &str) -> String {
+    use rand::RngExt;
+    let client = ClientG2048::<Sha256>::new();
+
+    let mut a = [0u8; 48];
+    rand::rng().fill(&mut a);
+    let a_pub = client.compute_public_ephemeral(&a);
+
+    let (status, challenge) = post_json(
+        &format!("{}/api/v1/account/challenge", server.base_url()),
+        &serde_json::json!({ "email": email, "client_public_a": hex::encode(&a_pub) }),
+    );
+    assert_eq!(status, 200, "account challenge failed: {challenge}");
+    let challenge_id = challenge["challenge_id"].as_str().expect("challenge_id");
+    let server_b = hex::decode(challenge["server_public_b"].as_str().unwrap()).unwrap();
+    let salt = hex::decode(challenge["srp_salt"].as_str().unwrap()).unwrap();
+
+    let verifier = client
+        .process_reply(&a, email.as_bytes(), password.as_bytes(), &salt, &server_b)
+        .expect("process_reply");
+    let m1 = hex::encode(verifier.proof());
+
+    let (status, body) = post_json(
+        &format!("{}/api/v1/account/verify", server.base_url()),
+        &serde_json::json!({ "challenge_id": challenge_id, "client_proof_m1": m1 }),
+    );
+    assert_eq!(status, 200, "account verify failed: {body}");
+    body["session_token"].as_str().unwrap().to_string()
+}
+
+/// Sign up + log in, returning the user-session token.
+fn account(server: &TestServer, email: &str, password: &str) -> String {
+    let (status, body) = signup(server, email, password);
+    assert_eq!(status, 200, "signup failed: {body}");
+    login_token(server, email, password)
+}
+
+/// Open self-registration so a second account can be created.
+fn open_registration(server: &TestServer, admin_token: &str) {
+    let (status, _) = put_json_auth(
+        &format!("{}/api/v1/admin/registration", server.base_url()),
+        admin_token,
+        &serde_json::json!({ "open": true }),
+    );
+    assert_eq!(status, 200);
+}
+
+/// Enroll a device under `user_token`. Returns (status, body).
+fn enroll(
+    server: &TestServer,
+    user_token: &str,
+    library_id: Option<&str>,
+    device_name: &str,
+) -> (u16, serde_json::Value) {
+    let mut body = serde_json::json!({ "device_name": device_name });
+    if let Some(lib) = library_id {
+        body["library_id"] = serde_json::Value::String(lib.to_string());
+    }
+    post_json_auth(
+        &format!("{}/api/v1/devices/enroll", server.base_url()),
+        user_token,
+        &body,
+    )
+}
+
+/// Push a single op as a device, then pull it back. Returns the number of ops
+/// the device can see — proves the device session token authenticates sync.
+fn push_then_pull_count(server: &TestServer, device_token: &str, op_id: &str) -> usize {
+    let (status, _) = post_json_auth(
+        &format!("{}/api/v1/push", server.base_url()),
+        device_token,
+        &serde_json::json!({
+            "ops": [{
+                "op_id": op_id,
+                "device_id": "dev",
+                "hlc": "2026-06-01T00:00:00.000Z-0001-dev",
+                "entity_type": "book",
+                "entity_id": "book-1",
+                "op_type": "create",
+                "payload": { "title": "ciphertext" }
+            }]
+        }),
+    );
+    assert_eq!(status, 200, "push should succeed for an active device");
+
+    let (status, pull) = get_json(
+        &format!("{}/api/v1/pull", server.base_url()),
+        Some(device_token),
+    );
+    assert_eq!(status, 200, "pull should succeed for an active device");
+    pull["ops"].as_array().map(|a| a.len()).unwrap_or(0)
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+/// (a) Open `register` works before any account exists, but is hard-gated once
+/// the instance is account-managed — guessing a `library_id` no longer works.
+#[test]
+fn register_open_until_first_account_then_gated() {
+    let server = TestServer::start();
+
+    // Fresh instance: legacy passwordless register still works (bootstrap/relay).
+    let (status, body) = post_json(
+        &format!("{}/api/v1/register", server.base_url()),
+        &serde_json::json!({ "library_id": "legacy-lib", "device_name": "relay" }),
+    );
+    assert_eq!(
+        status, 200,
+        "register must be open on a zero-account instance"
+    );
+    assert!(!body["auth_token"].as_str().unwrap().is_empty());
+
+    // Create the first account → instance is now managed.
+    account(&server, "admin@example.com", "admin pass");
+
+    // Guessing any library_id via the open path is now rejected.
+    let (status, _) = post_json(
+        &format!("{}/api/v1/register", server.base_url()),
+        &serde_json::json!({ "library_id": "victim-lib", "device_name": "attacker" }),
+    );
+    assert_eq!(
+        status, 403,
+        "open register must be closed on an account-managed instance"
+    );
+}
+
+/// (b) Device enrollment requires a valid account session.
+#[test]
+fn enrollment_requires_account_auth() {
+    let server = TestServer::start();
+    account(&server, "admin@example.com", "admin pass");
+
+    // No bearer → 401.
+    let (status, _) = post_json(
+        &format!("{}/api/v1/devices/enroll", server.base_url()),
+        &serde_json::json!({ "device_name": "laptop" }),
+    );
+    assert_eq!(status, 401, "enroll without a session must be unauthorized");
+
+    // Bogus bearer → 401.
+    let (status, _) = enroll(&server, "not-a-real-token", None, "laptop");
+    assert_eq!(
+        status, 401,
+        "enroll with an invalid session must be rejected"
+    );
+}
+
+/// (c) A successful enrollment issues a device session token that can sync, and
+/// binds the device to a library owned by the account.
+#[test]
+fn enrolled_device_can_sync() {
+    let server = TestServer::start();
+    let token = account(&server, "admin@example.com", "admin pass");
+
+    let (status, body) = enroll(&server, &token, None, "laptop");
+    assert_eq!(status, 200, "enrollment should succeed: {body}");
+    assert_eq!(body["status"], "active");
+    let device_token = body["session_token"].as_str().expect("session_token");
+    assert!(!body["library_id"].as_str().unwrap().is_empty());
+
+    assert_eq!(
+        push_then_pull_count(&server, device_token, "op-1"),
+        1,
+        "the enrolled device must be able to push and pull"
+    );
+
+    // A guessed/garbage device token cannot sync.
+    let (status, _) = get_json(
+        &format!("{}/api/v1/pull", server.base_url()),
+        Some("garbage-device-token"),
+    );
+    assert_eq!(status, 401);
+}
+
+/// (d) Enrolling into a library owned by a different account is forbidden.
+#[test]
+fn cannot_enroll_into_foreign_library() {
+    let server = TestServer::start();
+    let admin = account(&server, "admin@example.com", "admin pass");
+    open_registration(&server, &admin);
+    let bob = account(&server, "bob@example.com", "bob pass");
+
+    // Admin creates a library by enrolling their first device.
+    let (status, body) = enroll(&server, &admin, None, "admin-laptop");
+    assert_eq!(status, 200);
+    let admin_lib = body["library_id"].as_str().unwrap().to_string();
+
+    // Bob tries to enroll into the admin's library → 403.
+    let (status, _) = enroll(&server, &bob, Some(&admin_lib), "bob-intruder");
+    assert_eq!(
+        status, 403,
+        "must not enroll into another account's library"
+    );
+}
+
+/// (e) Approval flow: with approvals enabled, the second device on a library is
+/// held pending, cannot mint a session, and only syncs after the owner approves.
+#[test]
+fn approval_flow_pending_then_approved() {
+    let server = TestServer::start();
+    let token = account(&server, "admin@example.com", "admin pass");
+
+    // Enable the device-approval gate.
+    let (status, cfg) = put_json_auth(
+        &format!("{}/api/v1/admin/device-approvals", server.base_url()),
+        &token,
+        &serde_json::json!({ "required": true }),
+    );
+    assert_eq!(status, 200);
+    assert_eq!(cfg["device_approvals_required"], true);
+
+    // First device: still active (nothing to approve against) + can sync.
+    let (status, dev_a) = enroll(&server, &token, None, "device-a");
+    assert_eq!(status, 200);
+    assert_eq!(dev_a["status"], "active");
+    let lib = dev_a["library_id"].as_str().unwrap().to_string();
+    let a_token = dev_a["session_token"].as_str().unwrap().to_string();
+    assert_eq!(push_then_pull_count(&server, &a_token, "op-a"), 1);
+
+    // Second device into the same library: pending, no token.
+    let (status, dev_b) = enroll(&server, &token, Some(&lib), "device-b");
+    assert_eq!(status, 200);
+    assert_eq!(dev_b["status"], "pending");
+    assert!(dev_b["session_token"].is_null());
+    let b_id = dev_b["device_id"].as_str().unwrap().to_string();
+
+    // Pending device cannot mint a session yet.
+    let (status, _) = post_json_auth(
+        &format!("{}/api/v1/devices/{b_id}/session", server.base_url()),
+        &token,
+        &serde_json::json!({}),
+    );
+    assert_eq!(status, 403, "pending device must not get a session token");
+
+    // Owner approves device B.
+    let (status, approved) = post_json_auth(
+        &format!("{}/api/v1/devices/{b_id}/approval", server.base_url()),
+        &token,
+        &serde_json::json!({ "decision": "approve" }),
+    );
+    assert_eq!(status, 200, "approval should succeed: {approved}");
+    assert_eq!(approved["status"], "active");
+
+    // Now device B can mint a session and pull the existing op.
+    let (status, sess) = post_json_auth(
+        &format!("{}/api/v1/devices/{b_id}/session", server.base_url()),
+        &token,
+        &serde_json::json!({}),
+    );
+    assert_eq!(status, 200, "approved device must get a session: {sess}");
+    let b_token = sess["session_token"].as_str().unwrap();
+    let (status, pull) = get_json(&format!("{}/api/v1/pull", server.base_url()), Some(b_token));
+    assert_eq!(status, 200);
+    assert_eq!(pull["ops"].as_array().unwrap().len(), 1);
+}
+
+/// (e) A rejected device is permanently blocked from minting a session.
+#[test]
+fn approval_flow_rejection_blocks_device() {
+    let server = TestServer::start();
+    let token = account(&server, "admin@example.com", "admin pass");
+    put_json_auth(
+        &format!("{}/api/v1/admin/device-approvals", server.base_url()),
+        &token,
+        &serde_json::json!({ "required": true }),
+    );
+
+    let (_, dev_a) = enroll(&server, &token, None, "device-a");
+    let lib = dev_a["library_id"].as_str().unwrap().to_string();
+    let (_, dev_b) = enroll(&server, &token, Some(&lib), "device-b");
+    let b_id = dev_b["device_id"].as_str().unwrap().to_string();
+
+    let (status, rejected) = post_json_auth(
+        &format!("{}/api/v1/devices/{b_id}/approval", server.base_url()),
+        &token,
+        &serde_json::json!({ "decision": "reject" }),
+    );
+    assert_eq!(status, 200);
+    assert_eq!(rejected["status"], "rejected");
+
+    let (status, _) = post_json_auth(
+        &format!("{}/api/v1/devices/{b_id}/session", server.base_url()),
+        &token,
+        &serde_json::json!({}),
+    );
+    assert_eq!(status, 403, "rejected device must never get a session");
+}
+
+/// (f) Account device listing/deregistration is strictly scoped to the owner.
+#[test]
+fn account_device_management_is_user_scoped() {
+    let server = TestServer::start();
+    let admin = account(&server, "admin@example.com", "admin pass");
+    open_registration(&server, &admin);
+    let bob = account(&server, "bob@example.com", "bob pass");
+
+    let (_, admin_dev) = enroll(&server, &admin, None, "admin-laptop");
+    let admin_device_id = admin_dev["device_id"].as_str().unwrap().to_string();
+    enroll(&server, &bob, None, "bob-phone");
+
+    // Each account sees only its own device.
+    let (status, admin_list) = get_json(
+        &format!("{}/api/v1/account/devices", server.base_url()),
+        Some(&admin),
+    );
+    assert_eq!(status, 200);
+    let admin_devices = admin_list["devices"].as_array().unwrap();
+    assert_eq!(admin_devices.len(), 1);
+    assert_eq!(admin_devices[0]["device_name"], "admin-laptop");
+
+    let (_, bob_list) = get_json(
+        &format!("{}/api/v1/account/devices", server.base_url()),
+        Some(&bob),
+    );
+    assert_eq!(bob_list["devices"].as_array().unwrap().len(), 1);
+    assert_eq!(bob_list["devices"][0]["device_name"], "bob-phone");
+
+    // Bob cannot delete the admin's device.
+    let (status, _) = delete_json(
+        &format!(
+            "{}/api/v1/account/devices/{admin_device_id}",
+            server.base_url()
+        ),
+        Some(&bob),
+    );
+    assert_eq!(
+        status, 404,
+        "cross-user device deletion must not be allowed"
+    );
+
+    // The admin can delete their own device.
+    let (status, _) = delete_json(
+        &format!(
+            "{}/api/v1/account/devices/{admin_device_id}",
+            server.base_url()
+        ),
+        Some(&admin),
+    );
+    assert_eq!(status, 200);
+    let (_, admin_list) = get_json(
+        &format!("{}/api/v1/account/devices", server.base_url()),
+        Some(&admin),
+    );
+    assert_eq!(admin_list["devices"].as_array().unwrap().len(), 0);
+}


### PR DESCRIPTION
## Description

Replaces the unauthenticated `POST /api/v1/register` device-registration hole with **authenticated, Secret-Key-gated device enrollment**, routing device onboarding through the account-level SRP layer (issues #117/#119). A device can now only join a library after proving possession of the account password + Secret Key, devices/libraries are scoped to the owning account, and an optional trusted-device approval flow lets an existing device vouch for new ones. This is the server-side half of #120; sync-client/orchestrator/CLI migration is deferred to #123.

### What's included

- **Authenticated enrollment** (`POST /api/v1/devices/enroll`) — gated behind a user session. Library ownership is enforced: omitted `library_id` mints a new owned library; an existing `library_id` must be owned by the caller (else 403).
- **Register hard-gating** — once any account exists, the legacy unauthenticated `register` path returns 403. Fresh, accountless instances (passwordless and library-SRP relays) are untouched, preserving full backward compatibility.
- **Active-device-only auth** — `require_auth` now joins `devices` and only accepts sessions for `status = 'active'` devices, so a `pending`/`rejected` device is denied even with a lingering session row.
- **Optional approval flow** (off by default) — when `device_approvals_required` is set, a new device on a library that already has an active device is held `pending` with no token until approved via `POST /api/v1/devices/{id}/approval`; the approved device then claims its token from `POST /api/v1/devices/{id}/session`. Admins toggle the requirement via `GET`/`PUT /api/v1/admin/device-approvals`.
- **User-scoped device management** — `GET /api/v1/account/devices` and `DELETE /api/v1/account/devices/{id}`, scoped to the authenticated account (cross-user access → 404; deletes cascade child `sessions`/`cursors` before the device to satisfy FK constraints).
- **Schema (`V6__device_enrollment.sql`)** — additive: `devices.status` (active/pending/rejected, default `active`), nullable `devices.device_public_key`, and `instance_config.device_approvals_required` (default 0).
- **Tests** — 7 new integration tests in `tests/device_enrollment.rs` plus a `register_rejected_on_account_managed_instance` unit test.

## Related Issues

Closes #120. Relates to #117, #119; follow-up client migration tracked in #123.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI / infrastructure
- [ ] Other (describe below)

## Crate

- [ ] `toku-core` — Domain models, traits, state machine
- [ ] `toku-db` — SQLite persistence, migrations, FTS5
- [ ] `toku-import` — Importers (Goodreads, Calibre, StoryGraph)
- [ ] `toku-meta` — Metadata fetching (Open Library, Google Books)
- [ ] `toku-cli` — CLI binary
- [ ] `toku-export` — Exporters (CSV, JSON, Markdown, BibTeX)
- [ ] `docs/` — Documentation
- [x] `toku-sync` — Sync relay server (enrollment, auth, schema)

## Data Integrity Checklist

- [x] No user data is sent to any server without explicit opt-in
- [x] Import operations are idempotent (re-importing the same file creates no duplicates)
- [x] User edits to metadata are never overwritten by auto-enrichment
- [x] New fields track provenance (source + timestamp)
- [x] Export round-trip is preserved (if applicable)

## Checklist

- [ ] I have read [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] `cargo fmt --check` passes
- [x] `cargo clippy --workspace -- -D warnings` passes
- [x] `cargo test --workspace` passes
- [ ] I have updated documentation (if applicable)
