### PR TITLE
feat: organize ebook files on disk with configurable path templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Disk organization: `toku file organize [<book>|--all]` moves (or `--copy`) associated
+  ebook files into a managed library laid out by a configurable path template, updating the
+  stored DB paths in a single transaction. `--dry-run` previews the plan without touching
+  disk or the database; re-running is idempotent, and colliding targets get a deterministic
+  numeric suffix (e.g. `Title (2).epub`). Template tokens `{author}`, `{title}`, `{series}`,
+  `{format}`, `{year}` are
+  sanitized for cross-platform (Linux/macOS/Windows) safety. Configured via a new `[files]`
+  section in `config.toml` — `library_root` (defaults to `<data_dir>/library`) and
+  `organize_template` (defaults to `{author}/{title}.{format}`). Supports
+  `--format table|json|csv` (#152)
 - Inline manual-merge editor for sync conflicts: the web conflicts page now offers a
   "Merge manually" action alongside keep-local/keep-remote, revealing an editable field
   (textarea for note/review content, 0–10 number input for review ratings) pre-filled with

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -714,7 +714,7 @@ All statistics computed locally from SQLite queries. No server needed.
 ### 6.1 — File Management (Phase 6)
 
 - Associate ebook files (.epub, .pdf, .mobi, .azw3) with book entries 🟡
-- Organize files on disk using configurable templates (`{author}/{title}.{format}`) 🟡
+- Organize files on disk using configurable templates (`{author}/{title}.{format}`) 🟢
 - Multiple formats per book 🟢
 - File integrity checking (SHA-256 checksums) 🟢
 - Disk usage reporting 🟢

--- a/crates/toku-cli/src/main.rs
+++ b/crates/toku-cli/src/main.rs
@@ -446,6 +446,24 @@ enum FileAction {
         #[arg(long)]
         delete_file: bool,
     },
+
+    /// Organize associated files on disk using the configured path template
+    Organize {
+        /// Book title to organize (omit and use --all to organize everything)
+        book: Option<String>,
+
+        /// Organize files for every book in the library
+        #[arg(long)]
+        all: bool,
+
+        /// Preview the planned moves without touching disk or the database
+        #[arg(long)]
+        dry_run: bool,
+
+        /// Copy files into the library instead of moving them
+        #[arg(long)]
+        copy: bool,
+    },
 }
 
 #[derive(Subcommand)]
@@ -977,7 +995,7 @@ fn main() -> Result<()> {
         Commands::Lookup { query, limit } => cmd_lookup(&query, limit, &cli.format),
         Commands::Reading { action } => cmd_reading(&repo, action, &cli.format),
         Commands::Tag { action } => cmd_tag(&repo, action, &cli.format),
-        Commands::File { action } => cmd_file(&db, &repo, action, &cli.format),
+        Commands::File { action } => cmd_file(&db, &repo, action, &data_dir, &cli.format),
         Commands::Export { target } => cmd_export(&db, &data_dir, target),
         Commands::Bulk { action } => cmd_bulk(&db, &repo, action),
         Commands::Stats {
@@ -2286,6 +2304,7 @@ fn cmd_file(
     db: &Database,
     repo: &BookRepository,
     action: FileAction,
+    data_dir: &Path,
     output_format: &OutputFormat,
 ) -> Result<()> {
     let files = FileRepository::new(db);
@@ -2405,6 +2424,168 @@ fn cmd_file(
                 }
                 None => anyhow::bail!("no file matching \"{target}\" linked to \"{}\"", book.title),
             }
+        }
+        FileAction::Organize {
+            book,
+            all,
+            dry_run,
+            copy,
+        } => cmd_file_organize(db, repo, data_dir, book, all, dry_run, copy, output_format),
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn cmd_file_organize(
+    db: &Database,
+    repo: &BookRepository,
+    data_dir: &Path,
+    book: Option<String>,
+    all: bool,
+    dry_run: bool,
+    copy: bool,
+    output_format: &OutputFormat,
+) -> Result<()> {
+    use toku_files::{PathTemplate, PlanAction, apply_plan, plan_organize};
+
+    // Exactly one of <book> or --all.
+    if book.is_some() && all {
+        anyhow::bail!("specify either a book or --all, not both");
+    }
+    if book.is_none() && !all {
+        anyhow::bail!("specify a book to organize, or --all for the whole library");
+    }
+
+    let config = TokuConfig::load(data_dir).context("failed to load config")?;
+    let root = match &config.files.library_root {
+        Some(dir) => PathBuf::from(dir),
+        None => data_dir.join("library"),
+    };
+    let template =
+        PathTemplate::parse(&config.files.organize_template).map_err(|e| anyhow::anyhow!("{e}"))?;
+
+    // Which books to organize.
+    let book_ids: Vec<uuid::Uuid> = match &book {
+        Some(query) => vec![resolve_book(repo, query)?.id],
+        None => repo.list_books()?.into_iter().map(|b| b.id).collect(),
+    };
+
+    let plan =
+        plan_organize(db, &book_ids, &root, &template, copy).map_err(|e| anyhow::anyhow!("{e}"))?;
+
+    if plan.is_empty() {
+        eprintln!("No associated files to organize.");
+        return Ok(());
+    }
+
+    render_organize_plan(&plan, dry_run, output_format);
+
+    let actionable = plan
+        .iter()
+        .filter(|p| matches!(p.action, PlanAction::Move | PlanAction::Copy))
+        .count();
+
+    if dry_run {
+        eprintln!(
+            "\nDry run: {} file(s) would be {}, {} skipped. Nothing changed.",
+            actionable,
+            if copy { "copied" } else { "moved" },
+            plan.len() - actionable,
+        );
+        return Ok(());
+    }
+
+    if actionable == 0 {
+        eprintln!("\nEverything is already organized. Nothing to do.");
+        return Ok(());
+    }
+
+    let summary = apply_plan(db, &plan).map_err(|e| anyhow::anyhow!("{e}"))?;
+    eprintln!(
+        "\n✓ Organized library at {}: {} moved, {} copied, {} skipped.",
+        root.display(),
+        summary.moved,
+        summary.copied,
+        summary.skipped,
+    );
+    Ok(())
+}
+
+fn render_organize_plan(
+    plan: &[toku_files::PlannedMove],
+    dry_run: bool,
+    output_format: &OutputFormat,
+) {
+    use toku_files::PlanAction;
+
+    let action_label = |a: &PlanAction| -> String {
+        match a {
+            PlanAction::Move => "move".to_string(),
+            PlanAction::Copy => "copy".to_string(),
+            PlanAction::Skip { reason } => format!("skip ({reason})"),
+        }
+    };
+
+    match output_format {
+        OutputFormat::Json => {
+            let items: Vec<serde_json::Value> = plan
+                .iter()
+                .map(|p| {
+                    serde_json::json!({
+                        "book": p.book_title,
+                        "format": p.format,
+                        "action": action_label(&p.action),
+                        "from": p.from.to_string_lossy(),
+                        "to": p.to.to_string_lossy(),
+                    })
+                })
+                .collect();
+            if let Ok(s) = serde_json::to_string_pretty(&items) {
+                println!("{s}");
+            }
+        }
+        OutputFormat::Csv => {
+            println!("action,book,format,from,to");
+            for p in plan {
+                println!(
+                    "{},\"{}\",{},\"{}\",\"{}\"",
+                    action_label(&p.action),
+                    p.book_title.replace('"', "\"\""),
+                    p.format,
+                    p.from.to_string_lossy().replace('"', "\"\""),
+                    p.to.to_string_lossy().replace('"', "\"\""),
+                );
+            }
+        }
+        OutputFormat::Table => {
+            use tabled::{Table, Tabled};
+
+            #[derive(Tabled)]
+            struct Row {
+                #[tabled(rename = "Action")]
+                action: String,
+                #[tabled(rename = "Book")]
+                book: String,
+                #[tabled(rename = "Format")]
+                format: String,
+                #[tabled(rename = "Target")]
+                to: String,
+            }
+            let rows: Vec<Row> = plan
+                .iter()
+                .map(|p| Row {
+                    action: action_label(&p.action),
+                    book: p.book_title.clone(),
+                    format: p.format.clone(),
+                    to: p.to.to_string_lossy().to_string(),
+                })
+                .collect();
+            let heading = if dry_run {
+                "Planned changes (dry run):"
+            } else {
+                "Planned changes:"
+            };
+            eprintln!("{heading}");
+            println!("{}", Table::new(rows));
         }
     }
 }

--- a/crates/toku-core/src/config.rs
+++ b/crates/toku-core/src/config.rs
@@ -16,6 +16,34 @@ pub struct TokuConfig {
     pub metadata_source: String,
     /// Sync configuration (optional — absent until `toku sync init`)
     pub sync: Option<SyncConfig>,
+    /// Ebook file management configuration (disk organization).
+    pub files: FilesConfig,
+}
+
+/// File-management configuration stored in `config.toml` under `[files]`.
+///
+/// Controls how `toku file organize` lays out ebook files on disk.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(default)]
+pub struct FilesConfig {
+    /// Managed library root. When unset, defaults to `<data_dir>/library`.
+    pub library_root: Option<String>,
+    /// Path template used to organize files, relative to the library root.
+    /// Supports the `{author}`, `{title}`, `{series}`, `{format}`, and `{year}`
+    /// tokens, e.g. `{author}/{title}.{format}`.
+    pub organize_template: String,
+}
+
+/// Default path template: `{author}/{title}.{format}`.
+pub const DEFAULT_ORGANIZE_TEMPLATE: &str = "{author}/{title}.{format}";
+
+impl Default for FilesConfig {
+    fn default() -> Self {
+        Self {
+            library_root: None,
+            organize_template: DEFAULT_ORGANIZE_TEMPLATE.to_string(),
+        }
+    }
 }
 
 /// Sync configuration stored in `config.toml` under `[sync]`.
@@ -40,6 +68,7 @@ impl Default for TokuConfig {
             color: "auto".to_string(),
             metadata_source: "openlibrary".to_string(),
             sync: None,
+            files: FilesConfig::default(),
         }
     }
 }
@@ -109,6 +138,7 @@ mod tests {
             color: "never".to_string(),
             metadata_source: "google".to_string(),
             sync: None,
+            files: FilesConfig::default(),
         };
         cfg.save(&dir).expect("save should succeed");
 

--- a/crates/toku-db/src/repo.rs
+++ b/crates/toku-db/src/repo.rs
@@ -1,8 +1,8 @@
 use rusqlite::{OptionalExtension, params};
 use toku_core::{
-    Author, AuthorCount, Book, BookAuthor, ContributorRole, FilterCondition, FilterExpr,
-    FilterField, PaceRating, ReadingProgress, ReadingSession, ReadingStatus, Shelf, SmartFilter,
-    Tag, TagCount, TagType, Work,
+    Author, AuthorCount, Book, BookAuthor, BookSeries, ContributorRole, FilterCondition,
+    FilterExpr, FilterField, PaceRating, ReadingProgress, ReadingSession, ReadingStatus, Series,
+    Shelf, SmartFilter, Tag, TagCount, TagType, Work,
 };
 use uuid::Uuid;
 
@@ -281,6 +281,43 @@ impl<'a> BookRepository<'a> {
                 };
 
                 Ok((author, book_author))
+            })?
+            .filter_map(|r| r.ok())
+            .collect();
+
+        Ok(results)
+    }
+
+    /// Get all series a book belongs to, with its position in each.
+    /// Ordered by series name for deterministic results.
+    pub fn get_book_series(&self, book_id: &Uuid) -> Result<Vec<(Series, BookSeries)>, DbError> {
+        let mut stmt = self.db.conn.prepare(
+            "SELECT s.id, s.name, s.total_books, bs.position
+             FROM book_series bs
+             JOIN series s ON s.id = bs.series_id
+             WHERE bs.book_id = ?1
+             ORDER BY s.name",
+        )?;
+
+        let results = stmt
+            .query_map(params![book_id.to_string()], |row| {
+                let series_id: String = row.get(0)?;
+                let name: String = row.get(1)?;
+                let total_books: Option<i32> = row.get(2)?;
+                let position: Option<String> = row.get(3)?;
+
+                let sid = Uuid::parse_str(&series_id).unwrap_or_default();
+                let series = Series {
+                    id: sid,
+                    name,
+                    total_books,
+                };
+                let book_series = BookSeries {
+                    book_id: *book_id,
+                    series_id: sid,
+                    position,
+                };
+                Ok((series, book_series))
             })?
             .filter_map(|r| r.ok())
             .collect();

--- a/crates/toku-files/src/lib.rs
+++ b/crates/toku-files/src/lib.rs
@@ -12,9 +12,17 @@ use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use uuid::Uuid;
 
+mod organize;
 mod repo;
+mod template;
 
+pub use organize::{
+    OrganizeOutcome, OrganizeSummary, PlanAction, PlannedMove, apply_plan, plan_organize,
+};
 pub use repo::FileRepository;
+pub use template::{
+    PathTemplate, TemplateContext, UNKNOWN_AUTHOR, UNKNOWN_SERIES, UNKNOWN_YEAR, sanitize_segment,
+};
 
 /// Supported ebook file formats.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -135,6 +143,12 @@ pub enum FileError {
 
     #[error("I/O error: {0}")]
     Io(String),
+
+    #[error("invalid path template: {0}")]
+    Template(String),
+
+    #[error("organize failed: {0}")]
+    Organize(String),
 
     #[error("database error: {0}")]
     Db(#[from] toku_db::DbError),

--- a/crates/toku-files/src/organize.rs
+++ b/crates/toku-files/src/organize.rs
@@ -1,0 +1,343 @@
+//! Disk organization: plan and apply file moves into a managed library (issue #152).
+//!
+//! Organization is a two-phase operation:
+//!
+//! 1. [`plan_organize`] is a pure, read-only computation that resolves every
+//!    associated file's target path from the configured template, handling
+//!    collisions and idempotency. It never touches the filesystem or database.
+//! 2. [`apply_plan`] executes a plan: it moves/copies files on disk, then updates
+//!    the stored DB paths in a single transaction. Filesystem changes are rolled
+//!    back if the transaction cannot commit, so DB and disk stay consistent.
+
+use std::collections::HashSet;
+use std::path::{Path, PathBuf};
+
+use chrono::Utc;
+use rusqlite::params;
+use toku_db::{BookRepository, Database};
+use uuid::Uuid;
+
+use crate::template::{PathTemplate, TemplateContext};
+use crate::{FileError, FileRepository};
+
+/// What [`apply_plan`] will do with a single file.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PlanAction {
+    /// Move the file from its current location to the target.
+    Move,
+    /// Copy the file, leaving the original in place.
+    Copy,
+    /// Leave the file untouched. `reason` explains why.
+    Skip { reason: String },
+}
+
+impl PlanAction {
+    fn is_actionable(&self) -> bool {
+        matches!(self, PlanAction::Move | PlanAction::Copy)
+    }
+}
+
+/// A single planned file operation produced by [`plan_organize`].
+#[derive(Debug, Clone)]
+pub struct PlannedMove {
+    pub file_id: Uuid,
+    pub book_id: Uuid,
+    pub book_title: String,
+    pub format: String,
+    /// Current on-disk path.
+    pub from: PathBuf,
+    /// Resolved target path (equal to `from` for a skipped, already-organized file).
+    pub to: PathBuf,
+    pub action: PlanAction,
+}
+
+impl PlannedMove {
+    fn is_actionable(&self) -> bool {
+        self.action.is_actionable()
+    }
+}
+
+/// Counts summarizing an applied plan.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct OrganizeSummary {
+    pub moved: usize,
+    pub copied: usize,
+    pub skipped: usize,
+}
+
+/// Outcome of a full organize run (kept for API symmetry / future extension).
+pub type OrganizeOutcome = OrganizeSummary;
+
+/// Build an organization plan for the given books without touching disk or DB.
+///
+/// `book_ids` selects which books to consider; pass every book id for `--all`.
+/// `root` is the managed library root; `template` drives the on-disk layout.
+/// When `copy` is true, actionable files are copied instead of moved.
+pub fn plan_organize(
+    db: &Database,
+    book_ids: &[Uuid],
+    root: &Path,
+    template: &PathTemplate,
+    copy: bool,
+) -> Result<Vec<PlannedMove>, FileError> {
+    let books = BookRepository::new(db);
+    let files = FileRepository::new(db);
+
+    let mut plan = Vec::new();
+    // Target paths already claimed within this plan (for collision resolution).
+    let mut claimed: HashSet<PathBuf> = HashSet::new();
+
+    for book_id in book_ids {
+        let book = books.get_book(book_id)?;
+        let author = books
+            .get_book_authors(book_id)?
+            .into_iter()
+            .next()
+            .map(|(a, _)| a.name)
+            .unwrap_or_default();
+        let series = books
+            .get_book_series(book_id)?
+            .into_iter()
+            .next()
+            .map(|(s, _)| s.name);
+        let year = extract_year(book.pub_date.as_deref());
+
+        for file in files.list_files(book_id)? {
+            let ctx = TemplateContext {
+                author: author.clone(),
+                title: book.title.clone(),
+                series: series.clone(),
+                format: file.format.as_str().to_string(),
+                year: year.clone(),
+            };
+
+            let from = PathBuf::from(&file.path);
+
+            // A missing source cannot be organized.
+            if !from.exists() {
+                plan.push(PlannedMove {
+                    file_id: file.id,
+                    book_id: *book_id,
+                    book_title: book.title.clone(),
+                    format: file.format.as_str().to_string(),
+                    from: from.clone(),
+                    to: from,
+                    action: PlanAction::Skip {
+                        reason: "source file missing".to_string(),
+                    },
+                });
+                continue;
+            }
+
+            let segments = template.render(&ctx)?;
+            let base_target = segments
+                .iter()
+                .fold(root.to_path_buf(), |acc, s| acc.join(s));
+
+            let (to, action) = resolve_target(&from, &base_target, &claimed, copy);
+            claimed.insert(to.clone());
+
+            plan.push(PlannedMove {
+                file_id: file.id,
+                book_id: *book_id,
+                book_title: book.title.clone(),
+                format: file.format.as_str().to_string(),
+                from,
+                to,
+                action,
+            });
+        }
+    }
+
+    Ok(plan)
+}
+
+/// Resolve the final target for a file, handling idempotency and collisions.
+fn resolve_target(
+    from: &Path,
+    base_target: &Path,
+    claimed: &HashSet<PathBuf>,
+    copy: bool,
+) -> (PathBuf, PlanAction) {
+    let mut candidate = base_target.to_path_buf();
+    let mut n = 1;
+    loop {
+        // Already sitting at this exact location → nothing to do.
+        if same_file(from, &candidate) {
+            return (
+                candidate,
+                PlanAction::Skip {
+                    reason: "already organized".to_string(),
+                },
+            );
+        }
+
+        let taken = claimed.contains(&candidate) || candidate.exists();
+        if !taken {
+            let action = if copy {
+                PlanAction::Copy
+            } else {
+                PlanAction::Move
+            };
+            return (candidate, action);
+        }
+
+        // Collision with a different file: append a deterministic ` (n)` suffix.
+        n += 1;
+        candidate = with_suffix(base_target, n);
+    }
+}
+
+/// Apply an organization plan: perform filesystem moves/copies, then update the
+/// stored paths in a single transaction. Filesystem changes are undone if the
+/// transaction cannot commit.
+pub fn apply_plan(db: &Database, plan: &[PlannedMove]) -> Result<OrganizeSummary, FileError> {
+    let actionable: Vec<&PlannedMove> = plan.iter().filter(|p| p.is_actionable()).collect();
+
+    // Phase 1: filesystem. Track completed ops so we can roll them back on error.
+    let mut done: Vec<&PlannedMove> = Vec::new();
+    for pm in &actionable {
+        if let Some(parent) = pm.to.parent()
+            && let Err(e) = std::fs::create_dir_all(parent)
+        {
+            undo_fs(&done);
+            return Err(FileError::Organize(format!(
+                "creating {}: {e}",
+                parent.display()
+            )));
+        }
+        let result = match pm.action {
+            PlanAction::Move => move_file(&pm.from, &pm.to),
+            PlanAction::Copy => std::fs::copy(&pm.from, &pm.to)
+                .map(|_| ())
+                .map_err(|e| FileError::Io(e.to_string())),
+            PlanAction::Skip { .. } => Ok(()),
+        };
+        if let Err(e) = result {
+            undo_fs(&done);
+            return Err(FileError::Organize(format!(
+                "{} → {}: {e}",
+                pm.from.display(),
+                pm.to.display()
+            )));
+        }
+        done.push(pm);
+    }
+
+    // Phase 2: database. Update all paths atomically.
+    let now = Utc::now().to_rfc3339();
+    let tx = db.conn.unchecked_transaction()?;
+    for pm in &actionable {
+        let res = tx.execute(
+            "UPDATE files SET path = ?2, updated_at = ?3 WHERE id = ?1",
+            params![pm.file_id.to_string(), pm.to.to_string_lossy(), now],
+        );
+        if let Err(e) = res {
+            // tx drops → rollback; undo the filesystem changes too.
+            drop(tx);
+            undo_fs(&done);
+            return Err(FileError::Sqlite(e));
+        }
+    }
+    if let Err(e) = tx.commit() {
+        undo_fs(&done);
+        return Err(FileError::Sqlite(e));
+    }
+
+    let mut summary = OrganizeSummary::default();
+    for pm in plan {
+        match pm.action {
+            PlanAction::Move => summary.moved += 1,
+            PlanAction::Copy => summary.copied += 1,
+            PlanAction::Skip { .. } => summary.skipped += 1,
+        }
+    }
+    Ok(summary)
+}
+
+/// Best-effort reversal of completed filesystem operations.
+fn undo_fs(done: &[&PlannedMove]) {
+    for pm in done.iter().rev() {
+        match pm.action {
+            // Move the file back to its original location.
+            PlanAction::Move => {
+                let _ = std::fs::rename(&pm.to, &pm.from);
+            }
+            // Remove the copy we created.
+            PlanAction::Copy => {
+                let _ = std::fs::remove_file(&pm.to);
+            }
+            PlanAction::Skip { .. } => {}
+        }
+    }
+}
+
+/// Move a file, falling back to copy+remove when `rename` fails (e.g. across
+/// filesystems / mount points).
+fn move_file(from: &Path, to: &Path) -> Result<(), FileError> {
+    match std::fs::rename(from, to) {
+        Ok(()) => Ok(()),
+        Err(_) => {
+            std::fs::copy(from, to).map_err(|e| FileError::Io(e.to_string()))?;
+            std::fs::remove_file(from).map_err(|e| FileError::Io(e.to_string()))?;
+            Ok(())
+        }
+    }
+}
+
+/// True when both paths resolve to the same file on disk.
+fn same_file(a: &Path, b: &Path) -> bool {
+    match (a.canonicalize(), b.canonicalize()) {
+        (Ok(ca), Ok(cb)) => ca == cb,
+        _ => false,
+    }
+}
+
+/// Insert a ` (n)` suffix before the file extension of `path`.
+fn with_suffix(path: &Path, n: usize) -> PathBuf {
+    let name = path.file_name().and_then(|s| s.to_str()).unwrap_or("");
+    let new_name = match name.rfind('.') {
+        Some(dot) if dot > 0 => format!("{} ({}){}", &name[..dot], n, &name[dot..]),
+        _ => format!("{name} ({n})"),
+    };
+    match path.parent() {
+        Some(p) => p.join(new_name),
+        None => PathBuf::from(new_name),
+    }
+}
+
+/// Extract a four-digit year from an ISO-ish `pub_date` (e.g. `1969`, `1969-05`).
+fn extract_year(pub_date: Option<&str>) -> Option<String> {
+    let date = pub_date?.trim();
+    let year: String = date.chars().take_while(|c| c.is_ascii_digit()).collect();
+    if year.len() == 4 { Some(year) } else { None }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn extracts_four_digit_year() {
+        assert_eq!(extract_year(Some("1969")), Some("1969".to_string()));
+        assert_eq!(extract_year(Some("1969-05-01")), Some("1969".to_string()));
+        assert_eq!(extract_year(Some("")), None);
+        assert_eq!(extract_year(Some("May 1969")), None);
+        assert_eq!(extract_year(None), None);
+    }
+
+    #[test]
+    fn suffix_inserts_before_extension() {
+        let p = PathBuf::from("/lib/Author/Title.epub");
+        assert_eq!(
+            with_suffix(&p, 2),
+            PathBuf::from("/lib/Author/Title (2).epub")
+        );
+    }
+
+    #[test]
+    fn suffix_without_extension() {
+        let p = PathBuf::from("/lib/Author/Title");
+        assert_eq!(with_suffix(&p, 3), PathBuf::from("/lib/Author/Title (3)"));
+    }
+}

--- a/crates/toku-files/src/repo.rs
+++ b/crates/toku-files/src/repo.rs
@@ -125,6 +125,15 @@ impl<'a> FileRepository<'a> {
             .execute("DELETE FROM files WHERE id = ?1", params![id.to_string()])?;
         Ok(())
     }
+
+    /// Update the stored on-disk path of a file record and bump `updated_at`.
+    pub fn update_path(&self, id: &Uuid, new_path: &str) -> Result<(), FileError> {
+        self.db.conn.execute(
+            "UPDATE files SET path = ?2, updated_at = ?3 WHERE id = ?1",
+            params![id.to_string(), new_path, Utc::now().to_rfc3339()],
+        )?;
+        Ok(())
+    }
 }
 
 fn row_to_file(row: &rusqlite::Row<'_>) -> Result<EbookFile, String> {

--- a/crates/toku-files/src/template.rs
+++ b/crates/toku-files/src/template.rs
@@ -1,0 +1,446 @@
+//! Path-template engine for disk organization (issue #152, ADR-011 §4).
+//!
+//! Renders a configurable template such as `{author}/{title}.{format}` into a
+//! filesystem-safe *relative* path. The template's `/` characters are the path
+//! separators; every other segment is sanitized so the result is portable across
+//! Linux, macOS, and Windows.
+
+use crate::FileError;
+
+/// Fallback used when a book has no author.
+pub const UNKNOWN_AUTHOR: &str = "Unknown Author";
+/// Fallback used when the template references `{series}` but the book has none.
+pub const UNKNOWN_SERIES: &str = "No Series";
+/// Fallback used when the template references `{year}` but no year is known.
+pub const UNKNOWN_YEAR: &str = "Unknown Year";
+
+/// Maximum length (in characters) of a single sanitized path segment. Keeps well
+/// under common filesystem limits (255 bytes) while leaving room for a collision
+/// suffix like ` (10)`.
+const MAX_SEGMENT_LEN: usize = 200;
+
+/// Values used to resolve template tokens for one file.
+#[derive(Debug, Clone)]
+pub struct TemplateContext {
+    /// Primary author display name. Empty falls back to [`UNKNOWN_AUTHOR`].
+    pub author: String,
+    /// Book title. Always present.
+    pub title: String,
+    /// First series name, if any.
+    pub series: Option<String>,
+    /// File format extension (`epub`, `pdf`, `mobi`, `azw3`).
+    pub format: String,
+    /// Four-digit publication year, if known.
+    pub year: Option<String>,
+}
+
+impl TemplateContext {
+    /// Resolve a token name to its raw (pre-sanitization) value.
+    fn resolve(&self, token: &str) -> Option<String> {
+        let value = match token {
+            "author" => {
+                let a = self.author.trim();
+                if a.is_empty() {
+                    UNKNOWN_AUTHOR.to_string()
+                } else {
+                    a.to_string()
+                }
+            }
+            "title" => self.title.clone(),
+            "series" => self
+                .series
+                .as_deref()
+                .map(str::trim)
+                .filter(|s| !s.is_empty())
+                .unwrap_or(UNKNOWN_SERIES)
+                .to_string(),
+            "format" => self.format.clone(),
+            "year" => self
+                .year
+                .as_deref()
+                .map(str::trim)
+                .filter(|s| !s.is_empty())
+                .unwrap_or(UNKNOWN_YEAR)
+                .to_string(),
+            _ => return None,
+        };
+        Some(value)
+    }
+}
+
+/// A parsed path template. Cheap to clone and reuse across many files.
+#[derive(Debug, Clone)]
+pub struct PathTemplate {
+    raw: String,
+}
+
+impl PathTemplate {
+    /// Parse a template string, validating that every `{token}` is recognized and
+    /// that the template is not empty / not absolute.
+    pub fn parse(template: &str) -> Result<Self, FileError> {
+        let trimmed = template.trim();
+        if trimmed.is_empty() {
+            return Err(FileError::Template(
+                "template is empty; expected something like {author}/{title}.{format}".to_string(),
+            ));
+        }
+        if trimmed.starts_with('/') || trimmed.starts_with('\\') {
+            return Err(FileError::Template(
+                "template must be relative (cannot start with a path separator)".to_string(),
+            ));
+        }
+
+        // Validate tokens.
+        for token in extract_tokens(trimmed)? {
+            match token.as_str() {
+                "author" | "title" | "series" | "format" | "year" => {}
+                other => {
+                    return Err(FileError::Template(format!(
+                        "unknown template token {{{other}}} (supported: author, title, series, format, year)"
+                    )));
+                }
+            }
+        }
+
+        Ok(Self {
+            raw: trimmed.to_string(),
+        })
+    }
+
+    /// Render the template into sanitized relative path segments.
+    ///
+    /// The returned vector is guaranteed non-empty and every segment is a
+    /// filesystem-safe, non-empty string.
+    pub fn render(&self, ctx: &TemplateContext) -> Result<Vec<String>, FileError> {
+        // Split on both separators so a template authored on Windows still works.
+        let raw_segments: Vec<&str> = self
+            .raw
+            .split(['/', '\\'])
+            .filter(|s| !s.is_empty())
+            .collect();
+
+        let mut segments = Vec::with_capacity(raw_segments.len());
+        for raw in raw_segments {
+            let substituted = substitute(raw, ctx)?;
+            let sanitized = sanitize_segment(&substituted);
+            // Drop segments that are purely a path-navigation artifact.
+            if sanitized == "." || sanitized == ".." {
+                continue;
+            }
+            segments.push(sanitized);
+        }
+
+        if segments.is_empty() {
+            return Err(FileError::Template(
+                "template rendered to an empty path".to_string(),
+            ));
+        }
+        Ok(segments)
+    }
+}
+
+/// Extract the set of token names referenced by a template, validating brace
+/// balance.
+fn extract_tokens(template: &str) -> Result<Vec<String>, FileError> {
+    let mut tokens = Vec::new();
+    let mut chars = template.char_indices().peekable();
+    while let Some((_, c)) = chars.next() {
+        match c {
+            '{' => {
+                let mut name = String::new();
+                let mut closed = false;
+                for (_, tc) in chars.by_ref() {
+                    if tc == '}' {
+                        closed = true;
+                        break;
+                    }
+                    if tc == '{' {
+                        return Err(FileError::Template("nested '{' in template".to_string()));
+                    }
+                    name.push(tc);
+                }
+                if !closed {
+                    return Err(FileError::Template("unclosed '{' in template".to_string()));
+                }
+                tokens.push(name);
+            }
+            '}' => {
+                return Err(FileError::Template(
+                    "unexpected '}' in template".to_string(),
+                ));
+            }
+            _ => {}
+        }
+    }
+    Ok(tokens)
+}
+
+/// Replace `{token}` occurrences in a single raw segment with resolved values.
+fn substitute(segment: &str, ctx: &TemplateContext) -> Result<String, FileError> {
+    let mut out = String::with_capacity(segment.len());
+    let mut chars = segment.chars().peekable();
+    while let Some(c) = chars.next() {
+        if c == '{' {
+            let mut name = String::new();
+            for tc in chars.by_ref() {
+                if tc == '}' {
+                    break;
+                }
+                name.push(tc);
+            }
+            let value = ctx
+                .resolve(&name)
+                .ok_or_else(|| FileError::Template(format!("unknown template token {{{name}}}")))?;
+            out.push_str(&value);
+        } else {
+            out.push(c);
+        }
+    }
+    Ok(out)
+}
+
+/// Sanitize a single path segment so it is safe on Linux, macOS, and Windows.
+///
+/// - Replaces filesystem-illegal characters (`< > : " / \ | ? *`) and control
+///   characters with `_`.
+/// - Collapses runs of whitespace to a single space.
+/// - Trims leading/trailing whitespace and dots (Windows rejects trailing dots).
+/// - Escapes reserved Windows device names (CON, PRN, ...).
+/// - Caps the length to [`MAX_SEGMENT_LEN`], preserving a trailing extension.
+/// - Never returns an empty string (falls back to `_`).
+pub fn sanitize_segment(segment: &str) -> String {
+    // 1. Replace illegal / control characters.
+    let mut cleaned = String::with_capacity(segment.len());
+    let mut last_was_space = false;
+    for c in segment.chars() {
+        let mapped = if matches!(c, '<' | '>' | ':' | '"' | '/' | '\\' | '|' | '?' | '*')
+            || (c as u32) < 0x20
+        {
+            '_'
+        } else {
+            c
+        };
+        if mapped.is_whitespace() {
+            // Collapse whitespace runs.
+            if !last_was_space {
+                cleaned.push(' ');
+                last_was_space = true;
+            }
+        } else {
+            cleaned.push(mapped);
+            last_was_space = false;
+        }
+    }
+
+    // 2. Trim leading/trailing whitespace and dots.
+    let trimmed = cleaned
+        .trim_matches(|c: char| c.is_whitespace() || c == '.')
+        .to_string();
+
+    let mut result = if trimmed.is_empty() {
+        "_".to_string()
+    } else {
+        trimmed
+    };
+
+    // 3. Escape reserved Windows device names (case-insensitive), comparing the
+    //    stem before any extension.
+    let stem = result.split('.').next().unwrap_or(&result);
+    if is_reserved_device_name(stem) {
+        result = format!("_{result}");
+    }
+
+    // 4. Length cap, preserving the extension where possible.
+    if result.chars().count() > MAX_SEGMENT_LEN {
+        result = truncate_preserving_ext(&result, MAX_SEGMENT_LEN);
+    }
+
+    result
+}
+
+fn is_reserved_device_name(name: &str) -> bool {
+    let upper = name.to_ascii_uppercase();
+    matches!(
+        upper.as_str(),
+        "CON"
+            | "PRN"
+            | "AUX"
+            | "NUL"
+            | "COM1"
+            | "COM2"
+            | "COM3"
+            | "COM4"
+            | "COM5"
+            | "COM6"
+            | "COM7"
+            | "COM8"
+            | "COM9"
+            | "LPT1"
+            | "LPT2"
+            | "LPT3"
+            | "LPT4"
+            | "LPT5"
+            | "LPT6"
+            | "LPT7"
+            | "LPT8"
+            | "LPT9"
+    )
+}
+
+/// Truncate `s` to at most `max` characters, keeping a trailing `.ext` (if short)
+/// intact so the file remains recognizable by extension.
+fn truncate_preserving_ext(s: &str, max: usize) -> String {
+    if let Some(dot) = s.rfind('.') {
+        let ext = &s[dot..];
+        // Only preserve reasonably short extensions.
+        if ext.chars().count() <= 10 && dot > 0 {
+            let stem = &s[..dot];
+            let keep = max.saturating_sub(ext.chars().count());
+            let truncated: String = stem.chars().take(keep).collect();
+            let truncated = truncated
+                .trim_matches(|c: char| c.is_whitespace() || c == '.')
+                .to_string();
+            let truncated = if truncated.is_empty() {
+                "_".to_string()
+            } else {
+                truncated
+            };
+            return format!("{truncated}{ext}");
+        }
+    }
+    s.chars().take(max).collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ctx() -> TemplateContext {
+        TemplateContext {
+            author: "Ursula K. Le Guin".to_string(),
+            title: "The Left Hand of Darkness".to_string(),
+            series: Some("Hainish Cycle".to_string()),
+            format: "epub".to_string(),
+            year: Some("1969".to_string()),
+        }
+    }
+
+    #[test]
+    fn renders_default_template() {
+        let t = PathTemplate::parse("{author}/{title}.{format}").unwrap();
+        let segs = t.render(&ctx()).unwrap();
+        assert_eq!(
+            segs,
+            vec![
+                "Ursula K. Le Guin".to_string(),
+                "The Left Hand of Darkness.epub".to_string()
+            ]
+        );
+    }
+
+    #[test]
+    fn renders_all_tokens() {
+        let t = PathTemplate::parse("{series}/{year} - {title} ({author}).{format}").unwrap();
+        let segs = t.render(&ctx()).unwrap();
+        assert_eq!(segs[0], "Hainish Cycle");
+        assert_eq!(
+            segs[1],
+            "1969 - The Left Hand of Darkness (Ursula K. Le Guin).epub"
+        );
+    }
+
+    #[test]
+    fn rejects_unknown_token() {
+        assert!(PathTemplate::parse("{author}/{bogus}.{format}").is_err());
+    }
+
+    #[test]
+    fn rejects_empty_and_absolute() {
+        assert!(PathTemplate::parse("   ").is_err());
+        assert!(PathTemplate::parse("/{title}").is_err());
+    }
+
+    #[test]
+    fn rejects_unbalanced_braces() {
+        assert!(PathTemplate::parse("{author/{title}").is_err());
+        assert!(PathTemplate::parse("author}/{title}").is_err());
+    }
+
+    #[test]
+    fn sanitizes_illegal_characters() {
+        // A title with slashes, colons and quotes should not create subfolders.
+        let mut c = ctx();
+        c.title = "A: \"Weird\" <Title>/With\\Slashes?".to_string();
+        let t = PathTemplate::parse("{title}.{format}").unwrap();
+        let segs = t.render(&c).unwrap();
+        assert_eq!(segs.len(), 1);
+        let seg = &segs[0];
+        assert!(!seg.contains('/'));
+        assert!(!seg.contains('\\'));
+        assert!(!seg.contains(':'));
+        assert!(!seg.contains('"'));
+        assert!(!seg.contains('?'));
+        assert!(seg.ends_with(".epub"));
+    }
+
+    #[test]
+    fn author_fallback_when_empty() {
+        let mut c = ctx();
+        c.author = "   ".to_string();
+        let t = PathTemplate::parse("{author}/{title}.{format}").unwrap();
+        let segs = t.render(&c).unwrap();
+        assert_eq!(segs[0], UNKNOWN_AUTHOR);
+    }
+
+    #[test]
+    fn series_and_year_fallbacks() {
+        let mut c = ctx();
+        c.series = None;
+        c.year = None;
+        let t = PathTemplate::parse("{series}/{year}/{title}.{format}").unwrap();
+        let segs = t.render(&c).unwrap();
+        assert_eq!(segs[0], UNKNOWN_SERIES);
+        assert_eq!(segs[1], UNKNOWN_YEAR);
+    }
+
+    #[test]
+    fn escapes_reserved_device_name() {
+        let mut c = ctx();
+        c.title = "CON".to_string();
+        let t = PathTemplate::parse("{title}.{format}").unwrap();
+        let segs = t.render(&c).unwrap();
+        assert_eq!(segs[0], "_CON.epub");
+    }
+
+    #[test]
+    fn trims_trailing_dots_and_spaces() {
+        assert_eq!(sanitize_segment("name...  "), "name");
+        assert_eq!(sanitize_segment("  spaced  name  "), "spaced name");
+    }
+
+    #[test]
+    fn empty_segment_falls_back() {
+        // Whitespace-only collapses to the "_" fallback.
+        assert_eq!(sanitize_segment("   "), "_");
+        // Illegal characters are replaced 1:1 with underscores (all safe).
+        assert_eq!(sanitize_segment("???"), "___");
+    }
+
+    #[test]
+    fn caps_long_segment_preserving_extension() {
+        let long = "a".repeat(500);
+        let seg = sanitize_segment(&format!("{long}.epub"));
+        assert!(seg.chars().count() <= MAX_SEGMENT_LEN);
+        assert!(seg.ends_with(".epub"));
+    }
+
+    #[test]
+    fn ignores_dot_navigation_segments() {
+        let mut c = ctx();
+        c.author = "..".to_string();
+        let t = PathTemplate::parse("{author}/{title}.{format}").unwrap();
+        let segs = t.render(&c).unwrap();
+        // ".." author sanitizes to "_" (dots trimmed), so it is kept but safe.
+        assert_ne!(segs[0], "..");
+    }
+}

--- a/crates/toku-files/tests/organize.rs
+++ b/crates/toku-files/tests/organize.rs
@@ -1,0 +1,237 @@
+//! Integration tests for disk organization (issue #152).
+
+use std::path::PathBuf;
+
+use toku_core::{Author, Book};
+use toku_db::{BookRepository, Database};
+use toku_files::{
+    EbookFile, FileFormat, FileRepository, PathTemplate, PlanAction, apply_plan, plan_organize,
+    sha256_file,
+};
+
+/// Seed a book with a single author and return the book id.
+fn seed_book(db: &Database, title: &str, author: &str) -> uuid::Uuid {
+    let repo = BookRepository::new(db);
+    let book = Book::new(title);
+    repo.create_book(&book).unwrap();
+    let a = Author::new(author);
+    repo.add_book_author(&a, &book.id, toku_core::ContributorRole::Author, 0)
+        .unwrap();
+    book.id
+}
+
+/// Link an on-disk file to a book and return the created record.
+fn link_file(db: &Database, book_id: uuid::Uuid, path: &std::path::Path) -> EbookFile {
+    let files = FileRepository::new(db);
+    let format = FileFormat::from_path(path).unwrap();
+    let size = std::fs::metadata(path).unwrap().len() as i64;
+    let sum = sha256_file(path).unwrap();
+    let f = EbookFile::new(
+        book_id,
+        path.to_string_lossy().to_string(),
+        format,
+        size,
+        sum,
+    );
+    files.add_file(&f).unwrap();
+    f
+}
+
+fn stored_path(db: &Database, book_id: &uuid::Uuid, format: FileFormat) -> String {
+    FileRepository::new(db)
+        .list_files(book_id)
+        .unwrap()
+        .into_iter()
+        .find(|f| f.format == format)
+        .unwrap()
+        .path
+}
+
+#[test]
+fn move_updates_db_path_and_relocates_file() {
+    let dir = tempfile::tempdir().unwrap();
+    let db = Database::open_in_memory().unwrap();
+    let book_id = seed_book(&db, "Dune", "Frank Herbert");
+
+    let src = dir.path().join("dune.epub");
+    std::fs::write(&src, b"epub bytes").unwrap();
+    link_file(&db, book_id, &src);
+
+    let root = dir.path().join("library");
+    let tmpl = PathTemplate::parse("{author}/{title}.{format}").unwrap();
+    let plan = plan_organize(&db, &[book_id], &root, &tmpl, false).unwrap();
+    assert_eq!(plan.len(), 1);
+    assert_eq!(plan[0].action, PlanAction::Move);
+
+    let summary = apply_plan(&db, &plan).unwrap();
+    assert_eq!(summary.moved, 1);
+    assert_eq!(summary.copied, 0);
+
+    let expected = root.join("Frank Herbert").join("Dune.epub");
+    assert!(expected.exists(), "file should be at target");
+    assert!(!src.exists(), "original should be gone after move");
+    assert_eq!(
+        stored_path(&db, &book_id, FileFormat::Epub),
+        expected.to_string_lossy()
+    );
+}
+
+#[test]
+fn copy_leaves_original_in_place() {
+    let dir = tempfile::tempdir().unwrap();
+    let db = Database::open_in_memory().unwrap();
+    let book_id = seed_book(&db, "Dune", "Frank Herbert");
+
+    let src = dir.path().join("dune.epub");
+    std::fs::write(&src, b"epub bytes").unwrap();
+    link_file(&db, book_id, &src);
+
+    let root = dir.path().join("library");
+    let tmpl = PathTemplate::parse("{author}/{title}.{format}").unwrap();
+    let plan = plan_organize(&db, &[book_id], &root, &tmpl, true).unwrap();
+    assert_eq!(plan[0].action, PlanAction::Copy);
+
+    let summary = apply_plan(&db, &plan).unwrap();
+    assert_eq!(summary.copied, 1);
+
+    let expected = root.join("Frank Herbert").join("Dune.epub");
+    assert!(expected.exists());
+    assert!(src.exists(), "copy must leave original in place");
+    assert_eq!(
+        stored_path(&db, &book_id, FileFormat::Epub),
+        expected.to_string_lossy()
+    );
+}
+
+#[test]
+fn dry_run_plan_touches_nothing() {
+    let dir = tempfile::tempdir().unwrap();
+    let db = Database::open_in_memory().unwrap();
+    let book_id = seed_book(&db, "Dune", "Frank Herbert");
+
+    let src = dir.path().join("dune.epub");
+    std::fs::write(&src, b"epub bytes").unwrap();
+    link_file(&db, book_id, &src);
+
+    let root = dir.path().join("library");
+    let tmpl = PathTemplate::parse("{author}/{title}.{format}").unwrap();
+    // Building the plan is the dry run: we simply do not call apply_plan.
+    let plan = plan_organize(&db, &[book_id], &root, &tmpl, false).unwrap();
+    assert_eq!(plan.len(), 1);
+
+    assert!(src.exists(), "source must be untouched by planning");
+    assert!(
+        !root.exists(),
+        "library root must not be created by planning"
+    );
+    assert_eq!(
+        stored_path(&db, &book_id, FileFormat::Epub),
+        src.to_string_lossy()
+    );
+}
+
+#[test]
+fn rerun_is_idempotent() {
+    let dir = tempfile::tempdir().unwrap();
+    let db = Database::open_in_memory().unwrap();
+    let book_id = seed_book(&db, "Dune", "Frank Herbert");
+
+    let src = dir.path().join("dune.epub");
+    std::fs::write(&src, b"epub bytes").unwrap();
+    link_file(&db, book_id, &src);
+
+    let root = dir.path().join("library");
+    let tmpl = PathTemplate::parse("{author}/{title}.{format}").unwrap();
+
+    let plan = plan_organize(&db, &[book_id], &root, &tmpl, false).unwrap();
+    apply_plan(&db, &plan).unwrap();
+
+    // Second run: the file is already at its target, so nothing is actionable.
+    let plan2 = plan_organize(&db, &[book_id], &root, &tmpl, false).unwrap();
+    assert_eq!(plan2.len(), 1);
+    assert!(matches!(plan2[0].action, PlanAction::Skip { .. }));
+
+    let summary = apply_plan(&db, &plan2).unwrap();
+    assert_eq!(summary.moved, 0);
+    assert_eq!(summary.copied, 0);
+    assert_eq!(summary.skipped, 1);
+}
+
+#[test]
+fn collision_appends_numeric_suffix() {
+    let dir = tempfile::tempdir().unwrap();
+    let db = Database::open_in_memory().unwrap();
+
+    // Two different books rendering to the same target folder+name.
+    let b1 = seed_book(&db, "Dune", "Frank Herbert");
+    let b2 = seed_book(&db, "Dune", "Frank Herbert");
+
+    let s1 = dir.path().join("a.epub");
+    std::fs::write(&s1, b"first").unwrap();
+    link_file(&db, b1, &s1);
+    let s2 = dir.path().join("b.epub");
+    std::fs::write(&s2, b"second-different").unwrap();
+    link_file(&db, b2, &s2);
+
+    let root = dir.path().join("library");
+    let tmpl = PathTemplate::parse("{author}/{title}.{format}").unwrap();
+    let plan = plan_organize(&db, &[b1, b2], &root, &tmpl, false).unwrap();
+    assert_eq!(plan.len(), 2);
+
+    apply_plan(&db, &plan).unwrap();
+
+    let base = root.join("Frank Herbert").join("Dune.epub");
+    let suffixed = root.join("Frank Herbert").join("Dune (2).epub");
+    assert!(base.exists());
+    assert!(suffixed.exists(), "collision should produce a (2) file");
+}
+
+#[test]
+fn missing_source_is_skipped() {
+    let dir = tempfile::tempdir().unwrap();
+    let db = Database::open_in_memory().unwrap();
+    let book_id = seed_book(&db, "Dune", "Frank Herbert");
+
+    // Record points at a non-existent path.
+    let files = FileRepository::new(&db);
+    let ghost = dir.path().join("ghost.epub");
+    let f = EbookFile::new(
+        book_id,
+        ghost.to_string_lossy().to_string(),
+        FileFormat::Epub,
+        1,
+        "deadbeef".to_string(),
+    );
+    files.add_file(&f).unwrap();
+
+    let root = dir.path().join("library");
+    let tmpl = PathTemplate::parse("{author}/{title}.{format}").unwrap();
+    let plan = plan_organize(&db, &[book_id], &root, &tmpl, false).unwrap();
+    assert!(matches!(plan[0].action, PlanAction::Skip { .. }));
+
+    let summary = apply_plan(&db, &plan).unwrap();
+    assert_eq!(summary.skipped, 1);
+    assert!(!root.exists());
+}
+
+#[test]
+fn unknown_author_falls_back() {
+    let dir = tempfile::tempdir().unwrap();
+    let db = Database::open_in_memory().unwrap();
+
+    // Book with no author.
+    let repo = BookRepository::new(&db);
+    let book = Book::new("Beowulf");
+    repo.create_book(&book).unwrap();
+
+    let src = dir.path().join("beowulf.epub");
+    std::fs::write(&src, b"old english").unwrap();
+    link_file(&db, book.id, &src);
+
+    let root = dir.path().join("library");
+    let tmpl = PathTemplate::parse("{author}/{title}.{format}").unwrap();
+    let plan = plan_organize(&db, &[book.id], &root, &tmpl, false).unwrap();
+
+    let expected: PathBuf = root.join("Unknown Author").join("Beowulf.epub");
+    assert_eq!(plan[0].to, expected);
+}

--- a/docs/adr/011-file-management.md
+++ b/docs/adr/011-file-management.md
@@ -113,6 +113,12 @@ CREATE INDEX idx_files_checksum ON files(checksum);
   content-addressed cover store — keeping a single portable, user-owned data directory.
 - Template resolution sanitizes path segments (filesystem-illegal characters, length
   limits) and resolves collisions deterministically so re-runs are idempotent.
+- **Interface** (#152): `toku file organize [<book>|--all]` builds a plan and applies it,
+  moving files by default (`--copy` to copy) and updating stored DB paths in a single
+  transaction. `--dry-run` previews the plan without touching disk or DB. Configuration
+  lives under `[files]` in `config.toml`: `library_root` (defaults to `<data_dir>/library`)
+  and `organize_template` (defaults to `{author}/{title}.{format}`). Supported tokens:
+  `{author}`, `{title}`, `{series}`, `{format}`, `{year}`.
 
 ### 5. Format conversion — optional Calibre shell-out
 


### PR DESCRIPTION
## Description

Adds Calibre-style disk organization for associated ebook files (ROADMAP §6.1, ADR-011 §4). A new `toku file organize` command lays files out on disk from a configurable path template and keeps the database in sync.

**What's included**

- **Path-template engine** (`toku-files`) — renders `{author}`, `{title}`, `{series}`, `{format}`, `{year}` tokens into a relative path, with sensible fallbacks (`Unknown Author`, `No Series`, `Unknown Year`) and cross-platform (Linux/macOS/Windows) segment sanitization: illegal characters, reserved Windows device names, trailing dots/spaces, and length caps.
- **Organize service** (`toku-files`) — a pure `plan_organize` (deterministic `(n)` collision suffixing, idempotent skip when already in place, skip for missing sources) plus `apply_plan`, which performs the filesystem moves/copies and then updates all stored paths in a single transaction, rolling back the filesystem changes if the transaction can't commit. Moves fall back to copy+remove across filesystems.
- **CLI** (`toku-cli`) — `toku file organize [<book>|--all]` with `--dry-run` (preview only, touches nothing), `--copy` (copy instead of move), and `--format table|json|csv`.
- **Config** (`toku-core`) — new `[files]` section: `library_root` (defaults to `<data_dir>/library`) and `organize_template` (defaults to `{author}/{title}.{format}`).
- **DB** (`toku-db`) — `get_book_series` for the `{series}` token and `FileRepository::update_path`. No migration needed (reuses the existing `files.path` column).

## Related Issues

Closes #152

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI / infrastructure
- [ ] Other (describe below)

## Crate

- [x] `toku-core` — Domain models, traits, state machine
- [x] `toku-db` — SQLite persistence, migrations, FTS5
- [ ] `toku-import` — Importers (Goodreads, Calibre, StoryGraph)
- [ ] `toku-meta` — Metadata fetching (Open Library, Google Books)
- [x] `toku-cli` — CLI binary
- [ ] `toku-export` — Exporters (CSV, JSON, Markdown, BibTeX)
- [x] `docs/` — Documentation

<!-- Also touches `toku-files` (template engine + organize service), which is not listed above. -->

## Data Integrity Checklist

- [x] No user data is sent to any server without explicit opt-in (`toku-files` is network-free; organization is fully local)
- [x] Import operations are idempotent — `toku file organize` is idempotent: re-running produces no changes
- [x] User edits to metadata are never overwritten by auto-enrichment (no metadata fields changed)
- [x] New fields track provenance (source + timestamp) — no new metadata fields; file records already track provenance
- [x] Export round-trip is preserved (if applicable) — not affected

## Checklist

- [ ] I have read [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] `cargo fmt --check` passes
- [x] `cargo clippy --workspace -- -D warnings` passes
- [x] `cargo test --workspace` passes
- [x] I have updated documentation (if applicable)
