### PR TITLE
feat: add first-run onboarding and session auth to the web dashboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -154,6 +154,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the approved device then claims its token from `POST /api/v1/devices/{id}/session`.
   Rejected devices are denied. Administrators toggle the requirement with
   `GET`/`PUT /api/v1/admin/device-approvals`
+- First-run onboarding and session authentication for the web dashboard. `toku serve`
+  now has two modes: the default **local** mode is unchanged (no login, binds loopback
+  only, and refuses non-loopback hosts), while `toku serve --hosted` requires sign-in so
+  the dashboard can be exposed on a network. On first run, hosted mode walks you through
+  creating an admin account and shows your **Emergency Kit** (email + Secret Key) once.
+  Sign-in verifies your password server-side (SRP verifier, constant-time compare), issues
+  a fresh 24-hour session cookie, and locks the account for 15 minutes after 5 failed
+  attempts. All forms are CSRF-protected and `/healthz` stays public for liveness probes.
+  The trusted-server trade-off (the hosted dashboard renders your decrypted library
+  server-side) is documented in `docs/web-auth.md`
 
 ### Changed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -410,6 +410,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "axum-extra"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9963ff19f40c6102c76756ef0a46004c0d58957d87259fc9208ff8441c12ab96"
+dependencies = [
+ "axum",
+ "axum-core",
+ "bytes",
+ "cookie",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "rustversion",
+ "serde_core",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
 name = "base16ct"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -934,6 +957,7 @@ version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ddef33a339a91ea89fb53151bd0a4689cfce27055c291dfa69945475d22c747"
 dependencies = [
+ "percent-encoding",
  "time",
  "version_check",
 ]
@@ -6058,16 +6082,29 @@ name = "toku-web"
 version = "0.2.1"
 dependencies = [
  "axum",
+ "axum-extra",
+ "base64 0.22.1",
  "chrono",
+ "form_urlencoded",
+ "hex",
+ "http-body-util",
  "maud",
+ "rand 0.10.1",
+ "rusqlite",
  "serde",
  "serde_json",
+ "sha2 0.11.0",
+ "srp",
+ "subtle",
+ "tempfile",
  "thiserror 2.0.18",
+ "time",
  "tokio",
  "tokio-stream",
  "toku-core",
  "toku-db",
  "toku-import",
+ "tower",
  "urlencoding",
  "uuid",
 ]

--- a/README.md
+++ b/README.md
@@ -68,6 +68,8 @@ their ever-growing libraries.
 - 🖥️ Interactive TUI browser with split-pane layout, filters, and live detail view
 - 🔄 Bulk operations for tagging, status changes, and deletions across filtered sets
 - 🌐 Web dashboard (`toku serve`) with statistics, import wizard, library views, and dark mode
+  — loopback-only by default, or run authenticated for network access
+  ([hosted mode & auth](docs/web-auth.md))
 - 🍎 macOS app (SwiftUI) with sidebar navigation, sortable table/grid views, and Swift Charts
 - 📱 iOS app (iPhone + iPad) with cover grid, barcode scanner, and reading progress updates
 - 🪟 Windows desktop app (Tauri v2) wrapping the web UI in a native window with system tray

--- a/crates/toku-cli/src/main.rs
+++ b/crates/toku-cli/src/main.rs
@@ -228,6 +228,16 @@ enum Commands {
         /// Host to bind (use 127.0.0.1 for local-only access)
         #[arg(long, default_value = "127.0.0.1")]
         host: String,
+
+        /// Run in hosted mode: require account login + sessions (needed for
+        /// any non-loopback / network-facing deployment).
+        #[arg(long, env = "TOKU_WEB_HOSTED")]
+        hosted: bool,
+
+        /// Mark auth cookies `Secure` (default in hosted mode). Disable only
+        /// for plain-HTTP testing of hosted mode on localhost.
+        #[arg(long, env = "TOKU_WEB_INSECURE_COOKIES")]
+        insecure_cookies: bool,
     },
 
     /// Manage work grouping (link editions of the same creative work)
@@ -751,14 +761,29 @@ fn main() -> Result<()> {
             clap_complete::generate(*shell, &mut Cli::command(), "toku", &mut std::io::stdout());
             return Ok(());
         }
-        Commands::Serve { port, host } => {
+        Commands::Serve {
+            port,
+            host,
+            hosted,
+            insecure_cookies,
+        } => {
             let db_path = data_dir.join("toku.db");
+            let mode = if *hosted {
+                toku_web::WebMode::Hosted
+            } else {
+                toku_web::WebMode::Local
+            };
+            // Hosted mode marks cookies Secure by default (TLS expected, e.g. via
+            // a reverse proxy); --insecure-cookies opts out for local testing.
+            let secure_cookies = *hosted && !*insecure_cookies;
+            let host = host.clone();
+            let port = *port;
             let rt = tokio::runtime::Builder::new_multi_thread()
                 .enable_all()
                 .build()
                 .context("failed to build tokio runtime")?;
-            return rt.block_on(async {
-                toku_web::serve(db_path, host, *port)
+            return rt.block_on(async move {
+                toku_web::serve(db_path, &host, port, mode, secure_cookies)
                     .await
                     .map_err(|e| anyhow::anyhow!("{e}"))
             });

--- a/crates/toku-db/migrations/V16__web_auth.sql
+++ b/crates/toku-db/migrations/V16__web_auth.sql
@@ -1,0 +1,39 @@
+-- Web-tier authentication for `toku serve` hosted mode (issue #122).
+--
+-- Additive and backward-compatible: local single-user mode (the historical
+-- default) never reads these tables. They are only consulted when the dashboard
+-- runs in hosted mode, where unauthenticated requests are redirected to login.
+--
+-- These mirror the shape of toku-sync's `users` / `user_sessions` (migration
+-- V5 in that crate) so the web tier can later federate to a toku-sync account
+-- server without a schema rewrite. The web tier stores only the SRP verifier +
+-- salt (never the password or Secret Key) and opaque wrapped key material; it
+-- cannot derive any plaintext secret from these columns.
+
+CREATE TABLE web_users (
+    id                   TEXT    PRIMARY KEY,            -- uuid v7
+    email                TEXT    NOT NULL UNIQUE,        -- account handle / login
+    srp_salt             TEXT    NOT NULL,               -- hex-encoded SRP salt
+    srp_verifier         TEXT    NOT NULL,               -- hex-encoded SRP verifier (g^x mod N)
+    wrapped_private_key  TEXT,                           -- opaque wrapped account private key (#116)
+    account_public_key   TEXT,                           -- account public key (#116)
+    kdf_params           TEXT,                           -- versioned KDF params blob (#116)
+    role                 TEXT    NOT NULL DEFAULT 'user'
+                                 CHECK (role IN ('admin', 'user')),
+    status               TEXT    NOT NULL DEFAULT 'active'
+                                 CHECK (status IN ('active', 'disabled')),
+    failed_attempts      INTEGER NOT NULL DEFAULT 0,
+    locked_until         TEXT,                           -- ISO-8601 datetime; NULL = not locked
+    created_at           TEXT    NOT NULL
+);
+
+-- Cookie-backed browser sessions issued after a successful login. The raw
+-- session token lives only in the user's cookie; the server stores its SHA-256
+-- hash. CSRF is enforced separately via a double-submit cookie.
+CREATE TABLE web_sessions (
+    token_hash   TEXT PRIMARY KEY,   -- sha256(session token)
+    user_id      TEXT NOT NULL REFERENCES web_users(id),
+    expires_at   TEXT NOT NULL,      -- ISO-8601 UTC datetime
+    created_at   TEXT NOT NULL
+);
+CREATE INDEX idx_web_sessions_expires ON web_sessions(expires_at);

--- a/crates/toku-web/Cargo.toml
+++ b/crates/toku-web/Cargo.toml
@@ -16,8 +16,25 @@ chrono.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 uuid.workspace = true
+rusqlite.workspace = true
 axum = { version = "0.8", features = ["multipart"] }
+axum-extra = { version = "0.10", features = ["cookie"] }
 maud = "0.27"
 tokio = { workspace = true, features = ["rt-multi-thread", "net", "sync"] }
 tokio-stream = { version = "0.1", features = ["sync"] }
 urlencoding = "2"
+sha2.workspace = true
+hex = "0.4"
+base64 = "0.22"
+rand = "0.10"
+form_urlencoded = "1"
+# SRP-6a (RFC 5054) verifier check for hosted-mode login — flagged for
+# dependency review (RC). Same crate/version as toku-sync.
+srp = { version = "0.7.0-rc.3", features = ["getrandom"] }
+subtle = "2"
+time = "0.3"
+
+[dev-dependencies]
+tower = { version = "0.5", features = ["util"] }
+http-body-util = "0.1"
+tempfile = "3"

--- a/crates/toku-web/src/auth.rs
+++ b/crates/toku-web/src/auth.rs
@@ -1,0 +1,556 @@
+//! Hosted-mode authentication for the web dashboard.
+//!
+//! `toku serve` runs in one of two modes (see [`WebMode`]):
+//!
+//! - **Local** (default): no authentication, binds loopback only. This preserves
+//!   the historical single-user behaviour where the dashboard renders the local
+//!   SQLite directly for one trusted user on their own machine.
+//! - **Hosted**: every route is gated behind a cookie session. The first run has
+//!   no admin account, so all requests are redirected to `/setup` to create one
+//!   (Secret Key + Emergency Kit). Subsequent requests are redirected to `/login`
+//!   until they present a valid session cookie.
+//!
+//! # Trusted-server trade-off (flag for threat model #125)
+//!
+//! The dashboard renders **server-side HTML from the decrypted local library**,
+//! so in hosted mode the server process necessarily holds plaintext. Login sends
+//! the password to the server over TLS, which recomputes the SRP verifier and
+//! compares it in constant time. This is the *trusted-server* posture: the
+//! zero-knowledge guarantees of ADR-010 apply to the sync relay, not to a
+//! dashboard you intentionally point at your own decrypted library. True
+//! in-browser (zero-knowledge) unlock would require client-side WASM crypto and
+//! is deliberately out of scope for issue #122.
+
+use std::path::Path;
+
+use axum::extract::{FromRequestParts, Request, State};
+use axum::http::request::Parts;
+use axum::http::{Method, StatusCode, header};
+use axum::middleware::Next;
+use axum::response::{IntoResponse, Redirect, Response};
+use axum_extra::extract::CookieJar;
+use axum_extra::extract::cookie::{Cookie, SameSite};
+use rand::RngExt;
+use sha2::{Digest, Sha256};
+use srp::ClientG2048;
+use subtle::ConstantTimeEq;
+
+use crate::AppState;
+
+/// Name of the session cookie holding the opaque session token.
+pub const SESSION_COOKIE: &str = "toku_session";
+/// Name of the CSRF double-submit cookie.
+pub const CSRF_COOKIE: &str = "toku_csrf";
+/// Form field / query parameter carrying the CSRF token.
+pub const CSRF_FIELD: &str = "csrf_token";
+
+/// Session lifetime in hours.
+const SESSION_TTL_HOURS: i64 = 24;
+/// Failed logins before the account is locked.
+const MAX_FAILED_ATTEMPTS: i64 = 5;
+/// Lockout duration in minutes.
+const LOCKOUT_MINUTES: i64 = 15;
+/// Maximum buffered body size when extracting a CSRF field (64 KiB).
+const CSRF_BODY_LIMIT: usize = 64 * 1024;
+
+/// Operating mode for the dashboard.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum WebMode {
+    /// No authentication, loopback only (historical single-user behaviour).
+    Local,
+    /// Authentication required; first-run onboarding then login.
+    Hosted,
+}
+
+impl WebMode {
+    /// True when authentication should be enforced.
+    pub fn is_hosted(self) -> bool {
+        matches!(self, WebMode::Hosted)
+    }
+}
+
+use std::sync::atomic::{AtomicBool, Ordering};
+
+/// Process-wide flag mirroring the current [`WebMode`], so the shared page
+/// layout (which has no access to request state) can render the "Sign out"
+/// affordance only in hosted mode.
+static HOSTED: AtomicBool = AtomicBool::new(false);
+
+/// Record whether the server is running in hosted mode.
+pub fn set_hosted(hosted: bool) {
+    HOSTED.store(hosted, Ordering::Relaxed);
+}
+
+/// True when the server is running in hosted (authenticated) mode.
+pub fn is_hosted_global() -> bool {
+    HOSTED.load(Ordering::Relaxed)
+}
+
+/// The CSRF token for the current request, injected by [`csrf_protect`]. In
+/// local mode (no CSRF middleware) this resolves to an empty token and forms
+/// omit the hidden field.
+#[derive(Clone, Debug, Default)]
+pub struct CsrfToken(pub String);
+
+impl CsrfToken {
+    /// The token string, empty when CSRF protection is disabled.
+    pub fn value(&self) -> &str {
+        &self.0
+    }
+}
+
+impl<S: Send + Sync> FromRequestParts<S> for CsrfToken {
+    type Rejection = std::convert::Infallible;
+
+    async fn from_request_parts(parts: &mut Parts, _state: &S) -> Result<Self, Self::Rejection> {
+        Ok(parts
+            .extensions
+            .get::<CsrfToken>()
+            .cloned()
+            .unwrap_or_default())
+    }
+}
+
+// ── Crypto / token helpers ───────────────────────────────────────────────────
+
+/// SHA-256 a string and hex-encode the digest.
+pub fn sha256_hex(input: &str) -> String {
+    hex::encode(Sha256::digest(input.as_bytes()))
+}
+
+/// Generate a 256-bit CSPRNG token, base64url (no pad) encoded.
+pub fn generate_token() -> String {
+    use base64::Engine;
+    let mut bytes = [0u8; 32];
+    rand::rng().fill(&mut bytes);
+    base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(bytes)
+}
+
+/// Generate a fresh 16-byte SRP salt, hex-encoded.
+fn generate_salt_hex() -> String {
+    let mut bytes = [0u8; 16];
+    rand::rng().fill(&mut bytes);
+    hex::encode(bytes)
+}
+
+/// Compute the hex-encoded SRP-6a verifier for an account.
+///
+/// The SRP identity is the account email and the password is the account
+/// password — matching toku-sync's account flow so the two tiers stay
+/// interoperable. Deterministic for a given (email, password, salt).
+fn compute_verifier_hex(email: &str, password: &str, salt: &[u8]) -> String {
+    let client = ClientG2048::<Sha256>::new();
+    hex::encode(client.compute_verifier(email.as_bytes(), password.as_bytes(), salt))
+}
+
+// ── Account / session persistence (blocking; call via spawn_blocking) ─────────
+
+/// Outcome of creating the first admin account.
+pub struct AdminCreated {
+    /// Formatted Secret Key (`TK-…`) to surface once in the Emergency Kit.
+    pub secret_key: String,
+    /// The account email.
+    pub email: String,
+}
+
+/// True when at least one admin account exists.
+pub fn admin_exists(db_path: &Path) -> Result<bool, String> {
+    let db = open(db_path)?;
+    let count: i64 = db
+        .conn
+        .query_row(
+            "SELECT COUNT(*) FROM web_users WHERE role = 'admin'",
+            [],
+            |row| row.get(0),
+        )
+        .map_err(|e| e.to_string())?;
+    Ok(count > 0)
+}
+
+/// Create the first-run admin account, returning its Emergency Kit material.
+///
+/// Generates a Secret Key, derives the account key hierarchy (so the Secret Key
+/// gates the account per ADR-010) and an SRP verifier from the password, and
+/// persists the user as `admin`. Refuses if an admin already exists.
+pub fn create_admin(db_path: &Path, email: &str, password: &str) -> Result<AdminCreated, String> {
+    let email = email.trim();
+    if email.is_empty() || !email.contains('@') {
+        return Err("a valid email is required".into());
+    }
+    if password.len() < 8 {
+        return Err("password must be at least 8 characters".into());
+    }
+
+    let secret_key = toku_core::SecretKey::generate().map_err(|e| e.to_string())?;
+    let (account_keys, _data_key) = toku_core::AccountKeys::create(password, secret_key.as_bytes())
+        .map_err(|e| e.to_string())?;
+
+    let salt_hex = generate_salt_hex();
+    let salt_bytes = hex::decode(&salt_hex).map_err(|e| e.to_string())?;
+    let verifier_hex = compute_verifier_hex(email, password, &salt_bytes);
+
+    let wrapped_private_key =
+        serde_json::to_string(&account_keys.wrapped_private_key).map_err(|e| e.to_string())?;
+    let kdf_params = serde_json::to_string(&account_keys.kdf).map_err(|e| e.to_string())?;
+    let account_public_key = account_keys.public_key.clone();
+
+    let user_id = uuid::Uuid::now_v7().to_string();
+
+    let db = open(db_path)?;
+    let tx = db.conn.unchecked_transaction().map_err(|e| e.to_string())?;
+
+    let existing_admins: i64 = tx
+        .query_row(
+            "SELECT COUNT(*) FROM web_users WHERE role = 'admin'",
+            [],
+            |row| row.get(0),
+        )
+        .map_err(|e| e.to_string())?;
+    if existing_admins > 0 {
+        return Err("an administrator account already exists".into());
+    }
+
+    tx.execute(
+        "INSERT INTO web_users
+         (id, email, srp_salt, srp_verifier, wrapped_private_key,
+          account_public_key, kdf_params, role, status, created_at)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, 'admin', 'active', datetime('now'))",
+        rusqlite::params![
+            user_id,
+            email,
+            salt_hex,
+            verifier_hex,
+            wrapped_private_key,
+            account_public_key,
+            kdf_params,
+        ],
+    )
+    .map_err(|e| e.to_string())?;
+    tx.commit().map_err(|e| e.to_string())?;
+
+    Ok(AdminCreated {
+        secret_key: secret_key.format(),
+        email: email.to_string(),
+    })
+}
+
+/// Result of a login attempt.
+pub enum LoginOutcome {
+    /// Authenticated; carries a freshly issued session token (raw, for the cookie).
+    Success { session_token: String },
+    /// Wrong email/password.
+    Invalid,
+    /// Account locked due to too many failed attempts.
+    Locked,
+}
+
+/// Verify credentials and, on success, issue a new session (session fixation is
+/// avoided because a brand-new token is always minted here).
+pub fn login(db_path: &Path, email: &str, password: &str) -> Result<LoginOutcome, String> {
+    let email = email.trim();
+    let db = open(db_path)?;
+
+    let row: Option<(String, String, String, String, i64, Option<String>)> = db
+        .conn
+        .query_row(
+            "SELECT id, srp_salt, srp_verifier, status, failed_attempts, locked_until
+             FROM web_users WHERE email = ?1",
+            [email],
+            |r| {
+                Ok((
+                    r.get(0)?,
+                    r.get(1)?,
+                    r.get(2)?,
+                    r.get(3)?,
+                    r.get(4)?,
+                    r.get(5)?,
+                ))
+            },
+        )
+        .ok();
+
+    let Some((user_id, salt_hex, verifier_hex, status, failed_attempts, locked_until)) = row else {
+        return Ok(LoginOutcome::Invalid);
+    };
+
+    if status != "active" {
+        return Ok(LoginOutcome::Invalid);
+    }
+
+    if let Some(until) = &locked_until {
+        let still_locked: bool = db
+            .conn
+            .query_row("SELECT ?1 > datetime('now')", [until], |r| r.get(0))
+            .unwrap_or(false);
+        if still_locked {
+            return Ok(LoginOutcome::Locked);
+        }
+    }
+
+    let salt_bytes = hex::decode(&salt_hex).map_err(|e| e.to_string())?;
+    let expected = compute_verifier_hex(email, password, &salt_bytes);
+
+    let matches: bool = expected.as_bytes().ct_eq(verifier_hex.as_bytes()).into();
+    if !matches {
+        record_failure(&db, &user_id, failed_attempts)?;
+        return Ok(LoginOutcome::Invalid);
+    }
+
+    // Reset failure counter and mint a fresh session.
+    db.conn
+        .execute(
+            "UPDATE web_users SET failed_attempts = 0, locked_until = NULL WHERE id = ?1",
+            [&user_id],
+        )
+        .map_err(|e| e.to_string())?;
+
+    let token = generate_token();
+    let token_hash = sha256_hex(&token);
+    db.conn
+        .execute(
+            "INSERT INTO web_sessions (token_hash, user_id, expires_at, created_at)
+             VALUES (?1, ?2, datetime('now', ?3), datetime('now'))",
+            rusqlite::params![token_hash, user_id, format!("+{SESSION_TTL_HOURS} hours")],
+        )
+        .map_err(|e| e.to_string())?;
+
+    Ok(LoginOutcome::Success {
+        session_token: token,
+    })
+}
+
+/// Increment the failure counter, locking the account at the threshold.
+fn record_failure(db: &toku_db::Database, user_id: &str, current: i64) -> Result<(), String> {
+    let next = current + 1;
+    if next >= MAX_FAILED_ATTEMPTS {
+        db.conn
+            .execute(
+                "UPDATE web_users
+                 SET failed_attempts = 0, locked_until = datetime('now', ?2)
+                 WHERE id = ?1",
+                rusqlite::params![user_id, format!("+{LOCKOUT_MINUTES} minutes")],
+            )
+            .map_err(|e| e.to_string())?;
+    } else {
+        db.conn
+            .execute(
+                "UPDATE web_users SET failed_attempts = ?2 WHERE id = ?1",
+                rusqlite::params![user_id, next],
+            )
+            .map_err(|e| e.to_string())?;
+    }
+    Ok(())
+}
+
+/// Returns true when the raw session token maps to a live session for an
+/// active user (honouring expiry).
+fn session_valid(db_path: &Path, token: &str) -> Result<bool, String> {
+    let token_hash = sha256_hex(token);
+    let db = open(db_path)?;
+    let found: Option<i64> = db
+        .conn
+        .query_row(
+            "SELECT 1
+             FROM web_sessions s JOIN web_users u ON u.id = s.user_id
+             WHERE s.token_hash = ?1
+               AND s.expires_at > datetime('now')
+               AND u.status = 'active'",
+            [&token_hash],
+            |r| r.get(0),
+        )
+        .ok();
+    Ok(found.is_some())
+}
+
+/// Delete a session (logout). Best-effort.
+pub fn delete_session(db_path: &Path, token: &str) -> Result<(), String> {
+    let token_hash = sha256_hex(token);
+    let db = open(db_path)?;
+    let _ = db.conn.execute(
+        "DELETE FROM web_sessions WHERE token_hash = ?1",
+        [&token_hash],
+    );
+    Ok(())
+}
+
+fn open(db_path: &Path) -> Result<toku_db::Database, String> {
+    toku_db::Database::open_no_migrate(db_path).map_err(|e| e.to_string())
+}
+
+// ── Cookie builders ──────────────────────────────────────────────────────────
+
+/// Build the session cookie (HttpOnly, SameSite=Lax).
+pub fn session_cookie(value: String, secure: bool) -> Cookie<'static> {
+    let mut c = Cookie::new(SESSION_COOKIE, value);
+    c.set_http_only(true);
+    c.set_same_site(SameSite::Lax);
+    c.set_path("/");
+    c.set_secure(secure);
+    c.set_max_age(time::Duration::hours(SESSION_TTL_HOURS));
+    c
+}
+
+/// Build an expired session cookie to clear it on logout.
+pub fn clear_session_cookie(secure: bool) -> Cookie<'static> {
+    let mut c = Cookie::new(SESSION_COOKIE, "");
+    c.set_http_only(true);
+    c.set_same_site(SameSite::Lax);
+    c.set_path("/");
+    c.set_secure(secure);
+    c.set_max_age(time::Duration::seconds(0));
+    c
+}
+
+/// Build the CSRF double-submit cookie (HttpOnly, SameSite=Strict).
+fn csrf_cookie(value: String, secure: bool) -> Cookie<'static> {
+    let mut c = Cookie::new(CSRF_COOKIE, value);
+    c.set_http_only(true);
+    c.set_same_site(SameSite::Strict);
+    c.set_path("/");
+    c.set_secure(secure);
+    c
+}
+
+// ── Middleware ───────────────────────────────────────────────────────────────
+
+/// Gate protected routes: redirect to onboarding/login when unauthenticated.
+///
+/// Mounted only in hosted mode.
+pub async fn require_auth(
+    State(state): State<AppState>,
+    jar: CookieJar,
+    req: Request,
+    next: Next,
+) -> Response {
+    let db_path = state.db_path.clone();
+
+    // First-run: no admin yet → force onboarding.
+    let has_admin = match run_blocking(move || admin_exists(&db_path)).await {
+        Ok(v) => v,
+        Err(_) => return StatusCode::INTERNAL_SERVER_ERROR.into_response(),
+    };
+    if !has_admin {
+        return Redirect::to("/setup").into_response();
+    }
+
+    let token = jar.get(SESSION_COOKIE).map(|c| c.value().to_string());
+    let Some(token) = token else {
+        return Redirect::to("/login").into_response();
+    };
+
+    let db_path = state.db_path.clone();
+    let valid = match run_blocking(move || session_valid(&db_path, &token)).await {
+        Ok(v) => v,
+        Err(_) => return StatusCode::INTERNAL_SERVER_ERROR.into_response(),
+    };
+
+    if valid {
+        next.run(req).await
+    } else {
+        Redirect::to("/login").into_response()
+    }
+}
+
+/// Double-submit CSRF protection for all routes (mounted in hosted mode).
+///
+/// Ensures a `toku_csrf` cookie exists and injects the token into request
+/// extensions so forms can embed it. On unsafe methods the submitted token
+/// (urlencoded `csrf_token` field, or `?csrf=` query for multipart) must match
+/// the cookie.
+pub async fn csrf_protect(
+    State(state): State<AppState>,
+    jar: CookieJar,
+    mut req: Request,
+    next: Next,
+) -> Response {
+    let existing = jar.get(CSRF_COOKIE).map(|c| c.value().to_string());
+    let (token, newly_issued) = match existing {
+        Some(t) => (t, false),
+        None => (generate_token(), true),
+    };
+
+    let unsafe_method = !matches!(
+        *req.method(),
+        Method::GET | Method::HEAD | Method::OPTIONS | Method::TRACE
+    );
+
+    if unsafe_method {
+        // A request that can't carry our cookie back (newly issued = no cookie
+        // was sent) cannot have a valid token.
+        if newly_issued {
+            return (StatusCode::FORBIDDEN, "missing CSRF token").into_response();
+        }
+        let (submitted, rebuilt) = match extract_csrf_submission(req).await {
+            Ok(v) => v,
+            Err(resp) => return resp,
+        };
+        req = rebuilt;
+        let ok = submitted
+            .map(|s| s.as_bytes().ct_eq(token.as_bytes()).into())
+            .unwrap_or(false);
+        if !ok {
+            return (StatusCode::FORBIDDEN, "CSRF validation failed").into_response();
+        }
+    }
+
+    req.extensions_mut().insert(CsrfToken(token.clone()));
+    let mut resp = next.run(req).await;
+    if newly_issued {
+        let cookie = csrf_cookie(token, state.secure_cookies);
+        if let Ok(value) = header::HeaderValue::from_str(&cookie.to_string()) {
+            resp.headers_mut().append(header::SET_COOKIE, value);
+        }
+    }
+    resp
+}
+
+/// Pull the CSRF token out of an unsafe request without losing the body.
+///
+/// For `application/x-www-form-urlencoded` the body is buffered, scanned for the
+/// `csrf_token` field, and a fresh request is rebuilt so downstream extractors
+/// still see the full body. For multipart (file uploads) the token is read from
+/// the `?csrf=` query parameter instead, leaving the streamed body untouched.
+async fn extract_csrf_submission(req: Request) -> Result<(Option<String>, Request), Response> {
+    let content_type = req
+        .headers()
+        .get(header::CONTENT_TYPE)
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("")
+        .to_ascii_lowercase();
+
+    if content_type.starts_with("application/x-www-form-urlencoded") {
+        let (parts, body) = req.into_parts();
+        let bytes = match axum::body::to_bytes(body, CSRF_BODY_LIMIT).await {
+            Ok(b) => b,
+            Err(_) => {
+                return Err(
+                    (StatusCode::PAYLOAD_TOO_LARGE, "request body too large").into_response()
+                );
+            }
+        };
+        let token = form_urlencoded::parse(&bytes)
+            .find(|(k, _)| k == CSRF_FIELD)
+            .map(|(_, v)| v.into_owned());
+        let req = Request::from_parts(parts, axum::body::Body::from(bytes));
+        Ok((token, req))
+    } else {
+        // Multipart or anything else: read from the query string.
+        let token = req.uri().query().and_then(|q| {
+            form_urlencoded::parse(q.as_bytes())
+                .find(|(k, _)| k == "csrf")
+                .map(|(_, v)| v.into_owned())
+        });
+        Ok((token, req))
+    }
+}
+
+/// Run a blocking DB closure on the blocking pool.
+async fn run_blocking<T, F>(f: F) -> Result<T, String>
+where
+    F: FnOnce() -> Result<T, String> + Send + 'static,
+    T: Send + 'static,
+{
+    tokio::task::spawn_blocking(f)
+        .await
+        .map_err(|e| e.to_string())?
+}

--- a/crates/toku-web/src/auth_handlers.rs
+++ b/crates/toku-web/src/auth_handlers.rs
@@ -1,0 +1,126 @@
+//! Route handlers for hosted-mode authentication.
+
+use axum::extract::State;
+use axum::response::{Html, IntoResponse, Redirect, Response};
+use axum_extra::extract::CookieJar;
+
+use crate::AppState;
+use crate::auth::{self, CsrfToken};
+use crate::auth_views;
+
+#[derive(serde::Deserialize)]
+pub struct LoginForm {
+    pub email: String,
+    pub password: String,
+}
+
+#[derive(serde::Deserialize)]
+pub struct SetupForm {
+    pub email: String,
+    pub password: String,
+}
+
+/// `GET /login` — show the sign-in form (or bounce to setup when no admin).
+pub async fn login_page(State(state): State<AppState>, csrf: CsrfToken) -> Response {
+    let db_path = state.db_path.clone();
+    match tokio::task::spawn_blocking(move || auth::admin_exists(&db_path)).await {
+        Ok(Ok(false)) => return Redirect::to("/setup").into_response(),
+        Ok(Ok(true)) => {}
+        _ => return internal_error(),
+    }
+    Html(auth_views::login_page(csrf.value(), None).into_string()).into_response()
+}
+
+/// `POST /login` — verify credentials and start a session.
+pub async fn login_submit(
+    State(state): State<AppState>,
+    jar: CookieJar,
+    csrf: CsrfToken,
+    form: axum::extract::Form<LoginForm>,
+) -> Response {
+    let db_path = state.db_path.clone();
+    let email = form.email.clone();
+    let password = form.password.clone();
+
+    let outcome =
+        tokio::task::spawn_blocking(move || auth::login(&db_path, &email, &password)).await;
+
+    match outcome {
+        Ok(Ok(auth::LoginOutcome::Success { session_token })) => {
+            let jar = jar.add(auth::session_cookie(session_token, state.secure_cookies));
+            (jar, Redirect::to("/library")).into_response()
+        }
+        Ok(Ok(auth::LoginOutcome::Invalid)) => Html(
+            auth_views::login_page(csrf.value(), Some("Invalid email or password.")).into_string(),
+        )
+        .into_response(),
+        Ok(Ok(auth::LoginOutcome::Locked)) => Html(
+            auth_views::login_page(
+                csrf.value(),
+                Some("Too many failed attempts. Try again later."),
+            )
+            .into_string(),
+        )
+        .into_response(),
+        _ => internal_error(),
+    }
+}
+
+/// `POST /logout` — destroy the session and clear the cookie.
+pub async fn logout(State(state): State<AppState>, jar: CookieJar) -> Response {
+    if let Some(token) = jar.get(auth::SESSION_COOKIE).map(|c| c.value().to_string()) {
+        let db_path = state.db_path.clone();
+        let _ = tokio::task::spawn_blocking(move || auth::delete_session(&db_path, &token)).await;
+    }
+    let jar = jar.add(auth::clear_session_cookie(state.secure_cookies));
+    (jar, Redirect::to("/login")).into_response()
+}
+
+/// `GET /setup` — first-run onboarding (404s into login once an admin exists).
+pub async fn setup_page(State(state): State<AppState>, csrf: CsrfToken) -> Response {
+    let db_path = state.db_path.clone();
+    match tokio::task::spawn_blocking(move || auth::admin_exists(&db_path)).await {
+        Ok(Ok(true)) => return Redirect::to("/login").into_response(),
+        Ok(Ok(false)) => {}
+        _ => return internal_error(),
+    }
+    Html(auth_views::setup_page(csrf.value(), None).into_string()).into_response()
+}
+
+/// `POST /setup` — create the admin account and show the Emergency Kit once.
+pub async fn setup_submit(
+    State(state): State<AppState>,
+    csrf: CsrfToken,
+    form: axum::extract::Form<SetupForm>,
+) -> Response {
+    let db_path = state.db_path.clone();
+    let email = form.email.clone();
+    let password = form.password.clone();
+
+    let result =
+        tokio::task::spawn_blocking(move || auth::create_admin(&db_path, &email, &password)).await;
+
+    match result {
+        Ok(Ok(created)) => {
+            Html(auth_views::emergency_kit_page(&created.email, &created.secret_key).into_string())
+                .into_response()
+        }
+        Ok(Err(msg)) => {
+            Html(auth_views::setup_page(csrf.value(), Some(&msg)).into_string()).into_response()
+        }
+        _ => internal_error(),
+    }
+}
+
+/// Unauthenticated liveness probe for Docker/orchestration (#124).
+pub async fn healthz() -> &'static str {
+    "ok"
+}
+
+fn internal_error() -> Response {
+    (
+        axum::http::StatusCode::INTERNAL_SERVER_ERROR,
+        "internal error",
+    )
+        .into_response()
+}

--- a/crates/toku-web/src/auth_views.rs
+++ b/crates/toku-web/src/auth_views.rs
@@ -1,0 +1,159 @@
+//! Views for hosted-mode authentication: login, first-run setup, and the
+//! one-time Emergency Kit.
+
+use maud::{DOCTYPE, Markup, PreEscaped, html};
+
+const AUTH_CSS: &str = r#"
+:root { color-scheme: light dark; }
+* { box-sizing: border-box; }
+body {
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+    margin: 0; min-height: 100vh; display: flex; align-items: center;
+    justify-content: center; background: #f5f5f7; color: #1d1d1f; padding: 2rem;
+}
+.auth-card {
+    background: #fff; border-radius: 14px; box-shadow: 0 8px 30px rgba(0,0,0,.08);
+    padding: 2.5rem; width: 100%; max-width: 28rem;
+}
+.auth-card.wide { max-width: 40rem; }
+.logo { font-size: 1.5rem; font-weight: 700; margin-bottom: .25rem; }
+h1 { font-size: 1.35rem; margin: .25rem 0 1.25rem; }
+label { display: block; font-weight: 600; margin: 1rem 0 .35rem; font-size: .9rem; }
+input[type=email], input[type=password], input[type=text] {
+    width: 100%; padding: .65rem .75rem; border: 1px solid #d2d2d7;
+    border-radius: 8px; font-size: 1rem;
+}
+.btn {
+    margin-top: 1.5rem; width: 100%; padding: .7rem; border: 0; border-radius: 8px;
+    background: #0071e3; color: #fff; font-size: 1rem; font-weight: 600; cursor: pointer;
+}
+.btn:hover { background: #0077ed; }
+.muted { color: #6e6e73; font-size: .85rem; }
+.error { background: #fdecea; color: #b3261e; padding: .75rem 1rem; border-radius: 8px;
+    margin-bottom: 1rem; font-size: .9rem; }
+.kit { background: #1d1d1f; color: #f5f5f7; padding: 1.25rem; border-radius: 10px;
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 1.05rem;
+    letter-spacing: .04em; word-break: break-all; margin: 1rem 0; text-align: center; }
+.warn { background: #fff4e5; color: #7a4f01; padding: 1rem; border-radius: 8px;
+    font-size: .9rem; margin: 1rem 0; }
+.actions { display: flex; gap: .75rem; margin-top: 1.5rem; }
+.actions a, .actions button { flex: 1; text-align: center; }
+a.secondary { display: block; padding: .7rem; border-radius: 8px; border: 1px solid #d2d2d7;
+    color: #0071e3; text-decoration: none; font-weight: 600; }
+"#;
+
+fn shell(title: &str, inner: Markup) -> Markup {
+    html! {
+        (DOCTYPE)
+        html lang="en" {
+            head {
+                meta charset="utf-8";
+                meta name="viewport" content="width=device-width, initial-scale=1";
+                title { (title) " — Toku" }
+                style { (PreEscaped(AUTH_CSS)) }
+            }
+            body { (inner) }
+        }
+    }
+}
+
+/// A hidden CSRF field, rendered only when a token is present (hosted mode).
+pub fn csrf_field(token: &str) -> Markup {
+    html! {
+        @if !token.is_empty() {
+            input type="hidden" name="csrf_token" value=(token);
+        }
+    }
+}
+
+/// Append `?csrf=<token>` to a form action for multipart submissions, where the
+/// token can't ride in the buffered body. Returns the bare action in local mode.
+pub fn action_with_csrf(action: &str, token: &str) -> String {
+    if token.is_empty() {
+        action.to_string()
+    } else {
+        format!("{action}?csrf={}", urlencoding::encode(token))
+    }
+}
+
+/// The login page. `error` shows a message above the form when present.
+pub fn login_page(csrf: &str, error: Option<&str>) -> Markup {
+    shell(
+        "Sign in",
+        html! {
+            div.auth-card {
+                div.logo { "📚 Toku" }
+                h1 { "Sign in" }
+                @if let Some(msg) = error {
+                    div.error { (msg) }
+                }
+                form method="post" action="/login" {
+                    (csrf_field(csrf))
+                    label for="email" { "Email" }
+                    input id="email" type="email" name="email" required autofocus;
+                    label for="password" { "Password" }
+                    input id="password" type="password" name="password" required;
+                    button.btn type="submit" { "Sign in" }
+                }
+            }
+        },
+    )
+}
+
+/// The first-run setup page (no admin exists yet).
+pub fn setup_page(csrf: &str, error: Option<&str>) -> Markup {
+    shell(
+        "Welcome to Toku",
+        html! {
+            div.auth-card {
+                div.logo { "📚 Toku" }
+                h1 { "Create your administrator account" }
+                p.muted {
+                    "This is the first run of your Toku server. Create the admin \
+                     account that controls this instance."
+                }
+                @if let Some(msg) = error {
+                    div.error { (msg) }
+                }
+                form method="post" action="/setup" {
+                    (csrf_field(csrf))
+                    label for="email" { "Email" }
+                    input id="email" type="email" name="email" required autofocus;
+                    label for="password" { "Password" }
+                    input id="password" type="password" name="password"
+                          minlength="8" required;
+                    p.muted { "At least 8 characters." }
+                    button.btn type="submit" { "Create account" }
+                }
+            }
+        },
+    )
+}
+
+/// The one-time Emergency Kit shown immediately after account creation.
+pub fn emergency_kit_page(email: &str, secret_key: &str) -> Markup {
+    shell(
+        "Your Emergency Kit",
+        html! {
+            div.auth-card.wide {
+                div.logo { "📚 Toku" }
+                h1 { "Save your Emergency Kit" }
+                p { "Account: " strong { (email) } }
+                p {
+                    "This is your " strong { "Secret Key" }
+                    ". It is shown " strong { "once" } " and is required — together with \
+                     your password — to unlock your account on a new device."
+                }
+                div.kit { (secret_key) }
+                div.warn {
+                    "⚠️ We cannot recover this for you. There is no server-side copy. \
+                     Store it offline (print it or save it in a password manager). \
+                     Your local library remains your ultimate backup."
+                }
+                div.actions {
+                    a.secondary href="/login" { "I’ve saved it — continue to sign in" }
+                }
+            }
+        },
+    )
+}

--- a/crates/toku-web/src/conflicts_handlers.rs
+++ b/crates/toku-web/src/conflicts_handlers.rs
@@ -22,7 +22,10 @@ fn parse_keep(value: &str) -> Result<ConflictKeep, WebError> {
 }
 
 /// `GET /conflicts` — list unresolved sync conflicts with resolution actions.
-pub async fn conflicts_page(State(state): State<AppState>) -> Result<Html<String>, WebError> {
+pub async fn conflicts_page(
+    State(state): State<AppState>,
+    csrf: crate::auth::CsrfToken,
+) -> Result<Html<String>, WebError> {
     let db_path = state.db_path.clone();
 
     let conflicts = tokio::task::spawn_blocking(move || {
@@ -32,7 +35,9 @@ pub async fn conflicts_page(State(state): State<AppState>) -> Result<Html<String
     .await
     .map_err(|e| WebError::Internal(e.to_string()))??;
 
-    Ok(Html(views::conflicts_page(&conflicts).into_string()))
+    Ok(Html(
+        views::conflicts_page(&conflicts, csrf.value()).into_string(),
+    ))
 }
 
 /// `POST /conflicts/resolve/{id}` — resolve one conflict, then redirect back.

--- a/crates/toku-web/src/import_handlers.rs
+++ b/crates/toku-web/src/import_handlers.rs
@@ -110,8 +110,8 @@ impl ImportObserver for WebImportObserver {
 // ── Handlers ────────────────────────────────────────────────────────
 
 /// `GET /import` — import type selection page.
-pub async fn import_page() -> Html<String> {
-    Html(import_views::import_page().into_string())
+pub async fn import_page(csrf: crate::auth::CsrfToken) -> Html<String> {
+    Html(import_views::import_page(csrf.value()).into_string())
 }
 
 /// `POST /import/upload` — handle CSV file upload (Goodreads or StoryGraph).
@@ -297,6 +297,7 @@ pub struct CalibreForm {
 /// `GET /import/preview/{id}` — show dry-run preview.
 pub async fn import_preview(
     State(state): State<AppState>,
+    csrf: crate::auth::CsrfToken,
     Path(id): Path<String>,
 ) -> Result<Html<String>, WebError> {
     let sessions = state
@@ -314,7 +315,7 @@ pub async fn import_preview(
         .ok_or_else(|| WebError::Internal("no preview available".into()))?;
 
     Ok(Html(
-        import_views::preview_page(&id, &session.source, report).into_string(),
+        import_views::preview_page(&id, &session.source, report, csrf.value()).into_string(),
     ))
 }
 

--- a/crates/toku-web/src/import_views.rs
+++ b/crates/toku-web/src/import_views.rs
@@ -38,7 +38,7 @@ fn base(title: &str, content: Markup) -> Markup {
 }
 
 /// Import type selection page.
-pub fn import_page() -> Markup {
+pub fn import_page(csrf: &str) -> Markup {
     base(
         "Import Library",
         html! {
@@ -51,7 +51,7 @@ pub fn import_page() -> Markup {
                     div.import-card {
                         h2 { "📗 Goodreads" }
                         p { "Import from a Goodreads CSV export." }
-                        form action="/import/upload" method="post" enctype="multipart/form-data" {
+                        form action=(crate::auth_views::action_with_csrf("/import/upload", csrf)) method="post" enctype="multipart/form-data" {
                             input type="hidden" name="source" value="goodreads";
                             div.form-field {
                                 label for="gr-file" { "CSV file" }
@@ -65,7 +65,7 @@ pub fn import_page() -> Markup {
                     div.import-card {
                         h2 { "📘 StoryGraph" }
                         p { "Import from a StoryGraph CSV export." }
-                        form action="/import/upload" method="post" enctype="multipart/form-data" {
+                        form action=(crate::auth_views::action_with_csrf("/import/upload", csrf)) method="post" enctype="multipart/form-data" {
                             input type="hidden" name="source" value="storygraph";
                             div.form-field {
                                 label for="sg-file" { "CSV file" }
@@ -80,6 +80,7 @@ pub fn import_page() -> Markup {
                         h2 { "📙 Calibre" }
                         p { "Import from a Calibre library directory." }
                         form action="/import/calibre" method="post" {
+                            (crate::auth_views::csrf_field(csrf))
                             div.form-field {
                                 label for="cal-path" { "Library path" }
                                 input id="cal-path" type="text" name="path"
@@ -99,7 +100,12 @@ pub fn import_page() -> Markup {
 }
 
 /// Dry-run preview page.
-pub fn preview_page(session_id: &str, source: &ImportSourceKind, report: &ImportReport) -> Markup {
+pub fn preview_page(
+    session_id: &str,
+    source: &ImportSourceKind,
+    report: &ImportReport,
+    csrf: &str,
+) -> Markup {
     let source_name = match source {
         ImportSourceKind::Goodreads => "Goodreads",
         ImportSourceKind::Calibre { .. } => "Calibre",
@@ -229,6 +235,7 @@ pub fn preview_page(session_id: &str, source: &ImportSourceKind, report: &Import
                 // Actions
                 div.preview-actions {
                     form action={ "/import/execute/" (session_id) } method="post" {
+                        (crate::auth_views::csrf_field(csrf))
                         button.btn.btn-primary type="submit" { "Confirm Import" }
                     }
                     a.btn.btn-secondary href="/import" { "Cancel" }

--- a/crates/toku-web/src/lib.rs
+++ b/crates/toku-web/src/lib.rs
@@ -10,6 +10,9 @@ use std::sync::{Arc, Mutex};
 use axum::Router;
 use axum::routing::{get, post};
 
+mod auth;
+mod auth_handlers;
+mod auth_views;
 mod charts;
 mod conflicts_handlers;
 mod error;
@@ -22,6 +25,7 @@ mod sync_handlers;
 mod sync_status;
 mod views;
 
+pub use auth::WebMode;
 pub use error::WebError;
 
 /// Shared application state for Axum handlers.
@@ -31,27 +35,14 @@ pub struct AppState {
     pub import_sessions: import_handlers::ImportSessions,
     pub temp_dir: PathBuf,
     pub covers_dir: PathBuf,
+    /// Authentication mode (local = no auth, hosted = auth required).
+    pub mode: WebMode,
+    /// Whether to mark auth cookies `Secure` (disable for plain-HTTP testing).
+    pub secure_cookies: bool,
 }
 
-/// Build the Axum router for the web dashboard.
-pub fn build_router(db_path: PathBuf, temp_dir: PathBuf) -> Router {
-    let covers_dir = db_path
-        .parent()
-        .unwrap_or_else(|| std::path::Path::new("."))
-        .join("covers");
-
-    // Record the data dir so the header sync badge can read sync state.
-    if let Some(data_dir) = db_path.parent() {
-        sync_status::set_data_dir(data_dir.to_path_buf());
-    }
-
-    let state = AppState {
-        db_path,
-        import_sessions: Arc::new(Mutex::new(HashMap::new())),
-        temp_dir,
-        covers_dir,
-    };
-
+/// Routes that render the dashboard itself (gated behind auth in hosted mode).
+fn dashboard_routes() -> Router<AppState> {
     Router::new()
         // Root
         .route("/", get(handlers::root))
@@ -97,15 +88,91 @@ pub fn build_router(db_path: PathBuf, temp_dir: PathBuf) -> Router {
             get(import_handlers::import_progress_sse),
         )
         .route("/import/results/{id}", get(import_handlers::import_results))
-        .with_state(state)
 }
 
-/// Start serving using a pre-bound listener.
+/// Build the Axum router for the web dashboard.
+pub fn build_router(
+    db_path: PathBuf,
+    temp_dir: PathBuf,
+    mode: WebMode,
+    secure_cookies: bool,
+) -> Router {
+    let covers_dir = db_path
+        .parent()
+        .unwrap_or_else(|| std::path::Path::new("."))
+        .join("covers");
+
+    // Record the data dir so the header sync badge can read sync state.
+    if let Some(data_dir) = db_path.parent() {
+        sync_status::set_data_dir(data_dir.to_path_buf());
+    }
+
+    let state = AppState {
+        db_path,
+        import_sessions: Arc::new(Mutex::new(HashMap::new())),
+        temp_dir,
+        covers_dir,
+        mode,
+        secure_cookies,
+    };
+
+    auth::set_hosted(mode.is_hosted());
+
+    let dashboard = dashboard_routes();
+
+    if mode.is_hosted() {
+        // Public, unauthenticated routes.
+        let public = Router::new()
+            .route(
+                "/login",
+                get(auth_handlers::login_page).post(auth_handlers::login_submit),
+            )
+            .route(
+                "/setup",
+                get(auth_handlers::setup_page).post(auth_handlers::setup_submit),
+            )
+            .route(
+                "/logout",
+                get(auth_handlers::logout).post(auth_handlers::logout),
+            )
+            .route("/healthz", get(auth_handlers::healthz));
+
+        // Auth gate on the dashboard routes only; CSRF protection on everything.
+        let protected = dashboard.route_layer(axum::middleware::from_fn_with_state(
+            state.clone(),
+            auth::require_auth,
+        ));
+
+        protected
+            .merge(public)
+            .layer(axum::middleware::from_fn_with_state(
+                state.clone(),
+                auth::csrf_protect,
+            ))
+            .with_state(state)
+    } else {
+        dashboard
+            .route("/healthz", get(auth_handlers::healthz))
+            .with_state(state)
+    }
+}
+
+/// Start serving using a pre-bound listener (local mode; used by the desktop app).
 ///
 /// Runs migrations once at startup, then serves the dashboard on the
 /// listener's local address. Use this when you need to control the
 /// listener (e.g. binding to a random port for the desktop app).
 pub async fn serve_on(db_path: PathBuf, listener: tokio::net::TcpListener) -> Result<(), WebError> {
+    serve_on_with(db_path, listener, WebMode::Local, false).await
+}
+
+/// Start serving using a pre-bound listener with an explicit mode.
+pub async fn serve_on_with(
+    db_path: PathBuf,
+    listener: tokio::net::TcpListener,
+    mode: WebMode,
+    secure_cookies: bool,
+) -> Result<(), WebError> {
     // Run migrations once at startup
     toku_db::Database::open(&db_path)
         .map_err(|e| WebError::Internal(format!("failed to open database: {e}")))?;
@@ -115,7 +182,7 @@ pub async fn serve_on(db_path: PathBuf, listener: tokio::net::TcpListener) -> Re
     std::fs::create_dir_all(&temp_dir)
         .map_err(|e| WebError::Internal(format!("failed to create temp dir: {e}")))?;
 
-    let app = build_router(db_path, temp_dir);
+    let app = build_router(db_path, temp_dir, mode, secure_cookies);
 
     axum::serve(listener, app)
         .await
@@ -127,13 +194,43 @@ pub async fn serve_on(db_path: PathBuf, listener: tokio::net::TcpListener) -> Re
 /// Start the web dashboard server.
 ///
 /// Runs migrations once, then serves the dashboard on `{host}:{port}`.
-pub async fn serve(db_path: PathBuf, host: &str, port: u16) -> Result<(), WebError> {
+pub async fn serve(
+    db_path: PathBuf,
+    host: &str,
+    port: u16,
+    mode: WebMode,
+    secure_cookies: bool,
+) -> Result<(), WebError> {
+    // In hosted mode the server is meant to face a network; in local mode we
+    // refuse anything but loopback to preserve the single-user, no-auth posture.
+    if mode == WebMode::Local && !is_loopback_host(host) {
+        return Err(WebError::Internal(format!(
+            "refusing to bind {host} without authentication: local mode is loopback-only. \
+             Use --hosted to enable authentication for network access."
+        )));
+    }
+
     let addr = format!("{host}:{port}");
     let listener = tokio::net::TcpListener::bind(&addr)
         .await
         .map_err(|e| WebError::Internal(format!("failed to bind {addr}: {e}")))?;
 
-    eprintln!("Toku dashboard → http://{addr}/library");
+    match mode {
+        WebMode::Hosted => {
+            eprintln!("Toku dashboard (hosted) → http://{addr}/  — authentication required")
+        }
+        WebMode::Local => eprintln!("Toku dashboard → http://{addr}/library"),
+    }
 
-    serve_on(db_path, listener).await
+    serve_on_with(db_path, listener, mode, secure_cookies).await
+}
+
+/// True when the host string is a loopback address or `localhost`.
+fn is_loopback_host(host: &str) -> bool {
+    if host.eq_ignore_ascii_case("localhost") {
+        return true;
+    }
+    host.parse::<std::net::IpAddr>()
+        .map(|ip| ip.is_loopback())
+        .unwrap_or(false)
 }

--- a/crates/toku-web/src/views.rs
+++ b/crates/toku-web/src/views.rs
@@ -33,6 +33,10 @@ fn base(title: &str, content: Markup) -> Markup {
                             " "
                             a.nav-link href="/sync" { "Sync" }
                             (crate::sync_status::header_badge())
+                            @if crate::auth::is_hosted_global() {
+                                " "
+                                a.nav-link href="/logout" { "Sign out" }
+                            }
                         }
                     }
                 }
@@ -112,7 +116,7 @@ pub fn sync_page(o: &SyncOverview) -> Markup {
 }
 
 /// Render the sync conflicts page.
-pub fn conflicts_page(conflicts: &[SyncConflict]) -> Markup {
+pub fn conflicts_page(conflicts: &[SyncConflict], csrf: &str) -> Markup {
     let content = html! {
         div.dashboard-header {
             h1 { "Sync Conflicts" }
@@ -128,10 +132,12 @@ pub fn conflicts_page(conflicts: &[SyncConflict]) -> Markup {
                 p { (conflicts.len()) " unresolved conflict" @if conflicts.len() != 1 { "s" } "." }
                 div.conflict-bulk {
                     form method="post" action="/conflicts/resolve-all" {
+                        (crate::auth_views::csrf_field(csrf))
                         input type="hidden" name="keep" value="local";
                         button.btn.btn-secondary type="submit" { "Keep all local" }
                     }
                     form method="post" action="/conflicts/resolve-all" {
+                        (crate::auth_views::csrf_field(csrf))
                         input type="hidden" name="keep" value="remote";
                         button.btn.btn-secondary type="submit" { "Keep all remote" }
                     }
@@ -139,14 +145,14 @@ pub fn conflicts_page(conflicts: &[SyncConflict]) -> Markup {
             }
 
             @for c in conflicts {
-                (conflict_card(c))
+                (conflict_card(c, csrf))
             }
         }
     };
     base("Sync Conflicts", content)
 }
 
-fn conflict_card(c: &SyncConflict) -> Markup {
+fn conflict_card(c: &SyncConflict, csrf: &str) -> Markup {
     let field = c.field_name.as_deref().unwrap_or("value");
     let local = c.local_value.as_deref().unwrap_or("(empty)");
     let remote = c.remote_value.as_deref().unwrap_or("(empty)");
@@ -172,10 +178,12 @@ fn conflict_card(c: &SyncConflict) -> Markup {
             }
             div.conflict-actions {
                 form method="post" action=(resolve_action) {
+                    (crate::auth_views::csrf_field(csrf))
                     input type="hidden" name="keep" value="local";
                     button.btn.btn-primary type="submit" { "Keep local" }
                 }
                 form method="post" action=(resolve_action) {
+                    (crate::auth_views::csrf_field(csrf))
                     input type="hidden" name="keep" value="remote";
                     button.btn.btn-primary type="submit" { "Keep remote" }
                 }

--- a/crates/toku-web/tests/auth.rs
+++ b/crates/toku-web/tests/auth.rs
@@ -1,0 +1,430 @@
+//! Integration tests for hosted-mode onboarding + session auth (issue #122).
+//!
+//! These exercise the full Axum router via `tower::ServiceExt::oneshot`, so they
+//! cover the middleware stack (CSRF + auth gate) end to end.
+
+use axum::Router;
+use axum::body::Body;
+use axum::http::{Request, StatusCode, header};
+use http_body_util::BodyExt;
+use tower::ServiceExt;
+
+use toku_web::{WebMode, build_router};
+
+/// A migrated, empty database plus a temp dir, kept alive for the test.
+struct TestEnv {
+    _dir: tempfile::TempDir,
+    db_path: std::path::PathBuf,
+    temp_dir: std::path::PathBuf,
+}
+
+fn setup_env() -> TestEnv {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let db_path = dir.path().join("toku.db");
+    // build_router does NOT migrate; the real server does this once at startup.
+    toku_db::Database::open(&db_path).expect("migrate db");
+    let temp_dir = dir.path().join("uploads");
+    std::fs::create_dir_all(&temp_dir).expect("temp dir");
+    TestEnv {
+        _dir: dir,
+        db_path,
+        temp_dir,
+    }
+}
+
+fn hosted_router(env: &TestEnv) -> Router {
+    // secure_cookies = false so cookies are usable over the plain-HTTP test client.
+    build_router(
+        env.db_path.clone(),
+        env.temp_dir.clone(),
+        WebMode::Hosted,
+        false,
+    )
+}
+
+fn local_router(env: &TestEnv) -> Router {
+    build_router(
+        env.db_path.clone(),
+        env.temp_dir.clone(),
+        WebMode::Local,
+        false,
+    )
+}
+
+/// Collect all `Set-Cookie` values from a response.
+fn set_cookies(resp: &axum::response::Response) -> Vec<String> {
+    resp.headers()
+        .get_all(header::SET_COOKIE)
+        .iter()
+        .filter_map(|v| v.to_str().ok())
+        .map(|s| s.to_string())
+        .collect()
+}
+
+/// Extract a single cookie's value (the `name=value` part) by cookie name.
+fn cookie_value(resp: &axum::response::Response, name: &str) -> Option<String> {
+    set_cookies(resp).into_iter().find_map(|c| {
+        let pair = c.split(';').next().unwrap_or("").trim().to_string();
+        let (k, v) = pair.split_once('=')?;
+        if k == name { Some(v.to_string()) } else { None }
+    })
+}
+
+fn location(resp: &axum::response::Response) -> Option<String> {
+    resp.headers()
+        .get(header::LOCATION)
+        .and_then(|v| v.to_str().ok())
+        .map(|s| s.to_string())
+}
+
+async fn body_string(resp: axum::response::Response) -> String {
+    let bytes = resp.into_body().collect().await.unwrap().to_bytes();
+    String::from_utf8_lossy(&bytes).to_string()
+}
+
+fn get(uri: &str) -> Request<Body> {
+    Request::builder()
+        .uri(uri)
+        .method("GET")
+        .body(Body::empty())
+        .unwrap()
+}
+
+fn get_with_cookie(uri: &str, cookie: &str) -> Request<Body> {
+    Request::builder()
+        .uri(uri)
+        .method("GET")
+        .header(header::COOKIE, cookie)
+        .body(Body::empty())
+        .unwrap()
+}
+
+fn form_post(uri: &str, cookie: Option<&str>, body: String) -> Request<Body> {
+    let mut b = Request::builder()
+        .uri(uri)
+        .method("POST")
+        .header(header::CONTENT_TYPE, "application/x-www-form-urlencoded");
+    if let Some(c) = cookie {
+        b = b.header(header::COOKIE, c);
+    }
+    b.body(Body::from(body)).unwrap()
+}
+
+/// Perform a GET to obtain a fresh CSRF cookie + token (they share the value in
+/// the double-submit scheme), returning `(csrf_token, cookie_header)`.
+async fn fetch_csrf(router: &Router, uri: &str) -> (String, String) {
+    let resp = router.clone().oneshot(get(uri)).await.unwrap();
+    let token = cookie_value(&resp, "toku_csrf").expect("csrf cookie issued");
+    let cookie_header = format!("toku_csrf={token}");
+    (token, cookie_header)
+}
+
+/// Create the admin account through the real `/setup` POST flow.
+async fn create_admin(router: &Router, email: &str, password: &str) {
+    let (token, cookie) = fetch_csrf(router, "/setup").await;
+    let body = format!(
+        "email={}&password={}&csrf_token={}",
+        urlencoding::encode(email),
+        urlencoding::encode(password),
+        urlencoding::encode(&token),
+    );
+    let resp = router
+        .clone()
+        .oneshot(form_post("/setup", Some(&cookie), body))
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK, "setup should succeed");
+    let html = body_string(resp).await;
+    assert!(
+        html.contains("TK-"),
+        "emergency kit page should show the Secret Key"
+    );
+}
+
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn hosted_first_run_redirects_to_setup() {
+    let env = setup_env();
+    let router = hosted_router(&env);
+
+    let resp = router.clone().oneshot(get("/")).await.unwrap();
+    assert!(resp.status().is_redirection());
+    assert_eq!(location(&resp).as_deref(), Some("/setup"));
+}
+
+#[tokio::test]
+async fn hosted_unauthenticated_redirects_to_login_once_admin_exists() {
+    let env = setup_env();
+    let router = hosted_router(&env);
+    create_admin(&router, "admin@example.com", "correct horse").await;
+
+    let resp = router.clone().oneshot(get("/library")).await.unwrap();
+    assert!(resp.status().is_redirection());
+    assert_eq!(location(&resp).as_deref(), Some("/login"));
+}
+
+#[tokio::test]
+async fn setup_rejects_second_admin() {
+    let env = setup_env();
+    let router = hosted_router(&env);
+    create_admin(&router, "admin@example.com", "correct horse").await;
+
+    // GET /setup now bounces to /login.
+    let resp = router.clone().oneshot(get("/setup")).await.unwrap();
+    assert!(resp.status().is_redirection());
+    assert_eq!(location(&resp).as_deref(), Some("/login"));
+
+    // POST /setup is refused even with a valid CSRF token.
+    let (token, cookie) = fetch_csrf(&router, "/login").await;
+    let body = format!(
+        "email=second%40example.com&password=another+password&csrf_token={}",
+        urlencoding::encode(&token),
+    );
+    let resp = router
+        .clone()
+        .oneshot(form_post("/setup", Some(&cookie), body))
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let html = body_string(resp).await;
+    assert!(
+        html.contains("already exists"),
+        "second setup should report an existing admin, got: {html}"
+    );
+}
+
+#[tokio::test]
+async fn valid_login_sets_session_and_grants_access() {
+    let env = setup_env();
+    let router = hosted_router(&env);
+    create_admin(&router, "admin@example.com", "correct horse").await;
+
+    let (token, cookie) = fetch_csrf(&router, "/login").await;
+    let body = format!(
+        "email=admin%40example.com&password=correct+horse&csrf_token={}",
+        urlencoding::encode(&token),
+    );
+    let resp = router
+        .clone()
+        .oneshot(form_post("/login", Some(&cookie), body))
+        .await
+        .unwrap();
+    assert!(resp.status().is_redirection());
+    assert_eq!(location(&resp).as_deref(), Some("/library"));
+
+    let session = cookie_value(&resp, "toku_session").expect("session cookie set on login");
+    assert!(!session.is_empty());
+
+    // The session cookie now grants access to a gated route.
+    let resp = router
+        .clone()
+        .oneshot(get_with_cookie(
+            "/library",
+            &format!("toku_session={session}"),
+        ))
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+}
+
+#[tokio::test]
+async fn invalid_password_is_rejected() {
+    let env = setup_env();
+    let router = hosted_router(&env);
+    create_admin(&router, "admin@example.com", "correct horse").await;
+
+    let (token, cookie) = fetch_csrf(&router, "/login").await;
+    let body = format!(
+        "email=admin%40example.com&password=wrong+password&csrf_token={}",
+        urlencoding::encode(&token),
+    );
+    let resp = router
+        .clone()
+        .oneshot(form_post("/login", Some(&cookie), body))
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    assert!(cookie_value(&resp, "toku_session").is_none());
+    let html = body_string(resp).await;
+    assert!(html.contains("Invalid email or password"));
+}
+
+#[tokio::test]
+async fn session_fixation_token_changes_on_login() {
+    let env = setup_env();
+    let router = hosted_router(&env);
+    create_admin(&router, "admin@example.com", "correct horse").await;
+
+    // Attacker-supplied session cookie value that is not a valid session.
+    let planted = "attacker-fixed-token";
+
+    let (token, csrf_cookie) = fetch_csrf(&router, "/login").await;
+    // Send both the CSRF cookie and the planted session cookie.
+    let cookie = format!("{csrf_cookie}; toku_session={planted}");
+    let body = format!(
+        "email=admin%40example.com&password=correct+horse&csrf_token={}",
+        urlencoding::encode(&token),
+    );
+    let resp = router
+        .clone()
+        .oneshot(form_post("/login", Some(&cookie), body))
+        .await
+        .unwrap();
+
+    let issued = cookie_value(&resp, "toku_session").expect("fresh session issued");
+    assert_ne!(
+        issued, planted,
+        "login must mint a brand-new token, never reuse a pre-auth one"
+    );
+}
+
+#[tokio::test]
+async fn csrf_missing_token_is_forbidden() {
+    let env = setup_env();
+    let router = hosted_router(&env);
+    create_admin(&router, "admin@example.com", "correct horse").await;
+
+    // POST with no CSRF cookie/token at all.
+    let body = "email=admin%40example.com&password=correct+horse".to_string();
+    let resp = router
+        .clone()
+        .oneshot(form_post("/login", None, body))
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+}
+
+#[tokio::test]
+async fn csrf_bad_token_is_forbidden() {
+    let env = setup_env();
+    let router = hosted_router(&env);
+    create_admin(&router, "admin@example.com", "correct horse").await;
+
+    let (_token, cookie) = fetch_csrf(&router, "/login").await;
+    // Submit a token that does not match the cookie.
+    let body = "email=admin%40example.com&password=correct+horse&csrf_token=not-the-real-token"
+        .to_string();
+    let resp = router
+        .clone()
+        .oneshot(form_post("/login", Some(&cookie), body))
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+}
+
+#[tokio::test]
+async fn lockout_after_repeated_failures() {
+    let env = setup_env();
+    let router = hosted_router(&env);
+    create_admin(&router, "admin@example.com", "correct horse").await;
+
+    // Five wrong attempts trip the lockout threshold.
+    for _ in 0..5 {
+        let (token, cookie) = fetch_csrf(&router, "/login").await;
+        let body = format!(
+            "email=admin%40example.com&password=wrong&csrf_token={}",
+            urlencoding::encode(&token),
+        );
+        let _ = router
+            .clone()
+            .oneshot(form_post("/login", Some(&cookie), body))
+            .await
+            .unwrap();
+    }
+
+    // Even the correct password is now refused with the lockout message.
+    let (token, cookie) = fetch_csrf(&router, "/login").await;
+    let body = format!(
+        "email=admin%40example.com&password=correct+horse&csrf_token={}",
+        urlencoding::encode(&token),
+    );
+    let resp = router
+        .clone()
+        .oneshot(form_post("/login", Some(&cookie), body))
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    assert!(cookie_value(&resp, "toku_session").is_none());
+    let html = body_string(resp).await;
+    assert!(
+        html.contains("Too many failed attempts"),
+        "expected lockout message, got: {html}"
+    );
+}
+
+#[tokio::test]
+async fn logout_clears_session() {
+    let env = setup_env();
+    let router = hosted_router(&env);
+    create_admin(&router, "admin@example.com", "correct horse").await;
+
+    let (token, cookie) = fetch_csrf(&router, "/login").await;
+    let body = format!(
+        "email=admin%40example.com&password=correct+horse&csrf_token={}",
+        urlencoding::encode(&token),
+    );
+    let resp = router
+        .clone()
+        .oneshot(form_post("/login", Some(&cookie), body))
+        .await
+        .unwrap();
+    let session = cookie_value(&resp, "toku_session").expect("session cookie");
+
+    // Logout invalidates the session server-side.
+    let resp = router
+        .clone()
+        .oneshot(get_with_cookie(
+            "/logout",
+            &format!("toku_session={session}"),
+        ))
+        .await
+        .unwrap();
+    assert!(resp.status().is_redirection());
+
+    // The old token no longer grants access.
+    let resp = router
+        .clone()
+        .oneshot(get_with_cookie(
+            "/library",
+            &format!("toku_session={session}"),
+        ))
+        .await
+        .unwrap();
+    assert!(resp.status().is_redirection());
+    assert_eq!(location(&resp).as_deref(), Some("/login"));
+}
+
+#[tokio::test]
+async fn healthz_is_public_in_hosted_mode() {
+    let env = setup_env();
+    let router = hosted_router(&env);
+    let resp = router.clone().oneshot(get("/healthz")).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+}
+
+// ---------------------------------------------------------------------------
+// Local mode keeps the historical no-auth behaviour.
+
+#[tokio::test]
+async fn local_mode_requires_no_auth() {
+    let env = setup_env();
+    let router = local_router(&env);
+
+    let resp = router.clone().oneshot(get("/library")).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    // No auth cookies are ever issued in local mode.
+    let resp = router.clone().oneshot(get("/")).await.unwrap();
+    assert!(cookie_value(&resp, "toku_csrf").is_none());
+    assert!(cookie_value(&resp, "toku_session").is_none());
+}
+
+#[tokio::test]
+async fn local_mode_has_no_login_route() {
+    let env = setup_env();
+    let router = local_router(&env);
+    // /login is only mounted in hosted mode.
+    let resp = router.clone().oneshot(get("/login")).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+}

--- a/docs/web-auth.md
+++ b/docs/web-auth.md
@@ -1,0 +1,103 @@
+# Web dashboard authentication
+
+`toku serve` starts the Toku web dashboard. It runs in one of two modes:
+
+- **Local mode** (default) — no authentication, loopback-only. This preserves the historical
+  single-user behaviour: the dashboard renders your local SQLite library directly for one
+  trusted user on their own machine.
+- **Hosted mode** (`--hosted`) — every route is gated behind a cookie session, so you can expose
+  the dashboard on a network (a home server, a LAN, behind a reverse proxy) without leaving your
+  library open to anyone who can reach the port.
+
+Hosted-mode auth is **self-contained**: the admin account and sessions live in your local
+`toku.db`, so the dashboard does not depend on a running `toku-sync` server. (Forward-compatible:
+the session layer stays in place if the web tier later federates to a sync server over REST.)
+
+## Local mode (default)
+
+```bash
+toku serve
+# Dashboard on http://127.0.0.1:3000 — no login, loopback only.
+```
+
+Local mode refuses to bind a non-loopback host. If you pass `--host 0.0.0.0` without `--hosted`,
+the server exits with an error rather than silently exposing an unauthenticated dashboard. Use
+hosted mode for network access.
+
+## Hosted mode
+
+```bash
+toku serve --hosted --host 0.0.0.0 --port 3000
+```
+
+Flags / environment variables:
+
+| Flag | Env | Effect |
+| --- | --- | --- |
+| `--hosted` | `TOKU_WEB_HOSTED=1` | Enable authentication and allow non-loopback binds. |
+| `--insecure-cookies` | `TOKU_WEB_INSECURE_COOKIES=1` | Drop the `Secure` attribute on auth cookies (for local HTTP testing only — **never** in production). |
+
+In hosted mode, auth cookies are marked `Secure` by default, so the dashboard expects to be
+served over HTTPS (terminate TLS at a reverse proxy such as Caddy, nginx, or Traefik). Only use
+`--insecure-cookies` for plain-HTTP testing on `localhost`.
+
+### First-run onboarding
+
+On first run there is no admin account, so every request is redirected to `/setup`. The setup
+form asks for an email and a password and then:
+
+1. generates a **Secret Key** and derives the account key hierarchy (per
+   [ADR-010](./adr/010-self-host-auth.md)), and
+2. stores an SRP verifier (not the password) plus the wrapped keys as the `admin` account.
+
+The **Emergency Kit** (your email + Secret Key) is shown **once**, immediately after setup. Save
+it — print it or store it in a password manager. It cannot be recovered: if you lose both your
+password and your Secret Key, the account cannot be unlocked. See [recovery](./recovery.md).
+
+Once an admin exists, `/setup` redirects to `/login` and a second admin cannot be created through
+it.
+
+### Login, sessions, and lockout
+
+`/login` accepts the admin email and password over TLS. The server recomputes the SRP verifier
+and compares it to the stored verifier in constant time. On success it mints a **fresh** session
+token (so a pre-authentication cookie is never reused — session-fixation safe) and sets an
+`HttpOnly`, `SameSite=Lax` session cookie. Sessions last 24 hours.
+
+After 5 failed attempts the account locks for 15 minutes; correct credentials are refused with a
+lockout message until the window passes.
+
+Sign out from the header link (or `POST /logout`), which deletes the session server-side and
+clears the cookie.
+
+### CSRF protection
+
+All state-changing requests in hosted mode are protected with a double-submit CSRF token: a
+`toku_csrf` cookie plus a matching hidden form field (`csrf_token`) on every form. File uploads
+(multipart) carry the token as a `?csrf=` query parameter instead. Mismatched or missing tokens
+are rejected with `403`. The `SameSite=Lax` session cookie is an additional CSRF defence.
+
+### Health check
+
+`GET /healthz` is unauthenticated in both modes, for container/orchestration liveness probes.
+
+## Trusted-server trade-off (threat model)
+
+> **Important.** In hosted mode the dashboard renders **server-side HTML from your decrypted
+> local library**, so the server process necessarily holds plaintext, and login sends your
+> password to the server (over TLS) to be verified.
+
+This is the **trusted-server** posture. The zero-knowledge guarantees of
+[ADR-010](./adr/010-self-host-auth.md) apply to the `toku-sync` *relay* (which only ever sees
+end-to-end-encrypted operations), **not** to a dashboard you intentionally point at your own
+decrypted library. True in-browser, zero-knowledge unlock (client-side WASM crypto with the
+server never seeing plaintext) is **out of scope** for the initial hosted dashboard and is
+tracked for the threat-model work in issue #125.
+
+Practical guidance:
+
+- Run hosted mode only on hardware you trust, behind TLS.
+- Treat the host as a trusted tier: anyone with root on the box, or the ability to read process
+  memory, can read your library regardless of the login gate.
+- Keep the dashboard off the public internet unless you have a specific reason and additional
+  controls (VPN, authenticating reverse proxy, etc.).


### PR DESCRIPTION
## Description

Adds first-run onboarding and session authentication to the `toku serve` web dashboard (Issue #122), implemented as **self-contained web-tier auth** backed by the local `toku.db` (no dependency on a running `toku-sync`).

`toku serve` now runs in one of two modes:

- **Local** (default, unchanged): no authentication, binds loopback only, and refuses non-loopback hosts — preserving the historical single-user posture.
- **Hosted** (`--hosted`): every route is gated behind a cookie session, so the dashboard can be safely exposed on a network.

**What's included:**

- `WebMode {Local, Hosted}` config; CLI flags `--hosted` (`TOKU_WEB_HOSTED`) and `--insecure-cookies` (`TOKU_WEB_INSECURE_COOKIES`, plain-HTTP testing only).
- Refinery migration `V16__web_auth.sql` adding `web_users` + `web_sessions` to `toku.db` (single migration/backup story).
- First-run `/setup` onboarding: generates a Secret Key + account key hierarchy, stores an SRP verifier (never the password), and shows the **Emergency Kit once**. A second admin is refused.
- `/login`: server recomputes the SRP verifier and constant-time-compares it; mints a **fresh** session token on success (session-fixation safe); `HttpOnly`/`SameSite=Lax`/`Secure` cookie; 24h TTL; account lockout after 5 failures for 15 minutes.
- CSRF double-submit protection on all state-changing routes (threaded through existing import + conflict forms; multipart uploads via `?csrf=`). `/healthz` stays public.
- maud views for login / setup / emergency-kit; "Sign out" affordance in hosted mode.
- Full integration test suite (`crates/toku-web/tests/auth.rs`, 13 tests) covering every acceptance criterion.
- Docs: new `docs/web-auth.md` (local vs hosted, onboarding, lockout, CSRF) + README pointer.

**Trusted-server trade-off:** in hosted mode the dashboard renders your decrypted library server-side, so the server holds plaintext and verifies your password. This is the trusted-server posture — distinct from the zero-knowledge sync relay. In-browser zero-knowledge unlock is intentionally out of scope here and is flagged for the threat-model work in #125. Documented in `docs/web-auth.md`.

**New dependencies** (flagged for review): `axum-extra` (cookie), `srp 0.7.0-rc.3` (same crate/version already used by `toku-sync`), `subtle`, `time`, `base64`, `hex`, `rand`, `form_urlencoded`; dev-deps `tower` (util), `http-body-util`, `tempfile`.

**CI / Terraform:** no CI gate jobs were added or renamed, so no change to `kafkade/github-infra` `repo_toku.tf` is required.

## Related Issues

Closes #122. Relates to #125 (threat model — trusted-server trade-off flagged).

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI / infrastructure
- [ ] Other (describe below)

## Crate

- [ ] `toku-core` — Domain models, traits, state machine
- [x] `toku-db` — SQLite persistence, migrations, FTS5
- [ ] `toku-import` — Importers (Goodreads, Calibre, StoryGraph)
- [ ] `toku-meta` — Metadata fetching (Open Library, Google Books)
- [x] `toku-cli` — CLI binary
- [ ] `toku-export` — Exporters (CSV, JSON, Markdown, BibTeX)
- [x] `docs/` — Documentation
- [x] `toku-web` — Web dashboard (hosted-mode auth)

## Data Integrity Checklist

- [x] No user data is sent to any server without explicit opt-in
- [ ] Import operations are idempotent (re-importing the same file creates no duplicates)
- [ ] User edits to metadata are never overwritten by auto-enrichment
- [ ] New fields track provenance (source + timestamp)
- [ ] Export round-trip is preserved (if applicable)

## Checklist

- [x] I have read [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] `cargo fmt --check` passes
- [x] `cargo clippy --workspace -- -D warnings` passes
- [x] `cargo test --workspace` passes
- [x] I have updated documentation (if applicable)
