### PR TITLE
fix: correct release workflow artifact action and crates.io publish set

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -96,7 +96,7 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Download all artifacts
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@v7
         with:
           path: artifacts
           merge-multiple: true
@@ -154,7 +154,8 @@ jobs:
           echo "✅ Tag $TAG_VERSION matches Cargo.toml"
 
       # Publish crates in dependency order:
-      # toku-core (no deps) → toku-db → toku-import, toku-meta, toku-export → toku-cli
+      # toku-core (no deps) → toku-db → toku-import, toku-meta, toku-export,
+      # toku-web, toku-sync-client → toku-cli
       # Polls crates.io index between publishes to avoid timing issues.
       - name: Publish workspace crates
         env:
@@ -188,5 +189,7 @@ jobs:
           publish_crate toku-import
           publish_crate toku-meta
           publish_crate toku-export
+          publish_crate toku-web
+          publish_crate toku-sync-client
           publish_crate toku-cli
           echo "✅ All crates published"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5880,7 +5880,7 @@ dependencies = [
 
 [[package]]
 name = "toku-cli"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "apple-native-keyring-store",
@@ -5915,7 +5915,7 @@ dependencies = [
 
 [[package]]
 name = "toku-core"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -5934,7 +5934,7 @@ dependencies = [
 
 [[package]]
 name = "toku-db"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -5951,7 +5951,7 @@ dependencies = [
 
 [[package]]
 name = "toku-desktop"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "tauri",
  "tauri-build",
@@ -5963,7 +5963,7 @@ dependencies = [
 
 [[package]]
 name = "toku-export"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "chrono",
  "csv",
@@ -5979,7 +5979,7 @@ dependencies = [
 
 [[package]]
 name = "toku-ffi"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "cbindgen",
  "chrono",
@@ -5994,7 +5994,7 @@ dependencies = [
 
 [[package]]
 name = "toku-import"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "chrono",
  "csv",
@@ -6009,7 +6009,7 @@ dependencies = [
 
 [[package]]
 name = "toku-meta"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "reqwest 0.12.28",
  "serde",
@@ -6023,7 +6023,7 @@ dependencies = [
 
 [[package]]
 name = "toku-sync"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -6054,7 +6054,7 @@ dependencies = [
 
 [[package]]
 name = "toku-sync-client"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "apple-native-keyring-store",
@@ -6079,7 +6079,7 @@ dependencies = [
 
 [[package]]
 name = "toku-web"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "axum",
  "axum-extra",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,13 +23,13 @@ license = "MIT"
 repository = "https://github.com/kafkade/toku"
 
 [workspace.dependencies]
-toku-core = { path = "crates/toku-core", version = "0.2.1" }
-toku-db = { path = "crates/toku-db", version = "0.2.1" }
-toku-meta = { path = "crates/toku-meta", version = "0.2.1" }
-toku-import = { path = "crates/toku-import", version = "0.2.1" }
-toku-export = { path = "crates/toku-export", version = "0.2.1" }
-toku-web = { path = "crates/toku-web", version = "0.2.1" }
-toku-sync-client = { path = "crates/toku-sync-client", version = "0.2.1" }
+toku-core = { path = "crates/toku-core", version = "0.3.0" }
+toku-db = { path = "crates/toku-db", version = "0.3.0" }
+toku-meta = { path = "crates/toku-meta", version = "0.3.0" }
+toku-import = { path = "crates/toku-import", version = "0.3.0" }
+toku-export = { path = "crates/toku-export", version = "0.3.0" }
+toku-web = { path = "crates/toku-web", version = "0.3.0" }
+toku-sync-client = { path = "crates/toku-sync-client", version = "0.3.0" }
 thiserror = "2"
 uuid = { version = "1", features = ["v7", "serde"] }
 chrono = { version = "0.4", default-features = false, features = ["std", "clock", "serde"] }


### PR DESCRIPTION
## Description

Fixes multiple errors in the release workflow (`.github/workflows/release.yml`) that would break tagged releases, plus a coupled packaging bug in the workspace manifest.

**What's included**

- **Artifact action version mismatch** — `download-artifact@v8` could not read artifacts produced by `upload-artifact@v7`. Aligned download to `@v7` so the release job can fetch the built binaries.
- **Incomplete crates.io publish set** — `toku-cli` depends on `toku-web` and `toku-sync-client`, but neither was published, so `cargo publish -p toku-cli` would fail. Added both to the publish step in dependency order (after `toku-export`, before `toku-cli`) and updated the ordering comment.
- **Stale internal dependency pins** — the workspace package version is `0.3.0`, but `[workspace.dependencies]` still pinned the internal `toku-*` crates at `0.2.1`. A `0.3.0` publish would have recorded sibling deps as `^0.2.1`, producing a broken release. Bumped all seven pins to `0.3.0`.

No crate source code changed; `cargo metadata` resolves cleanly with the bumped pins.

## Related Issues

<!-- None referenced -->

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [x] CI / infrastructure
- [ ] Other (describe below)

## Crate

<!-- Workspace manifest + release CI only; no individual crate source touched -->

- [ ] `toku-core` — Domain models, traits, state machine
- [ ] `toku-db` — SQLite persistence, migrations, FTS5
- [ ] `toku-import` — Importers (Goodreads, Calibre, StoryGraph)
- [ ] `toku-meta` — Metadata fetching (Open Library, Google Books)
- [ ] `toku-cli` — CLI binary
- [ ] `toku-export` — Exporters (CSV, JSON, Markdown, BibTeX)
- [ ] `docs/` — Documentation

## Data Integrity Checklist

- [x] No user data is sent to any server without explicit opt-in
- [x] Import operations are idempotent (re-importing the same file creates no duplicates)
- [x] User edits to metadata are never overwritten by auto-enrichment
- [x] New fields track provenance (source + timestamp)
- [x] Export round-trip is preserved (if applicable)

## Checklist

- [ ] I have read [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] `cargo fmt --check` passes
- [x] `cargo clippy --workspace -- -D warnings` passes
- [x] `cargo test --workspace` passes
- [ ] I have updated documentation (if applicable)
