### PR TITLE
feat: add provenance/source fields to files table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   format from the extension, recording size, and storing a SHA-256 checksum (with
   duplicate-checksum detection). Supports `--format table|json|csv` and `NO_COLOR`;
   `remove` takes a format or path and an optional `--delete-file`. Backed by a new
-  local-only `files` table and `toku-files` crate (#148)
+  local-only `files` table and `toku-files` crate (#148). The `files` table tracks
+  provenance (`source` + optional `source_ref`) so importer-created file records are
+  distinguishable from user-added ones (#153)
 - One-time `toku sync migrate` upgrade path from the legacy relay model to the account
   model (#126): generates a Secret Key + account, makes the first account the admin and
   adopts all pre-existing relay libraries/devices, re-keys every server op and snapshot from

--- a/crates/toku-db/migrations/V18__files_provenance.sql
+++ b/crates/toku-db/migrations/V18__files_provenance.sql
@@ -1,0 +1,4 @@
+-- Provenance for ebook file associations: record how a file record originated.
+-- Free-text, matching metadata_provenance/import_logs conventions.
+ALTER TABLE files ADD COLUMN source TEXT NOT NULL DEFAULT 'user';   -- user, calibre, goodreads, ...
+ALTER TABLE files ADD COLUMN source_ref TEXT;                       -- optional external reference (import id / original path)

--- a/crates/toku-files/src/lib.rs
+++ b/crates/toku-files/src/lib.rs
@@ -66,6 +66,9 @@ impl std::str::FromStr for FileFormat {
     }
 }
 
+/// Default provenance for a file record: added directly by the user.
+pub const SOURCE_USER: &str = "user";
+
 /// An ebook file associated with a book.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct EbookFile {
@@ -76,6 +79,11 @@ pub struct EbookFile {
     pub size_bytes: i64,
     /// SHA-256 checksum, hex-encoded.
     pub checksum: String,
+    /// Provenance of this file association (e.g. `user`, `calibre`, `goodreads`).
+    pub source: String,
+    /// Optional external reference from the source (e.g. an import id or the
+    /// original path in the source library). `None` for user-added files.
+    pub source_ref: Option<String>,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
 }
@@ -96,9 +104,20 @@ impl EbookFile {
             format,
             size_bytes,
             checksum,
+            source: SOURCE_USER.to_string(),
+            source_ref: None,
             created_at: now,
             updated_at: now,
         }
+    }
+
+    /// Set the provenance of this file record. Use for importer-created records
+    /// (e.g. `with_source("calibre", Some(original_path))`).
+    #[must_use]
+    pub fn with_source(mut self, source: impl Into<String>, source_ref: Option<String>) -> Self {
+        self.source = source.into();
+        self.source_ref = source_ref;
+        self
     }
 }
 

--- a/crates/toku-files/src/repo.rs
+++ b/crates/toku-files/src/repo.rs
@@ -28,8 +28,8 @@ impl<'a> FileRepository<'a> {
         }
         self.db.conn.execute(
             "INSERT INTO files (id, book_id, path, format, size_bytes, checksum,
-             created_at, updated_at)
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
+             source, source_ref, created_at, updated_at)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)",
             params![
                 file.id.to_string(),
                 file.book_id.to_string(),
@@ -37,6 +37,8 @@ impl<'a> FileRepository<'a> {
                 file.format.as_str(),
                 file.size_bytes,
                 file.checksum,
+                file.source,
+                file.source_ref,
                 file.created_at.to_rfc3339(),
                 file.updated_at.to_rfc3339(),
             ],
@@ -47,7 +49,7 @@ impl<'a> FileRepository<'a> {
     /// List all files associated with a book, ordered by format.
     pub fn list_files(&self, book_id: &Uuid) -> Result<Vec<EbookFile>, FileError> {
         let mut stmt = self.db.conn.prepare(
-            "SELECT id, book_id, path, format, size_bytes, checksum, created_at, updated_at
+            "SELECT id, book_id, path, format, size_bytes, checksum, source, source_ref, created_at, updated_at
              FROM files WHERE book_id = ?1 ORDER BY format",
         )?;
         let files = stmt
@@ -65,7 +67,7 @@ impl<'a> FileRepository<'a> {
         checksum: &str,
     ) -> Result<Option<EbookFile>, FileError> {
         let mut stmt = self.db.conn.prepare(
-            "SELECT id, book_id, path, format, size_bytes, checksum, created_at, updated_at
+            "SELECT id, book_id, path, format, size_bytes, checksum, source, source_ref, created_at, updated_at
              FROM files WHERE book_id = ?1 AND checksum = ?2",
         )?;
         let mut rows = stmt
@@ -129,8 +131,8 @@ fn row_to_file(row: &rusqlite::Row<'_>) -> Result<EbookFile, String> {
     let id_str: String = row.get(0).map_err(|e| e.to_string())?;
     let book_id_str: String = row.get(1).map_err(|e| e.to_string())?;
     let format_str: String = row.get(3).map_err(|e| e.to_string())?;
-    let created_str: String = row.get(6).map_err(|e| e.to_string())?;
-    let updated_str: String = row.get(7).map_err(|e| e.to_string())?;
+    let created_str: String = row.get(8).map_err(|e| e.to_string())?;
+    let updated_str: String = row.get(9).map_err(|e| e.to_string())?;
     Ok(EbookFile {
         id: Uuid::parse_str(&id_str).map_err(|e| e.to_string())?,
         book_id: Uuid::parse_str(&book_id_str).map_err(|e| e.to_string())?,
@@ -140,6 +142,8 @@ fn row_to_file(row: &rusqlite::Row<'_>) -> Result<EbookFile, String> {
             .map_err(|_| format!("bad format: {format_str}"))?,
         size_bytes: row.get(4).map_err(|e| e.to_string())?,
         checksum: row.get(5).map_err(|e| e.to_string())?,
+        source: row.get(6).map_err(|e| e.to_string())?,
+        source_ref: row.get(7).map_err(|e| e.to_string())?,
         created_at: chrono::DateTime::parse_from_rfc3339(&created_str)
             .map_err(|e| e.to_string())?
             .with_timezone(&Utc),

--- a/crates/toku-files/tests/file_association.rs
+++ b/crates/toku-files/tests/file_association.rs
@@ -79,3 +79,53 @@ fn duplicate_checksum_rejected() {
     );
     assert!(files.add_file(&dup).is_err());
 }
+
+#[test]
+fn provenance_round_trips() {
+    let dir = tempfile::tempdir().unwrap();
+    let db = Database::open_in_memory().unwrap();
+    let book_id = seed_book(&db);
+    let files = FileRepository::new(&db);
+
+    // Default record: user-added, no external reference.
+    let user_epub = dir.path().join("user.epub");
+    std::fs::write(&user_epub, b"user bytes").unwrap();
+    let f_user = EbookFile::new(
+        book_id,
+        user_epub.to_string_lossy().to_string(),
+        FileFormat::Epub,
+        10,
+        sha256_file(&user_epub).unwrap(),
+    );
+    assert_eq!(f_user.source, "user");
+    assert_eq!(f_user.source_ref, None);
+
+    // Importer-created record with provenance.
+    let cal_pdf = dir.path().join("calibre.pdf");
+    std::fs::write(&cal_pdf, b"calibre bytes").unwrap();
+    let f_cal = EbookFile::new(
+        book_id,
+        cal_pdf.to_string_lossy().to_string(),
+        FileFormat::Pdf,
+        13,
+        sha256_file(&cal_pdf).unwrap(),
+    )
+    .with_source("calibre", Some("/library/Calibre/dune.pdf".to_string()));
+
+    files.add_file(&f_user).unwrap();
+    files.add_file(&f_cal).unwrap();
+
+    let listed = files.list_files(&book_id).unwrap();
+    assert_eq!(listed.len(), 2);
+
+    let epub = listed
+        .iter()
+        .find(|f| f.format == FileFormat::Epub)
+        .unwrap();
+    assert_eq!(epub.source, "user");
+    assert_eq!(epub.source_ref, None);
+
+    let pdf = listed.iter().find(|f| f.format == FileFormat::Pdf).unwrap();
+    assert_eq!(pdf.source, "calibre");
+    assert_eq!(pdf.source_ref.as_deref(), Some("/library/Calibre/dune.pdf"));
+}


### PR DESCRIPTION
## Description

Adds **provenance/source tracking** to the `files` table, closing the one
remaining gap between the shipped `toku-files` crate and the schema described in
issue #153 (the `files` table previously had no `source`/provenance fields).

### What's included

- **New migration `V18__files_provenance.sql`** — adds two columns to `files`
  via `ALTER TABLE`:
  - `source TEXT NOT NULL DEFAULT 'user'` — origin of the association
    (`user`, `calibre`, `goodreads`, …), stored as free text to match the
    existing `metadata_provenance` / `import_logs` convention.
  - `source_ref TEXT` (nullable) — optional external reference (e.g. an import
    id or the original path in a Calibre library) for lossless provenance.
  - A **new** migration rather than an edit to the (unreleased-but-possibly-
    applied) `V17`, following the `V13` ALTER-TABLE precedent and avoiding
    refinery checksum divergence.
- **`EbookFile` model** (`toku-files`) — new `source: String` and
  `source_ref: Option<String>` fields. `EbookFile::new(...)` is unchanged
  (defaults to `source = "user"`, `source_ref = None`), so existing callers —
  including the `toku file add` CLI — keep compiling. Added a
  `with_source(source, source_ref)` builder for importer-created records.
- **`FileRepository`** — `INSERT`, both `SELECT`s, and `row_to_file` now
  read/write the two columns.
- **Tests** — new `provenance_round_trips` integration test verifying the
  default (`user` / `None`) and a custom (`calibre` + `source_ref`) round-trip.

## Related Issues

Closes #153

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI / infrastructure
- [ ] Other (describe below)

## Crate

- [x] `toku-db` — SQLite persistence, migrations, FTS5
- [ ] `toku-core` — Domain models, traits, state machine
- [ ] `toku-import` — Importers (Goodreads, Calibre, StoryGraph)
- [ ] `toku-meta` — Metadata fetching (Open Library, Google Books)
- [ ] `toku-cli` — CLI binary
- [ ] `toku-export` — Exporters (CSV, JSON, Markdown, BibTeX)
- [ ] `docs/` — Documentation
- Also touches `toku-files` (model + repository).

## Data Integrity Checklist

- [x] No user data is sent to any server without explicit opt-in (file records are local-only; never synced)
- [ ] Import operations are idempotent (re-importing the same file creates no duplicates)
- [ ] User edits to metadata are never overwritten by auto-enrichment
- [x] New fields track provenance (source + timestamp) (`source` + `source_ref`; `created_at` provides the timestamp)
- [ ] Export round-trip is preserved (if applicable)

## Checklist

- [x] I have read [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] `cargo fmt --check` passes
- [x] `cargo clippy --workspace -- -D warnings` passes
- [x] `cargo test --workspace` passes
- [ ] I have updated documentation (if applicable)
