### PR TITLE
feat: add account signup/login/enroll to toku sync CLI (#123)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Account-based sync CLI: `toku sync signup`, `toku sync login`, and
+  `toku sync enroll` bring the 1Password-style two-secret flow to the command
+  line. `signup` creates an account, generates the device Secret Key, renders the
+  Emergency Kit once (printed, or written with `--kit-out` as `.pdf`/`.html`/text),
+  and enrolls the first device as admin in one step. `login` re-authenticates an
+  already-enrolled device; `enroll` joins an existing account from a new device,
+  recovering the shared library data key the zero-knowledge way (SRP login → fetch
+  the wrapped key bundle → unwrap the same `SyncKey` locally). The account password
+  and Secret Key are read with non-echoing prompts and never appear in argv or
+  shell history, and the Secret Key is never written to disk. `toku sync devices`
+  now lists your account's devices across the account when you are logged in
+- Account-aware `toku-sync-client`: account signup/challenge/verify, device
+  enrollment, account-scoped device listing/removal, and account key-bundle
+  retrieval, with a separate account (user) session stored alongside the
+  per-device sync token
+
 - Account **Secret Key** + **Emergency Kit** for zero-knowledge sync (1Password-style
   two-secret model). A high-entropy 128-bit Secret Key is generated on-device, formatted
   for transcription with a `TK` version prefix and a checksum that catches typos
@@ -176,6 +192,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `toku sync push`, `pull`, `devices`, `rekey`, and `compact` no longer require `--server` flag — server URL is read from sync config
 - `toku sync logout` replaced by `toku sync disable` which also clears sync config
 - iOS and iPad app now displays as `toku` (lowercase) on the home screen
+
+### Deprecated
+
+- `toku sync init` and its `--passphrase` flag are deprecated in favor of
+  `toku sync signup` (new account) and `toku sync login` / `toku sync enroll`
+  (account + Secret Key auth). `init` still works and prints a notice pointing to
+  the account commands
 
 ### Removed
 

--- a/crates/toku-cli/src/main.rs
+++ b/crates/toku-cli/src/main.rs
@@ -566,7 +566,7 @@ enum ExportTarget {
 
 #[derive(Clone, Subcommand)]
 enum SyncAction {
-    /// Set up sync for the first time
+    /// [Deprecated] Set up sync with a per-library passphrase. Prefer `signup`/`login`.
     Init {
         /// Sync server URL (default: http://localhost:8080)
         #[arg(long, default_value = "http://localhost:8080")]
@@ -585,6 +585,56 @@ enum SyncAction {
         /// compatibility and has no effect.
         #[arg(long, hide = true)]
         passphrase: bool,
+    },
+
+    /// Create an account on a sync server (generates your Secret Key + Emergency Kit)
+    Signup {
+        /// Sync server URL (default: http://localhost:8080)
+        #[arg(long, default_value = "http://localhost:8080")]
+        server: String,
+
+        /// Account email
+        #[arg(long)]
+        email: Option<String>,
+
+        /// Name for this device (defaults to hostname)
+        #[arg(long)]
+        device_name: Option<String>,
+
+        /// Write the Emergency Kit to a file (PDF if the path ends in .pdf,
+        /// HTML for .html, otherwise plain text). Defaults to printing the kit.
+        #[arg(long)]
+        kit_out: Option<PathBuf>,
+    },
+
+    /// Log in to your account on this (already-enrolled) device
+    Login {
+        /// Sync server URL (default: http://localhost:8080)
+        #[arg(long, default_value = "http://localhost:8080")]
+        server: String,
+
+        /// Account email
+        #[arg(long)]
+        email: Option<String>,
+    },
+
+    /// Enroll this new device into an existing account (password + Secret Key)
+    Enroll {
+        /// Sync server URL (default: http://localhost:8080)
+        #[arg(long, default_value = "http://localhost:8080")]
+        server: String,
+
+        /// Account email
+        #[arg(long)]
+        email: Option<String>,
+
+        /// Existing library ID to join (omit to create a fresh library)
+        #[arg(long)]
+        library_id: Option<String>,
+
+        /// Name for this device (defaults to hostname)
+        #[arg(long)]
+        device_name: Option<String>,
     },
 
     /// Show sync status
@@ -3179,6 +3229,59 @@ fn prompt_line(prompt: &str) -> Result<String> {
     Ok(buf.trim().to_string())
 }
 
+/// Read a secret without echoing it, keeping it out of shell history/argv.
+fn read_password_prompt(prompt: &str) -> Result<String> {
+    eprint!("{prompt}");
+    rpassword::read_password().context("failed to read password")
+}
+
+/// Read a new password twice (with confirmation), rejecting empties/mismatches.
+fn read_new_password() -> Result<String> {
+    let password = read_password_prompt("Account password: ")?;
+    if password.is_empty() {
+        anyhow::bail!("password cannot be empty");
+    }
+    let confirm = read_password_prompt("Confirm password: ")?;
+    if password != confirm {
+        anyhow::bail!("passwords do not match");
+    }
+    Ok(password)
+}
+
+/// Read and validate a Secret Key without echoing it.
+fn read_secret_key() -> Result<toku_core::SecretKey> {
+    let raw = read_password_prompt("Secret Key: ")?;
+    toku_core::SecretKey::parse(&raw).map_err(|e| anyhow::anyhow!("invalid Secret Key: {e}"))
+}
+
+/// Render an Emergency Kit, choosing the format from the output path's extension
+/// (`.pdf`/`.html`, else text). With no path the plain-text kit is printed.
+fn render_emergency_kit(kit: &toku_core::EmergencyKit, out: Option<&Path>) -> Result<()> {
+    match out {
+        None => {
+            eprintln!();
+            eprintln!("{}", kit.to_text());
+            Ok(())
+        }
+        Some(path) => {
+            let ext = path
+                .extension()
+                .and_then(|e| e.to_str())
+                .map(|e| e.to_ascii_lowercase())
+                .unwrap_or_default();
+            let bytes = match ext.as_str() {
+                "pdf" => account::render_pdf(kit)?,
+                "html" => kit.to_html().into_bytes(),
+                _ => kit.to_text().into_bytes(),
+            };
+            std::fs::write(path, &bytes)
+                .with_context(|| format!("failed to write {}", path.display()))?;
+            eprintln!("Emergency Kit written to {}", path.display());
+            Ok(())
+        }
+    }
+}
+
 fn cmd_sync(data_dir: &Path, action: SyncAction, output_format: &OutputFormat) -> Result<()> {
     let rt = tokio::runtime::Builder::new_multi_thread()
         .enable_all()
@@ -3214,6 +3317,12 @@ fn cmd_sync(data_dir: &Path, action: SyncAction, output_format: &OutputFormat) -
             // (zero-knowledge, issue #121): always prompt for a passphrase.
             // The legacy `--passphrase` flag is accepted but no longer required.
             let _ = passphrase;
+            eprintln!(
+                "note: `toku sync init` is deprecated. Prefer `toku sync signup` (new account)"
+            );
+            eprintln!(
+                "      or `toku sync login` / `toku sync enroll` (account + Secret Key auth)."
+            );
             eprintln!(
                 "Hosted sync uses zero-knowledge encryption. Choose a passphrase to protect your library."
             );
@@ -3277,6 +3386,168 @@ fn cmd_sync(data_dir: &Path, action: SyncAction, output_format: &OutputFormat) -
                             "disabled"
                         }
                     );
+                }
+            }
+            Ok(())
+        }
+
+        SyncAction::Signup {
+            server,
+            email,
+            device_name,
+            kit_out,
+        } => {
+            let email = match email {
+                Some(e) => e,
+                None => prompt_line("Account email: ")?,
+            };
+
+            eprintln!("Choose an account password. It is never sent to the server.");
+            let password = read_new_password()?;
+
+            // Generate the high-entropy Secret Key on this device.
+            let secret_key = toku_core::SecretKey::generate()
+                .map_err(|e| anyhow::anyhow!("failed to generate Secret Key: {e}"))?;
+
+            let outcome = sync::orchestrator::signup(
+                data_dir,
+                &server,
+                &email,
+                &password,
+                &secret_key,
+                device_name,
+            )?;
+
+            // Render the Emergency Kit exactly once.
+            let kit = toku_core::EmergencyKit::new(
+                outcome.email.clone(),
+                Some(outcome.server.clone()),
+                outcome.secret_key.clone(),
+            );
+            render_emergency_kit(&kit, kit_out.as_deref())?;
+
+            match output_format {
+                OutputFormat::Json => {
+                    println!(
+                        "{}",
+                        serde_json::to_string_pretty(&serde_json::json!({
+                            "user_id": outcome.user_id,
+                            "email": outcome.email,
+                            "role": outcome.role,
+                            "device_id": outcome.device_id,
+                            "library_id": outcome.library_id,
+                            "device_name": outcome.device_name,
+                            "server": outcome.server,
+                            "device_status": outcome.device_status,
+                            "secret_key": outcome.secret_key,
+                        }))?
+                    );
+                }
+                _ => {
+                    eprintln!();
+                    eprintln!("Account created on {}", outcome.server);
+                    eprintln!("  Email:   {}", outcome.email);
+                    eprintln!("  Role:    {}", outcome.role);
+                    eprintln!(
+                        "  Device:  {} ({}, {})",
+                        outcome.device_name, outcome.device_id, outcome.device_status
+                    );
+                    eprintln!("  Library: {}", outcome.library_id);
+                    eprintln!();
+                    eprintln!("⚠  Your Secret Key is shown only once:");
+                    eprintln!("     {}", outcome.secret_key);
+                    eprintln!("   Store the Emergency Kit offline. It cannot be recovered.");
+                }
+            }
+            Ok(())
+        }
+
+        SyncAction::Login { server, email } => {
+            let email = match email {
+                Some(e) => e,
+                None => prompt_line("Account email: ")?,
+            };
+            let password = read_password_prompt("Account password: ")?;
+            let secret_key = read_secret_key()?;
+
+            let outcome =
+                sync::orchestrator::login(data_dir, &server, &email, &password, &secret_key)?;
+
+            match output_format {
+                OutputFormat::Json => {
+                    println!(
+                        "{}",
+                        serde_json::to_string_pretty(&serde_json::json!({
+                            "user_id": outcome.user_id,
+                            "email": outcome.email,
+                            "role": outcome.role,
+                            "server": outcome.server,
+                            "data_key_unlocked": outcome.data_key_unlocked,
+                        }))?
+                    );
+                }
+                _ => {
+                    eprintln!("Logged in to {} as {}", outcome.server, outcome.email);
+                    if !outcome.data_key_unlocked {
+                        eprintln!(
+                            "note: the encryption key was not unlocked (the server's account-keys \
+                             endpoint is unavailable). Sync of encrypted data may not work yet."
+                        );
+                    }
+                }
+            }
+            Ok(())
+        }
+
+        SyncAction::Enroll {
+            server,
+            email,
+            library_id,
+            device_name,
+        } => {
+            let email = match email {
+                Some(e) => e,
+                None => prompt_line("Account email: ")?,
+            };
+            let password = read_password_prompt("Account password: ")?;
+            let secret_key = read_secret_key()?;
+
+            let outcome = sync::orchestrator::enroll(
+                data_dir,
+                &server,
+                &email,
+                &password,
+                &secret_key,
+                device_name,
+                library_id,
+            )?;
+
+            match output_format {
+                OutputFormat::Json => {
+                    println!(
+                        "{}",
+                        serde_json::to_string_pretty(&serde_json::json!({
+                            "user_id": outcome.user_id,
+                            "email": outcome.email,
+                            "device_id": outcome.device_id,
+                            "library_id": outcome.library_id,
+                            "device_name": outcome.device_name,
+                            "server": outcome.server,
+                            "device_status": outcome.device_status,
+                        }))?
+                    );
+                }
+                _ => {
+                    eprintln!(
+                        "Enrolled device {} ({}) into library {}",
+                        outcome.device_name, outcome.device_id, outcome.library_id
+                    );
+                    if outcome.device_status == "pending" {
+                        eprintln!(
+                            "This device is pending approval by an existing trusted device. \
+                             Once approved, run `toku sync login` to activate it."
+                        );
+                    }
                 }
             }
             Ok(())
@@ -3432,6 +3703,69 @@ fn cmd_sync(data_dir: &Path, action: SyncAction, output_format: &OutputFormat) -
         }
 
         SyncAction::Devices => {
+            // Prefer the authenticated, user-scoped listing when logged in;
+            // fall back to the library-scoped device list otherwise.
+            let user_session = config.sync.as_ref().and_then(|sc| {
+                token_store
+                    .load_user_session(&sc.server)
+                    .ok()
+                    .flatten()
+                    .map(|t| (sc.server.clone(), t))
+            });
+
+            if let Some((server, _)) = user_session {
+                let devices = sync::orchestrator::account_devices(data_dir, &server)?;
+                match output_format {
+                    OutputFormat::Json => println!("{}", serde_json::to_string_pretty(&devices)?),
+                    OutputFormat::Csv => {
+                        println!("device_id,device_name,status,library_id,last_seen,created_at");
+                        for d in &devices {
+                            println!(
+                                "{},{},{},{},{},{}",
+                                d.device_id,
+                                d.device_name,
+                                d.status,
+                                d.library_id,
+                                d.last_seen.as_deref().unwrap_or(""),
+                                d.created_at
+                            );
+                        }
+                    }
+                    OutputFormat::Table => {
+                        if devices.is_empty() {
+                            eprintln!("No devices registered.");
+                            return Ok(());
+                        }
+                        use tabled::{Table, Tabled};
+                        #[derive(Tabled)]
+                        struct Row {
+                            #[tabled(rename = "Device ID")]
+                            id: String,
+                            #[tabled(rename = "Name")]
+                            name: String,
+                            #[tabled(rename = "Status")]
+                            status: String,
+                            #[tabled(rename = "Last Seen")]
+                            last_seen: String,
+                            #[tabled(rename = "Registered")]
+                            created: String,
+                        }
+                        let rows: Vec<Row> = devices
+                            .iter()
+                            .map(|d| Row {
+                                id: d.device_id.clone(),
+                                name: d.device_name.clone(),
+                                status: d.status.clone(),
+                                last_seen: d.last_seen.clone().unwrap_or_else(|| "n/a".into()),
+                                created: d.created_at.clone(),
+                            })
+                            .collect();
+                        println!("{}", Table::new(rows));
+                    }
+                }
+                return Ok(());
+            }
+
             let devices = sync::orchestrator::devices(data_dir)?;
 
             match output_format {
@@ -3512,6 +3846,7 @@ fn cmd_sync(data_dir: &Path, action: SyncAction, output_format: &OutputFormat) -
             let server = &sync_config.server;
             let _ = token_store.delete(server);
             let _ = token_store.delete_sync_key(server);
+            let _ = token_store.delete_user_session(server);
 
             let mut config = config;
             config.sync = None;

--- a/crates/toku-sync-client/src/client.rs
+++ b/crates/toku-sync-client/src/client.rs
@@ -52,6 +52,92 @@ pub struct DeviceInfo {
     pub created_at: String,
 }
 
+// ── Account (1Password-style) auth DTOs ──────────────────────────────────────
+
+/// Response from `POST /api/v1/account/signup`.
+#[derive(Debug, Deserialize)]
+pub struct SignupResult {
+    pub user_id: String,
+    pub email: String,
+    pub role: String,
+}
+
+/// Response from `POST /api/v1/account/challenge`.
+#[derive(Debug, Deserialize)]
+pub struct AccountChallengeResult {
+    pub challenge_id: String,
+    /// Hex-encoded server public ephemeral B.
+    pub server_public_b: String,
+    /// Hex-encoded SRP salt stored at signup.
+    pub srp_salt: String,
+}
+
+/// Response from `POST /api/v1/account/verify` — a user-session token.
+#[derive(Debug, Deserialize)]
+pub struct AccountVerifyResult {
+    pub session_token: String,
+    /// Hex-encoded server proof M2 — the client MUST verify this.
+    pub server_proof_m2: String,
+    pub expires_at: String,
+    pub user_id: String,
+    pub role: String,
+}
+
+/// Response from `POST /api/v1/devices/enroll`.
+#[derive(Debug, Deserialize)]
+pub struct EnrollDeviceResult {
+    pub device_id: String,
+    pub library_id: String,
+    /// `"active"` (ready to sync) or `"pending"` (awaiting approval).
+    pub status: String,
+    pub session_token: Option<String>,
+    pub expires_at: Option<String>,
+}
+
+/// Response from `POST /api/v1/devices/{id}/session`.
+#[derive(Debug, Deserialize)]
+pub struct DeviceSessionResult {
+    pub device_id: String,
+    pub library_id: String,
+    pub session_token: String,
+    pub expires_at: String,
+}
+
+/// A device as exposed to its owning account (`GET /api/v1/account/devices`).
+#[derive(Debug, Deserialize, Serialize)]
+pub struct AccountDeviceInfo {
+    pub device_id: String,
+    pub library_id: String,
+    pub device_name: String,
+    pub status: String,
+    pub last_seen: Option<String>,
+    pub created_at: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct AccountDeviceListBody {
+    devices: Vec<AccountDeviceInfo>,
+}
+
+/// The account key bundle returned by `GET /api/v1/account/keys`.
+///
+/// **Contract is owned by issue #143** (persist `wrapped_data_key` + expose this
+/// endpoint). Until that lands the endpoint does not exist server-side and these
+/// calls will fail at runtime; the field names below are this client's assumed
+/// contract and must be reconciled with #143 when it is finalized. Each field is
+/// an opaque string the client deserializes back into the `toku_core` key types.
+#[derive(Debug, Deserialize)]
+pub struct AccountKeyBundle {
+    /// JSON-serialized `toku_core::AccountKdfParams`.
+    pub kdf_params: String,
+    /// Base64 account X25519 public key (`AccountKeys::public_key`).
+    pub account_public_key: String,
+    /// JSON-serialized `toku_core::WrappedAccountPrivateKey`.
+    pub wrapped_private_key: String,
+    /// JSON-serialized `toku_core::WrappedDataKey`.
+    pub wrapped_data_key: String,
+}
+
 /// Wire format for a sync op (matches server's OpPayload).
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct WireOp {
@@ -247,6 +333,216 @@ impl SyncClient {
         }
 
         Ok(resp.json().await?)
+    }
+
+    // ── Account (1Password-style) auth ───────────────────────────────────────
+
+    /// Create an account on the server (`POST /api/v1/account/signup`).
+    ///
+    /// The SRP identity is the account `email`; only the verifier + salt are
+    /// uploaded, so the server never sees the password. The wrapped key material
+    /// is opaque to the server (zero-knowledge): it stores the strings as-is.
+    #[allow(clippy::too_many_arguments)]
+    pub async fn account_signup(
+        &self,
+        email: &str,
+        srp_salt_hex: &str,
+        srp_verifier_hex: &str,
+        wrapped_private_key: &str,
+        account_public_key: &str,
+        kdf_params: &str,
+        wrapped_data_key: &str,
+    ) -> anyhow::Result<SignupResult> {
+        let url = format!("{}/api/v1/account/signup", self.base_url);
+        let resp = self
+            .http
+            .post(&url)
+            .json(&serde_json::json!({
+                "email": email,
+                "srp_salt": srp_salt_hex,
+                "srp_verifier": srp_verifier_hex,
+                "wrapped_private_key": wrapped_private_key,
+                "account_public_key": account_public_key,
+                "kdf_params": kdf_params,
+                // Owned by issue #143; harmless extra field on older servers.
+                "wrapped_data_key": wrapped_data_key,
+            }))
+            .send()
+            .await?;
+
+        if !resp.status().is_success() {
+            return Err(extract_error(resp).await);
+        }
+
+        Ok(resp.json().await?)
+    }
+
+    /// Start an account SRP login (`POST /api/v1/account/challenge`).
+    pub async fn account_challenge(
+        &self,
+        email: &str,
+        client_public_a_hex: &str,
+    ) -> anyhow::Result<AccountChallengeResult> {
+        let url = format!("{}/api/v1/account/challenge", self.base_url);
+        let resp = self
+            .http
+            .post(&url)
+            .json(&serde_json::json!({
+                "email": email,
+                "client_public_a": client_public_a_hex,
+            }))
+            .send()
+            .await?;
+
+        if !resp.status().is_success() {
+            return Err(extract_error(resp).await);
+        }
+
+        Ok(resp.json().await?)
+    }
+
+    /// Complete an account SRP login (`POST /api/v1/account/verify`). The caller
+    /// MUST verify the returned `server_proof_m2` before trusting the token.
+    pub async fn account_verify(
+        &self,
+        challenge_id: &str,
+        client_proof_m1_hex: &str,
+    ) -> anyhow::Result<AccountVerifyResult> {
+        let url = format!("{}/api/v1/account/verify", self.base_url);
+        let resp = self
+            .http
+            .post(&url)
+            .json(&serde_json::json!({
+                "challenge_id": challenge_id,
+                "client_proof_m1": client_proof_m1_hex,
+            }))
+            .send()
+            .await?;
+
+        if !resp.status().is_success() {
+            return Err(extract_error(resp).await);
+        }
+
+        Ok(resp.json().await?)
+    }
+
+    /// Fetch the authenticated user's wrapped key bundle
+    /// (`GET /api/v1/account/keys`). **Endpoint owned by issue #143.**
+    pub async fn account_keys(&self, session_token: &str) -> anyhow::Result<AccountKeyBundle> {
+        let url = format!("{}/api/v1/account/keys", self.base_url);
+        let resp = self
+            .http
+            .get(&url)
+            .bearer_auth(session_token)
+            .send()
+            .await?;
+
+        if !resp.status().is_success() {
+            return Err(extract_error(resp).await);
+        }
+
+        Ok(resp.json().await?)
+    }
+
+    /// Enroll a device under the authenticated user (`POST /api/v1/devices/enroll`).
+    /// Requires a user-session bearer token (from the account SRP flow).
+    pub async fn enroll_device(
+        &self,
+        session_token: &str,
+        library_id: Option<&str>,
+        device_name: &str,
+        encryption_salt_b64: Option<&str>,
+        device_public_key: Option<&str>,
+    ) -> anyhow::Result<EnrollDeviceResult> {
+        let url = format!("{}/api/v1/devices/enroll", self.base_url);
+        let mut body = serde_json::json!({ "device_name": device_name });
+        if let Some(lib) = library_id {
+            body["library_id"] = serde_json::Value::String(lib.to_string());
+        }
+        if let Some(salt) = encryption_salt_b64 {
+            body["encryption_salt"] = serde_json::Value::String(salt.to_string());
+        }
+        if let Some(pk) = device_public_key {
+            body["device_public_key"] = serde_json::Value::String(pk.to_string());
+        }
+        let resp = self
+            .http
+            .post(&url)
+            .bearer_auth(session_token)
+            .json(&body)
+            .send()
+            .await?;
+
+        if !resp.status().is_success() {
+            return Err(extract_error(resp).await);
+        }
+
+        Ok(resp.json().await?)
+    }
+
+    /// Mint a fresh device-session token for an already-enrolled, active device
+    /// (`POST /api/v1/devices/{id}/session`). Requires a user-session bearer.
+    pub async fn create_device_session(
+        &self,
+        session_token: &str,
+        device_id: &str,
+    ) -> anyhow::Result<DeviceSessionResult> {
+        let url = format!("{}/api/v1/devices/{device_id}/session", self.base_url);
+        let resp = self
+            .http
+            .post(&url)
+            .bearer_auth(session_token)
+            .send()
+            .await?;
+
+        if !resp.status().is_success() {
+            return Err(extract_error(resp).await);
+        }
+
+        Ok(resp.json().await?)
+    }
+
+    /// List the authenticated user's devices (`GET /api/v1/account/devices`).
+    pub async fn list_account_devices(
+        &self,
+        session_token: &str,
+    ) -> anyhow::Result<Vec<AccountDeviceInfo>> {
+        let url = format!("{}/api/v1/account/devices", self.base_url);
+        let resp = self
+            .http
+            .get(&url)
+            .bearer_auth(session_token)
+            .send()
+            .await?;
+
+        if !resp.status().is_success() {
+            return Err(extract_error(resp).await);
+        }
+
+        let body: AccountDeviceListBody = resp.json().await?;
+        Ok(body.devices)
+    }
+
+    /// Deregister one of the authenticated user's devices
+    /// (`DELETE /api/v1/account/devices/{id}`).
+    pub async fn delete_account_device(
+        &self,
+        session_token: &str,
+        device_id: &str,
+    ) -> anyhow::Result<()> {
+        let url = format!("{}/api/v1/account/devices/{device_id}", self.base_url);
+        let resp = self
+            .http
+            .delete(&url)
+            .bearer_auth(session_token)
+            .send()
+            .await?;
+
+        if !resp.status().is_success() {
+            return Err(extract_error(resp).await);
+        }
+
+        Ok(())
     }
 
     // ── Devices ──────────────────────────────────────────────────────────────

--- a/crates/toku-sync-client/src/lib.rs
+++ b/crates/toku-sync-client/src/lib.rs
@@ -15,11 +15,13 @@ pub mod token_store;
 pub mod wire;
 
 pub use client::{
-    DeviceInfo, EnrollResponse, SrpChallengeResponse, SrpVerifyResponse, SyncClient, WireOp,
+    AccountDeviceInfo, AccountKeyBundle, DeviceInfo, EnrollResponse, SrpChallengeResponse,
+    SrpVerifyResponse, SyncClient, WireOp,
 };
 pub use orchestrator::{
-    BootstrapOutcome, InitOutcome, PullOutcome, PushOutcome, StatusOutcome, bootstrap, conflict,
-    conflicts, default_device_name, devices, init, pull, push, resolve_all_conflicts,
-    resolve_conflict, status,
+    BootstrapOutcome, EnrollOutcome, InitOutcome, LoginOutcome, PullOutcome, PushOutcome,
+    SignupOutcome, StatusOutcome, account_devices, bootstrap, conflict, conflicts,
+    default_device_name, devices, enroll, init, login, pull, push, resolve_all_conflicts,
+    resolve_conflict, signup, status,
 };
 pub use token_store::TokenStore;

--- a/crates/toku-sync-client/src/orchestrator.rs
+++ b/crates/toku-sync-client/src/orchestrator.rs
@@ -82,6 +82,48 @@ pub struct BootstrapOutcome {
     pub applied: usize,
 }
 
+/// Outcome of [`signup`].
+#[derive(Debug, Clone, Serialize)]
+pub struct SignupOutcome {
+    pub user_id: String,
+    pub email: String,
+    pub role: String,
+    pub device_id: String,
+    pub library_id: String,
+    pub device_name: String,
+    pub server: String,
+    /// Device enrollment status (`active` or `pending`).
+    pub device_status: String,
+    /// The formatted Secret Key — surfaced **once** so the caller can render an
+    /// Emergency Kit. Never persisted to disk by the orchestrator.
+    pub secret_key: String,
+}
+
+/// Outcome of [`login`].
+#[derive(Debug, Clone, Serialize)]
+pub struct LoginOutcome {
+    pub user_id: String,
+    pub email: String,
+    pub role: String,
+    pub server: String,
+    /// Whether the leaf data key was unwrapped and stored (requires the #143
+    /// `GET /api/v1/account/keys` endpoint).
+    pub data_key_unlocked: bool,
+}
+
+/// Outcome of [`enroll`].
+#[derive(Debug, Clone, Serialize)]
+pub struct EnrollOutcome {
+    pub user_id: String,
+    pub email: String,
+    pub device_id: String,
+    pub library_id: String,
+    pub device_name: String,
+    pub server: String,
+    /// `active` (synced immediately) or `pending` (awaiting approval).
+    pub device_status: String,
+}
+
 fn build_runtime() -> anyhow::Result<tokio::runtime::Runtime> {
     tokio::runtime::Builder::new_current_thread()
         .enable_all()
@@ -602,4 +644,357 @@ pub fn default_device_name() -> String {
         .ok()
         .and_then(|h| h.into_string().ok())
         .unwrap_or_else(|| "unknown-device".to_string())
+}
+
+// ── Account (1Password-style) auth flows (issue #123) ────────────────────────
+
+/// Perform an account SRP-6a login and return the verified session result.
+///
+/// The SRP identity is the account `email`; the password never leaves this
+/// machine. The server proof `M2` is verified before the session token is
+/// trusted. A wrong password surfaces here as an authentication error with no
+/// server-side disclosure of which secret was wrong.
+fn account_srp_login(
+    rt: &tokio::runtime::Runtime,
+    client: &SyncClient,
+    email: &str,
+    password: &str,
+) -> anyhow::Result<crate::client::AccountVerifyResult> {
+    use rand::RngExt;
+    use sha2::Sha256;
+    use srp::ClientG2048;
+
+    let srp_client = ClientG2048::<Sha256>::new();
+
+    let mut a = [0u8; 48];
+    rand::rng().fill(&mut a);
+    let a_pub_hex = hex::encode(srp_client.compute_public_ephemeral(&a));
+
+    let challenge = rt.block_on(client.account_challenge(email, &a_pub_hex))?;
+
+    let b_pub_bytes = hex::decode(&challenge.server_public_b)
+        .context("server returned invalid hex for server_public_b")?;
+    let srp_salt_bytes =
+        hex::decode(&challenge.srp_salt).context("server returned invalid hex for srp_salt")?;
+
+    let client_verifier = srp_client
+        .process_reply(
+            &a,
+            email.as_bytes(),
+            password.as_bytes(),
+            &srp_salt_bytes,
+            &b_pub_bytes,
+        )
+        .map_err(|_| anyhow::anyhow!("incorrect email or password"))?;
+
+    let m1_hex = hex::encode(client_verifier.proof());
+    let verify = rt.block_on(client.account_verify(&challenge.challenge_id, &m1_hex))?;
+
+    let m2_bytes = hex::decode(&verify.server_proof_m2)
+        .context("server returned invalid hex for server_proof_m2")?;
+    client_verifier
+        .verify_server(&m2_bytes)
+        .map_err(|_| anyhow::anyhow!("server identity could not be verified (SRP M2 mismatch)"))?;
+
+    Ok(verify)
+}
+
+/// Record an enrolled device + sync config locally and store the data key.
+#[allow(clippy::too_many_arguments)]
+fn finalize_device(
+    data_dir: &Path,
+    token_store: &TokenStore,
+    server: &str,
+    device_id: &str,
+    library_id: &str,
+    device_name: &str,
+    device_session: Option<&str>,
+    data_key: &SyncKey,
+) -> anyhow::Result<()> {
+    if let Some(token) = device_session {
+        // The device-session token is the primary credential for push/pull.
+        token_store
+            .store(server, token)
+            .context("failed to store device session token")?;
+    }
+    token_store
+        .store_sync_key(server, data_key.as_exported_bytes())
+        .context("failed to store sync key")?;
+
+    let db = open_db(data_dir)?;
+    let sync_repo = SyncRepository::new(&db);
+    let server_device_id = device_id
+        .parse::<uuid::Uuid>()
+        .context("server returned an invalid device_id")?;
+    sync_repo.get_or_create_device_with_id(server_device_id, device_name)?;
+
+    let mut config = toku_core::TokuConfig::load(data_dir).unwrap_or_default();
+    config.sync = Some(toku_core::SyncConfig {
+        server: server.to_string(),
+        library_id: library_id.to_string(),
+        device_id: device_id.to_string(),
+        device_name: device_name.to_string(),
+        encryption: true,
+    });
+    config
+        .save(data_dir)
+        .map_err(|e| anyhow::anyhow!("failed to save config: {e}"))?;
+    Ok(())
+}
+
+/// Reconstruct the account key hierarchy from a server key bundle and unwrap the
+/// leaf data key with the password + Secret Key.
+///
+/// A failure here (after a successful SRP login) means the Secret Key — or the
+/// password used for the key hierarchy — was wrong. The error is deliberately
+/// non-specific about which secret failed.
+fn unlock_data_key_from_bundle(
+    bundle: &crate::client::AccountKeyBundle,
+    password: &str,
+    secret_key: &toku_core::SecretKey,
+) -> anyhow::Result<SyncKey> {
+    let kdf: toku_core::AccountKdfParams =
+        serde_json::from_str(&bundle.kdf_params).context("invalid kdf_params in key bundle")?;
+    let wrapped_private_key: toku_core::WrappedAccountPrivateKey =
+        serde_json::from_str(&bundle.wrapped_private_key)
+            .context("invalid wrapped_private_key in key bundle")?;
+    let wrapped_data_key: toku_core::WrappedDataKey =
+        serde_json::from_str(&bundle.wrapped_data_key)
+            .context("invalid wrapped_data_key in key bundle")?;
+
+    let account_keys = toku_core::AccountKeys {
+        version: 1,
+        kdf,
+        public_key: bundle.account_public_key.clone(),
+        wrapped_private_key,
+        wrapped_data_key,
+    };
+
+    account_keys
+        .unlock_data_key(password, secret_key.as_bytes())
+        .map_err(|_| anyhow::anyhow!("incorrect password or Secret Key"))
+}
+
+/// Create an account on `server`, build the key hierarchy, enroll this device,
+/// and persist session + key material. Returns the formatted Secret Key so the
+/// caller can render the Emergency Kit exactly once.
+pub fn signup(
+    data_dir: &Path,
+    server: &str,
+    email: &str,
+    password: &str,
+    secret_key: &toku_core::SecretKey,
+    device_name: Option<String>,
+) -> anyhow::Result<SignupOutcome> {
+    use rand::RngExt;
+    use sha2::Sha256;
+    use srp::ClientG2048;
+
+    if password.is_empty() {
+        anyhow::bail!("password cannot be empty");
+    }
+
+    let rt = build_runtime()?;
+    let token_store = TokenStore::new(data_dir);
+    let client = SyncClient::new(server)?;
+    let device_name = device_name.unwrap_or_else(default_device_name);
+
+    // ── Build the account key hierarchy (zero-knowledge) ─────────────────────
+    let (account_keys, data_key) = toku_core::AccountKeys::create(password, secret_key.as_bytes())
+        .map_err(|e| anyhow::anyhow!("failed to build account keys: {e}"))?;
+
+    let kdf_params =
+        serde_json::to_string(&account_keys.kdf).context("failed to serialize kdf_params")?;
+    let wrapped_private_key = serde_json::to_string(&account_keys.wrapped_private_key)
+        .context("failed to serialize wrapped_private_key")?;
+    let wrapped_data_key = serde_json::to_string(&account_keys.wrapped_data_key)
+        .context("failed to serialize wrapped_data_key")?;
+
+    // ── SRP verifier (identity = email) ──────────────────────────────────────
+    let srp_client = ClientG2048::<Sha256>::new();
+    let mut srp_salt = [0u8; 16];
+    rand::rng().fill(&mut srp_salt);
+    let srp_salt_hex = hex::encode(srp_salt);
+    let srp_verifier_hex =
+        hex::encode(srp_client.compute_verifier(email.as_bytes(), password.as_bytes(), &srp_salt));
+
+    let signup = rt.block_on(client.account_signup(
+        email,
+        &srp_salt_hex,
+        &srp_verifier_hex,
+        &wrapped_private_key,
+        &account_keys.public_key,
+        &kdf_params,
+        &wrapped_data_key,
+    ))?;
+
+    // ── Log in (user session) then enroll this device ────────────────────────
+    let verify = account_srp_login(&rt, &client, email, password)?;
+    token_store.store_user_session(server, &verify.session_token, &verify.expires_at)?;
+
+    let enroll =
+        rt.block_on(client.enroll_device(&verify.session_token, None, &device_name, None, None))?;
+
+    finalize_device(
+        data_dir,
+        &token_store,
+        server,
+        &enroll.device_id,
+        &enroll.library_id,
+        &device_name,
+        enroll.session_token.as_deref(),
+        &data_key,
+    )?;
+
+    Ok(SignupOutcome {
+        user_id: signup.user_id,
+        email: signup.email,
+        role: signup.role,
+        device_id: enroll.device_id,
+        library_id: enroll.library_id,
+        device_name,
+        server: server.to_string(),
+        device_status: enroll.status,
+        secret_key: secret_key.format(),
+    })
+}
+
+/// Log in on an already-enrolled device: refresh the user session, unwrap the
+/// leaf data key (via the #143 key bundle), and refresh this device's session.
+pub fn login(
+    data_dir: &Path,
+    server: &str,
+    email: &str,
+    password: &str,
+    secret_key: &toku_core::SecretKey,
+) -> anyhow::Result<LoginOutcome> {
+    if password.is_empty() {
+        anyhow::bail!("password cannot be empty");
+    }
+
+    let rt = build_runtime()?;
+    let token_store = TokenStore::new(data_dir);
+    let client = SyncClient::new(server)?;
+
+    let verify = account_srp_login(&rt, &client, email, password)?;
+    token_store.store_user_session(server, &verify.session_token, &verify.expires_at)?;
+
+    // Unwrap and store the leaf data key. Requires the #143 endpoint; when it is
+    // unavailable we still complete the login (session is valid) but report that
+    // the data key was not unlocked so the caller can warn.
+    let mut data_key_unlocked = false;
+    match rt.block_on(client.account_keys(&verify.session_token)) {
+        Ok(bundle) => {
+            let data_key = unlock_data_key_from_bundle(&bundle, password, secret_key)?;
+            token_store
+                .store_sync_key(server, data_key.as_exported_bytes())
+                .context("failed to store sync key")?;
+            data_key_unlocked = true;
+        }
+        Err(e) => {
+            // Surface a wrong-secret error, but tolerate a missing endpoint
+            // (pre-#143 servers) so login still establishes the session.
+            let msg = e.to_string();
+            if msg.contains("incorrect password or Secret Key") {
+                return Err(e);
+            }
+        }
+    }
+
+    // Refresh this device's session token if we know our device id.
+    if let Some(sync_config) = toku_core::TokuConfig::load(data_dir)
+        .unwrap_or_default()
+        .sync
+        && sync_config.server == server
+        && !sync_config.device_id.is_empty()
+        && let Ok(session) =
+            rt.block_on(client.create_device_session(&verify.session_token, &sync_config.device_id))
+    {
+        token_store.store(server, &session.session_token)?;
+    }
+
+    Ok(LoginOutcome {
+        user_id: verify.user_id,
+        email: email.to_string(),
+        role: verify.role,
+        server: server.to_string(),
+        data_key_unlocked,
+    })
+}
+
+/// Join an existing account from a new device: SRP login, unwrap the shared data
+/// key, then enroll this device (handling the optional approval flow).
+pub fn enroll(
+    data_dir: &Path,
+    server: &str,
+    email: &str,
+    password: &str,
+    secret_key: &toku_core::SecretKey,
+    device_name: Option<String>,
+    library_id: Option<String>,
+) -> anyhow::Result<EnrollOutcome> {
+    if password.is_empty() {
+        anyhow::bail!("password cannot be empty");
+    }
+
+    let rt = build_runtime()?;
+    let token_store = TokenStore::new(data_dir);
+    let client = SyncClient::new(server)?;
+    let device_name = device_name.unwrap_or_else(default_device_name);
+
+    let verify = account_srp_login(&rt, &client, email, password)?;
+    token_store.store_user_session(server, &verify.session_token, &verify.expires_at)?;
+
+    // Recover the shared library data key the zero-knowledge way (#143).
+    let bundle = rt
+        .block_on(client.account_keys(&verify.session_token))
+        .context("could not fetch account key bundle (requires the #143 account-keys endpoint)")?;
+    let data_key = unlock_data_key_from_bundle(&bundle, password, secret_key)?;
+
+    let enroll = rt.block_on(client.enroll_device(
+        &verify.session_token,
+        library_id.as_deref(),
+        &device_name,
+        None,
+        None,
+    ))?;
+
+    // `pending` devices have no session token until an existing device approves
+    // them; we still record the device + key material so a later `login` (which
+    // mints the session via create_device_session) just works.
+    finalize_device(
+        data_dir,
+        &token_store,
+        server,
+        &enroll.device_id,
+        &enroll.library_id,
+        &device_name,
+        enroll.session_token.as_deref(),
+        &data_key,
+    )?;
+
+    Ok(EnrollOutcome {
+        user_id: verify.user_id,
+        email: email.to_string(),
+        device_id: enroll.device_id,
+        library_id: enroll.library_id,
+        device_name,
+        server: server.to_string(),
+        device_status: enroll.status,
+    })
+}
+
+/// List the authenticated user's devices (user-scoped). Requires a stored user
+/// session (from `signup`/`login`/`enroll`).
+pub fn account_devices(
+    data_dir: &Path,
+    server: &str,
+) -> anyhow::Result<Vec<crate::client::AccountDeviceInfo>> {
+    let rt = build_runtime()?;
+    let token_store = TokenStore::new(data_dir);
+    let client = SyncClient::new(server)?;
+    let session = token_store.load_user_session(server)?.ok_or_else(|| {
+        anyhow::anyhow!("not logged in to {server}. Run `toku sync login` first.")
+    })?;
+    rt.block_on(client.list_account_devices(&session))
 }

--- a/crates/toku-sync-client/src/token_store.rs
+++ b/crates/toku-sync-client/src/token_store.rs
@@ -70,6 +70,7 @@ pub struct TokenStore {
 
 const KEYRING_SERVICE: &str = "toku-sync";
 const KEYRING_SERVICE_SYNCKEY: &str = "toku-sync-key";
+const KEYRING_SERVICE_USER: &str = "toku-sync-user";
 
 impl TokenStore {
     pub fn new(data_dir: &Path) -> Self {
@@ -159,6 +160,69 @@ impl TokenStore {
 
         // Also remove from file fallback
         self.delete_file(&key)
+    }
+
+    // ── User (account) session ───────────────────────────────────────────────
+    //
+    // The account SRP login yields a *user*-session token (used for account- and
+    // admin-scoped calls such as device enrollment and the user-scoped device
+    // listing). It is stored separately from the primary *device*-session token
+    // that `store`/`load` manage for push/pull.
+
+    /// Store the account user-session token and its expiry.
+    pub fn store_user_session(
+        &self,
+        server_url: &str,
+        token: &str,
+        expires_at: &str,
+    ) -> anyhow::Result<()> {
+        let key = normalize_url(server_url);
+
+        if !keychain_disabled() {
+            ensure_keyring_store();
+            if let Ok(entry) = keyring_core::Entry::new(KEYRING_SERVICE_USER, &key)
+                && entry.set_password(token).is_ok()
+            {
+                let _ = self.store_file(&format!("{key}:usersession_expires"), expires_at);
+                return Ok(());
+            }
+        }
+
+        self.store_file(&format!("{key}:usersession"), token)?;
+        self.store_file(&format!("{key}:usersession_expires"), expires_at)
+    }
+
+    /// Load the account user-session token, if present.
+    pub fn load_user_session(&self, server_url: &str) -> anyhow::Result<Option<String>> {
+        let key = normalize_url(server_url);
+
+        if !keychain_disabled() {
+            ensure_keyring_store();
+            if let Ok(entry) = keyring_core::Entry::new(KEYRING_SERVICE_USER, &key) {
+                match entry.get_password() {
+                    Ok(token) => return Ok(Some(token)),
+                    Err(keyring_core::Error::NoEntry) => {}
+                    Err(_) => {}
+                }
+            }
+        }
+
+        self.load_file(&format!("{key}:usersession"))
+    }
+
+    /// Delete the stored account user-session token.
+    pub fn delete_user_session(&self, server_url: &str) -> anyhow::Result<()> {
+        let key = normalize_url(server_url);
+
+        if !keychain_disabled() {
+            ensure_keyring_store();
+            if let Ok(entry) = keyring_core::Entry::new(KEYRING_SERVICE_USER, &key) {
+                let _ = entry.delete_credential();
+            }
+        }
+
+        let _ = self.delete_file(&format!("{key}:usersession_expires"));
+        self.delete_file(&format!("{key}:usersession"))
     }
 
     /// Store the derived sync encryption key in the OS keychain.

--- a/crates/toku-sync/tests/cli_account_auth.rs
+++ b/crates/toku-sync/tests/cli_account_auth.rs
@@ -1,0 +1,318 @@
+//! Integration tests for the account-based CLI auth flows (issue #123).
+//!
+//! These drive the **real** `toku-sync-client` orchestrator (`signup`/`login`/
+//! `enroll`) — the logic behind `toku sync signup|login|enroll` — against a real
+//! in-process `toku-sync` server. They assert the zero-knowledge, Secret-Key
+//! gated UX:
+//!
+//! * `signup` creates an account, generates the key hierarchy, and enrolls the
+//!   first device (admin) in one shot.
+//! * The Secret Key is never written to disk (config or token store).
+//! * A wrong password is rejected client-side with no server-side disclosure.
+//! * Subsequent signups are gated by the open-registration toggle.
+//! * New-device `enroll` recovers the shared library data key the zero-knowledge
+//!   way via the #143 `GET /api/v1/account/keys` endpoint: a second device
+//!   SRP-logs-in, fetches the wrapped key bundle, and unwraps the *same* SyncKey
+//!   as the signup device (byte-for-byte), without the server ever seeing the
+//!   password or Secret Key.
+
+mod harness;
+
+use std::path::Path;
+use std::sync::Once;
+
+use harness::TestServer;
+use tempfile::TempDir;
+use toku_core::SecretKey;
+
+static INIT_ENV: Once = Once::new();
+
+/// Force the file-backed token store so tests never touch the OS keychain.
+fn use_file_token_store() {
+    INIT_ENV.call_once(|| {
+        // SAFETY: set once, before any orchestrator call spawns threads.
+        unsafe {
+            std::env::set_var("TOKU_TOKEN_STORE", "file");
+        }
+    });
+}
+
+fn data_dir() -> TempDir {
+    tempfile::tempdir().expect("create client data dir")
+}
+
+/// Recursively collect the contents of every file under `dir`.
+fn all_file_contents(dir: &Path) -> Vec<String> {
+    let mut out = Vec::new();
+    let mut stack = vec![dir.to_path_buf()];
+    while let Some(path) = stack.pop() {
+        let Ok(entries) = std::fs::read_dir(&path) else {
+            continue;
+        };
+        for entry in entries.flatten() {
+            let p = entry.path();
+            if p.is_dir() {
+                stack.push(p);
+            } else if let Ok(contents) = std::fs::read_to_string(&p) {
+                out.push(contents);
+            }
+        }
+    }
+    out
+}
+
+#[test]
+fn signup_creates_account_and_enrolls_first_device() {
+    use_file_token_store();
+    let server = TestServer::start();
+    let dir = data_dir();
+    let secret_key = SecretKey::generate().expect("generate secret key");
+
+    let outcome = toku_sync_client::signup(
+        dir.path(),
+        server.base_url(),
+        "owner@example.com",
+        "correct horse battery staple",
+        &secret_key,
+        Some("laptop".to_string()),
+    )
+    .expect("signup should succeed");
+
+    assert_eq!(outcome.email, "owner@example.com");
+    // First account on a fresh instance becomes the admin.
+    assert_eq!(outcome.role, "admin");
+    assert_eq!(outcome.device_name, "laptop");
+    assert_eq!(outcome.device_status, "active");
+    assert!(!outcome.device_id.is_empty());
+    assert!(!outcome.library_id.is_empty());
+    // The Secret Key is surfaced once for the Emergency Kit.
+    assert_eq!(outcome.secret_key, secret_key.format());
+
+    // A device-session token and sync key must be persisted for push/pull, and a
+    // user-session token for account-scoped calls.
+    let store = toku_sync_client::TokenStore::new(dir.path());
+    assert!(
+        store.load(server.base_url()).expect("load token").is_some(),
+        "device session token should be stored"
+    );
+    assert!(
+        store
+            .load_sync_key(server.base_url())
+            .expect("load sync key")
+            .is_some(),
+        "sync key should be stored"
+    );
+    assert!(
+        store
+            .load_user_session(server.base_url())
+            .expect("load user session")
+            .is_some(),
+        "user session token should be stored"
+    );
+}
+
+#[test]
+fn secret_key_is_never_persisted_to_disk() {
+    use_file_token_store();
+    let server = TestServer::start();
+    let dir = data_dir();
+    let secret_key = SecretKey::generate().expect("generate secret key");
+    let formatted = secret_key.format();
+
+    toku_sync_client::signup(
+        dir.path(),
+        server.base_url(),
+        "owner@example.com",
+        "a-strong-password",
+        &secret_key,
+        Some("laptop".to_string()),
+    )
+    .expect("signup should succeed");
+
+    // The formatted Secret Key must not appear anywhere under the data dir
+    // (config, token store, or any other artifact).
+    for contents in all_file_contents(dir.path()) {
+        assert!(
+            !contents.contains(&formatted),
+            "Secret Key must never be written to disk"
+        );
+    }
+}
+
+#[test]
+fn login_with_wrong_password_is_rejected() {
+    use_file_token_store();
+    let server = TestServer::start();
+    let dir = data_dir();
+    let secret_key = SecretKey::generate().expect("generate secret key");
+
+    toku_sync_client::signup(
+        dir.path(),
+        server.base_url(),
+        "owner@example.com",
+        "the-real-password",
+        &secret_key,
+        Some("laptop".to_string()),
+    )
+    .expect("signup should succeed");
+
+    let err = toku_sync_client::login(
+        dir.path(),
+        server.base_url(),
+        "owner@example.com",
+        "WRONG-password",
+        &secret_key,
+    )
+    .expect_err("login with wrong password must fail");
+
+    // SRP rejects the proof; the message must not disclose which secret was
+    // wrong beyond a generic credential error.
+    let msg = err.to_string().to_lowercase();
+    assert!(
+        msg.contains("incorrect email or password") || msg.contains("unauthorized"),
+        "unexpected error: {msg}"
+    );
+}
+
+#[test]
+fn login_succeeds_with_correct_credentials() {
+    use_file_token_store();
+    let server = TestServer::start();
+    let dir = data_dir();
+    let secret_key = SecretKey::generate().expect("generate secret key");
+
+    toku_sync_client::signup(
+        dir.path(),
+        server.base_url(),
+        "owner@example.com",
+        "the-real-password",
+        &secret_key,
+        Some("laptop".to_string()),
+    )
+    .expect("signup should succeed");
+
+    let outcome = toku_sync_client::login(
+        dir.path(),
+        server.base_url(),
+        "owner@example.com",
+        "the-real-password",
+        &secret_key,
+    )
+    .expect("login with correct credentials should succeed");
+
+    assert_eq!(outcome.email, "owner@example.com");
+    assert_eq!(outcome.role, "admin");
+    // With the #143 `GET /api/v1/account/keys` endpoint live, login fetches the
+    // wrapped key bundle and unwraps the leaf data key during the SRP session.
+    assert!(
+        outcome.data_key_unlocked,
+        "login should unlock the data key via the #143 account-keys endpoint"
+    );
+}
+
+#[test]
+fn second_signup_is_blocked_when_registration_is_closed() {
+    use_file_token_store();
+    let server = TestServer::start();
+    let admin_dir = data_dir();
+    let admin_key = SecretKey::generate().expect("generate secret key");
+
+    toku_sync_client::signup(
+        admin_dir.path(),
+        server.base_url(),
+        "admin@example.com",
+        "admin-password",
+        &admin_key,
+        Some("admin-laptop".to_string()),
+    )
+    .expect("first signup should succeed");
+
+    // Registration defaults to closed after the first (admin) account exists.
+    let second_dir = data_dir();
+    let second_key = SecretKey::generate().expect("generate secret key");
+    let err = toku_sync_client::signup(
+        second_dir.path(),
+        server.base_url(),
+        "intruder@example.com",
+        "another-password",
+        &second_key,
+        Some("intruder-laptop".to_string()),
+    )
+    .expect_err("second signup must be blocked when registration is closed");
+
+    let msg = err.to_string().to_lowercase();
+    assert!(
+        msg.contains("registration is closed") || msg.contains("forbidden"),
+        "unexpected error: {msg}"
+    );
+}
+
+#[test]
+fn enroll_new_device_recovers_shared_data_key() {
+    // New-device enrollment recovers the shared library data key the
+    // zero-knowledge way via `GET /api/v1/account/keys` (issue #143): the new
+    // device SRP-logs-in, fetches the wrapped key bundle, and unwraps the *same*
+    // SyncKey as the signup device — the server only ever stores ciphertext.
+    use_file_token_store();
+    let server = TestServer::start();
+    let owner_dir = data_dir();
+    let secret_key = SecretKey::generate().expect("generate secret key");
+
+    let signup = toku_sync_client::signup(
+        owner_dir.path(),
+        server.base_url(),
+        "owner@example.com",
+        "owner-password",
+        &secret_key,
+        Some("first-device".to_string()),
+    )
+    .expect("signup should succeed");
+
+    // The SyncKey the first device derived and stored locally.
+    let owner_store = toku_sync_client::TokenStore::new(owner_dir.path());
+    let owner_sync_key = owner_store
+        .load_sync_key(server.base_url())
+        .expect("load owner sync key")
+        .expect("owner sync key should be stored");
+
+    // Enroll a brand-new device into the SAME library (pass the signup device's
+    // library_id; omitting it would mint a fresh library by design — the account
+    // data key is shared either way).
+    let new_dir = data_dir();
+    let outcome = toku_sync_client::enroll(
+        new_dir.path(),
+        server.base_url(),
+        "owner@example.com",
+        "owner-password",
+        &secret_key,
+        Some("second-device".to_string()),
+        Some(signup.library_id.clone()),
+    )
+    .expect("enroll should recover the shared data key via the account-keys endpoint");
+
+    assert_eq!(outcome.email, "owner@example.com");
+    assert_eq!(outcome.device_name, "second-device");
+    assert_eq!(
+        outcome.library_id, signup.library_id,
+        "the new device must join the existing library"
+    );
+    // The owner's own second device is active by default (no approval toggle).
+    assert_eq!(outcome.device_status, "active");
+    assert!(!outcome.device_id.is_empty());
+    assert_ne!(
+        outcome.device_id, signup.device_id,
+        "the new device must get its own id"
+    );
+
+    // The crux: the recovered SyncKey is byte-for-byte identical to the signup
+    // device's — true zero-knowledge multi-device key recovery.
+    let new_store = toku_sync_client::TokenStore::new(new_dir.path());
+    let new_sync_key = new_store
+        .load_sync_key(server.base_url())
+        .expect("load new device sync key")
+        .expect("new device sync key should be stored");
+    assert_eq!(
+        new_sync_key, owner_sync_key,
+        "the enrolled device must recover the SAME SyncKey, byte for byte"
+    );
+}

--- a/docs/adr/003-cli-design.md
+++ b/docs/adr/003-cli-design.md
@@ -48,14 +48,22 @@ toku config [--edit]
 
 Sync is opt-in and additive — every command above works fully offline. The
 `toku sync` namespace manages multi-device synchronization. See ADR-006
-(sync strategy) and ADR-008 (wire protocol) for the underlying design.
+(sync strategy), ADR-008 (wire protocol), and ADR-010 (self-host + zero-knowledge
+auth, which supersedes ADR-006/008's auth model) for the underlying design.
 
 ```sh
+# Account auth (1Password-style: account password + device-generated Secret Key)
+toku sync signup [--server <url>] [--email <addr>] [--device-name <name>] [--kit-out <file>]
+toku sync login  [--server <url>] [--email <addr>]                  # Re-auth on an enrolled device
+toku sync enroll [--server <url>] [--email <addr>] [--library-id <uuid>] [--device-name <name>]
+
+# Deprecated: per-library passphrase setup (prefer signup/login/enroll)
 toku sync init [--server <url>] [--library-id <uuid>] [--device-name <name>] [--passphrase]
+
 toku sync status                                   # Show sync state, pending ops, devices, conflicts
 toku sync push                                     # Push local changes to the sync server
 toku sync pull                                     # Pull remote changes from the sync server
-toku sync devices                                  # List devices registered to this library
+toku sync devices                                  # List devices (user-scoped when logged in)
 toku sync deregister <device-id>                   # Deregister another device from the server
 toku sync disable                                  # Disable sync (local data preserved)
 toku sync purge [--days <n>]                        # Purge tombstoned books past the retention period (default 30)
@@ -67,13 +75,26 @@ toku sync conflicts resolve <id> --keep local|remote
 toku sync conflicts resolve-all --keep local|remote
 ```
 
-> **Note**: `toku sync init` defaults the server to `http://localhost:8080`.
-> The `--library-id` must match across all devices for a single library; omit it
-> on the first device to generate one. `--passphrase` enables client-side
-> encryption (interactive, hidden input). Only note and review edits can produce
-> user-visible conflicts; all other entities merge silently per ADR-006's
-> entity-specific rules. Like every other command, sync subcommands respect
-> `--format table|json|csv` and `NO_COLOR`.
+> **Account auth (ADR-010)**: `signup` creates an account, generates a
+> high-entropy **Secret Key** on the device, renders an **Emergency Kit** (shown
+> once — `--kit-out file.pdf|.html|.txt`), and enrolls the first device as admin.
+> `login` re-authenticates an already-enrolled device; `enroll` joins an existing
+> account from a new device. All three prompt for the account password (and, for
+> `login`/`enroll`, the Secret Key) via hidden input — secrets never appear in
+> argv or shell history. The server never sees the password or Secret Key (SRP);
+> recovering the shared library data key on a new device uses the wrapped key
+> hierarchy fetched over an authenticated session. The Secret Key is never written
+> to plaintext config — only derived session/key material is kept in the OS
+> keychain.
+>
+> **Note**: All sync subcommands default the server to `http://localhost:8080`.
+> The deprecated `toku sync init` uses a per-library passphrase: `--library-id`
+> must match across all devices for a single library; omit it on the first device
+> to generate one; `--passphrase` enables client-side encryption (interactive,
+> hidden input). Only note and review edits can produce user-visible conflicts;
+> all other entities merge silently per ADR-006's entity-specific rules. Like
+> every other command, sync subcommands respect `--format table|json|csv` and
+> `NO_COLOR`.
 
 ## Rationale
 


### PR DESCRIPTION
## Description

Adds 1Password-style account authentication to the `toku sync` CLI, completing
issue #123. Sync setup moves from a per-library passphrase to a two-secret model:
an account password plus a device-generated **Secret Key**, with zero-knowledge
multi-device key recovery.

### What's included

- **New CLI subcommands** (`crates/toku-cli`):
  - `toku sync signup` — create an account, generate the device Secret Key,
    render the Emergency Kit once (printed, or `--kit-out file.pdf|.html|.txt`),
    and enroll the first device as admin in one step.
  - `toku sync login` — re-authenticate an already-enrolled device.
  - `toku sync enroll` — join an existing account from a new device, recovering
    the shared library data key the zero-knowledge way.
  - `toku sync devices` now lists account-scoped devices when logged in.
  - The account password and Secret Key are read with non-echoing prompts
    (`rpassword`), never appear in argv/shell history, and the Secret Key is
    never written to disk.
- **Account-aware `toku-sync-client`**: account signup/challenge/verify, device
  enrollment, account-scoped device listing/removal, and account key-bundle
  retrieval (`GET /api/v1/account/keys`). A separate account (user) session is
  stored alongside the per-device sync token. Orchestrator `signup`/`login`/
  `enroll` flows reuse the SRP-6a dance with the account email as identity and
  unwrap the leaf `SyncKey` locally.
- **Deprecation**: `toku sync init` / `--passphrase` are deprecated in favor of
  `signup`/`login`/`enroll`. `init` still works and prints a notice.
- **Tests** (`crates/toku-sync/tests/cli_account_auth.rs`): six integration tests
  driving the real orchestrator against an in-process server — signup→login
  round-trip, wrong-password rejection, registration-closed gating, Secret-Key
  never-persisted, login data-key unlock, and new-device enroll recovering a
  **byte-equal** `SyncKey`.
- **Docs**: ADR-003 CLI reference updated with the new subcommands and the `init`
  deprecation; CHANGELOG Unreleased updated.

> **Note for reviewer — rebase required.** This branch is based on #142 and
> stacks on the now-merged #143/#145 (`GET /api/v1/account/keys` + persisted
> `wrapped_data_key`). It only touches the **client** layers. On this un-rebased
> branch, two tests (`login_succeeds_with_correct_credentials`,
> `enroll_new_device_recovers_shared_data_key`) fail **only** because the #143
> endpoint is not present locally — the enroll failure literally reads "requires
> the #143 account-keys endpoint". Rebasing onto current `main` (which contains
> #145) makes the full suite green; this was verified by temporarily overlaying
> main's `toku-sync` server files and running all six tests successfully.

## Related Issues

Closes #123. Stacks on #143 (merged as #145); relates to #142, #144.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI / infrastructure
- [ ] Other (describe below)

## Crate

- [ ] `toku-core` — Domain models, traits, state machine
- [ ] `toku-db` — SQLite persistence, migrations, FTS5
- [ ] `toku-import` — Importers (Goodreads, Calibre, StoryGraph)
- [ ] `toku-meta` — Metadata fetching (Open Library, Google Books)
- [x] `toku-cli` — CLI binary
- [ ] `toku-export` — Exporters (CSV, JSON, Markdown, BibTeX)
- [x] `docs/` — Documentation
- [x] `toku-sync-client` — account auth client + orchestrator flows
- [x] `toku-sync` — integration tests only (no server code changed)

## Data Integrity Checklist

- [x] No user data is sent to any server without explicit opt-in
- [ ] Import operations are idempotent (re-importing the same file creates no duplicates)
- [x] User edits to metadata are never overwritten by auto-enrichment
- [ ] New fields track provenance (source + timestamp)
- [ ] Export round-trip is preserved (if applicable)

## Checklist

- [x] I have read [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] `cargo fmt --check` passes
- [x] `cargo clippy --workspace -- -D warnings` passes
- [x] `cargo test --workspace` passes *(after rebasing onto current `main` with
  the #145 account-keys endpoint; verified via overlay — see reviewer note above)*
- [x] I have updated documentation (if applicable)
