### PR TITLE
feat: inline manual-merge editor for sync conflicts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Inline manual-merge editor for sync conflicts: the web conflicts page now offers a
+  "Merge manually" action alongside keep-local/keep-remote, revealing an editable field
+  (textarea for note/review content, 0–10 number input for review ratings) pre-filled with
+  the local value. Resolving with a custom value writes it to the entity, bumps the HLC, and
+  emits a propagating `SyncOp::Update` so the merged value syncs to other devices. The CLI
+  gains `toku sync conflicts resolve <id> --value "..."` for the same custom-value path (#129)
 - File association CLI: `toku file add/list/remove` links ebook files (`.epub`,
   `.pdf`, `.mobi`, `.azw3`) to books with multiple formats per book, auto-detecting
   format from the extension, recording size, and storing a SHA-256 checksum (with

--- a/crates/toku-cli/src/main.rs
+++ b/crates/toku-cli/src/main.rs
@@ -802,14 +802,18 @@ enum ConflictAction {
         id: String,
     },
 
-    /// Resolve a single conflict by keeping the local or remote value
+    /// Resolve a single conflict, keeping one side or a custom merged value
     Resolve {
         /// Conflict ID
         id: String,
 
-        /// Which side to keep
-        #[arg(long, value_enum)]
-        keep: KeepArg,
+        /// Which side to keep (mutually exclusive with --value)
+        #[arg(long, value_enum, group = "resolution")]
+        keep: Option<KeepArg>,
+
+        /// Resolve with a custom merged value (mutually exclusive with --keep)
+        #[arg(long, group = "resolution")]
+        value: Option<String>,
     },
 
     /// Resolve every unresolved conflict the same way
@@ -4448,7 +4452,7 @@ fn print_conflict_human(c: &toku_db::SyncConflict) {
     eprintln!("  Local  [{}]: {local}", c.local_hlc);
     eprintln!("  Remote [{}]: {remote}", c.remote_hlc);
     eprintln!(
-        "  Resolve: toku sync conflicts resolve {} --keep local|remote",
+        "  Resolve: toku sync conflicts resolve {} --keep local|remote  (or --value \"...\")",
         c.id
     );
 }
@@ -4524,15 +4528,24 @@ fn cmd_sync_conflicts(
             Ok(())
         }
 
-        ConflictAction::Resolve { id, keep } => {
-            let resolved = sync::orchestrator::resolve_conflict(data_dir, &id, keep.into())?;
+        ConflictAction::Resolve { id, keep, value } => {
+            let (resolved, kept) = if let Some(value) = value {
+                let resolved =
+                    sync::orchestrator::resolve_conflict_with_value(data_dir, &id, Some(&value))?;
+                (resolved, "custom".to_string())
+            } else if let Some(keep) = keep {
+                let resolved = sync::orchestrator::resolve_conflict(data_dir, &id, keep.into())?;
+                let kept = match keep {
+                    KeepArg::Local => "local",
+                    KeepArg::Remote => "remote",
+                };
+                (resolved, kept.to_string())
+            } else {
+                anyhow::bail!("provide either --keep local|remote or --value \"...\"");
+            };
             if !resolved {
                 anyhow::bail!("no unresolved conflict found with id {id}");
             }
-            let kept = match keep {
-                KeepArg::Local => "local",
-                KeepArg::Remote => "remote",
-            };
             match output_format {
                 OutputFormat::Json => {
                     println!(

--- a/crates/toku-db/src/sync_repo.rs
+++ b/crates/toku-db/src/sync_repo.rs
@@ -344,7 +344,58 @@ impl<'a> SyncRepository<'a> {
             return Ok(false);
         }
 
-        self.apply_resolution(&conflict, keep)?;
+        self.apply_resolution(&conflict, conflict.kept_value(keep))?;
+
+        let now = chrono::Utc::now().to_rfc3339();
+        self.db.conn.execute(
+            "UPDATE sync_conflicts SET resolved = 1, resolved_at = ?1 WHERE id = ?2",
+            params![now, id],
+        )?;
+        Ok(true)
+    }
+
+    /// Resolve a single conflict with a user-supplied merged value.
+    ///
+    /// Unlike [`resolve_conflict`], this writes an arbitrary value (rather than
+    /// the local or remote side) to the underlying note/review entity, bumps the
+    /// per-field HLC, emits a propagating sync op, and marks the conflict
+    /// resolved. A no-op (returns `false`) if the conflict is missing or already
+    /// resolved. Returns [`DbError::InvalidOperation`] if the value is invalid
+    /// for the field (e.g. a non-integer or out-of-range review rating).
+    pub fn resolve_conflict_with_value(
+        &self,
+        id: &str,
+        value: Option<&str>,
+    ) -> Result<bool, DbError> {
+        let Some(conflict) = self.get_conflict(id)? else {
+            return Ok(false);
+        };
+        if conflict.resolved {
+            return Ok(false);
+        }
+
+        let field = conflict.field_name.as_deref().ok_or_else(|| {
+            DbError::InvalidOperation("conflict has no field to resolve".to_string())
+        })?;
+        let entity_type = EntityType::from_str(&conflict.entity_type)
+            .map_err(|_| DbError::InvalidOperation("unknown conflict entity type".to_string()))?;
+
+        // Validate the merged value against the target field's domain.
+        if let (EntityType::Review, "rating") = (entity_type, field)
+            && let Some(v) = value
+        {
+            let rating: i64 = v
+                .trim()
+                .parse()
+                .map_err(|_| DbError::InvalidOperation(format!("invalid rating value: {v:?}")))?;
+            if !(0..=10).contains(&rating) {
+                return Err(DbError::InvalidOperation(format!(
+                    "rating must be between 0 and 10, got {rating}"
+                )));
+            }
+        }
+
+        self.apply_resolution(&conflict, value)?;
 
         let now = chrono::Utc::now().to_rfc3339();
         self.db.conn.execute(
@@ -359,7 +410,7 @@ impl<'a> SyncRepository<'a> {
         let conflicts = self.list_unresolved_conflicts()?;
         let mut resolved = 0;
         for conflict in &conflicts {
-            self.apply_resolution(conflict, keep)?;
+            self.apply_resolution(conflict, conflict.kept_value(keep))?;
             resolved += 1;
         }
         if resolved > 0 {
@@ -372,14 +423,17 @@ impl<'a> SyncRepository<'a> {
         Ok(resolved)
     }
 
-    /// Write the chosen value into the live entity, bump its HLC, and emit a
+    /// Write the given value into the live entity, bump its HLC, and emit a
     /// propagating sync op. Best-effort: if no device identity exists yet, the
     /// entity value is still updated but no op is generated.
-    fn apply_resolution(&self, conflict: &SyncConflict, keep: ConflictKeep) -> Result<(), DbError> {
+    fn apply_resolution(
+        &self,
+        conflict: &SyncConflict,
+        value: Option<&str>,
+    ) -> Result<(), DbError> {
         let field = conflict.field_name.as_deref().ok_or_else(|| {
             DbError::InvalidOperation("conflict has no field to resolve".to_string())
         })?;
-        let value = conflict.kept_value(keep);
 
         let entity_type = EntityType::from_str(&conflict.entity_type)
             .map_err(|_| DbError::InvalidOperation("unknown conflict entity type".to_string()))?;
@@ -882,5 +936,152 @@ mod tests {
         seed_book_and_note(&db, &note_id, "x");
         insert_conflict(&db, "c1", &note_id, "a", "b", true);
         assert!(!repo.resolve_conflict("c1", ConflictKeep::Local).unwrap());
+    }
+
+    fn seed_review(db: &Database, review_id: &str, content: Option<&str>, rating: Option<i64>) {
+        let now = "2026-06-15T10:00:00Z";
+        db.conn
+            .execute(
+                "INSERT OR IGNORE INTO books (id, title, created_at, updated_at)
+                 VALUES (?1, 'Dune', ?2, ?2)",
+                params!["01972123-aaaa-7000-8000-000000000abc", now],
+            )
+            .unwrap();
+        db.conn
+            .execute(
+                "INSERT INTO reviews (id, book_id, content, rating, created_at, updated_at)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?5)",
+                params![
+                    review_id,
+                    "01972123-aaaa-7000-8000-000000000abc",
+                    content,
+                    rating,
+                    now
+                ],
+            )
+            .unwrap();
+    }
+
+    fn insert_rating_conflict(db: &Database, id: &str, entity_id: &str, local: &str, remote: &str) {
+        db.conn
+            .execute(
+                "INSERT INTO sync_conflicts
+                 (id, entity_type, entity_id, field_name, local_value, remote_value,
+                  local_hlc, remote_hlc, resolved, created_at)
+                 VALUES (?1, 'review', ?2, 'rating', ?3, ?4, ?5, ?6, 0,
+                         '2026-06-15T10:30:00Z')",
+                params![
+                    id,
+                    entity_id,
+                    local,
+                    remote,
+                    format!("hlc-a-{id}"),
+                    format!("hlc-b-{id}")
+                ],
+            )
+            .unwrap();
+    }
+
+    #[test]
+    fn resolve_conflict_with_value_updates_note_and_emits_op() {
+        let db = test_db();
+        let repo = SyncRepository::new(&db);
+        repo.get_or_create_device("test-device").unwrap();
+
+        let note_id = Uuid::now_v7().to_string();
+        seed_book_and_note(&db, &note_id, "remote text");
+        insert_conflict(&db, "c1", &note_id, "local text", "remote text", false);
+
+        let resolved = repo
+            .resolve_conflict_with_value("c1", Some("merged text"))
+            .unwrap();
+        assert!(resolved);
+
+        // Note content set to the custom merged value.
+        let content: String = db
+            .conn
+            .query_row(
+                "SELECT content FROM notes WHERE id = ?1",
+                params![note_id],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(content, "merged text");
+
+        // Conflict marked resolved and excluded from listings.
+        assert_eq!(repo.count_unresolved_conflicts().unwrap(), 0);
+        let conflict = repo.get_conflict("c1").unwrap().unwrap();
+        assert!(conflict.resolved);
+        assert!(conflict.resolved_at.is_some());
+
+        // A propagating op was emitted.
+        let ops = repo.get_unpushed_ops().unwrap();
+        assert_eq!(ops.len(), 1);
+        assert_eq!(ops[0].entity_type, EntityType::Note);
+        assert_eq!(ops[0].op_type, OpType::Update);
+    }
+
+    #[test]
+    fn resolve_conflict_with_value_updates_review_rating() {
+        let db = test_db();
+        let repo = SyncRepository::new(&db);
+        repo.get_or_create_device("test-device").unwrap();
+
+        let review_id = Uuid::now_v7().to_string();
+        seed_review(&db, &review_id, Some("nice"), Some(4));
+        insert_rating_conflict(&db, "c1", &review_id, "4", "8");
+
+        assert!(repo.resolve_conflict_with_value("c1", Some("6")).unwrap());
+
+        let rating: i64 = db
+            .conn
+            .query_row(
+                "SELECT rating FROM reviews WHERE id = ?1",
+                params![review_id],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(rating, 6);
+        assert_eq!(repo.count_unresolved_conflicts().unwrap(), 0);
+    }
+
+    #[test]
+    fn resolve_conflict_with_invalid_rating_is_rejected() {
+        let db = test_db();
+        let repo = SyncRepository::new(&db);
+        repo.get_or_create_device("test-device").unwrap();
+
+        let review_id = Uuid::now_v7().to_string();
+        seed_review(&db, &review_id, Some("nice"), Some(4));
+        insert_rating_conflict(&db, "c1", &review_id, "4", "8");
+
+        assert!(repo.resolve_conflict_with_value("c1", Some("99")).is_err());
+        assert!(
+            repo.resolve_conflict_with_value("c1", Some("notnum"))
+                .is_err()
+        );
+        // Conflict left unresolved after a rejected value.
+        assert_eq!(repo.count_unresolved_conflicts().unwrap(), 1);
+    }
+
+    #[test]
+    fn resolve_with_value_missing_or_resolved_conflict_is_noop() {
+        let db = test_db();
+        let repo = SyncRepository::new(&db);
+
+        assert!(
+            !repo
+                .resolve_conflict_with_value("missing", Some("x"))
+                .unwrap()
+        );
+
+        let note_id = Uuid::now_v7().to_string();
+        seed_book_and_note(&db, &note_id, "x");
+        insert_conflict(&db, "c1", &note_id, "a", "b", true);
+        assert!(
+            !repo
+                .resolve_conflict_with_value("c1", Some("merged"))
+                .unwrap()
+        );
     }
 }

--- a/crates/toku-sync-client/src/orchestrator.rs
+++ b/crates/toku-sync-client/src/orchestrator.rs
@@ -655,6 +655,18 @@ pub fn resolve_conflict(data_dir: &Path, id: &str, keep: ConflictKeep) -> anyhow
     Ok(sync_repo.resolve_conflict(id, keep)?)
 }
 
+/// Resolve a single conflict with a user-supplied merged value.
+/// Returns `false` if the conflict is missing or already resolved.
+pub fn resolve_conflict_with_value(
+    data_dir: &Path,
+    id: &str,
+    value: Option<&str>,
+) -> anyhow::Result<bool> {
+    let db = open_db(data_dir)?;
+    let sync_repo = SyncRepository::new(&db);
+    Ok(sync_repo.resolve_conflict_with_value(id, value)?)
+}
+
 /// Resolve every unresolved conflict with the same choice. Returns the count resolved.
 pub fn resolve_all_conflicts(data_dir: &Path, keep: ConflictKeep) -> anyhow::Result<usize> {
     let db = open_db(data_dir)?;

--- a/crates/toku-web/src/conflicts_handlers.rs
+++ b/crates/toku-web/src/conflicts_handlers.rs
@@ -11,6 +11,9 @@ use crate::views;
 #[derive(serde::Deserialize)]
 pub struct ResolveForm {
     pub keep: String,
+    /// Custom merged value, used only when `keep == "custom"`.
+    #[serde(default)]
+    pub value: Option<String>,
 }
 
 fn parse_keep(value: &str) -> Result<ConflictKeep, WebError> {
@@ -41,14 +44,28 @@ pub async fn conflicts_page(
 }
 
 /// `POST /conflicts/resolve/{id}` — resolve one conflict, then redirect back.
+///
+/// Supports keeping the local/remote side, or (`keep == "custom"`) writing an
+/// arbitrary user-supplied merged value.
 pub async fn resolve_conflict(
     State(state): State<AppState>,
     Path(id): Path<String>,
     Form(form): Form<ResolveForm>,
 ) -> Result<Redirect, WebError> {
-    let keep = parse_keep(&form.keep)?;
     let db_path = state.db_path.clone();
 
+    if form.keep == "custom" {
+        let value = form.value.unwrap_or_default();
+        tokio::task::spawn_blocking(move || {
+            let db = Database::open(&db_path)?;
+            SyncRepository::new(&db).resolve_conflict_with_value(&id, Some(&value))
+        })
+        .await
+        .map_err(|e| WebError::Internal(e.to_string()))??;
+        return Ok(Redirect::to("/conflicts"));
+    }
+
+    let keep = parse_keep(&form.keep)?;
     tokio::task::spawn_blocking(move || {
         let db = Database::open(&db_path)?;
         SyncRepository::new(&db).resolve_conflict(&id, keep)

--- a/crates/toku-web/src/views.rs
+++ b/crates/toku-web/src/views.rs
@@ -157,6 +157,13 @@ fn conflict_card(c: &SyncConflict, csrf: &str) -> Markup {
     let local = c.local_value.as_deref().unwrap_or("(empty)");
     let remote = c.remote_value.as_deref().unwrap_or("(empty)");
     let resolve_action = format!("/conflicts/resolve/{}", c.id);
+    // Prefill the merge editor with the local value (falling back to remote).
+    let merge_prefill = c
+        .local_value
+        .as_deref()
+        .or(c.remote_value.as_deref())
+        .unwrap_or("");
+    let is_rating = c.entity_type == "review" && c.field_name.as_deref() == Some("rating");
 
     html! {
         div.conflict-card {
@@ -186,6 +193,24 @@ fn conflict_card(c: &SyncConflict, csrf: &str) -> Markup {
                     (crate::auth_views::csrf_field(csrf))
                     input type="hidden" name="keep" value="remote";
                     button.btn.btn-primary type="submit" { "Keep remote" }
+                }
+            }
+            details.conflict-merge {
+                summary.conflict-merge-toggle { "Merge manually" }
+                form.conflict-merge-form method="post" action=(resolve_action) {
+                    (crate::auth_views::csrf_field(csrf))
+                    input type="hidden" name="keep" value="custom";
+                    @if is_rating {
+                        label.conflict-merge-label for=(format!("merge-{}", c.id)) { "Merged rating (0–10)" }
+                        input.conflict-merge-input id=(format!("merge-{}", c.id))
+                            type="number" name="value" min="0" max="10" step="1"
+                            value=(merge_prefill) required;
+                    } @else {
+                        label.conflict-merge-label for=(format!("merge-{}", c.id)) { "Merged value" }
+                        textarea.conflict-merge-textarea id=(format!("merge-{}", c.id))
+                            name="value" rows="4" { (merge_prefill) }
+                    }
+                    button.btn.btn-primary.conflict-merge-submit type="submit" { "Resolve with merged value" }
                 }
             }
         }
@@ -937,6 +962,23 @@ main {
 .conflict-actions { display: flex; gap: 0.5rem; margin-top: 1rem; }
 .conflict-actions form { display: inline; }
 .conflict-actions .btn-primary { margin-left: 0; }
+.conflict-merge { margin-top: 0.75rem; border-top: 1px solid var(--border); padding-top: 0.75rem; }
+.conflict-merge-toggle {
+    cursor: pointer; font-size: 0.85rem; font-weight: 600; color: var(--accent);
+    user-select: none;
+}
+.conflict-merge-form { margin-top: 0.75rem; display: flex; flex-direction: column; gap: 0.5rem; }
+.conflict-merge-label { font-size: 0.8rem; font-weight: 600; color: var(--text-secondary); }
+.conflict-merge-textarea, .conflict-merge-input {
+    width: 100%; box-sizing: border-box; padding: 0.5rem 0.6rem;
+    background: var(--bg); color: var(--text); border: 1px solid var(--border);
+    border-radius: 8px; font-family: inherit; font-size: 0.9rem; resize: vertical;
+}
+.conflict-merge-input { max-width: 8rem; }
+.conflict-merge-textarea:focus, .conflict-merge-input:focus {
+    outline: none; border-color: var(--accent);
+}
+.conflict-merge-submit { align-self: flex-start; margin-left: 0; }
 
 /* Responsive */
 @media (max-width: 640px) {


### PR DESCRIPTION
## Description

Adds a true "merge manually" path to the sync conflict-resolution UI (follow-up to #75). Previously users could only pick **keep local** or **keep remote**; now they can enter an arbitrary merged value and resolve the conflict with it, and that value propagates to other devices.

**What's included**

- **`toku-db`** — Refactored `apply_resolution` to take an explicit value, and added `resolve_conflict_with_value(id, value)`. It writes the user-supplied value to the note/review entity, bumps the entity HLC, emits a propagating `SyncOp::Update`, and marks the conflict resolved. Review ratings are validated to be integers in `0..=10`; invalid input is rejected. Covered by 4 new unit tests.
- **`toku-sync-client`** — Exposes the new path via an orchestrator `resolve_conflict_with_value` wrapper.
- **`toku-web`** — The conflicts page gains a "Merge manually" disclosure (`<details>`) on each conflict card, revealing an editable field pre-filled with the local value: a textarea for note/review content, and a `0–10` number input for review ratings. The handler routes `keep=custom` to the new value-based resolution. Includes styling; no JavaScript.
- **`toku-cli`** — `toku sync conflicts resolve <id>` now accepts `--value "..."`, mutually exclusive with `--keep` (exactly one required), reporting `kept: "custom"` in all output formats.

## Related Issues

Closes #129

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI / infrastructure
- [ ] Other (describe below)

## Crate

- [ ] `toku-core` — Domain models, traits, state machine
- [x] `toku-db` — SQLite persistence, migrations, FTS5
- [ ] `toku-import` — Importers (Goodreads, Calibre, StoryGraph)
- [ ] `toku-meta` — Metadata fetching (Open Library, Google Books)
- [x] `toku-cli` — CLI binary
- [ ] `toku-export` — Exporters (CSV, JSON, Markdown, BibTeX)
- [ ] `docs/` — Documentation
- [x] `toku-web` — Web dashboard / conflicts UI
- [x] `toku-sync-client` — Sync orchestration

## Data Integrity Checklist

- [x] No user data is sent to any server without explicit opt-in
- [x] Import operations are idempotent (re-importing the same file creates no duplicates)
- [x] User edits to metadata are never overwritten by auto-enrichment
- [x] New fields track provenance (source + timestamp)
- [x] Export round-trip is preserved (if applicable)

## Checklist

- [x] I have read [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] `cargo fmt --check` passes
- [x] `cargo clippy --workspace -- -D warnings` passes
- [x] `cargo test --workspace` passes
- [ ] I have updated documentation (if applicable)
