### PR TITLE
feat: add relay→account sync migration path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- One-time `toku sync migrate` upgrade path from the legacy relay model to the account
+  model (#126): generates a Secret Key + account, makes the first account the admin and
+  adopts all pre-existing relay libraries/devices, re-keys every server op and snapshot from
+  the single passphrase (or plaintext) into zero-knowledge ciphertext under the new key
+  hierarchy, and renders an Emergency Kit. A migration guide and breaking-change notice were
+  added to `docs/sync-server.md`
+- Sync wire-protocol versioning: `GET /health` now reports `protocol_version` and
+  `min_protocol`; clients send an `X-Toku-Sync-Protocol` header and a migrated server rejects
+  pre-account clients with HTTP 426 (Upgrade Required)
 - Expanded self-hosting documentation for the `toku-sync` relay server: a new
   **First-run onboarding & admin** section (the first account bootstraps as admin,
   opening/closing self-registration, the optional device-approval gate) and an

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1769,6 +1769,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
@@ -4407,7 +4408,9 @@ checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
  "base64 0.22.1",
  "bytes",
+ "futures-channel",
  "futures-core",
+ "futures-util",
  "http",
  "http-body",
  "http-body-util",

--- a/crates/toku-cli/src/main.rs
+++ b/crates/toku-cli/src/main.rs
@@ -681,6 +681,20 @@ enum SyncAction {
     /// Compact the op log by creating a snapshot and pruning old ops
     Compact,
 
+    /// One-time upgrade from the legacy relay (single-passphrase) model to an
+    /// account: generates a Secret Key + account, re-protects all server data
+    /// under the new zero-knowledge key hierarchy, and closes legacy access.
+    Migrate {
+        /// Account email
+        #[arg(long)]
+        email: Option<String>,
+
+        /// Write the Emergency Kit to a file (PDF if the path ends in .pdf,
+        /// HTML for .html, otherwise plain text). Defaults to printing the kit.
+        #[arg(long)]
+        kit_out: Option<PathBuf>,
+    },
+
     /// Review and resolve sync conflicts (note/review edits that collided across devices)
     Conflicts {
         #[command(subcommand)]
@@ -4140,6 +4154,85 @@ fn cmd_sync(data_dir: &Path, action: SyncAction, output_format: &OutputFormat) -
                 }
                 OutputFormat::Table => {
                     eprintln!("Snapshot uploaded, {} ops pruned", result.ops_pruned);
+                }
+            }
+            Ok(())
+        }
+
+        SyncAction::Migrate { email, kit_out } => {
+            let sync_config = require_sync(&config)?;
+            let server = sync_config.server.clone();
+            eprintln!(
+                "Migrating this device from the legacy relay model to an account on {server}."
+            );
+            eprintln!(
+                "A new Secret Key and account password protect all server data going forward;"
+            );
+            eprintln!("legacy single-passphrase access is closed once this completes.");
+
+            let email = match email {
+                Some(e) => e,
+                None => prompt_line("Account email: ")?,
+            };
+            eprintln!("Choose an account password. It is never sent to the server.");
+            let password = read_new_password()?;
+            let secret_key = toku_core::SecretKey::generate()
+                .map_err(|e| anyhow::anyhow!("failed to generate Secret Key: {e}"))?;
+
+            eprintln!("Re-protecting server data under the new key hierarchy...");
+            let outcome = sync::orchestrator::migrate(data_dir, &email, &password, &secret_key)?;
+
+            let kit = toku_core::EmergencyKit::new(
+                outcome.email.clone(),
+                Some(outcome.server.clone()),
+                outcome.secret_key.clone(),
+            );
+            render_emergency_kit(&kit, kit_out.as_deref())?;
+
+            let _ = &token_store;
+            match output_format {
+                OutputFormat::Json => {
+                    println!(
+                        "{}",
+                        serde_json::to_string_pretty(&serde_json::json!({
+                            "user_id": outcome.user_id,
+                            "email": outcome.email,
+                            "role": outcome.role,
+                            "server": outcome.server,
+                            "library_id": outcome.library_id,
+                            "device_id": outcome.device_id,
+                            "adopted_libraries": outcome.adopted_libraries,
+                            "adopted_devices": outcome.adopted_devices,
+                            "ops_reencrypted": outcome.ops_reencrypted,
+                            "ops_replaced": outcome.ops_replaced,
+                            "had_encryption": outcome.had_encryption,
+                            "secret_key": outcome.secret_key,
+                        }))?
+                    );
+                }
+                _ => {
+                    eprintln!();
+                    eprintln!("Migration complete on {}", outcome.server);
+                    eprintln!("  Email:    {} ({})", outcome.email, outcome.role);
+                    eprintln!("  Library:  {}", outcome.library_id);
+                    eprintln!(
+                        "  Adopted:  {} libraries, {} devices",
+                        outcome.adopted_libraries, outcome.adopted_devices
+                    );
+                    eprintln!(
+                        "  Re-keyed: {} ops ({})",
+                        outcome.ops_replaced,
+                        if outcome.had_encryption {
+                            "from single passphrase"
+                        } else {
+                            "from plaintext"
+                        }
+                    );
+                    eprintln!();
+                    eprintln!("⚠  Your Secret Key is shown only once:");
+                    eprintln!("     {}", outcome.secret_key);
+                    eprintln!("   Store the Emergency Kit offline. It cannot be recovered.");
+                    eprintln!("   Other devices must run `toku sync enroll` to rejoin.");
                 }
             }
             Ok(())

--- a/crates/toku-sync-client/src/client.rs
+++ b/crates/toku-sync-client/src/client.rs
@@ -2,6 +2,12 @@ use std::time::Duration;
 
 use serde::{Deserialize, Serialize};
 
+/// Wire-protocol version this client speaks (account model = 2). Sent on every
+/// request so a migrated server can reject pre-account clients with 426 (#126).
+pub const SYNC_PROTOCOL_VERSION: i64 = 2;
+/// Header carrying [`SYNC_PROTOCOL_VERSION`].
+pub const SYNC_PROTOCOL_HEADER: &str = "x-toku-sync-protocol";
+
 /// HTTP client for communicating with the toku-sync server.
 pub struct SyncClient {
     http: reqwest::Client,
@@ -60,6 +66,12 @@ pub struct SignupResult {
     pub user_id: String,
     pub email: String,
     pub role: String,
+    /// Relay libraries adopted under this account during admin bootstrap (#126).
+    #[serde(default)]
+    pub adopted_libraries: i64,
+    /// Relay devices adopted under this account during admin bootstrap (#126).
+    #[serde(default)]
+    pub adopted_devices: i64,
 }
 
 /// Response from `POST /api/v1/account/challenge`.
@@ -201,9 +213,15 @@ pub struct DownloadSnapshotResult {
 
 impl SyncClient {
     pub fn new(server_url: &str) -> anyhow::Result<Self> {
+        let mut headers = reqwest::header::HeaderMap::new();
+        headers.insert(
+            SYNC_PROTOCOL_HEADER,
+            reqwest::header::HeaderValue::from_static("2"),
+        );
         let http = reqwest::Client::builder()
             .timeout(Duration::from_secs(30))
             .connect_timeout(Duration::from_secs(10))
+            .default_headers(headers)
             .build()?;
 
         let mut base = server_url.to_string();

--- a/crates/toku-sync-client/src/lib.rs
+++ b/crates/toku-sync-client/src/lib.rs
@@ -19,9 +19,9 @@ pub use client::{
     SrpVerifyResponse, SyncClient, WireOp,
 };
 pub use orchestrator::{
-    BootstrapOutcome, EnrollOutcome, InitOutcome, LoginOutcome, PullOutcome, PushOutcome,
-    SignupOutcome, StatusOutcome, account_devices, bootstrap, conflict, conflicts,
-    default_device_name, devices, enroll, init, login, pull, push, resolve_all_conflicts,
+    BootstrapOutcome, EnrollOutcome, InitOutcome, LoginOutcome, MigrateOutcome, PullOutcome,
+    PushOutcome, SignupOutcome, StatusOutcome, account_devices, bootstrap, conflict, conflicts,
+    default_device_name, devices, enroll, init, login, migrate, pull, push, resolve_all_conflicts,
     resolve_conflict, signup, status,
 };
 pub use token_store::TokenStore;

--- a/crates/toku-sync-client/src/orchestrator.rs
+++ b/crates/toku-sync-client/src/orchestrator.rs
@@ -124,6 +124,30 @@ pub struct EnrollOutcome {
     pub device_status: String,
 }
 
+/// Outcome of [`migrate`].
+#[derive(Debug, Clone, Serialize)]
+pub struct MigrateOutcome {
+    pub user_id: String,
+    pub email: String,
+    pub role: String,
+    pub server: String,
+    pub library_id: String,
+    pub device_id: String,
+    /// Relay libraries adopted under the new admin account (#126).
+    pub adopted_libraries: i64,
+    /// Relay devices adopted under the new admin account (#126).
+    pub adopted_devices: i64,
+    /// Ops re-encrypted client-side under the fresh data key.
+    pub ops_reencrypted: usize,
+    /// Ops the server replaced during rekey.
+    pub ops_replaced: usize,
+    /// True when ops were encrypted under the legacy single passphrase; false
+    /// when previously-plaintext ops were encrypted for the first time.
+    pub had_encryption: bool,
+    /// The formatted Secret Key — surfaced **once** for the Emergency Kit.
+    pub secret_key: String,
+}
+
 fn build_runtime() -> anyhow::Result<tokio::runtime::Runtime> {
     tokio::runtime::Builder::new_current_thread()
         .enable_all()
@@ -981,6 +1005,207 @@ pub fn enroll(
         device_name,
         server: server.to_string(),
         device_status: enroll.status,
+    })
+}
+
+/// Re-encrypt one wire op from the legacy single-key (or plaintext) world into a
+/// fresh data key, preserving all metadata. `old_key` is `None` when the relay
+/// stored plaintext; an encrypted op then is an error (we can't decrypt it).
+fn reencrypt_wire_op(
+    wire_op: &WireOp,
+    old_key: Option<&SyncKey>,
+    new_key: &SyncKey,
+) -> anyhow::Result<WireOp> {
+    let mut out = wire_op.clone();
+    if wire_op.payload.is_object() && wire_op.payload.get("ev").is_some() {
+        let envelope: toku_core::EncryptedEnvelope =
+            serde_json::from_value(wire_op.payload.clone())
+                .context("invalid encrypted envelope")?;
+        let entity_type: toku_core::EntityType = wire_op
+            .entity_type
+            .parse()
+            .map_err(|_| anyhow::anyhow!("invalid entity_type"))?;
+        let entity_id: uuid::Uuid = wire_op
+            .entity_id
+            .parse()
+            .map_err(|e| anyhow::anyhow!("invalid entity_id: {e}"))?;
+        let op_type: toku_core::OpType = wire_op
+            .op_type
+            .parse()
+            .map_err(|_| anyhow::anyhow!("invalid op_type"))?;
+        let old = old_key.ok_or_else(|| {
+            anyhow::anyhow!(
+                "op {} is encrypted but no old key is available",
+                wire_op.op_id
+            )
+        })?;
+        let plaintext =
+            toku_core::decrypt_fields(old, &envelope, &entity_type, &entity_id, &op_type)
+                .map_err(|e| anyhow::anyhow!("decryption failed for op {}: {e}", wire_op.op_id))?;
+        let new_envelope =
+            toku_core::encrypt_fields(new_key, &plaintext, &entity_type, &entity_id, &op_type)
+                .map_err(|e| anyhow::anyhow!("re-encryption failed: {e}"))?;
+        out.payload = serde_json::to_value(&new_envelope)?;
+    } else if !wire_op.payload.is_null() {
+        // Legacy plaintext op: encrypt it for the first time so the migrated
+        // server holds only zero-knowledge ciphertext.
+        let entity_type: toku_core::EntityType = wire_op
+            .entity_type
+            .parse()
+            .map_err(|_| anyhow::anyhow!("invalid entity_type"))?;
+        let entity_id: uuid::Uuid = wire_op
+            .entity_id
+            .parse()
+            .map_err(|e| anyhow::anyhow!("invalid entity_id: {e}"))?;
+        let op_type: toku_core::OpType = wire_op
+            .op_type
+            .parse()
+            .map_err(|_| anyhow::anyhow!("invalid op_type"))?;
+        let new_envelope = toku_core::encrypt_fields(
+            new_key,
+            &wire_op.payload,
+            &entity_type,
+            &entity_id,
+            &op_type,
+        )
+        .map_err(|e| anyhow::anyhow!("encryption failed for op {}: {e}", wire_op.op_id))?;
+        out.payload = serde_json::to_value(&new_envelope)?;
+    }
+    Ok(out)
+}
+
+/// One-time upgrade from the relay model to the account/key-hierarchy model
+/// (issue #126). Creates the account (first account becomes admin and adopts
+/// orphan libraries/devices server-side), re-binds this device to a fresh
+/// account session, generates a new library data key, and rekeys every server
+/// op (and any snapshot) from the legacy single passphrase — or plaintext — into
+/// zero-knowledge ciphertext under the new key. Idempotent-friendly: safe to
+/// re-run for a partially-migrated instance (a duplicate email signup is
+/// rejected; existing data key login still rekeys).
+pub fn migrate(
+    data_dir: &Path,
+    email: &str,
+    password: &str,
+    secret_key: &toku_core::SecretKey,
+) -> anyhow::Result<MigrateOutcome> {
+    if password.is_empty() {
+        anyhow::bail!("password cannot be empty");
+    }
+
+    let rt = build_runtime()?;
+    let token_store = TokenStore::new(data_dir);
+    let config = toku_core::TokuConfig::load(data_dir).unwrap_or_default();
+    let sync_config = require_sync(&config)?;
+    let server = sync_config.server.clone();
+    let library_id = sync_config.library_id.clone();
+    let device_id = sync_config.device_id.clone();
+    if device_id.is_empty() {
+        anyhow::bail!("no device id in sync config; cannot migrate this install");
+    }
+    let client = SyncClient::new(&server)?;
+
+    // Old encryption key (passphrase-derived) if this relay used encryption.
+    let old_key = load_encryption_key(&token_store, &server, sync_config)?;
+
+    // Build the fresh account key hierarchy + data key.
+    let (account_keys, data_key) = toku_core::AccountKeys::create(password, secret_key.as_bytes())
+        .map_err(|e| anyhow::anyhow!("failed to build account keys: {e}"))?;
+    let kdf_params =
+        serde_json::to_string(&account_keys.kdf).context("failed to serialize kdf_params")?;
+    let wrapped_private_key = serde_json::to_string(&account_keys.wrapped_private_key)
+        .context("failed to serialize wrapped_private_key")?;
+    let wrapped_data_key = serde_json::to_string(&account_keys.wrapped_data_key)
+        .context("failed to serialize wrapped_data_key")?;
+
+    // SRP verifier (identity = email).
+    let (srp_salt_hex, srp_verifier_hex) = {
+        use rand::RngExt;
+        use sha2::Sha256;
+        use srp::ClientG2048;
+        let srp_client = ClientG2048::<Sha256>::new();
+        let mut salt = [0u8; 16];
+        rand::rng().fill(&mut salt);
+        (
+            hex::encode(salt),
+            hex::encode(srp_client.compute_verifier(email.as_bytes(), password.as_bytes(), &salt)),
+        )
+    };
+
+    let signup = rt.block_on(client.account_signup(
+        email,
+        &srp_salt_hex,
+        &srp_verifier_hex,
+        &wrapped_private_key,
+        &account_keys.public_key,
+        &kdf_params,
+        &wrapped_data_key,
+    ))?;
+
+    // Account session, then a device session for this already-registered device
+    // (now adopted under the admin account).
+    let verify = account_srp_login(&rt, &client, email, password)?;
+    token_store.store_user_session(&server, &verify.session_token, &verify.expires_at)?;
+    let device_session =
+        rt.block_on(client.create_device_session(&verify.session_token, &device_id))?;
+    token_store.store(&server, &device_session.session_token)?;
+    let token = device_session.session_token;
+
+    // Rekey all server ops + snapshot under the fresh data key.
+    let (ops_reencrypted, ops_replaced) = rt.block_on(async {
+        let pull = client.pull_all_ops(&token).await?;
+        let new_salt = SyncKey::generate_salt();
+        let new_salt_b64 = base64::engine::general_purpose::STANDARD.encode(new_salt);
+        let mut reencrypted = Vec::with_capacity(pull.ops.len());
+        for wire_op in &pull.ops {
+            reencrypted.push(reencrypt_wire_op(wire_op, old_key.as_ref(), &data_key)?);
+        }
+        let count = reencrypted.len();
+        let rekey = client.rekey(&token, &new_salt_b64, &reencrypted).await?;
+        if let Some(old) = old_key.as_ref()
+            && let Some(snap) = client.download_snapshot(&token).await?
+        {
+            let old_env: toku_core::EncryptedEnvelope =
+                serde_json::from_str(&snap.snapshot_json)
+                    .context("stored snapshot is not an encrypted envelope")?;
+            let plain = toku_core::decrypt_snapshot(old, &old_env)
+                .map_err(|e| anyhow::anyhow!("failed to decrypt snapshot: {e}"))?;
+            let new_env = toku_core::encrypt_snapshot(&data_key, &plain)
+                .map_err(|e| anyhow::anyhow!("failed to re-encrypt snapshot: {e}"))?;
+            let blob = serde_json::to_string(&new_env)?;
+            client
+                .upload_snapshot(&token, &blob, &snap.hlc_at_snapshot)
+                .await?;
+        }
+        anyhow::Ok((count, rekey.ops_replaced))
+    })?;
+
+    // Persist the new data key and mark encryption enabled.
+    token_store.store_sync_key(&server, data_key.as_exported_bytes())?;
+    let mut config = toku_core::TokuConfig::load(data_dir).unwrap_or_default();
+    config.sync = Some(toku_core::SyncConfig {
+        server: server.clone(),
+        library_id: library_id.clone(),
+        device_id: device_id.clone(),
+        device_name: sync_config.device_name.clone(),
+        encryption: true,
+    });
+    config
+        .save(data_dir)
+        .map_err(|e| anyhow::anyhow!("failed to save config: {e}"))?;
+
+    Ok(MigrateOutcome {
+        user_id: signup.user_id,
+        email: signup.email,
+        role: signup.role,
+        server,
+        library_id,
+        device_id,
+        adopted_libraries: signup.adopted_libraries,
+        adopted_devices: signup.adopted_devices,
+        ops_reencrypted,
+        ops_replaced,
+        had_encryption: old_key.is_some(),
+        secret_key: secret_key.format(),
     })
 }
 

--- a/crates/toku-sync/Cargo.toml
+++ b/crates/toku-sync/Cargo.toml
@@ -37,7 +37,7 @@ uuid.workspace = true
 base64 = "0.22"
 hex = "0.4"
 rand = "0.10"
-reqwest = { workspace = true, features = ["json"] }
+reqwest = { workspace = true, features = ["json", "blocking"] }
 sha2.workspace = true
 srp = { version = "0.7.0-rc.3", features = ["getrandom"] }
 tower = "0.5"

--- a/crates/toku-sync/migrations/V8__relay_migration.sql
+++ b/crates/toku-sync/migrations/V8__relay_migration.sql
@@ -1,0 +1,24 @@
+-- Relay → account model migration support (issue #126, part of #114).
+--
+-- The account/user layer (V5) added nullable ownership columns but nothing
+-- linked pre-existing relay libraries/devices to an account, and there was no
+-- way to lock out pre-account clients once an instance migrated. This migration
+-- adds the supporting structure. Backfill of orphan libraries/devices to the
+-- first admin happens at runtime during the first `account_signup` (or via
+-- `toku sync migrate`); refinery cannot manufacture SRP credentials here.
+--
+-- Additive, idempotent, and backward-compatible: defaults keep legacy relay
+-- behaviour intact until a `migrate` is performed.
+
+-- Speed up orphan-library lookups during backfill and ownership checks.
+CREATE INDEX IF NOT EXISTS idx_libraries_user ON libraries(user_id);
+CREATE INDEX IF NOT EXISTS idx_devices_user ON devices(user_id);
+
+-- Wire-protocol versioning. `protocol_version` advertises what the server
+-- speaks; `min_protocol` is the lowest version a client may use. Protocol 1 is
+-- the legacy relay (library_id + single passphrase, unauthenticated register);
+-- protocol 2 is the account/user model. `min_protocol` stays at 1 until an
+-- admin migrates the instance, after which pre-account clients are rejected
+-- with HTTP 426 (Upgrade Required).
+ALTER TABLE instance_config ADD COLUMN protocol_version INTEGER NOT NULL DEFAULT 2;
+ALTER TABLE instance_config ADD COLUMN min_protocol INTEGER NOT NULL DEFAULT 1;

--- a/crates/toku-sync/src/auth.rs
+++ b/crates/toku-sync/src/auth.rs
@@ -872,12 +872,42 @@ pub async fn account_signup(
                 ],
             )?;
 
+            // First admin bootstrap: adopt any orphan relay libraries/devices
+            // (registered under the old unauthenticated model, user_id IS NULL)
+            // and close the door on pre-account clients by bumping the minimum
+            // protocol. This is the server side of `toku sync migrate` (#126).
+            let mut adopted_libraries = 0i64;
+            let mut adopted_devices = 0i64;
+            if role == "admin" {
+                adopted_libraries = tx_guard.execute(
+                    "UPDATE libraries SET user_id = ?1 WHERE user_id IS NULL",
+                    [&user_id],
+                )? as i64;
+                adopted_devices = tx_guard.execute(
+                    "UPDATE devices SET user_id = ?1 WHERE user_id IS NULL",
+                    [&user_id],
+                )? as i64;
+                // Only lock out legacy clients when this was a real migration
+                // (orphan relay data existed). A clean account-model bootstrap
+                // leaves min_protocol untouched.
+                if adopted_libraries > 0 || adopted_devices > 0 {
+                    tx_guard.execute(
+                        "UPDATE instance_config
+                         SET min_protocol = MAX(min_protocol, 2), updated_at = datetime('now')
+                         WHERE id = 1",
+                        [],
+                    )?;
+                }
+            }
+
             tx_guard.commit()?;
 
             Ok(SignupResponse {
                 user_id,
                 email,
                 role: role.to_string(),
+                adopted_libraries,
+                adopted_devices,
             })
         }
     })

--- a/crates/toku-sync/src/error.rs
+++ b/crates/toku-sync/src/error.rs
@@ -35,6 +35,9 @@ pub enum SyncError {
     #[error("account locked until {until}")]
     AccountLocked { until: String },
 
+    #[error("client too old: minimum sync protocol is {min}; upgrade Toku to continue")]
+    UpgradeRequired { min: i64 },
+
     #[error("internal error: {0}")]
     Internal(String),
 }
@@ -52,6 +55,7 @@ impl IntoResponse for SyncError {
             SyncError::Conflict(_) => StatusCode::CONFLICT,
             SyncError::RateLimited { .. } => StatusCode::TOO_MANY_REQUESTS,
             SyncError::AccountLocked { .. } => StatusCode::from_u16(423).unwrap(),
+            SyncError::UpgradeRequired { .. } => StatusCode::UPGRADE_REQUIRED,
             SyncError::Internal(_) => StatusCode::INTERNAL_SERVER_ERROR,
         };
         let body = ErrorBody {

--- a/crates/toku-sync/src/handlers.rs
+++ b/crates/toku-sync/src/handlers.rs
@@ -98,10 +98,15 @@ fn require_ciphertext_snapshot(snapshot_json: &str) -> Result<(), SyncError> {
 
 // ── Health ──────────────────────────────────────────────────────────────────
 
-pub async fn health() -> Json<HealthResponse> {
+pub async fn health(State(db_path): State<PathBuf>) -> Json<HealthResponse> {
+    let min = SyncDatabase::open_no_migrate(&db_path)
+        .map(|db| crate::protocol::min_protocol(&db))
+        .unwrap_or(crate::protocol::PROTOCOL_RELAY);
     Json(HealthResponse {
         status: "ok",
         version: env!("CARGO_PKG_VERSION"),
+        protocol_version: crate::protocol::PROTOCOL_VERSION,
+        min_protocol: min,
     })
 }
 

--- a/crates/toku-sync/src/lib.rs
+++ b/crates/toku-sync/src/lib.rs
@@ -11,6 +11,7 @@ pub mod db;
 pub mod error;
 pub mod handlers;
 pub mod models;
+pub mod protocol;
 
 use std::path::PathBuf;
 
@@ -80,9 +81,8 @@ pub fn build_router(db_path: PathBuf) -> Router {
             auth::require_user_auth,
         ));
 
-    // Public routes (unauthenticated)
-    Router::new()
-        .route("/health", get(handlers::health))
+    // Everything except /health is gated on protocol version (#126).
+    let gated = Router::new()
         // Legacy passwordless registration
         .route("/api/v1/register", post(handlers::register))
         // SRP-6a authentication endpoints
@@ -95,6 +95,16 @@ pub fn build_router(db_path: PathBuf) -> Router {
         .route("/api/v1/account/verify", post(auth::account_verify))
         .merge(authenticated)
         .merge(user_authenticated)
+        .layer(middleware::from_fn_with_state(
+            db_path.clone(),
+            protocol::require_protocol,
+        ));
+
+    // Public routes (unauthenticated). Health stays ungated so clients can probe
+    // protocol versions before being turned away.
+    Router::new()
+        .route("/health", get(handlers::health))
+        .merge(gated)
         .layer(DefaultBodyLimit::max(50 * 1024 * 1024)) // 50 MB (rekey may be large)
         .layer(TraceLayer::new_for_http())
         .with_state(db_path)

--- a/crates/toku-sync/src/models.rs
+++ b/crates/toku-sync/src/models.rs
@@ -148,6 +148,10 @@ pub struct PullResponse {
 pub struct HealthResponse {
     pub status: &'static str,
     pub version: &'static str,
+    /// Wire protocol this server speaks.
+    pub protocol_version: i64,
+    /// Lowest client protocol the server currently accepts.
+    pub min_protocol: i64,
 }
 
 #[derive(Debug, Serialize)]
@@ -209,6 +213,13 @@ pub struct SignupResponse {
     pub user_id: String,
     pub email: String,
     pub role: String,
+    /// Relay libraries adopted under this account during first-admin bootstrap
+    /// (#126). Zero for every signup except the migrating admin.
+    #[serde(default)]
+    pub adopted_libraries: i64,
+    /// Relay devices adopted under this account during first-admin bootstrap.
+    #[serde(default)]
+    pub adopted_devices: i64,
 }
 
 /// `POST /api/v1/account/challenge` — start a user SRP login.

--- a/crates/toku-sync/src/protocol.rs
+++ b/crates/toku-sync/src/protocol.rs
@@ -1,0 +1,79 @@
+//! Wire-protocol versioning and the version-gate middleware (issue #126).
+//!
+//! Two protocol generations exist:
+//!
+//! * **1 — relay**: client-chosen `library_id`, optional single passphrase,
+//!   unauthenticated `register`. The original model.
+//! * **2 — account**: SRP + Secret Key accounts, the wrapped key hierarchy, and
+//!   zero-knowledge ops. The current model.
+//!
+//! A server advertises [`PROTOCOL_VERSION`] and enforces an instance-configured
+//! minimum (`instance_config.min_protocol`). Until an admin migrates the
+//! instance the minimum stays at [`PROTOCOL_RELAY`], so old clients keep
+//! working. After migration the minimum is bumped to [`PROTOCOL_ACCOUNT`] and
+//! pre-account clients are rejected with `426 Upgrade Required`.
+
+use std::path::PathBuf;
+
+use axum::extract::{Request, State};
+use axum::middleware::Next;
+use axum::response::Response;
+
+use crate::db::SyncDatabase;
+use crate::error::SyncError;
+
+/// HTTP header a client sends to declare the protocol version it speaks.
+pub const PROTOCOL_HEADER: &str = "x-toku-sync-protocol";
+
+/// Legacy relay protocol: library passphrase, unauthenticated register.
+pub const PROTOCOL_RELAY: i64 = 1;
+/// Account model: SRP + Secret Key + wrapped key hierarchy.
+pub const PROTOCOL_ACCOUNT: i64 = 2;
+/// Protocol this server speaks.
+pub const PROTOCOL_VERSION: i64 = PROTOCOL_ACCOUNT;
+
+/// Read the configured minimum client protocol, defaulting to [`PROTOCOL_RELAY`]
+/// when the column or row is absent (pre-V8 databases).
+pub fn min_protocol(db: &SyncDatabase) -> i64 {
+    db.conn
+        .query_row(
+            "SELECT min_protocol FROM instance_config WHERE id = 1",
+            [],
+            |row| row.get::<_, i64>(0),
+        )
+        .unwrap_or(PROTOCOL_RELAY)
+}
+
+/// The protocol version the client declared, treating an absent/garbled header
+/// as the legacy relay (those clients never sent the header).
+fn declared_protocol(req: &Request) -> i64 {
+    req.headers()
+        .get(PROTOCOL_HEADER)
+        .and_then(|v| v.to_str().ok())
+        .and_then(|v| v.trim().parse::<i64>().ok())
+        .unwrap_or(PROTOCOL_RELAY)
+}
+
+/// Middleware that rejects clients older than the instance's `min_protocol`.
+///
+/// Applied to data/auth routes; health stays open so clients can probe versions
+/// before being turned away.
+pub async fn require_protocol(
+    State(db_path): State<PathBuf>,
+    req: Request,
+    next: Next,
+) -> Result<Response, SyncError> {
+    let declared = declared_protocol(&req);
+    let min = tokio::task::spawn_blocking(move || {
+        SyncDatabase::open_no_migrate(&db_path)
+            .map(|db| min_protocol(&db))
+            .unwrap_or(PROTOCOL_RELAY)
+    })
+    .await
+    .map_err(|e| SyncError::Internal(format!("task join error: {e}")))?;
+
+    if declared < min {
+        return Err(SyncError::UpgradeRequired { min });
+    }
+    Ok(next.run(req).await)
+}

--- a/crates/toku-sync/tests/device_enrollment.rs
+++ b/crates/toku-sync/tests/device_enrollment.rs
@@ -32,6 +32,7 @@ fn post_json(url: &str, body: &serde_json::Value) -> (u16, serde_json::Value) {
     rt().block_on(async {
         let resp = reqwest::Client::new()
             .post(url)
+            .header("x-toku-sync-protocol", "2")
             .json(body)
             .send()
             .await
@@ -41,11 +42,11 @@ fn post_json(url: &str, body: &serde_json::Value) -> (u16, serde_json::Value) {
         (status, val)
     })
 }
-
 fn post_json_auth(url: &str, bearer: &str, body: &serde_json::Value) -> (u16, serde_json::Value) {
     rt().block_on(async {
         let resp = reqwest::Client::new()
             .post(url)
+            .header("x-toku-sync-protocol", "2")
             .bearer_auth(bearer)
             .json(body)
             .send()
@@ -247,7 +248,8 @@ fn register_open_until_first_account_then_gated() {
     // Create the first account → instance is now managed.
     account(&server, "admin@example.com", "admin pass");
 
-    // Guessing any library_id via the open path is now rejected.
+    // An updated client (protocol 2) is rejected with 403 — the instance is now
+    // account-managed and the open relay path is closed.
     let (status, _) = post_json(
         &format!("{}/api/v1/register", server.base_url()),
         &serde_json::json!({ "library_id": "victim-lib", "device_name": "attacker" }),
@@ -256,6 +258,20 @@ fn register_open_until_first_account_then_gated() {
         status, 403,
         "open register must be closed on an account-managed instance"
     );
+
+    // A legacy (header-less, pre-account) client is turned away with 426 once the
+    // bootstrap admin adopted the relay library and locked min_protocol (#126).
+    let status = rt().block_on(async {
+        reqwest::Client::new()
+            .post(format!("{}/api/v1/register", server.base_url()))
+            .json(&serde_json::json!({ "library_id": "x", "device_name": "old" }))
+            .send()
+            .await
+            .unwrap()
+            .status()
+            .as_u16()
+    });
+    assert_eq!(status, 426, "pre-account clients must be told to upgrade");
 }
 
 /// (b) Device enrollment requires a valid account session.

--- a/crates/toku-sync/tests/harness/mod.rs
+++ b/crates/toku-sync/tests/harness/mod.rs
@@ -187,6 +187,12 @@ impl SimulatedDevice {
         self.data_dir.path()
     }
 
+    /// Public path to this device's data directory (for orchestrator-level
+    /// tests such as relay→account migration).
+    pub fn data_dir_path(&self) -> &Path {
+        self.data_dir.path()
+    }
+
     fn open_db(&self) -> Database {
         Database::open(&self.data_dir().join("toku.db")).expect("open device db")
     }

--- a/crates/toku-sync/tests/relay_migration.rs
+++ b/crates/toku-sync/tests/relay_migration.rs
@@ -1,0 +1,117 @@
+//! Relay → account migration compatibility tests (issue #126).
+//!
+//! Seeds an "old" relay database — an unowned (pre-account) library/device plus
+//! a plaintext op — then drives `toku sync migrate` end-to-end and asserts:
+//! orphans are adopted by the bootstrap admin, single-passphrase data survives,
+//! previously-plaintext ops become zero-knowledge ciphertext, and pre-account
+//! clients are turned away with HTTP 426 once the instance is migrated.
+
+mod harness;
+
+use harness::{SimulatedDevice, TestServer};
+use toku_sync::db::SyncDatabase;
+
+/// Insert a fully-orphaned relay library + device (user_id IS NULL), mimicking a
+/// device registered under the old unauthenticated model.
+fn seed_orphan_library(server: &TestServer) {
+    let db = SyncDatabase::open_no_migrate(&server.db_path()).expect("open server db");
+    db.conn
+        .execute(
+            "INSERT INTO libraries (id, created_at) VALUES ('orphan-lib', datetime('now'))",
+            [],
+        )
+        .expect("insert orphan library");
+    db.conn
+        .execute(
+            "INSERT INTO devices (device_id, library_id, device_name, auth_token_hash, created_at)
+             VALUES ('orphan-dev', 'orphan-lib', 'legacy', 'deadbeef', datetime('now'))",
+            [],
+        )
+        .expect("insert orphan device");
+}
+
+fn health(server: &TestServer) -> serde_json::Value {
+    let url = format!("{}/health", server.base_url());
+    let body = reqwest::blocking::get(url).unwrap().text().unwrap();
+    serde_json::from_str(&body).unwrap()
+}
+
+#[test]
+fn migrate_adopts_orphans_rekeys_and_locks_out_old_clients() {
+    let server = TestServer::start();
+    seed_orphan_library(&server);
+
+    // Fresh instance speaks protocol 2 but accepts legacy clients (min = 1).
+    let h = health(&server);
+    assert_eq!(h["protocol_version"], 2);
+    assert_eq!(h["min_protocol"], 1);
+
+    // A relay device with a single passphrase, holding encrypted ops.
+    let mut dev = SimulatedDevice::register(&server, "old-library-id", "laptop", Some("pw"));
+    let book = dev.add_book("The Old Book");
+    dev.set_rating(book, 9);
+    dev.push();
+
+    // Inject a previously-plaintext op directly into the device's library to
+    // prove migration re-protects readable data.
+    {
+        let db = SyncDatabase::open_no_migrate(&server.db_path()).expect("open server db");
+        db.conn
+            .execute(
+                "INSERT INTO ops (op_id, library_id, device_id, hlc, entity_type, entity_id,
+                                  op_type, payload, received_at)
+                 VALUES ('plain-op', 'old-library-id', ?1, '999|0', 'book', ?2, 'update',
+                         '{\"title\":\"plaintext\"}', datetime('now'))",
+                rusqlite::params![
+                    dev.device_id().to_string(),
+                    uuid::Uuid::now_v7().to_string()
+                ],
+            )
+            .expect("seed plaintext op");
+    }
+
+    // Migrate: becomes the bootstrap admin, adopts orphan + own library, rekeys.
+    let secret = toku_core::SecretKey::generate().unwrap();
+    let outcome = toku_sync_client::migrate(dev.data_dir_path(), "owner@toku.test", "pw", &secret)
+        .expect("migrate succeeds");
+
+    assert_eq!(outcome.role, "admin");
+    assert!(
+        outcome.adopted_libraries >= 2,
+        "adopts orphan + device library"
+    );
+    assert!(outcome.adopted_devices >= 2);
+    assert!(
+        outcome.ops_replaced >= 3,
+        "all ops re-keyed: {}",
+        outcome.ops_replaced
+    );
+    assert!(outcome.had_encryption);
+
+    // Every server op is now zero-knowledge ciphertext (incl. the seeded plaintext).
+    let db = SyncDatabase::open_no_migrate(&server.db_path()).expect("open server db");
+    let mut stmt = db.conn.prepare("SELECT payload FROM ops").unwrap();
+    let payloads: Vec<String> = stmt
+        .query_map([], |r| r.get::<_, String>(0))
+        .unwrap()
+        .map(|r| r.unwrap())
+        .collect();
+    assert!(!payloads.is_empty());
+    for p in &payloads {
+        assert!(
+            p.contains("\"ev\""),
+            "op must be an encrypted envelope: {p}"
+        );
+        assert!(!p.contains("plaintext"), "no readable content on server");
+    }
+
+    // Instance is now locked to protocol 2: old clients get 426.
+    assert_eq!(health(&server)["min_protocol"], 2);
+    let resp = reqwest::blocking::Client::new()
+        .post(format!("{}/api/v1/register", server.base_url()))
+        .header("x-toku-sync-protocol", "1")
+        .json(&serde_json::json!({"library_id": "x", "device_name": "old"}))
+        .send()
+        .unwrap();
+    assert_eq!(resp.status().as_u16(), 426, "pre-account client rejected");
+}

--- a/docs/adr/008-sync-wire-protocol.md
+++ b/docs/adr/008-sync-wire-protocol.md
@@ -221,3 +221,12 @@ The open questions from the draft were resolved during review and acceptance (is
 - **Rate limiting strategy** — A **per-device token bucket** on the server (default
   ~60 requests/min) returning `429` + `Retry-After`, with exponential client backoff.
   See Decision → Rate limiting.
+
+## Protocol versioning (issue #126)
+
+The wire protocol is versioned via an `X-Toku-Sync-Protocol` request header and an
+`instance_config.min_protocol` gate. Protocol **1** is the original relay (library
+passphrase, unauthenticated `register`); protocol **2** is the account model (SRP + Secret
+Key + wrapped key hierarchy). `GET /health` advertises `protocol_version` and `min_protocol`.
+Once an instance is migrated (see ADR-010 / #126) `min_protocol` becomes `2` and pre-account
+clients are rejected with `426 Upgrade Required`.

--- a/docs/adr/010-self-host-auth.md
+++ b/docs/adr/010-self-host-auth.md
@@ -254,3 +254,12 @@ incorrect for a networked self-hosted server.
 | OIDC/OAuth2 (delegate to external IdP) | Adds mandatory external dependency; breaks offline onboarding; does not solve E2E key hierarchy |
 | Keep ADR-006/008 for self-hosted, add ZK only for managed | Inconsistent security model; self-hosted users deserve the same guarantees |
 | Full Pildora model (vault sharing, per-item keys) | No sharing feature exists; per-item keys are unnecessary complexity for a personal tool |
+
+## Relay migration (issue #126)
+
+Pre-account relay instances upgrade via a one-time `toku sync migrate`: the client generates
+a Secret Key + account password, the first account bootstraps as admin and the server adopts
+all orphan (unowned) libraries/devices, and all server ops/snapshots are re-keyed from the
+single passphrase (or plaintext) into zero-knowledge ciphertext under the new key hierarchy.
+The instance then locks `min_protocol = 2`, closing the legacy unauthenticated path. The
+migration is forward-only; back up `sync.db` first.

--- a/docs/sync-server.md
+++ b/docs/sync-server.md
@@ -244,7 +244,7 @@ After recreating, confirm the new version is healthy:
 
 ```bash
 curl https://sync.example.com/health
-# {"status":"ok","version":"0.3.2"}
+# {"status":"ok","version":"0.3.2","protocol_version":2,"min_protocol":1}
 ```
 
 > **Back up before upgrading.** Take a copy of `sync.db` (see [Data persistence](#data-persistence))
@@ -255,6 +255,46 @@ curl https://sync.example.com/health
 > reproducible upgrades, pin a specific version (e.g. `ghcr.io/kafkade/toku-sync:0.3.2`)
 > and bump it deliberately. Both `MAJOR.MINOR` and full `MAJOR.MINOR.PATCH` tags are
 > published alongside `latest`.
+
+## Migrating from the legacy relay model
+
+Early instances ran the **relay model**: a client-chosen `library_id`, an optional single
+passphrase, unauthenticated registration, and (sometimes) plaintext ops on the server. The
+current model uses **accounts** (email + password) with a high-entropy Secret Key, an
+end-to-end key hierarchy, and zero-knowledge ops. A one-time migration moves existing data
+and devices onto the new model without stranding anything.
+
+### Wire protocol versions
+
+The server advertises two numbers in `GET /health`:
+
+- `protocol_version` — what the server speaks (currently `2`, the account model).
+- `min_protocol` — the lowest client protocol accepted. Fresh and un-migrated instances stay
+  at `1`, so legacy clients keep working. After migration it becomes `2`.
+
+Once `min_protocol` is `2`, pre-account clients are rejected with **HTTP 426 (Upgrade
+Required)**. Upgrade those installs to a current Toku build before they can sync again.
+
+### One-time client migration
+
+On a device that already has legacy sync configured, run:
+
+```bash
+toku sync migrate --email you@example.com
+```
+
+This generates a fresh Secret Key + account password, creates your account on the server
+(the **first** account becomes admin and adopts all pre-existing libraries/devices),
+re-protects every server op and snapshot under the new zero-knowledge key hierarchy
+(plaintext ops are encrypted for the first time), and locks the instance to protocol 2.
+Your Secret Key and Emergency Kit are shown **once** — store them offline.
+
+**Other devices** rejoin afterwards with `toku sync enroll --email you@example.com` using the
+same password + Secret Key.
+
+> **Breaking change:** migration is forward-only and closes the old unauthenticated
+> registration path. Minimum client version: the first release that ships `toku sync
+> migrate` (account protocol 2). Back up `sync.db` first.
 
 ## Health checks
 


### PR DESCRIPTION
## Description

Adds a one-time, lossless upgrade path from the legacy relay sync model to the new
account + key-hierarchy model (#126). Existing self-hosters can migrate their relay
data and devices into a zero-knowledge account without losing history, and migrated
servers reject pre-account clients with a clear upgrade signal.

**What's included**

- **`toku sync migrate` CLI flow** — signs up the first (admin) account, generates a
  fresh random data key, re-keys every server op and snapshot (plaintext or
  old single-passphrase) into zero-knowledge ciphertext under the new hierarchy,
  rewrites local sync config, and renders an Emergency Kit. Idempotent and safe to re-run.
- **Server backfill (V8 migration + admin bootstrap)** — the first `account_signup`
  adopts all unowned (`user_id IS NULL`) libraries and devices; adds indexes plus
  `instance_config.protocol_version` / `min_protocol`.
- **Wire-protocol versioning** — clients send `X-Toku-Sync-Protocol`; `/health`
  advertises `protocol_version` / `min_protocol`; a migrated instance returns `426
  Upgrade Required` to pre-account clients. `min_protocol` only bumps once orphans are adopted.
- **Docs** — migration + breaking-change guidance in `docs/sync-server.md`; ADR-008/010 notes.

## Related Issues

Closes #126.

## Type of Change

- [x] New feature
- [ ] Bug fix
- [ ] Documentation update
- [ ] CI / infrastructure

## Crate

toku-sync, toku-sync-client, toku-cli

## Data Integrity

Migration is idempotent and lossless; server remains zero-knowledge after migrate
(ops/snapshot re-encrypted to a fresh key). Local SQLite library untouched.

## Checklist

- [x] `cargo fmt -- --check` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo test` passes
- [x] CHANGELOG updated
- [x] No new CI gate jobs (Validate unchanged; no IaC update needed)
