### PR TITLE
feat: make client-side E2E encryption mandatory (zero-knowledge) for hosted sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,8 +28,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   256-bit random values with a 24-hour TTL, SHA-256 hashed at rest
 - Account rate-limiting for SRP libraries: 5 consecutive failed login attempts lock
   the account for 15 minutes (HTTP 423); successful login resets the counter
-- Passwordless libraries continue to use the existing static bearer-token path
-  unchanged — full backward compatibility
 
 - User accounts, admin roles, and multi-user schema in the sync server
   (Immich-style self-hosting). A new `users` model stores SRP credentials and
@@ -159,11 +157,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Client-side E2E encryption is now mandatory for hosted/sync mode (zero-knowledge).**
+  `toku sync init` always prompts for an encryption passphrase — the passwordless,
+  plaintext opt-out has been removed. Every op payload and every snapshot is encrypted
+  on-device before upload; the server stores only ciphertext and rejects plaintext
+  uploads with HTTP 422. Snapshots, previously stored server-side as plaintext, are now
+  encrypted too. Local-only single-device usage is unaffected (it never uploads). See
+  `docs/sync-server.md` and ADR-010 for the zero-knowledge guarantee and the documented
+  server-visible metadata (op/device ids, HLC, entity/op type — never content)
 - Sync device registration is now gated once an instance has accounts: the legacy
   unauthenticated `POST /api/v1/register` path is rejected with 403 as soon as the
   first user account exists, so account-managed instances enroll devices only
-  through the authenticated flow. Fresh, accountless instances (passwordless and
-  library-SRP relays) are unaffected
+  through the authenticated flow. Fresh, accountless instances (library-SRP relays)
+  are unaffected
 - Sync session validation now requires an `active` device: a session token belonging
   to a `pending` or `rejected` device is rejected even if the session row still exists
 - `toku sync register` replaced by `toku sync init` with automatic defaults (hostname-based device name, auto-generated library ID)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -349,9 +349,9 @@ Rejected sync alternatives:
 #### Sync protocol — technical summary
 
 ```sh
-POST /sync/push     — Client sends new ops (encrypted or plaintext)
+POST /sync/push     — Client sends new ops (always client-side encrypted)
 GET  /sync/pull     — Client receives ops since cursor
-GET  /sync/snapshot — Client downloads latest compacted snapshot
+GET  /sync/snapshot — Client downloads latest compacted snapshot (encrypted)
 POST /sync/register — Register a new device
 GET  /sync/devices  — List registered devices
 DELETE /sync/device — Deregister a device
@@ -368,7 +368,7 @@ Each op:
   "entity_type": "book",
   "entity_id": "uuid",
   "op_type": "update",
-  "payload": "<encrypted-or-plaintext JSON>",
+  "payload": "<encrypted envelope (ciphertext) — never plaintext in hosted mode>",
   "checksum": "sha256"
 }
 ```
@@ -1380,7 +1380,7 @@ Before committing to the architecture, validate:
 
 **Deliverables** (5):
 
-1. **Sync data model + op-log**: Local `sync_ops` table with Hybrid Logical Clock (HLC) timestamps, op IDs (UUID v7), entity type/ID, and encrypted-or-plaintext payload. Every mutation writes to both the domain table and the op-log in a single transaction.
+1. **Sync data model + op-log**: Local `sync_ops` table with Hybrid Logical Clock (HLC) timestamps, op IDs (UUID v7), entity type/ID, and a payload that is always client-side encrypted (ciphertext) before upload. Every mutation writes to both the domain table and the op-log in a single transaction.
 2. **Sync server (`toku-sync` crate)**: Axum REST API for push/pull/snapshot/device management. Thin relay — stores ops and cursors, does not interpret content. Deployable as a Docker image (`kafkade/toku-sync`).
 3. **Push/pull protocol with entity-specific merge rules**: Push sends new ops since last cursor. Pull receives ops and applies entity-specific merge: LWW per field for books, append-only for reading sessions, monotonic for progress, LWW with conflict detection for notes/reviews. Soft deletes with 30-day tombstone retention.
 4. **Mandatory client-side E2E encryption + SRP auth**: Mandatory for hosted mode — no plaintext fallback. 1Password-style two-secret SRP (password + Secret Key). Key hierarchy: (Secret Key + password) → Argon2id → unlock key → wraps key pair → wraps library key. Emergency Kit generated at account creation.

--- a/crates/toku-cli/src/main.rs
+++ b/crates/toku-cli/src/main.rs
@@ -580,8 +580,10 @@ enum SyncAction {
         #[arg(long)]
         device_name: Option<String>,
 
-        /// Enable client-side encryption (prompts for passphrase)
-        #[arg(long)]
+        /// Deprecated: client-side encryption is now mandatory and you are
+        /// always prompted for a passphrase. This flag is kept for
+        /// compatibility and has no effect.
+        #[arg(long, hide = true)]
         passphrase: bool,
     },
 
@@ -3208,21 +3210,24 @@ fn cmd_sync(data_dir: &Path, action: SyncAction, output_format: &OutputFormat) -
             device_name,
             passphrase,
         } => {
-            let passphrase_value = if passphrase {
-                eprint!("Encryption passphrase: ");
-                let pass = rpassword::read_password().context("failed to read passphrase")?;
-                if pass.is_empty() {
-                    anyhow::bail!("passphrase cannot be empty");
-                }
-                eprint!("Confirm passphrase: ");
-                let confirm = rpassword::read_password().context("failed to read confirmation")?;
-                if pass != confirm {
-                    anyhow::bail!("passphrases do not match");
-                }
-                Some(pass)
-            } else {
-                None
-            };
+            // Client-side E2E encryption is mandatory for hosted mode
+            // (zero-knowledge, issue #121): always prompt for a passphrase.
+            // The legacy `--passphrase` flag is accepted but no longer required.
+            let _ = passphrase;
+            eprintln!(
+                "Hosted sync uses zero-knowledge encryption. Choose a passphrase to protect your library."
+            );
+            eprint!("Encryption passphrase: ");
+            let pass = rpassword::read_password().context("failed to read passphrase")?;
+            if pass.is_empty() {
+                anyhow::bail!("passphrase cannot be empty (encryption is mandatory)");
+            }
+            eprint!("Confirm passphrase: ");
+            let confirm = rpassword::read_password().context("failed to read confirmation")?;
+            if pass != confirm {
+                anyhow::bail!("passphrases do not match");
+            }
+            let passphrase_value = Some(pass);
 
             let outcome = sync::orchestrator::init(
                 data_dir,
@@ -3652,6 +3657,14 @@ fn cmd_sync(data_dir: &Path, action: SyncAction, output_format: &OutputFormat) -
                         )
                         .map_err(|e| anyhow::anyhow!("re-encryption failed: {e}"))?;
                         re_wire.payload = serde_json::to_value(&new_envelope)?;
+                    } else if !wire_op.payload.is_null() {
+                        // Zero-knowledge invariant: every op payload is either an
+                        // encrypted envelope or null. A plaintext payload means the
+                        // server is holding readable content — refuse to proceed.
+                        anyhow::bail!(
+                            "op {} has a plaintext payload; refusing to rekey readable data",
+                            wire_op.op_id
+                        );
                     }
                     re_encrypted_ops.push(re_wire);
                     if (i + 1) % 100 == 0 || i + 1 == total {
@@ -3665,6 +3678,27 @@ fn cmd_sync(data_dir: &Path, action: SyncAction, output_format: &OutputFormat) -
                     .rekey(&token, &new_salt_b64, &re_encrypted_ops)
                     .await
                     .context("rekey request failed")?;
+
+                // Re-encrypt the server snapshot (if any) under the new key so a
+                // later bootstrap can still decrypt it. The snapshot keeps its
+                // original HLC, so re-uploading prunes nothing extra.
+                if let Some(snap) = client.download_snapshot(&token).await? {
+                    let old_envelope: toku_core::EncryptedEnvelope =
+                        serde_json::from_str(&snap.snapshot_json)
+                            .context("stored snapshot is not an encrypted envelope")?;
+                    let snapshot_json = toku_core::decrypt_snapshot(&old_key, &old_envelope)
+                        .map_err(|e| anyhow::anyhow!("failed to decrypt snapshot: {e}"))?;
+                    let new_envelope = toku_core::encrypt_snapshot(&new_key, &snapshot_json)
+                        .map_err(|e| anyhow::anyhow!("failed to re-encrypt snapshot: {e}"))?;
+                    let blob = serde_json::to_string(&new_envelope)
+                        .context("failed to serialize re-encrypted snapshot")?;
+                    client
+                        .upload_snapshot(&token, &blob, &snap.hlc_at_snapshot)
+                        .await
+                        .context("failed to re-upload re-encrypted snapshot")?;
+                    eprintln!("Re-encrypted server snapshot under new key");
+                }
+
                 token_store.store_sync_key(server, new_key.as_exported_bytes())?;
                 eprintln!(
                     "Re-keyed {} ops with new passphrase",
@@ -3691,6 +3725,17 @@ fn cmd_sync(data_dir: &Path, action: SyncAction, output_format: &OutputFormat) -
             let mut clock = toku_core::HybridClock::new(&device.device_id);
             let hlc_str = clock.now().to_canonical();
 
+            // Zero-knowledge: snapshots are encrypted client-side before upload
+            // so the server only ever stores ciphertext (issue #121).
+            let key_bytes = token_store.load_sync_key(server)?.ok_or_else(|| {
+                anyhow::anyhow!(
+                    "hosted sync requires client-side encryption but no key is configured.\n\
+                     Run `toku sync init --passphrase` to enroll this device with encryption."
+                )
+            })?;
+            let key = toku_core::SyncKey::from_exported_bytes(&key_bytes)
+                .map_err(|e| anyhow::anyhow!("stored sync key is invalid: {e}"))?;
+
             eprintln!("Creating snapshot...");
             let snapshot = snapshot_repo
                 .export_snapshot(device.device_id, &hlc_str)
@@ -3706,10 +3751,16 @@ fn cmd_sync(data_dir: &Path, action: SyncAction, output_format: &OutputFormat) -
                 size_kb
             );
 
-            eprintln!("Uploading snapshot and pruning old ops...");
+            // Encrypt the snapshot and upload only the ciphertext envelope.
+            let envelope = toku_core::encrypt_snapshot(&key, &snapshot_json)
+                .map_err(|e| anyhow::anyhow!("failed to encrypt snapshot: {e}"))?;
+            let encrypted_blob = serde_json::to_string(&envelope)
+                .context("failed to serialize encrypted snapshot")?;
+
+            eprintln!("Uploading encrypted snapshot and pruning old ops...");
             let result = rt.block_on(async {
                 client
-                    .upload_snapshot(&token, &snapshot_json, &hlc_str)
+                    .upload_snapshot(&token, &encrypted_blob, &hlc_str)
                     .await
             })?;
 

--- a/crates/toku-core/src/crypto.rs
+++ b/crates/toku-core/src/crypto.rs
@@ -1,8 +1,10 @@
 //! Client-side encryption for sync ops.
 //!
-//! Implements optional AES-256-GCM encryption with Argon2id key derivation,
-//! per ADR-006 and ADR-008. When enabled, the `fields` JSON is encrypted
-//! before leaving the device; the server stores opaque blobs.
+//! Implements AES-256-GCM encryption with Argon2id key derivation, per
+//! ADR-010 (supersedes ADR-006/008). Client-side encryption is **mandatory**
+//! for hosted/sync mode: the `fields` JSON is encrypted before leaving the
+//! device and the server only ever stores opaque ciphertext (zero-knowledge).
+//! Local-only single-device usage never uploads and so needs no key.
 //!
 //! # Key derivation
 //!
@@ -260,6 +262,104 @@ pub fn decrypt_fields(
 
     serde_json::from_slice(&plaintext)
         .map_err(|e| TokuError::Crypto(format!("deserialize decrypted fields: {e}")))
+}
+
+// ---------------------------------------------------------------------------
+// Snapshot encryption
+// ---------------------------------------------------------------------------
+
+/// AAD string binding a snapshot envelope to its purpose and version.
+///
+/// Snapshots are not tied to a single op's metadata, so the AAD is a fixed
+/// domain separator rather than the per-op binding used by [`build_aad`].
+const SNAPSHOT_AAD: &str = "kind=snapshot,v=1";
+
+/// Encrypt a serialized library snapshot into an [`EncryptedEnvelope`].
+///
+/// Used by the hosted-sync snapshot flow so the server only ever stores
+/// ciphertext (zero-knowledge). `snapshot_json` is the already-serialized
+/// `LibrarySnapshot`; the returned envelope replaces it on the wire.
+pub fn encrypt_snapshot(
+    key: &SyncKey,
+    snapshot_json: &str,
+) -> Result<EncryptedEnvelope, TokuError> {
+    let cipher = Aes256Gcm::new_from_slice(key.as_bytes())
+        .map_err(|e| TokuError::Crypto(format!("cipher init: {e}")))?;
+
+    let mut nonce_bytes = [0u8; 12];
+    getrandom::fill(&mut nonce_bytes).expect("OS CSPRNG failed");
+    let nonce = Nonce::from_slice(&nonce_bytes);
+
+    let payload = Payload {
+        msg: snapshot_json.as_bytes(),
+        aad: SNAPSHOT_AAD.as_bytes(),
+    };
+
+    let ciphertext = cipher
+        .encrypt(nonce, payload)
+        .map_err(|e| TokuError::Crypto(format!("snapshot encryption failed: {e}")))?;
+
+    Ok(EncryptedEnvelope {
+        ev: ENCRYPTION_ENVELOPE_VERSION,
+        alg: ALGORITHM.to_string(),
+        nonce: BASE64_STANDARD.encode(nonce_bytes),
+        ciphertext: BASE64_STANDARD.encode(ciphertext),
+        aad: SNAPSHOT_AAD.to_string(),
+    })
+}
+
+/// Decrypt a snapshot [`EncryptedEnvelope`] back into its serialized JSON.
+///
+/// Verifies the envelope version, algorithm, and the fixed snapshot AAD
+/// before decryption.
+pub fn decrypt_snapshot(key: &SyncKey, envelope: &EncryptedEnvelope) -> Result<String, TokuError> {
+    if envelope.ev != ENCRYPTION_ENVELOPE_VERSION {
+        return Err(TokuError::Crypto(format!(
+            "unsupported envelope version: {}",
+            envelope.ev
+        )));
+    }
+    if envelope.alg != ALGORITHM {
+        return Err(TokuError::Crypto(format!(
+            "unsupported algorithm: {}",
+            envelope.alg
+        )));
+    }
+    if envelope.aad != SNAPSHOT_AAD {
+        return Err(TokuError::Crypto(
+            "AAD mismatch: snapshot envelope is not bound to a snapshot".to_string(),
+        ));
+    }
+
+    let nonce_bytes = BASE64_STANDARD
+        .decode(&envelope.nonce)
+        .map_err(|e| TokuError::Crypto(format!("nonce decode: {e}")))?;
+    if nonce_bytes.len() != 12 {
+        return Err(TokuError::Crypto(format!(
+            "invalid nonce length: {} (expected 12)",
+            nonce_bytes.len()
+        )));
+    }
+    let nonce = Nonce::from_slice(&nonce_bytes);
+
+    let ciphertext = BASE64_STANDARD
+        .decode(&envelope.ciphertext)
+        .map_err(|e| TokuError::Crypto(format!("ciphertext decode: {e}")))?;
+
+    let cipher = Aes256Gcm::new_from_slice(key.as_bytes())
+        .map_err(|e| TokuError::Crypto(format!("cipher init: {e}")))?;
+
+    let payload = Payload {
+        msg: &ciphertext,
+        aad: envelope.aad.as_bytes(),
+    };
+
+    let plaintext = cipher.decrypt(nonce, payload).map_err(|_| {
+        TokuError::Crypto("snapshot decryption failed (wrong key or tampered data)".to_string())
+    })?;
+
+    String::from_utf8(plaintext)
+        .map_err(|e| TokuError::Crypto(format!("snapshot is not valid UTF-8: {e}")))
 }
 
 // ---------------------------------------------------------------------------
@@ -733,5 +833,58 @@ mod tests {
 
             assert_eq!(decrypted, fields, "round trip failed for {et}");
         }
+    }
+
+    // --- Snapshot encryption ---
+
+    #[test]
+    fn snapshot_round_trip() {
+        let (key, _) = test_key_and_salt();
+        let snapshot = r#"{"version":1,"library":{"books":[]}}"#;
+
+        let envelope = encrypt_snapshot(&key, snapshot).unwrap();
+        assert_eq!(envelope.alg, ALGORITHM);
+        // Ciphertext must not leak the plaintext.
+        assert!(!envelope.ciphertext.contains("books"));
+
+        let decrypted = decrypt_snapshot(&key, &envelope).unwrap();
+        assert_eq!(decrypted, snapshot);
+    }
+
+    #[test]
+    fn snapshot_wrong_key_fails() {
+        let (key, _) = test_key_and_salt();
+        let envelope = encrypt_snapshot(&key, "{\"a\":1}").unwrap();
+
+        let other = SyncKey::derive("different-passphrase", &[9u8; 16]).unwrap();
+        assert!(decrypt_snapshot(&other, &envelope).is_err());
+    }
+
+    #[test]
+    fn snapshot_tampered_ciphertext_fails() {
+        let (key, _) = test_key_and_salt();
+        let mut envelope = encrypt_snapshot(&key, "{\"a\":1}").unwrap();
+
+        let mut raw = BASE64_STANDARD.decode(&envelope.ciphertext).unwrap();
+        raw[0] ^= 0xff;
+        envelope.ciphertext = BASE64_STANDARD.encode(&raw);
+
+        assert!(decrypt_snapshot(&key, &envelope).is_err());
+    }
+
+    #[test]
+    fn snapshot_rejects_op_envelope_aad() {
+        let (key, _) = test_key_and_salt();
+        // An op envelope must not be decryptable as a snapshot (AAD mismatch).
+        let op_envelope = encrypt_fields(
+            &key,
+            &test_fields(),
+            &test_entity_type(),
+            &test_entity_id(),
+            &test_op_type(),
+        )
+        .unwrap();
+
+        assert!(decrypt_snapshot(&key, &op_envelope).is_err());
     }
 }

--- a/crates/toku-sync-client/src/orchestrator.rs
+++ b/crates/toku-sync-client/src/orchestrator.rs
@@ -125,14 +125,15 @@ fn load_encryption_key(
 }
 
 /// Initialize sync: register the device with the server, persist the auth token and
-/// sync config, optionally enabling client-side encryption with the given passphrase.
+/// sync config, and enable **mandatory** client-side encryption from the passphrase.
 ///
-/// **When `passphrase` is `Some`**: Uses SRP-6a enrollment + login so the server
-/// never sees the password. The passphrase also derives the client-side AES
-/// encryption key.
+/// Hosted/sync mode is zero-knowledge (ADR-010, issue #121): a passphrase is
+/// **required**. It drives SRP-6a enrollment/login (so the server never sees the
+/// password) and derives the client-side AES data key used to encrypt every op.
 ///
-/// **When `passphrase` is `None`**: Falls back to the legacy unauthenticated
-/// registration path (passwordless library, static bearer token).
+/// Calling without a passphrase returns an error — the previous passwordless,
+/// plaintext opt-out has been removed. Local-only single-device usage never
+/// uploads and so needs neither sync nor a passphrase.
 pub fn init(
     data_dir: &Path,
     server: &str,
@@ -298,40 +299,17 @@ pub fn init(
         }
 
         _ => {
-            // ── Legacy passwordless path ─────────────────────────────────
-            let resp = rt.block_on(client.register(&library_id, &device_name, None, None))?;
-
-            token_store
-                .store(server, &resp.auth_token)
-                .context("failed to store auth token")?;
-
-            let db = open_db(data_dir)?;
-            let sync_repo = SyncRepository::new(&db);
-            let server_device_id = resp
-                .device_id
-                .parse::<uuid::Uuid>()
-                .context("server returned an invalid device_id")?;
-            sync_repo.get_or_create_device_with_id(server_device_id, &device_name)?;
-
-            let mut config = toku_core::TokuConfig::load(data_dir).unwrap_or_default();
-            config.sync = Some(toku_core::SyncConfig {
-                server: server.to_string(),
-                library_id: resp.library_id.clone(),
-                device_id: resp.device_id.clone(),
-                device_name: device_name.clone(),
-                encryption: false,
-            });
-            config
-                .save(data_dir)
-                .map_err(|e| anyhow::anyhow!("failed to save config: {e}"))?;
-
-            Ok(InitOutcome {
-                device_id: resp.device_id,
-                library_id: resp.library_id,
-                device_name,
-                server: server.to_string(),
-                encryption: false,
-            })
+            // ── Plaintext opt-out removed (issue #121) ───────────────────
+            //
+            // Hosted/sync mode now mandates client-side E2E encryption
+            // (zero-knowledge). A passwordless library would upload plaintext
+            // ops, which the server rejects, so we refuse up front with an
+            // actionable error instead of registering an unusable device.
+            Err(anyhow::anyhow!(
+                "hosted sync requires client-side encryption: a passphrase is mandatory.\n\
+                 Re-run with `toku sync init --passphrase` (you will be prompted securely).\n\
+                 Local-only, single-device usage needs no sync and no passphrase."
+            ))
         }
     }
 }
@@ -361,19 +339,22 @@ pub fn push(data_dir: &Path) -> anyhow::Result<PushOutcome> {
     }
 
     let total = unpushed.len();
-    let key = load_encryption_key(&token_store, server, sync_config)?;
+    // Zero-knowledge: hosted mode mandates client-side encryption. Refuse to
+    // push if no key is configured rather than uploading plaintext.
+    let key = load_encryption_key(&token_store, server, sync_config)?.ok_or_else(|| {
+        anyhow::anyhow!(
+            "hosted sync requires client-side encryption but no key is configured.\n\
+             Re-run `toku sync init --passphrase` to enroll this device with encryption."
+        )
+    })?;
     let wire_ops: Vec<WireOp> = unpushed
         .iter()
         .map(|op| {
-            if let Some(ref key) = key {
-                let mut encrypted = op.clone();
-                encrypted
-                    .encrypt(key)
-                    .map_err(|e| anyhow::anyhow!("failed to encrypt op {}: {e}", op.op_id))?;
-                Ok(wire::to_wire(&encrypted))
-            } else {
-                Ok(wire::to_wire(op))
-            }
+            let mut encrypted = op.clone();
+            encrypted
+                .encrypt(&key)
+                .map_err(|e| anyhow::anyhow!("failed to encrypt op {}: {e}", op.op_id))?;
+            Ok(wire::to_wire(&encrypted))
         })
         .collect::<anyhow::Result<Vec<_>>>()?;
 
@@ -496,8 +477,20 @@ pub fn bootstrap(data_dir: &Path) -> anyhow::Result<BootstrapOutcome> {
     let mut snapshot_books = 0usize;
 
     if let Some(snap) = rt.block_on(client.download_snapshot(&token))? {
+        // Zero-knowledge: snapshots are stored as ciphertext. Decrypt with the
+        // library data key before applying.
+        let key = load_encryption_key(&token_store, server, sync_config)?.ok_or_else(|| {
+            anyhow::anyhow!(
+                "downloaded an encrypted snapshot but no key is configured.\n\
+                 Re-run `toku sync init --passphrase` to enroll this device with encryption."
+            )
+        })?;
+        let envelope: toku_core::EncryptedEnvelope = serde_json::from_str(&snap.snapshot_json)
+            .context("snapshot is not an encrypted envelope")?;
+        let snapshot_json = toku_core::decrypt_snapshot(&key, &envelope)
+            .map_err(|e| anyhow::anyhow!("failed to decrypt snapshot: {e}"))?;
         let snapshot: toku_core::sync::LibrarySnapshot =
-            serde_json::from_str(&snap.snapshot_json).context("invalid snapshot JSON")?;
+            serde_json::from_str(&snapshot_json).context("invalid snapshot JSON")?;
         let db = open_db(data_dir)?;
         let snapshot_repo = SnapshotRepository::new(&db);
         let result = snapshot_repo

--- a/crates/toku-sync/src/error.rs
+++ b/crates/toku-sync/src/error.rs
@@ -23,6 +23,9 @@ pub enum SyncError {
     #[error("bad request: {0}")]
     BadRequest(String),
 
+    #[error("plaintext payload rejected: {0}")]
+    PlaintextRejected(String),
+
     #[error("conflict: {0}")]
     Conflict(String),
 
@@ -45,6 +48,7 @@ impl IntoResponse for SyncError {
             SyncError::Unauthorized => StatusCode::UNAUTHORIZED,
             SyncError::Forbidden(_) => StatusCode::FORBIDDEN,
             SyncError::BadRequest(_) => StatusCode::BAD_REQUEST,
+            SyncError::PlaintextRejected(_) => StatusCode::UNPROCESSABLE_ENTITY,
             SyncError::Conflict(_) => StatusCode::CONFLICT,
             SyncError::RateLimited { .. } => StatusCode::TOO_MANY_REQUESTS,
             SyncError::AccountLocked { .. } => StatusCode::from_u16(423).unwrap(),

--- a/crates/toku-sync/src/handlers.rs
+++ b/crates/toku-sync/src/handlers.rs
@@ -19,6 +19,83 @@ use crate::models::{
 const MAX_BATCH_SIZE: usize = 1000;
 const MAX_BATCH_SIZE_SQL: i64 = MAX_BATCH_SIZE as i64;
 
+// ── Zero-knowledge payload enforcement (issue #121) ───────────────────────────
+
+/// Returns `true` if `payload` is a well-formed encrypted envelope.
+///
+/// A valid envelope is a JSON object containing **exactly** the envelope keys
+/// (`ev`, `alg`, `nonce`, `ciphertext`, `aad`) with the expected primitive
+/// types. Requiring an exact key set prevents a client from smuggling
+/// plaintext fields alongside the ciphertext.
+fn is_encrypted_envelope(payload: &serde_json::Value) -> bool {
+    let Some(obj) = payload.as_object() else {
+        return false;
+    };
+    const KEYS: [&str; 5] = ["ev", "alg", "nonce", "ciphertext", "aad"];
+    if obj.len() != KEYS.len() || !KEYS.iter().all(|k| obj.contains_key(*k)) {
+        return false;
+    }
+    obj.get("ev").is_some_and(serde_json::Value::is_u64)
+        && obj.get("alg").is_some_and(serde_json::Value::is_string)
+        && obj.get("nonce").is_some_and(serde_json::Value::is_string)
+        && obj
+            .get("ciphertext")
+            .is_some_and(serde_json::Value::is_string)
+        && obj.get("aad").is_some_and(serde_json::Value::is_string)
+}
+
+/// Enforce zero-knowledge for a synced op payload.
+///
+/// Accepts either an encrypted envelope object or JSON `null` (content-free
+/// ops such as deletes). Any other shape — notably a plaintext `fields`
+/// object — is rejected so the server can never read user content. The op
+/// metadata (ids, hlc, entity/op type) intentionally stays cleartext; the
+/// `payload` must always be ciphertext.
+fn require_ciphertext_payload(payload: &serde_json::Value) -> Result<(), SyncError> {
+    if payload.is_null() || is_encrypted_envelope(payload) {
+        Ok(())
+    } else {
+        Err(SyncError::PlaintextRejected(
+            "op payload must be an encrypted envelope; plaintext is not allowed in hosted mode"
+                .into(),
+        ))
+    }
+}
+
+/// Reject a batch outright if any op carries a plaintext payload.
+fn require_ciphertext_batch(ops: &[OpPayload]) -> Result<(), SyncError> {
+    for op in ops {
+        require_ciphertext_payload(&op.payload).map_err(|_| {
+            SyncError::PlaintextRejected(format!(
+                "op {} carries a plaintext payload; hosted mode requires client-side encryption",
+                op.op_id
+            ))
+        })?;
+    }
+    Ok(())
+}
+
+/// Enforce zero-knowledge for an uploaded snapshot blob.
+///
+/// The snapshot must be a serialized encrypted envelope (ciphertext), never a
+/// plaintext `LibrarySnapshot`.
+fn require_ciphertext_snapshot(snapshot_json: &str) -> Result<(), SyncError> {
+    let value: serde_json::Value = serde_json::from_str(snapshot_json).map_err(|_| {
+        SyncError::PlaintextRejected(
+            "snapshot must be an encrypted envelope; plaintext is not allowed in hosted mode"
+                .into(),
+        )
+    })?;
+    if is_encrypted_envelope(&value) {
+        Ok(())
+    } else {
+        Err(SyncError::PlaintextRejected(
+            "snapshot must be an encrypted envelope; plaintext is not allowed in hosted mode"
+                .into(),
+        ))
+    }
+}
+
 // ── Health ──────────────────────────────────────────────────────────────────
 
 pub async fn health() -> Json<HealthResponse> {
@@ -687,6 +764,9 @@ pub async fn push_ops(
         )));
     }
 
+    // Zero-knowledge: reject the batch if any op carries a plaintext payload.
+    require_ciphertext_batch(&req.ops)?;
+
     let resp = tokio::task::spawn_blocking({
         let db_path = db_path.clone();
         let library_id = device.library_id.clone();
@@ -924,6 +1004,9 @@ pub async fn upload_snapshot(
         return Err(SyncError::BadRequest("hlc_at_snapshot is required".into()));
     }
 
+    // Zero-knowledge: the snapshot blob must be an encrypted envelope.
+    require_ciphertext_snapshot(&req.snapshot_json)?;
+
     let resp = tokio::task::spawn_blocking({
         let db_path = db_path.clone();
         let library_id = device.library_id.clone();
@@ -1043,6 +1126,9 @@ pub async fn rekey(
     if req.ops.is_empty() {
         return Err(SyncError::BadRequest("ops array is empty".into()));
     }
+
+    // Zero-knowledge: re-keyed ops must remain ciphertext.
+    require_ciphertext_batch(&req.ops)?;
 
     let resp = tokio::task::spawn_blocking({
         let db_path = db_path.clone();

--- a/crates/toku-sync/src/main.rs
+++ b/crates/toku-sync/src/main.rs
@@ -112,6 +112,25 @@ mod tests {
         }
     }
 
+    /// A structurally-valid encrypted-envelope payload for tests. Hosted mode
+    /// rejects plaintext payloads (issue #121), so test ops must look like
+    /// ciphertext. The `ciphertext` field carries `marker` so assertions can
+    /// still distinguish ops.
+    fn enc_payload(marker: &str) -> serde_json::Value {
+        serde_json::json!({
+            "ev": 1,
+            "alg": "aes-256-gcm",
+            "nonce": "AAAAAAAAAAAAAAAA",
+            "ciphertext": marker,
+            "aad": "v=1,entity_type=book,op_type=update",
+        })
+    }
+
+    /// A structurally-valid encrypted snapshot blob (serialized envelope).
+    fn enc_snapshot(marker: &str) -> String {
+        serde_json::to_string(&enc_payload(marker)).unwrap()
+    }
+
     #[tokio::test]
     async fn health_check() {
         let db_path = test_db_path();
@@ -264,7 +283,7 @@ mod tests {
                                     "entity_type": "book",
                                     "entity_id": "book-1",
                                     "op_type": "create",
-                                    "payload": {"title": "Dune"}
+                                    "payload": enc_payload("dune")
                                 },
                                 {
                                     "op_id": "op-2",
@@ -273,7 +292,7 @@ mod tests {
                                     "entity_type": "book",
                                     "entity_id": "book-1",
                                     "op_type": "update",
-                                    "payload": {"rating": 9}
+                                    "payload": enc_payload("rating")
                                 }
                             ]
                         }))
@@ -374,7 +393,7 @@ mod tests {
                 "entity_type": "book",
                 "entity_id": "b1",
                 "op_type": "create",
-                "payload": {}
+                "payload": null
             }]
         });
 
@@ -685,7 +704,7 @@ mod tests {
                                     "entity_type": "book",
                                     "entity_id": "b1",
                                     "op_type": "create",
-                                    "payload": {"title": "Dune"}
+                                    "payload": enc_payload("dune")
                                 },
                                 {
                                     "op_id": "snap-op-2",
@@ -694,7 +713,7 @@ mod tests {
                                     "entity_type": "book",
                                     "entity_id": "b1",
                                     "op_type": "update",
-                                    "payload": {"rating": 9}
+                                    "payload": enc_payload("rating")
                                 }
                             ]
                         }))
@@ -717,7 +736,7 @@ mod tests {
                     .header("Authorization", format!("Bearer {token}"))
                     .body(Body::from(
                         serde_json::to_string(&serde_json::json!({
-                            "snapshot_json": "{\"version\":1,\"books\":[{\"title\":\"Dune\"}]}",
+                            "snapshot_json": enc_snapshot("dune-snap"),
                             "hlc_at_snapshot": snapshot_hlc,
                         }))
                         .unwrap(),
@@ -752,7 +771,12 @@ mod tests {
             .unwrap();
         let download: serde_json::Value = serde_json::from_slice(&body).unwrap();
         assert_eq!(download["hlc_at_snapshot"], snapshot_hlc);
-        assert!(download["snapshot_json"].as_str().unwrap().contains("Dune"));
+        assert!(
+            download["snapshot_json"]
+                .as_str()
+                .unwrap()
+                .contains("dune-snap")
+        );
 
         // Verify the first op was pruned — pull/all should only return the second
         let resp = app
@@ -817,7 +841,7 @@ mod tests {
                     "entity_type": "book",
                     "entity_id": "b1",
                     "op_type": "create",
-                    "payload": {}
+                    "payload": null
                 })
             })
             .collect();
@@ -1107,7 +1131,7 @@ mod tests {
                 "entity_type": "book",
                 "entity_id": "b1",
                 "op_type": "create",
-                "payload": {"title": "Test Book"}
+                "payload": enc_payload("test-book")
             }]
         });
         let resp = app
@@ -1208,7 +1232,7 @@ mod tests {
                     "entity_type": "book",
                     "entity_id": "b1",
                     "op_type": "create",
-                    "payload": {}
+                    "payload": null
                 },
                 {
                     "op_id": "op-2",
@@ -1217,7 +1241,7 @@ mod tests {
                     "entity_type": "book",
                     "entity_id": "b1",
                     "op_type": "update",
-                    "payload": {"title": "Updated"}
+                    "payload": enc_payload("updated")
                 }
             ]
         });
@@ -1309,7 +1333,7 @@ mod tests {
                     "entity_type": "book",
                     "entity_id": format!("b{i}"),
                     "op_type": "create",
-                    "payload": {}
+                    "payload": null
                 })
             })
             .collect();
@@ -1424,7 +1448,7 @@ mod tests {
                                     "entity_type": "book",
                                     "entity_id": "b1",
                                     "op_type": "create",
-                                    "payload": {"title": "Dune"}
+                                    "payload": enc_payload("dune")
                                 },
                                 {
                                     "op_id": "rk-op-2",
@@ -1433,7 +1457,7 @@ mod tests {
                                     "entity_type": "book",
                                     "entity_id": "b1",
                                     "op_type": "update",
-                                    "payload": {"rating": 9}
+                                    "payload": enc_payload("rating")
                                 }
                             ]
                         }))
@@ -1465,7 +1489,7 @@ mod tests {
                                     "entity_type": "book",
                                     "entity_id": "b1",
                                     "op_type": "create",
-                                    "payload": {"ev": 1, "alg": "aes-256-gcm", "ciphertext": "new-ct-1"}
+                                    "payload": enc_payload("new-ct-1")
                                 },
                                 {
                                     "op_id": "rk-op-2",
@@ -1474,7 +1498,7 @@ mod tests {
                                     "entity_type": "book",
                                     "entity_id": "b1",
                                     "op_type": "update",
-                                    "payload": {"ev": 1, "alg": "aes-256-gcm", "ciphertext": "new-ct-2"}
+                                    "payload": enc_payload("new-ct-2")
                                 }
                             ]
                         }))
@@ -1596,7 +1620,7 @@ mod tests {
                                 "entity_type": "book",
                                 "entity_id": "b1",
                                 "op_type": "create",
-                                "payload": {}
+                                "payload": null
                             }]
                         }))
                         .unwrap(),

--- a/crates/toku-sync/src/models.rs
+++ b/crates/toku-sync/src/models.rs
@@ -58,6 +58,9 @@ pub struct OpPayload {
     pub entity_type: String,
     pub entity_id: String,
     pub op_type: String,
+    /// Zero-knowledge: in hosted mode this is always an encrypted envelope
+    /// (`{ev, alg, nonce, ciphertext, aad}`) or `null` for content-free ops.
+    /// The server rejects plaintext payloads (issue #121).
     pub payload: serde_json::Value,
 }
 
@@ -74,6 +77,8 @@ pub struct RekeyRequest {
 
 #[derive(Debug, Deserialize)]
 pub struct UploadSnapshotRequest {
+    /// Zero-knowledge: a serialized encrypted envelope over the
+    /// `LibrarySnapshot` JSON. The server rejects plaintext snapshots (#121).
     pub snapshot_json: String,
     pub hlc_at_snapshot: String,
 }

--- a/crates/toku-sync/tests/device_enrollment.rs
+++ b/crates/toku-sync/tests/device_enrollment.rs
@@ -205,7 +205,13 @@ fn push_then_pull_count(server: &TestServer, device_token: &str, op_id: &str) ->
                 "entity_type": "book",
                 "entity_id": "book-1",
                 "op_type": "create",
-                "payload": { "title": "ciphertext" }
+                "payload": {
+                    "ev": 1,
+                    "alg": "aes-256-gcm",
+                    "nonce": "AAAAAAAAAAAAAAAA",
+                    "ciphertext": "ciphertext",
+                    "aad": "v=1,entity_type=book,op_type=create"
+                }
             }]
         }),
     );

--- a/crates/toku-sync/tests/harness/mod.rs
+++ b/crates/toku-sync/tests/harness/mod.rs
@@ -35,6 +35,10 @@ use uuid::Uuid;
 /// Ensure the token store never touches the OS keychain during tests.
 static INIT_ENV: Once = Once::new();
 
+/// Default passphrase used when a test does not pin its own. Encryption is
+/// mandatory, so every device must enroll/login with a passphrase.
+pub const DEFAULT_TEST_PASSPHRASE: &str = "harness-default-passphrase";
+
 fn ensure_file_token_store() {
     INIT_ENV.call_once(|| {
         // SAFETY: called once, before any device spawns a thread that reads
@@ -113,9 +117,12 @@ pub struct SimulatedDevice {
 }
 
 impl SimulatedDevice {
-    /// Register a new device against `server`, joining `library_id`. Pass
-    /// `passphrase` to enable client-side encryption (both devices in a pair
-    /// must use the same passphrase to converge).
+    /// Register a new device against `server`, joining `library_id`.
+    ///
+    /// Client-side encryption is mandatory in hosted mode (issue #121), so a
+    /// passphrase is always used: pass an explicit one, or `None` to fall back
+    /// to [`DEFAULT_TEST_PASSPHRASE`]. Devices in the same library must share a
+    /// passphrase to converge.
     pub fn register(
         server: &TestServer,
         library_id: &str,
@@ -125,6 +132,7 @@ impl SimulatedDevice {
         ensure_file_token_store();
         let data_dir = tempfile::tempdir().expect("create device temp dir");
 
+        let passphrase = passphrase.or(Some(DEFAULT_TEST_PASSPHRASE));
         let outcome = toku_sync_client::init(
             data_dir.path(),
             server.base_url(),
@@ -153,6 +161,26 @@ impl SimulatedDevice {
 
     pub fn name(&self) -> &str {
         &self.name
+    }
+
+    /// The bearer token this device authenticates with (white-box: for tests
+    /// that drive the server over raw HTTP).
+    pub fn auth_token(&self, server: &TestServer) -> String {
+        let store = toku_sync_client::TokenStore::new(self.data_dir());
+        store
+            .load(server.base_url())
+            .expect("load auth token")
+            .expect("device has an auth token")
+    }
+
+    /// The client-side encryption key derived during enrollment (white-box).
+    pub fn sync_key(&self, server: &TestServer) -> toku_core::SyncKey {
+        let store = toku_sync_client::TokenStore::new(self.data_dir());
+        let bytes = store
+            .load_sync_key(server.base_url())
+            .expect("load sync key")
+            .expect("device has a sync key");
+        toku_core::SyncKey::from_exported_bytes(&bytes).expect("valid sync key")
     }
 
     fn data_dir(&self) -> &Path {

--- a/crates/toku-sync/tests/zero_knowledge.rs
+++ b/crates/toku-sync/tests/zero_knowledge.rs
@@ -1,0 +1,241 @@
+//! Zero-knowledge enforcement tests (issue #121).
+//!
+//! These tests assert the hosted-mode guarantee that the server can never read
+//! user content: op payloads and snapshots must be ciphertext, plaintext
+//! uploads are rejected, and what the server persists is undecryptable without
+//! the client-held key.
+
+mod harness;
+
+use harness::{SimulatedDevice, TestServer};
+use serde_json::json;
+use tokio::runtime::Runtime;
+use toku_core::{EntityType, HybridClock, OpType, SyncKey};
+use toku_sync::db::SyncDatabase;
+use uuid::Uuid;
+
+fn rt() -> Runtime {
+    Runtime::new().expect("tokio runtime")
+}
+
+/// POST `body` to `path` with a bearer token; return (status, body text).
+async fn post(
+    base_url: &str,
+    path: &str,
+    token: &str,
+    body: serde_json::Value,
+) -> (reqwest::StatusCode, String) {
+    let resp = reqwest::Client::new()
+        .post(format!("{base_url}{path}"))
+        .bearer_auth(token)
+        .json(&body)
+        .send()
+        .await
+        .expect("request sent");
+    let status = resp.status();
+    let text = resp.text().await.unwrap_or_default();
+    (status, text)
+}
+
+fn hlc_for(device_id: Uuid) -> String {
+    HybridClock::new(&device_id).now().to_canonical()
+}
+
+/// Build a wire op whose payload is `payload` (already-shaped JSON).
+fn wire_op(device_id: Uuid, entity_id: Uuid, payload: serde_json::Value) -> serde_json::Value {
+    json!({
+        "op_id": Uuid::now_v7().to_string(),
+        "device_id": device_id.to_string(),
+        "hlc": hlc_for(device_id),
+        "entity_type": EntityType::Book.as_str(),
+        "entity_id": entity_id.to_string(),
+        "op_type": OpType::Create.as_str(),
+        "payload": payload,
+    })
+}
+
+#[test]
+fn server_rejects_plaintext_op_push() {
+    let server = TestServer::start();
+    let device = SimulatedDevice::register(&server, "zk-plain-op", "device-a", None);
+    let token = device.auth_token(&server);
+
+    // A readable `fields` object must be refused.
+    let op = wire_op(
+        device.device_id(),
+        Uuid::now_v7(),
+        json!({ "title": "Plaintext Secret" }),
+    );
+    let (status, body) = rt().block_on(post(
+        server.base_url(),
+        "/api/v1/push",
+        &token,
+        json!({ "ops": [op] }),
+    ));
+
+    assert_eq!(
+        status,
+        reqwest::StatusCode::UNPROCESSABLE_ENTITY,
+        "plaintext push should be rejected (422); body: {body}"
+    );
+}
+
+#[test]
+fn server_accepts_ciphertext_and_stores_it_opaquely() {
+    let server = TestServer::start();
+    let device = SimulatedDevice::register(&server, "zk-cipher-op", "device-a", None);
+    let token = device.auth_token(&server);
+    let key = device.sync_key(&server);
+
+    let entity_id = Uuid::now_v7();
+    let secret_title = "Top Secret Title";
+    let envelope = toku_core::encrypt_fields(
+        &key,
+        &json!({ "title": secret_title }),
+        &EntityType::Book,
+        &entity_id,
+        &OpType::Create,
+    )
+    .expect("encrypt fields");
+
+    let op = wire_op(
+        device.device_id(),
+        entity_id,
+        serde_json::to_value(&envelope).unwrap(),
+    );
+    let op_id = op["op_id"].as_str().unwrap().to_string();
+
+    let (status, body) = rt().block_on(post(
+        server.base_url(),
+        "/api/v1/push",
+        &token,
+        json!({ "ops": [op] }),
+    ));
+    assert!(
+        status.is_success(),
+        "ciphertext push should succeed; status {status}, body: {body}"
+    );
+
+    // White-box: the persisted payload must be ciphertext, never the plaintext.
+    let db = SyncDatabase::open_no_migrate(&server.db_path()).expect("open server db");
+    let stored: String = db
+        .conn
+        .query_row(
+            "SELECT payload FROM ops WHERE op_id = ?1",
+            [&op_id],
+            |row| row.get(0),
+        )
+        .expect("stored op present");
+
+    assert!(
+        !stored.contains(secret_title),
+        "server must not store plaintext content; stored: {stored}"
+    );
+    let stored_value: serde_json::Value = serde_json::from_str(&stored).unwrap();
+    assert!(
+        stored_value.get("ev").is_some() && stored_value.get("ciphertext").is_some(),
+        "stored payload must be an encrypted envelope: {stored}"
+    );
+
+    // The server holds no key; a different key cannot decrypt the stored blob.
+    let stored_envelope: toku_core::EncryptedEnvelope =
+        serde_json::from_value(stored_value).unwrap();
+    let wrong_key = SyncKey::derive("not-the-real-passphrase", &[7u8; 16]).unwrap();
+    assert!(
+        toku_core::decrypt_fields(
+            &wrong_key,
+            &stored_envelope,
+            &EntityType::Book,
+            &entity_id,
+            &OpType::Create,
+        )
+        .is_err(),
+        "stored ciphertext must be undecryptable without the right key"
+    );
+
+    // Sanity: the real key still recovers the content (proves it round-trips).
+    let recovered = toku_core::decrypt_fields(
+        &key,
+        &stored_envelope,
+        &EntityType::Book,
+        &entity_id,
+        &OpType::Create,
+    )
+    .expect("decrypt with real key");
+    assert_eq!(recovered["title"], secret_title);
+}
+
+#[test]
+fn server_rejects_plaintext_snapshot() {
+    let server = TestServer::start();
+    let device = SimulatedDevice::register(&server, "zk-plain-snap", "device-a", None);
+    let token = device.auth_token(&server);
+
+    // A raw LibrarySnapshot-shaped JSON blob must be refused.
+    let (status, body) = rt().block_on(post(
+        server.base_url(),
+        "/api/v1/snapshot",
+        &token,
+        json!({
+            "snapshot_json": "{\"version\":1,\"library\":{\"books\":[]}}",
+            "hlc_at_snapshot": hlc_for(device.device_id()),
+        }),
+    ));
+
+    assert_eq!(
+        status,
+        reqwest::StatusCode::UNPROCESSABLE_ENTITY,
+        "plaintext snapshot should be rejected (422); body: {body}"
+    );
+}
+
+#[test]
+fn server_accepts_encrypted_snapshot_and_stores_it_opaquely() {
+    let server = TestServer::start();
+    let device = SimulatedDevice::register(&server, "zk-cipher-snap", "device-a", None);
+    let token = device.auth_token(&server);
+    let key = device.sync_key(&server);
+
+    let secret = "secret-library-contents";
+    let plaintext_snapshot = format!("{{\"version\":1,\"marker\":\"{secret}\"}}");
+    let envelope =
+        toku_core::encrypt_snapshot(&key, &plaintext_snapshot).expect("encrypt snapshot");
+    let blob = serde_json::to_string(&envelope).unwrap();
+
+    let (status, body) = rt().block_on(post(
+        server.base_url(),
+        "/api/v1/snapshot",
+        &token,
+        json!({
+            "snapshot_json": blob,
+            "hlc_at_snapshot": hlc_for(device.device_id()),
+        }),
+    ));
+    assert!(
+        status.is_success(),
+        "encrypted snapshot upload should succeed; status {status}, body: {body}"
+    );
+
+    // White-box: persisted snapshot must be ciphertext, never the plaintext.
+    let db = SyncDatabase::open_no_migrate(&server.db_path()).expect("open server db");
+    let stored: String = db
+        .conn
+        .query_row(
+            "SELECT snapshot_json FROM snapshots WHERE library_id = ?1",
+            ["zk-cipher-snap"],
+            |row| row.get(0),
+        )
+        .expect("stored snapshot present");
+
+    assert!(
+        !stored.contains(secret),
+        "server must not store plaintext snapshot content; stored: {stored}"
+    );
+    let stored_envelope: toku_core::EncryptedEnvelope =
+        serde_json::from_str(&stored).expect("stored snapshot is an envelope");
+    assert_eq!(
+        toku_core::decrypt_snapshot(&key, &stored_envelope).unwrap(),
+        plaintext_snapshot,
+        "the real key recovers the snapshot"
+    );
+}

--- a/docs/adr/010-self-host-auth.md
+++ b/docs/adr/010-self-host-auth.md
@@ -156,6 +156,28 @@ The following change:
 | Server trust model | Dumb relay — may store plaintext | Zero-knowledge — stores only encrypted blobs |
 | Auth endpoint | None | `POST /auth/login` (SRP exchange); `POST /auth/enroll` (new device) |
 
+### Zero-Knowledge Enforcement (issue #121)
+
+Mandatory encryption is enforced at the **server boundary**, not just by client convention:
+
+- `push` and `rekey` reject the whole batch (HTTP `422 Unprocessable Entity`) if any op
+  `payload` is not an encrypted envelope (`{ev, alg, nonce, ciphertext, aad}`) or `null`
+  (content-free ops such as deletes). The server requires the *exact* envelope key set, so a
+  client cannot smuggle plaintext fields alongside the ciphertext.
+- `snapshot` upload rejects any `snapshot_json` that is not a serialized encrypted envelope —
+  closing the previous gap where compacted library state was stored in plaintext.
+- The client makes encryption mandatory too: `toku sync init` always requires a passphrase
+  (the passwordless/plaintext opt-out is removed), `push` refuses to upload without a key, and
+  snapshots are encrypted on create / decrypted on bootstrap.
+
+**Server-visible metadata** is minimized to what relay/ordering requires: `op_id`, `device_id`,
+`hlc`, `entity_type`, `entity_id`, `op_type`. The `payload` and snapshot blobs are always
+ciphertext. `entity_type` and `op_type` are deliberately left cleartext — the client binds them
+into the AEAD AAD (so the server cannot re-target or swap an op undetected) and they are needed
+for indexing. Making `entity_type` opaque was evaluated and rejected: it would break the AAD
+binding and op-type indexing while leaking only aggregate counts, never content. This residual
+exposure is documented in `docs/sync-server.md`.
+
 ### Revised Threat Model
 
 | Threat | Old model (ADR-006/008) | New model (ADR-010) |

--- a/docs/sync-server.md
+++ b/docs/sync-server.md
@@ -2,12 +2,12 @@
 
 `toku-sync` is the optional relay server that lets you sync your Toku library across multiple
 devices. It is a small, single-binary HTTP service backed by SQLite. It stores **only** sync
-operations (which are end-to-end encrypted when you enable a passphrase) — it never needs access
-to your decrypted library.
+operations, which are **always** end-to-end encrypted client-side before upload — it can never
+read your library. This is a **zero-knowledge** design: see
+[Zero-knowledge guarantee](#zero-knowledge-guarantee) below.
 
 Syncing is entirely opt-in. Toku works fully offline without ever running this server. See
-[ADR-006](./adr/006-sync-strategy.md) and [ADR-008](./adr/008-sync-wire-protocol.md) for the
-design.
+[ADR-010](./adr/010-self-host-auth.md) (which supersedes ADR-006 and ADR-008) for the design.
 
 This guide covers deploying the server with Docker.
 
@@ -70,13 +70,47 @@ docker compose up -d
 Once the server is reachable, point your Toku CLI at it:
 
 ```bash
-toku sync init --server https://sync.example.com --passphrase "your-secret-passphrase"
+toku sync init --server https://sync.example.com
 toku sync push
 toku sync pull
 ```
 
-The passphrase enables end-to-end encryption — the server stores only opaque encrypted blobs.
+`toku sync init` always prompts for an encryption passphrase — client-side end-to-end
+encryption is **mandatory** in hosted mode, so the server only ever stores opaque ciphertext.
 Use the same passphrase on every device. See `toku sync --help` for the full command set.
+
+## Zero-knowledge guarantee
+
+In hosted mode the server is **zero-knowledge**: it can never read your library content.
+
+- **Op payloads** are encrypted client-side (AES-256-GCM, key derived from your passphrase)
+  before they leave the device. The server **rejects** any plaintext payload with HTTP `422`.
+- **Snapshots** (compacted library state) are likewise encrypted before upload; plaintext
+  snapshots are rejected with `422`.
+- **Re-key** uploads only ever carry re-encrypted ciphertext.
+
+What the server *can* see is limited to the routing/ordering metadata it needs to relay and
+order ops. It never sees field values, titles, notes, ratings, or any content:
+
+| Field | Server-visible? | Why |
+|-------|-----------------|-----|
+| `op_id` (UUID v7) | Yes | Dedup + cursor/ordering |
+| `device_id` | Yes | Per-device cursors and device management |
+| `hlc` (timestamp) | Yes | Hybrid Logical Clock ordering |
+| `entity_type` (e.g. `book`) | Yes | Indexing + bound into the ciphertext AAD |
+| `entity_id` (UUID) | Yes | Routing; opaque identifier, no content |
+| `op_type` (e.g. `update`) | Yes | Merge semantics; bound into the AAD |
+| `payload` | **No** | Always an encrypted envelope (or `null` for content-free ops) |
+| snapshot blob | **No** | Always an encrypted envelope |
+
+`entity_type` and `op_type` are intentionally left cleartext: the client binds them into the
+authenticated-encryption AAD so the server cannot swap or re-target an op without detection,
+and they are needed for indexing. This is an accepted, documented metadata exposure — it
+reveals *how many* ops of each kind exist, never their content. Making `entity_type` opaque
+was considered and rejected for this reason.
+
+Because the server holds no key, losing your passphrase (and Secret Key / Emergency Kit) means
+server-side data is unrecoverable by design. See [`recovery.md`](./recovery.md).
 
 ## Configuration
 


### PR DESCRIPTION
## Description

Makes client-side end-to-end encryption **mandatory** for hosted/sync mode, turning Toku's relay into a true zero-knowledge server. Previously encryption was opt-in: the server could store plaintext op payloads, and stored snapshots were always plaintext. This PR enforces ciphertext-only at the server boundary, makes the client always encrypt, and encrypts snapshots on-device.

### What's included

- **Server rejects plaintext (zero-knowledge boundary).** A new `PlaintextRejected` error returns HTTP 422. `push_ops`, `rekey`, and `upload_snapshot` validate that every op payload and snapshot is a well-formed encrypted envelope (`{ev, alg, nonce, ciphertext, aad}`, exact key-set). `null` payloads are still allowed for content-free delete ops. Op routing metadata (op/device ids, HLC, entity/op type) stays cleartext by design and is bound into the AAD.
- **Snapshot encryption in `toku-core`.** New `encrypt_snapshot` / `decrypt_snapshot` (AES-256-GCM under the SyncKey, fixed AAD `kind=snapshot,v=1`).
- **Client always encrypts.** `sync init` now always provisions a passphrase/key — the passwordless plaintext opt-out is removed. `push` requires the key and encrypts every payload; `bootstrap` decrypts the snapshot envelope before applying. `compact` encrypts the snapshot before upload; `rekey` re-encrypts the stored snapshot under the new key.
- **Docs.** ROADMAP, `docs/sync-server.md` (new "Zero-knowledge guarantee" section + server-visible-metadata table), and ADR-010 updated to describe the guarantee and the explicitly-accepted metadata exposure.
- **Tests.** New `zero_knowledge.rs` integration tests (reject/accept plaintext vs ciphertext for ops and snapshots); existing server/multi-device tests updated to push ciphertext.

## Related Issues

Closes #121
Relates to #114

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI / infrastructure
- [x] Other (security hardening / breaking change to the sync wire contract)

## Crate

- [x] `toku-core` — Domain models, traits, state machine
- [ ] `toku-db` — SQLite persistence, migrations, FTS5
- [ ] `toku-import` — Importers (Goodreads, Calibre, StoryGraph)
- [ ] `toku-meta` — Metadata fetching (Open Library, Google Books)
- [x] `toku-cli` — CLI binary
- [ ] `toku-export` — Exporters (CSV, JSON, Markdown, BibTeX)
- [x] `docs/` — Documentation
- [x] `toku-sync` / `toku-sync-client` — Sync server + client

## Data Integrity Checklist

- [x] No user data is sent to any server without explicit opt-in
- [ ] Import operations are idempotent (re-importing the same file creates no duplicates)
- [x] User edits to metadata are never overwritten by auto-enrichment
- [x] New fields track provenance (source + timestamp)
- [ ] Export round-trip is preserved (if applicable)

## Checklist

- [x] I have read [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] `cargo fmt --check` passes
- [x] `cargo clippy --workspace -- -D warnings` passes
- [x] `cargo test --workspace` passes
- [x] I have updated documentation (if applicable)
