### PR TITLE
feat: add file association CLI (toku file add/list/remove)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- File association CLI: `toku file add/list/remove` links ebook files (`.epub`,
+  `.pdf`, `.mobi`, `.azw3`) to books with multiple formats per book, auto-detecting
+  format from the extension, recording size, and storing a SHA-256 checksum (with
+  duplicate-checksum detection). Supports `--format table|json|csv` and `NO_COLOR`;
+  `remove` takes a format or path and an optional `--delete-file`. Backed by a new
+  local-only `files` table and `toku-files` crate (#148)
 - One-time `toku sync migrate` upgrade path from the legacy relay model to the account
   model (#126): generates a Secret Key + account, makes the first account the admin and
   adopts all pre-existing relay libraries/devices, re-keys every server op and snapshot from

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5906,6 +5906,7 @@ dependencies = [
  "toku-core",
  "toku-db",
  "toku-export",
+ "toku-files",
  "toku-import",
  "toku-meta",
  "toku-sync-client",
@@ -5992,6 +5993,21 @@ dependencies = [
  "toku-db",
  "toku-import",
  "toku-sync-client",
+ "uuid",
+]
+
+[[package]]
+name = "toku-files"
+version = "0.3.2"
+dependencies = [
+ "chrono",
+ "rusqlite",
+ "serde",
+ "sha2 0.11.0",
+ "tempfile",
+ "thiserror 2.0.18",
+ "toku-core",
+ "toku-db",
  "uuid",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ members = [
     "crates/toku-meta",
     "crates/toku-import",
     "crates/toku-export",
+    "crates/toku-files",
     "crates/toku-cli",
     "crates/toku-ffi",
     "crates/toku-web",
@@ -28,6 +29,7 @@ toku-db = { path = "crates/toku-db", version = "0.3.0" }
 toku-meta = { path = "crates/toku-meta", version = "0.3.0" }
 toku-import = { path = "crates/toku-import", version = "0.3.0" }
 toku-export = { path = "crates/toku-export", version = "0.3.0" }
+toku-files = { path = "crates/toku-files", version = "0.3.0" }
 toku-web = { path = "crates/toku-web", version = "0.3.0" }
 toku-sync-client = { path = "crates/toku-sync-client", version = "0.3.0" }
 thiserror = "2"

--- a/crates/toku-cli/Cargo.toml
+++ b/crates/toku-cli/Cargo.toml
@@ -17,6 +17,7 @@ toku-db.workspace = true
 toku-meta.workspace = true
 toku-import.workspace = true
 toku-export.workspace = true
+toku-files.workspace = true
 toku-web.workspace = true
 toku-sync-client.workspace = true
 clap = { version = "4", features = ["derive", "env"] }

--- a/crates/toku-cli/src/main.rs
+++ b/crates/toku-cli/src/main.rs
@@ -12,7 +12,7 @@ use toku_core::{
     TokuConfig, compute_stats, parse_duration_to_minutes,
 };
 use toku_db::{BookRepository, Database};
-
+use toku_files::{EbookFile, FileFormat, FileRepository, sha256_file};
 mod account;
 mod import_ui;
 mod sync;
@@ -190,6 +190,12 @@ enum Commands {
     Tag {
         #[command(subcommand)]
         action: TagAction,
+    },
+
+    /// Associate ebook files (.epub/.pdf/.mobi/.azw3) with books
+    File {
+        #[command(subcommand)]
+        action: FileAction,
     },
 
     /// Export your library (csv, json, markdown, backup)
@@ -409,6 +415,37 @@ enum TagAction {
 
     /// List all tags with book counts
     List,
+}
+
+#[derive(Subcommand)]
+enum FileAction {
+    /// Associate an ebook file with a book (format auto-detected from extension)
+    Add {
+        /// Book title
+        book: String,
+
+        /// Path to the ebook file
+        path: PathBuf,
+    },
+
+    /// List files associated with a book
+    List {
+        /// Book title
+        book: String,
+    },
+
+    /// Remove a file association by format or path
+    Remove {
+        /// Book title
+        book: String,
+
+        /// File format (epub/pdf/mobi/azw3) or exact path to remove
+        target: String,
+
+        /// Also delete the file from disk (default: only drop the DB record)
+        #[arg(long)]
+        delete_file: bool,
+    },
 }
 
 #[derive(Subcommand)]
@@ -936,6 +973,7 @@ fn main() -> Result<()> {
         Commands::Lookup { query, limit } => cmd_lookup(&query, limit, &cli.format),
         Commands::Reading { action } => cmd_reading(&repo, action, &cli.format),
         Commands::Tag { action } => cmd_tag(&repo, action, &cli.format),
+        Commands::File { action } => cmd_file(&db, &repo, action, &cli.format),
         Commands::Export { target } => cmd_export(&db, &data_dir, target),
         Commands::Bulk { action } => cmd_bulk(&db, &repo, action),
         Commands::Stats {
@@ -2221,6 +2259,148 @@ fn cmd_tag(repo: &BookRepository, action: TagAction, output_format: &OutputForma
             }
             eprintln!("\n{} tag(s)", tags.len());
             Ok(())
+        }
+    }
+}
+
+fn human_size(bytes: i64) -> String {
+    const UNITS: [&str; 5] = ["B", "KB", "MB", "GB", "TB"];
+    let mut size = bytes as f64;
+    let mut unit = 0;
+    while size >= 1024.0 && unit < UNITS.len() - 1 {
+        size /= 1024.0;
+        unit += 1;
+    }
+    if unit == 0 {
+        format!("{bytes} B")
+    } else {
+        format!("{size:.1} {}", UNITS[unit])
+    }
+}
+
+fn cmd_file(
+    db: &Database,
+    repo: &BookRepository,
+    action: FileAction,
+    output_format: &OutputFormat,
+) -> Result<()> {
+    let files = FileRepository::new(db);
+    match action {
+        FileAction::Add { book, path } => {
+            let book = resolve_book(repo, &book)?;
+            if !path.is_file() {
+                anyhow::bail!("file not found: {}", path.display());
+            }
+            let format = FileFormat::from_path(&path).map_err(|e| anyhow::anyhow!("{e}"))?;
+            let size_bytes = std::fs::metadata(&path)
+                .with_context(|| format!("reading {}", path.display()))?
+                .len() as i64;
+            let checksum = sha256_file(&path).map_err(|e| anyhow::anyhow!("{e}"))?;
+            let stored = path
+                .canonicalize()
+                .unwrap_or(path.clone())
+                .to_string_lossy()
+                .to_string();
+            let file = EbookFile::new(book.id, stored, format, size_bytes, checksum);
+            files.add_file(&file).map_err(|e| anyhow::anyhow!("{e}"))?;
+            eprintln!(
+                "✓ Linked {} ({}) to \"{}\"",
+                file.format,
+                human_size(file.size_bytes),
+                book.title
+            );
+            Ok(())
+        }
+        FileAction::List { book } => {
+            let book = resolve_book(repo, &book)?;
+            let list = files
+                .list_files(&book.id)
+                .map_err(|e| anyhow::anyhow!("{e}"))?;
+            if list.is_empty() {
+                eprintln!(
+                    "No files linked to \"{}\". Add one with: toku file add",
+                    book.title
+                );
+                return Ok(());
+            }
+            match output_format {
+                OutputFormat::Json => {
+                    println!("{}", serde_json::to_string_pretty(&list)?);
+                }
+                OutputFormat::Csv => {
+                    println!("format,size_bytes,checksum,exists,path");
+                    for f in &list {
+                        println!(
+                            "{},{},{},{},\"{}\"",
+                            f.format,
+                            f.size_bytes,
+                            f.checksum,
+                            Path::new(&f.path).exists(),
+                            f.path.replace('"', "\"\"")
+                        );
+                    }
+                }
+                OutputFormat::Table => {
+                    use tabled::{Table, Tabled};
+
+                    #[derive(Tabled)]
+                    struct Row {
+                        #[tabled(rename = "Format")]
+                        format: String,
+                        #[tabled(rename = "Size")]
+                        size: String,
+                        #[tabled(rename = "Checksum")]
+                        checksum: String,
+                        #[tabled(rename = "On disk")]
+                        exists: String,
+                        #[tabled(rename = "Path")]
+                        path: String,
+                    }
+                    let rows: Vec<Row> = list
+                        .iter()
+                        .map(|f| Row {
+                            format: f.format.to_string(),
+                            size: human_size(f.size_bytes),
+                            checksum: f.checksum.chars().take(12).collect(),
+                            exists: if Path::new(&f.path).exists() {
+                                "yes"
+                            } else {
+                                "MISSING"
+                            }
+                            .to_string(),
+                            path: f.path.clone(),
+                        })
+                        .collect();
+                    println!("{}", Table::new(rows));
+                }
+            }
+            eprintln!("\n{} file(s)", list.len());
+            Ok(())
+        }
+        FileAction::Remove {
+            book,
+            target,
+            delete_file,
+        } => {
+            let book = resolve_book(repo, &book)?;
+            let removed = match target.parse::<FileFormat>() {
+                Ok(fmt) => files.remove_by_format(&book.id, fmt),
+                Err(_) => files.remove_by_path(&book.id, &target),
+            }
+            .map_err(|e| anyhow::anyhow!("{e}"))?;
+            match removed {
+                Some(f) => {
+                    if delete_file {
+                        match std::fs::remove_file(&f.path) {
+                            Ok(()) => eprintln!("✓ Deleted file {}", f.path),
+                            Err(e) => eprintln!("⚠ Removed record, but file delete failed: {e}"),
+                        }
+                    }
+                    eprintln!("✓ Removed {} from \"{}\"", f.format, book.title);
+                    Ok(())
+                }
+                None => anyhow::bail!("no file matching \"{target}\" linked to \"{}\"", book.title),
+            }
         }
     }
 }

--- a/crates/toku-db/migrations/V17__files.sql
+++ b/crates/toku-db/migrations/V17__files.sql
@@ -1,0 +1,14 @@
+-- Ebook files associated with books (multi-format per book).
+-- Local-only: file binaries are never synced (see ROADMAP §6.4, Phase 7 cut line).
+CREATE TABLE files (
+    id TEXT PRIMARY KEY NOT NULL,
+    book_id TEXT NOT NULL REFERENCES books(id),
+    path TEXT NOT NULL,
+    format TEXT NOT NULL,              -- epub, pdf, mobi, azw3
+    size_bytes INTEGER NOT NULL,
+    checksum TEXT NOT NULL,            -- SHA-256, hex-encoded
+    created_at TEXT NOT NULL,          -- ISO 8601
+    updated_at TEXT NOT NULL           -- ISO 8601
+);
+CREATE INDEX idx_files_book ON files(book_id);
+CREATE INDEX idx_files_checksum ON files(checksum);

--- a/crates/toku-files/Cargo.toml
+++ b/crates/toku-files/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "toku-files"
+description = "Ebook file association and management for the Toku book manager"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[dependencies]
+toku-core.workspace = true
+toku-db.workspace = true
+thiserror.workspace = true
+uuid.workspace = true
+chrono.workspace = true
+rusqlite.workspace = true
+serde.workspace = true
+sha2.workspace = true
+
+[dev-dependencies]
+tempfile = "3"

--- a/crates/toku-files/src/lib.rs
+++ b/crates/toku-files/src/lib.rs
@@ -1,0 +1,182 @@
+//! Ebook file association for Toku.
+//!
+//! Links ebook files on disk (`.epub`, `.pdf`, `.mobi`, `.azw3`) to existing
+//! books, tracking format, size, and SHA-256 checksum. File binaries are
+//! local-only and are never synced (see ROADMAP §6.4 / Phase 7 cut line).
+
+use std::io::Read;
+use std::path::Path;
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use uuid::Uuid;
+
+mod repo;
+
+pub use repo::FileRepository;
+
+/// Supported ebook file formats.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum FileFormat {
+    Epub,
+    Pdf,
+    Mobi,
+    Azw3,
+}
+
+impl FileFormat {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Epub => "epub",
+            Self::Pdf => "pdf",
+            Self::Mobi => "mobi",
+            Self::Azw3 => "azw3",
+        }
+    }
+
+    /// Detect a format from a path's file extension. Case-insensitive.
+    pub fn from_path(path: &Path) -> Result<Self, FileError> {
+        let ext = path
+            .extension()
+            .and_then(|e| e.to_str())
+            .ok_or_else(|| FileError::UnsupportedFormat("(no extension)".to_string()))?;
+        ext.parse()
+    }
+}
+
+impl std::fmt::Display for FileFormat {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl std::str::FromStr for FileFormat {
+    type Err = FileError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.to_lowercase().as_str() {
+            "epub" => Ok(Self::Epub),
+            "pdf" => Ok(Self::Pdf),
+            "mobi" => Ok(Self::Mobi),
+            "azw3" => Ok(Self::Azw3),
+            _ => Err(FileError::UnsupportedFormat(s.to_string())),
+        }
+    }
+}
+
+/// An ebook file associated with a book.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EbookFile {
+    pub id: Uuid,
+    pub book_id: Uuid,
+    pub path: String,
+    pub format: FileFormat,
+    pub size_bytes: i64,
+    /// SHA-256 checksum, hex-encoded.
+    pub checksum: String,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+impl EbookFile {
+    pub fn new(
+        book_id: Uuid,
+        path: String,
+        format: FileFormat,
+        size_bytes: i64,
+        checksum: String,
+    ) -> Self {
+        let now = Utc::now();
+        Self {
+            id: Uuid::now_v7(),
+            book_id,
+            path,
+            format,
+            size_bytes,
+            checksum,
+            created_at: now,
+            updated_at: now,
+        }
+    }
+}
+
+/// Errors raised by file association operations.
+#[derive(Debug, thiserror::Error)]
+pub enum FileError {
+    #[error("file not found: {0}")]
+    FileNotFound(String),
+
+    #[error("unsupported format: {0} (expected epub, pdf, mobi, or azw3)")]
+    UnsupportedFormat(String),
+
+    #[error("duplicate file: a file with checksum {0} is already linked to this book")]
+    Duplicate(String),
+
+    #[error("I/O error: {0}")]
+    Io(String),
+
+    #[error("database error: {0}")]
+    Db(#[from] toku_db::DbError),
+
+    #[error("SQLite error: {0}")]
+    Sqlite(#[from] rusqlite::Error),
+}
+
+/// Compute the SHA-256 checksum (hex) of a file's contents.
+pub fn sha256_file(path: &Path) -> Result<String, FileError> {
+    let mut file = std::fs::File::open(path).map_err(|e| FileError::Io(e.to_string()))?;
+    let mut hasher = Sha256::new();
+    let mut buf = [0u8; 8192];
+    loop {
+        let n = file
+            .read(&mut buf)
+            .map_err(|e| FileError::Io(e.to_string()))?;
+        if n == 0 {
+            break;
+        }
+        hasher.update(&buf[..n]);
+    }
+    Ok(hex(&hasher.finalize()))
+}
+
+fn hex(bytes: &[u8]) -> String {
+    let mut s = String::with_capacity(bytes.len() * 2);
+    for b in bytes {
+        s.push_str(&format!("{b:02x}"));
+    }
+    s
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    #[test]
+    fn detects_format_from_extension() {
+        assert_eq!(
+            FileFormat::from_path(&PathBuf::from("a.EPUB")).unwrap(),
+            FileFormat::Epub
+        );
+        assert_eq!(
+            FileFormat::from_path(&PathBuf::from("a.pdf")).unwrap(),
+            FileFormat::Pdf
+        );
+        assert!(FileFormat::from_path(&PathBuf::from("a.txt")).is_err());
+        assert!(FileFormat::from_path(&PathBuf::from("noext")).is_err());
+    }
+
+    #[test]
+    fn computes_known_sha256() {
+        let dir = tempfile::tempdir().unwrap();
+        let p = dir.path().join("empty.epub");
+        std::fs::write(&p, b"").unwrap();
+        // SHA-256 of the empty string.
+        assert_eq!(
+            sha256_file(&p).unwrap(),
+            "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+        );
+    }
+}

--- a/crates/toku-files/src/repo.rs
+++ b/crates/toku-files/src/repo.rs
@@ -1,0 +1,150 @@
+//! Persistence for ebook file associations (`files` table).
+
+use chrono::Utc;
+use rusqlite::params;
+use toku_db::Database;
+use uuid::Uuid;
+
+use crate::{EbookFile, FileError, FileFormat};
+
+/// Repository for ebook file associations. Borrows a [`Database`] connection.
+pub struct FileRepository<'a> {
+    db: &'a Database,
+}
+
+impl<'a> FileRepository<'a> {
+    pub fn new(db: &'a Database) -> Self {
+        Self { db }
+    }
+
+    /// Associate a file with a book. Errors if a file with the same checksum is
+    /// already linked to the same book.
+    pub fn add_file(&self, file: &EbookFile) -> Result<(), FileError> {
+        if self
+            .find_by_checksum(&file.book_id, &file.checksum)?
+            .is_some()
+        {
+            return Err(FileError::Duplicate(file.checksum.clone()));
+        }
+        self.db.conn.execute(
+            "INSERT INTO files (id, book_id, path, format, size_bytes, checksum,
+             created_at, updated_at)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
+            params![
+                file.id.to_string(),
+                file.book_id.to_string(),
+                file.path,
+                file.format.as_str(),
+                file.size_bytes,
+                file.checksum,
+                file.created_at.to_rfc3339(),
+                file.updated_at.to_rfc3339(),
+            ],
+        )?;
+        Ok(())
+    }
+
+    /// List all files associated with a book, ordered by format.
+    pub fn list_files(&self, book_id: &Uuid) -> Result<Vec<EbookFile>, FileError> {
+        let mut stmt = self.db.conn.prepare(
+            "SELECT id, book_id, path, format, size_bytes, checksum, created_at, updated_at
+             FROM files WHERE book_id = ?1 ORDER BY format",
+        )?;
+        let files = stmt
+            .query_map(params![book_id.to_string()], |row| Ok(row_to_file(row)))?
+            .filter_map(|r| r.ok())
+            .filter_map(|r| r.ok())
+            .collect();
+        Ok(files)
+    }
+
+    /// Find a file linked to a book by exact checksum.
+    pub fn find_by_checksum(
+        &self,
+        book_id: &Uuid,
+        checksum: &str,
+    ) -> Result<Option<EbookFile>, FileError> {
+        let mut stmt = self.db.conn.prepare(
+            "SELECT id, book_id, path, format, size_bytes, checksum, created_at, updated_at
+             FROM files WHERE book_id = ?1 AND checksum = ?2",
+        )?;
+        let mut rows = stmt
+            .query_map(params![book_id.to_string(), checksum], |row| {
+                Ok(row_to_file(row))
+            })?
+            .filter_map(|r| r.ok())
+            .filter_map(|r| r.ok());
+        Ok(rows.next())
+    }
+
+    /// Remove a file association by format. Returns the removed file, if any.
+    pub fn remove_by_format(
+        &self,
+        book_id: &Uuid,
+        format: FileFormat,
+    ) -> Result<Option<EbookFile>, FileError> {
+        let existing: Vec<EbookFile> = self
+            .list_files(book_id)?
+            .into_iter()
+            .filter(|f| f.format == format)
+            .collect();
+        match existing.first() {
+            Some(file) => {
+                self.delete_record(&file.id)?;
+                Ok(Some(file.clone()))
+            }
+            None => Ok(None),
+        }
+    }
+
+    /// Remove a file association by exact path. Returns the removed file, if any.
+    pub fn remove_by_path(
+        &self,
+        book_id: &Uuid,
+        path: &str,
+    ) -> Result<Option<EbookFile>, FileError> {
+        let existing: Vec<EbookFile> = self
+            .list_files(book_id)?
+            .into_iter()
+            .filter(|f| f.path == path)
+            .collect();
+        match existing.first() {
+            Some(file) => {
+                self.delete_record(&file.id)?;
+                Ok(Some(file.clone()))
+            }
+            None => Ok(None),
+        }
+    }
+
+    fn delete_record(&self, id: &Uuid) -> Result<(), FileError> {
+        self.db
+            .conn
+            .execute("DELETE FROM files WHERE id = ?1", params![id.to_string()])?;
+        Ok(())
+    }
+}
+
+fn row_to_file(row: &rusqlite::Row<'_>) -> Result<EbookFile, String> {
+    let id_str: String = row.get(0).map_err(|e| e.to_string())?;
+    let book_id_str: String = row.get(1).map_err(|e| e.to_string())?;
+    let format_str: String = row.get(3).map_err(|e| e.to_string())?;
+    let created_str: String = row.get(6).map_err(|e| e.to_string())?;
+    let updated_str: String = row.get(7).map_err(|e| e.to_string())?;
+    Ok(EbookFile {
+        id: Uuid::parse_str(&id_str).map_err(|e| e.to_string())?,
+        book_id: Uuid::parse_str(&book_id_str).map_err(|e| e.to_string())?,
+        path: row.get(2).map_err(|e| e.to_string())?,
+        format: format_str
+            .parse()
+            .map_err(|_| format!("bad format: {format_str}"))?,
+        size_bytes: row.get(4).map_err(|e| e.to_string())?,
+        checksum: row.get(5).map_err(|e| e.to_string())?,
+        created_at: chrono::DateTime::parse_from_rfc3339(&created_str)
+            .map_err(|e| e.to_string())?
+            .with_timezone(&Utc),
+        updated_at: chrono::DateTime::parse_from_rfc3339(&updated_str)
+            .map_err(|e| e.to_string())?
+            .with_timezone(&Utc),
+    })
+}

--- a/crates/toku-files/tests/file_association.rs
+++ b/crates/toku-files/tests/file_association.rs
@@ -1,0 +1,81 @@
+use toku_core::Book;
+use toku_db::{BookRepository, Database};
+use toku_files::{EbookFile, FileFormat, FileRepository, sha256_file};
+
+fn seed_book(db: &Database) -> uuid::Uuid {
+    let repo = BookRepository::new(db);
+    let book = Book::new("Dune");
+    repo.create_book(&book).unwrap();
+    book.id
+}
+
+#[test]
+fn add_list_remove_roundtrip() {
+    let dir = tempfile::tempdir().unwrap();
+    let db = Database::open_in_memory().unwrap();
+    let book_id = seed_book(&db);
+    let files = FileRepository::new(&db);
+
+    let epub = dir.path().join("dune.epub");
+    std::fs::write(&epub, b"epub bytes").unwrap();
+    let pdf = dir.path().join("dune.pdf");
+    std::fs::write(&pdf, b"pdf bytes").unwrap();
+
+    let f1 = EbookFile::new(
+        book_id,
+        epub.to_string_lossy().to_string(),
+        FileFormat::Epub,
+        10,
+        sha256_file(&epub).unwrap(),
+    );
+    let f2 = EbookFile::new(
+        book_id,
+        pdf.to_string_lossy().to_string(),
+        FileFormat::Pdf,
+        9,
+        sha256_file(&pdf).unwrap(),
+    );
+    files.add_file(&f1).unwrap();
+    files.add_file(&f2).unwrap();
+
+    let listed = files.list_files(&book_id).unwrap();
+    assert_eq!(listed.len(), 2);
+
+    let removed = files.remove_by_format(&book_id, FileFormat::Epub).unwrap();
+    assert!(removed.is_some());
+    assert_eq!(files.list_files(&book_id).unwrap().len(), 1);
+
+    let removed = files.remove_by_path(&book_id, &f2.path).unwrap();
+    assert!(removed.is_some());
+    assert!(files.list_files(&book_id).unwrap().is_empty());
+}
+
+#[test]
+fn duplicate_checksum_rejected() {
+    let dir = tempfile::tempdir().unwrap();
+    let db = Database::open_in_memory().unwrap();
+    let book_id = seed_book(&db);
+    let files = FileRepository::new(&db);
+
+    let p = dir.path().join("a.epub");
+    std::fs::write(&p, b"same content").unwrap();
+    let sum = sha256_file(&p).unwrap();
+
+    let f = EbookFile::new(
+        book_id,
+        p.to_string_lossy().to_string(),
+        FileFormat::Epub,
+        12,
+        sum.clone(),
+    );
+    files.add_file(&f).unwrap();
+
+    let dup = EbookFile::new(
+        book_id,
+        "/elsewhere/a.epub".into(),
+        FileFormat::Epub,
+        12,
+        sum,
+    );
+    assert!(files.add_file(&dup).is_err());
+}


### PR DESCRIPTION
## Description

Adds a file-association CLI so users can link ebook files (`.epub`, `.pdf`, `.mobi`, `.azw3`) to existing books — the first deliverable of the Phase 6 file-management epic (ROADMAP §6.1).

**What's included:**

- **New `toku-files` crate** — domain model (`FileFormat`, `EbookFile`), a streaming `sha256_file()` helper, and `FileRepository` (add/list/remove + checksum lookup). Depends only on `toku-core` and `toku-db` (no network), so it scaffolds the crate that #153 calls for.
- **`files` table** (migration `V17__files.sql`) — tracks `book_id`, `path`, `format`, `size_bytes`, SHA-256 `checksum`, and timestamps, with indexes on `book_id` and `checksum`. Local-only: file binaries are explicitly **not** synced (ROADMAP §6.4 / Phase 7 cut line).
- **`toku file` subcommands** in the CLI:
  - `file add <book> <path>` — auto-detects format from the extension, records size, computes and stores SHA-256. Hard-errors on missing file, unsupported format, or a duplicate checksum already linked to the book.
  - `file list <book>` — shows format, size, short checksum, on-disk status, and path.
  - `file remove <book> <format|path>` — drops the association; `--delete-file` also removes the file from disk.
- All three commands honor `--format table|json|csv` and `NO_COLOR` (ADR-003).

## Related Issues

Closes #148. Scaffolds the `toku-files` crate + `files` table from #153. Part of the Phase 6 epic (#154).

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI / infrastructure
- [ ] Other (describe below)

## Crate

- [ ] `toku-core` — Domain models, traits, state machine
- [x] `toku-db` — SQLite persistence, migrations, FTS5
- [ ] `toku-import` — Importers (Goodreads, Calibre, StoryGraph)
- [ ] `toku-meta` — Metadata fetching (Open Library, Google Books)
- [x] `toku-cli` — CLI binary
- [ ] `toku-export` — Exporters (CSV, JSON, Markdown, BibTeX)
- [ ] `docs/` — Documentation
- [x] `toku-files` — New crate for ebook file association

## Data Integrity Checklist

- [x] No user data is sent to any server without explicit opt-in (file records are local-only and never synced)
- [x] Import operations are idempotent (duplicate checksums are rejected on re-add)
- [x] User edits to metadata are never overwritten by auto-enrichment (N/A — no enrichment here)
- [x] New fields track provenance (source + timestamp) (records store `created_at`/`updated_at`)
- [x] Export round-trip is preserved (if applicable) (N/A)

## Checklist

- [x] I have read [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] `cargo fmt --check` passes
- [x] `cargo clippy --workspace -- -D warnings` passes
- [x] `cargo test --workspace` passes
- [ ] I have updated documentation (if applicable)
