### PR TITLE
feat: add toku convert for optional Calibre ebook-convert format conversion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Format conversion: `toku convert <book> --to <format> [--from <format>] [--force]` converts
+  an associated ebook to another format by shelling out to Calibre's `ebook-convert`. The
+  output is written next to the source file (same name, new extension) and auto-associated with
+  the book (provenance `calibre-convert`). `--from` is inferred when the book has a single file
+  and required when it has several; `--force` overwrites an existing output. The Calibre
+  dependency is **optional and never hard** — if `ebook-convert` is not on `$PATH`, the command
+  prints install guidance (<https://calibre-ebook.com/download>) and exits non-zero instead of
+  panicking. Subprocess failures are reported with the underlying `ebook-convert` stderr.
+  DRM-free files only — no DRM stripping (#147)
 - Disk organization: `toku file organize [<book>|--all]` moves (or `--copy`) associated
   ebook files into a managed library laid out by a configurable path template, updating the
   stored DB paths in a single transaction. `--dry-run` previews the plan without touching

--- a/crates/toku-cli/src/main.rs
+++ b/crates/toku-cli/src/main.rs
@@ -12,7 +12,7 @@ use toku_core::{
     TokuConfig, compute_stats, parse_duration_to_minutes,
 };
 use toku_db::{BookRepository, Database};
-use toku_files::{EbookFile, FileFormat, FileRepository, sha256_file};
+use toku_files::{Converter, EbookFile, FileFormat, FileRepository, sha256_file};
 mod account;
 mod import_ui;
 mod sync;
@@ -196,6 +196,29 @@ enum Commands {
     File {
         #[command(subcommand)]
         action: FileAction,
+    },
+
+    /// Convert an associated ebook to another format (optional; needs Calibre)
+    ///
+    /// Shells out to Calibre's `ebook-convert`. The resulting file is written
+    /// next to the source file and auto-associated with the book. Requires
+    /// Calibre on your PATH (https://calibre-ebook.com/download); it is never a
+    /// hard dependency. DRM-free files only — no DRM stripping.
+    Convert {
+        /// Book title (or id) whose file should be converted
+        book: String,
+
+        /// Target format to convert to (epub/pdf/mobi/azw3)
+        #[arg(long)]
+        to: String,
+
+        /// Source format to convert from (auto-detected when the book has one file)
+        #[arg(long)]
+        from: Option<String>,
+
+        /// Overwrite the output file if it already exists on disk
+        #[arg(long)]
+        force: bool,
     },
 
     /// Export your library (csv, json, markdown, backup)
@@ -996,6 +1019,12 @@ fn main() -> Result<()> {
         Commands::Reading { action } => cmd_reading(&repo, action, &cli.format),
         Commands::Tag { action } => cmd_tag(&repo, action, &cli.format),
         Commands::File { action } => cmd_file(&db, &repo, action, &data_dir, &cli.format),
+        Commands::Convert {
+            book,
+            to,
+            from,
+            force,
+        } => cmd_convert(&db, &repo, &book, &to, from.as_deref(), force),
         Commands::Export { target } => cmd_export(&db, &data_dir, target),
         Commands::Bulk { action } => cmd_bulk(&db, &repo, action),
         Commands::Stats {
@@ -2431,6 +2460,152 @@ fn cmd_file(
             dry_run,
             copy,
         } => cmd_file_organize(db, repo, data_dir, book, all, dry_run, copy, output_format),
+    }
+}
+
+/// Convert an associated ebook file to another format via Calibre's
+/// `ebook-convert`, writing the output next to the source file and
+/// auto-associating it with the book.
+fn cmd_convert(
+    db: &Database,
+    repo: &BookRepository,
+    book_query: &str,
+    to: &str,
+    from: Option<&str>,
+    force: bool,
+) -> Result<()> {
+    let book = resolve_book(repo, book_query)?;
+    let target_format: FileFormat = to.parse().map_err(|_| {
+        anyhow::anyhow!("unsupported target format \"{to}\" (expected epub, pdf, mobi, or azw3)")
+    })?;
+
+    let files = FileRepository::new(db);
+    let associated = files
+        .list_files(&book.id)
+        .map_err(|e| anyhow::anyhow!("{e}"))?;
+    if associated.is_empty() {
+        anyhow::bail!(
+            "No files linked to \"{}\". Add one first with: toku file add \"{}\" <path>",
+            book.title,
+            book.title
+        );
+    }
+
+    // Pick the source file: honour --from, else auto-pick a single file, else
+    // bail asking the user to disambiguate.
+    let source = match from {
+        Some(f) => {
+            let fmt: FileFormat = f.parse().map_err(|_| {
+                anyhow::anyhow!(
+                    "unsupported source format \"{f}\" (expected epub, pdf, mobi, or azw3)"
+                )
+            })?;
+            associated
+                .iter()
+                .find(|file| file.format == fmt)
+                .cloned()
+                .ok_or_else(|| anyhow::anyhow!("no {fmt} file linked to \"{}\"", book.title))?
+        }
+        None => {
+            if associated.len() == 1 {
+                associated[0].clone()
+            } else {
+                let formats = associated
+                    .iter()
+                    .map(|f| f.format.to_string())
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                anyhow::bail!(
+                    "\"{}\" has multiple files ({formats}). Choose one with --from <format>",
+                    book.title
+                );
+            }
+        }
+    };
+
+    if source.format == target_format {
+        anyhow::bail!("source is already {target_format}; nothing to convert");
+    }
+
+    let src_path = PathBuf::from(&source.path);
+    if !src_path.is_file() {
+        anyhow::bail!(
+            "source file is missing on disk: {}\nRe-add it with: toku file add",
+            source.path
+        );
+    }
+
+    // Write the output next to the source: same stem, new extension.
+    let dst_path = src_path.with_extension(target_format.as_str());
+    if dst_path == src_path {
+        anyhow::bail!(
+            "source and output paths are identical: {}",
+            src_path.display()
+        );
+    }
+    if dst_path.exists() && !force {
+        anyhow::bail!(
+            "output already exists: {}\nPass --force to overwrite.",
+            dst_path.display()
+        );
+    }
+
+    let converter = Converter::new();
+    // Optional dependency: fail cleanly (non-zero) with install guidance if absent.
+    converter
+        .ensure_available()
+        .map_err(|e| anyhow::anyhow!("{e}"))?;
+
+    eprintln!(
+        "Converting {} → {} via ebook-convert…",
+        source.format, target_format
+    );
+    converter
+        .convert(&src_path, &dst_path)
+        .map_err(|e| anyhow::anyhow!("{e}"))?;
+
+    if !dst_path.is_file() {
+        anyhow::bail!(
+            "ebook-convert reported success but produced no output at {}",
+            dst_path.display()
+        );
+    }
+
+    let size_bytes = std::fs::metadata(&dst_path)
+        .with_context(|| format!("reading {}", dst_path.display()))?
+        .len() as i64;
+    let checksum = sha256_file(&dst_path).map_err(|e| anyhow::anyhow!("{e}"))?;
+    let stored = dst_path
+        .canonicalize()
+        .unwrap_or_else(|_| dst_path.clone())
+        .to_string_lossy()
+        .to_string();
+
+    let file = EbookFile::new(book.id, stored, target_format, size_bytes, checksum)
+        .with_source("calibre-convert", Some(source.path.clone()));
+
+    match files.add_file(&file) {
+        Ok(()) => {
+            eprintln!(
+                "✓ Converted to {} ({}) and linked to \"{}\"\n  {}",
+                target_format,
+                human_size(size_bytes),
+                book.title,
+                dst_path.display()
+            );
+            Ok(())
+        }
+        // The output already matched an existing association for this book.
+        Err(toku_files::FileError::Duplicate(_)) => {
+            eprintln!(
+                "✓ Converted to {} at {} (already linked to \"{}\")",
+                target_format,
+                dst_path.display(),
+                book.title
+            );
+            Ok(())
+        }
+        Err(e) => Err(anyhow::anyhow!("{e}")),
     }
 }
 

--- a/crates/toku-files/src/convert.rs
+++ b/crates/toku-files/src/convert.rs
@@ -1,0 +1,158 @@
+//! Format conversion by shelling out to Calibre's `ebook-convert` CLI.
+//!
+//! Building an ebook converter in Rust is a multi-month effort; Calibre's is
+//! mature, free, and battle-tested (see ROADMAP §6.2 / ADR-011 §5). The
+//! dependency is **optional and never hard**: if `ebook-convert` is not on
+//! `$PATH`, [`Converter::ensure_available`] returns [`ConvertError::NotInstalled`]
+//! carrying actionable install guidance instead of panicking.
+//!
+//! **DRM-free files only.** Toku does not strip DRM and will not add DRM-removal
+//! tooling.
+
+use std::ffi::OsString;
+use std::path::Path;
+use std::process::Command;
+
+/// Default Calibre conversion binary looked up on `$PATH`.
+pub const DEFAULT_BINARY: &str = "ebook-convert";
+
+/// Where to point users when `ebook-convert` is missing.
+const INSTALL_URL: &str = "https://calibre-ebook.com/download";
+
+/// Runs Calibre's `ebook-convert` to convert ebook files between formats.
+///
+/// The binary name/path is configurable ([`Converter::with_binary`]) so tests
+/// can inject a stand-in without a real Calibre install.
+#[derive(Debug, Clone)]
+pub struct Converter {
+    binary: OsString,
+}
+
+impl Default for Converter {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Converter {
+    /// A converter that invokes the default `ebook-convert` binary from `$PATH`.
+    pub fn new() -> Self {
+        Self {
+            binary: OsString::from(DEFAULT_BINARY),
+        }
+    }
+
+    /// A converter that invokes a specific binary name or path. Useful for
+    /// tests, or when Calibre lives outside `$PATH`.
+    pub fn with_binary(binary: impl Into<OsString>) -> Self {
+        Self {
+            binary: binary.into(),
+        }
+    }
+
+    /// Returns `true` if the conversion binary can be executed.
+    pub fn is_available(&self) -> bool {
+        self.ensure_available().is_ok()
+    }
+
+    /// Verify the conversion binary is runnable, running `<binary> --version`.
+    ///
+    /// Maps a missing binary to [`ConvertError::NotInstalled`] with install
+    /// guidance, so callers can surface a friendly message and exit cleanly
+    /// rather than panicking.
+    pub fn ensure_available(&self) -> Result<(), ConvertError> {
+        match Command::new(&self.binary).arg("--version").output() {
+            Ok(_) => Ok(()),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Err(ConvertError::NotInstalled {
+                binary: self.binary.to_string_lossy().into_owned(),
+            }),
+            Err(e) => Err(ConvertError::Io(e.to_string())),
+        }
+    }
+
+    /// Convert `src` into `dst`, inferring both formats from their extensions
+    /// (this is how `ebook-convert` itself decides). Returns the captured
+    /// stderr on a non-zero exit via [`ConvertError::Subprocess`].
+    ///
+    /// The caller is responsible for validating `src` exists and that `dst`
+    /// does not clobber anything it shouldn't.
+    pub fn convert(&self, src: &Path, dst: &Path) -> Result<(), ConvertError> {
+        self.ensure_available()?;
+
+        let output = Command::new(&self.binary)
+            .arg(src)
+            .arg(dst)
+            .output()
+            .map_err(|e| {
+                if e.kind() == std::io::ErrorKind::NotFound {
+                    ConvertError::NotInstalled {
+                        binary: self.binary.to_string_lossy().into_owned(),
+                    }
+                } else {
+                    ConvertError::Io(e.to_string())
+                }
+            })?;
+
+        if output.status.success() {
+            Ok(())
+        } else {
+            Err(ConvertError::Subprocess {
+                code: output.status.code(),
+                stderr: String::from_utf8_lossy(&output.stderr).trim().to_string(),
+            })
+        }
+    }
+}
+
+/// Errors raised while converting ebook formats.
+#[derive(Debug, thiserror::Error)]
+pub enum ConvertError {
+    #[error(
+        "`{binary}` was not found on your PATH.\n\n\
+         Format conversion is optional and relies on Calibre. Install it from\n\
+         {INSTALL_URL} (the `ebook-convert` command ships with Calibre), then\n\
+         ensure it is on your PATH and try again."
+    )]
+    NotInstalled { binary: String },
+
+    #[error("`ebook-convert` exited with {}: {stderr}", match code { Some(c) => c.to_string(), None => "a signal".to_string() })]
+    Subprocess { code: Option<i32>, stderr: String },
+
+    #[error("I/O error running the converter: {0}")]
+    Io(String),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn missing_binary_reports_not_installed() {
+        let converter = Converter::with_binary("toku-definitely-not-a-real-binary-xyz");
+        let err = converter.ensure_available().unwrap_err();
+        assert!(matches!(err, ConvertError::NotInstalled { .. }));
+        assert!(!converter.is_available());
+    }
+
+    #[test]
+    fn not_installed_message_is_actionable() {
+        let err = ConvertError::NotInstalled {
+            binary: "ebook-convert".to_string(),
+        };
+        let msg = err.to_string();
+        assert!(msg.contains("ebook-convert"));
+        assert!(msg.contains("Calibre"));
+        assert!(msg.contains(INSTALL_URL));
+    }
+
+    #[test]
+    fn subprocess_message_includes_stderr() {
+        let err = ConvertError::Subprocess {
+            code: Some(1),
+            stderr: "boom: bad input".to_string(),
+        };
+        let msg = err.to_string();
+        assert!(msg.contains("boom: bad input"));
+        assert!(msg.contains('1'));
+    }
+}

--- a/crates/toku-files/src/lib.rs
+++ b/crates/toku-files/src/lib.rs
@@ -12,10 +12,12 @@ use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use uuid::Uuid;
 
+mod convert;
 mod organize;
 mod repo;
 mod template;
 
+pub use convert::{ConvertError, Converter, DEFAULT_BINARY};
 pub use organize::{
     OrganizeOutcome, OrganizeSummary, PlanAction, PlannedMove, apply_plan, plan_organize,
 };

--- a/crates/toku-files/tests/convert.rs
+++ b/crates/toku-files/tests/convert.rs
@@ -1,0 +1,94 @@
+//! Integration tests for the Calibre `ebook-convert` shell-out.
+//!
+//! These use a fake `ebook-convert` shell script so the tests do not require a
+//! real Calibre install. They are Unix-only because the fakes are `/bin/sh`
+//! scripts.
+#![cfg(unix)]
+
+use std::fs;
+use std::os::unix::fs::PermissionsExt;
+use std::path::PathBuf;
+
+use toku_files::{ConvertError, Converter};
+
+/// Write an executable fake `ebook-convert` script and return its path.
+fn write_fake(dir: &std::path::Path, name: &str, body: &str) -> PathBuf {
+    let path = dir.join(name);
+    fs::write(&path, body).unwrap();
+    let mut perms = fs::metadata(&path).unwrap().permissions();
+    perms.set_mode(0o755);
+    fs::set_permissions(&path, perms).unwrap();
+    path
+}
+
+#[test]
+fn converts_successfully_with_fake_binary() {
+    let dir = tempfile::tempdir().unwrap();
+    // Fake converter: appends a marker so the output differs from the input.
+    let bin = write_fake(
+        dir.path(),
+        "ebook-convert",
+        "#!/bin/sh\n\
+         if [ \"$1\" = \"--version\" ]; then echo fake; exit 0; fi\n\
+         { cat \"$1\"; echo converted; } > \"$2\"\n\
+         exit 0\n",
+    );
+
+    let src = dir.path().join("book.epub");
+    fs::write(&src, b"epub bytes").unwrap();
+    let dst = dir.path().join("book.mobi");
+
+    let converter = Converter::with_binary(&bin);
+    assert!(converter.is_available());
+    converter.convert(&src, &dst).unwrap();
+
+    assert!(dst.is_file(), "output file should exist");
+    let contents = fs::read_to_string(&dst).unwrap();
+    assert!(contents.contains("epub bytes"));
+    assert!(contents.contains("converted"));
+}
+
+#[test]
+fn surfaces_stderr_on_subprocess_failure() {
+    let dir = tempfile::tempdir().unwrap();
+    let bin = write_fake(
+        dir.path(),
+        "ebook-convert",
+        "#!/bin/sh\n\
+         if [ \"$1\" = \"--version\" ]; then echo fake; exit 0; fi\n\
+         echo 'boom: unsupported input' 1>&2\n\
+         exit 7\n",
+    );
+
+    let src = dir.path().join("book.epub");
+    fs::write(&src, b"epub bytes").unwrap();
+    let dst = dir.path().join("book.mobi");
+
+    let converter = Converter::with_binary(&bin);
+    let err = converter.convert(&src, &dst).unwrap_err();
+    match err {
+        ConvertError::Subprocess { code, stderr } => {
+            assert_eq!(code, Some(7));
+            assert!(stderr.contains("boom: unsupported input"));
+        }
+        other => panic!("expected Subprocess error, got {other:?}"),
+    }
+    assert!(!dst.exists(), "no output should be produced on failure");
+}
+
+#[test]
+fn missing_binary_is_not_installed() {
+    let converter = Converter::with_binary("toku-no-such-ebook-convert-binary");
+    assert!(!converter.is_available());
+    let err = converter.ensure_available().unwrap_err();
+    assert!(matches!(err, ConvertError::NotInstalled { .. }));
+
+    // `convert` should short-circuit with the same error, without touching disk.
+    let dir = tempfile::tempdir().unwrap();
+    let src = dir.path().join("book.epub");
+    fs::write(&src, b"x").unwrap();
+    let dst = dir.path().join("book.mobi");
+    let err = converter.convert(&src, &dst).unwrap_err();
+    assert!(matches!(err, ConvertError::NotInstalled { .. }));
+    assert!(!dst.exists());
+}

--- a/docs/adr/003-cli-design.md
+++ b/docs/adr/003-cli-design.md
@@ -36,6 +36,8 @@ toku import goodreads|calibre|storygraph <path> [--dry-run]
 toku export csv|json|backup [--output <path>]
 toku stats [--year <year>]
 toku tag add|remove|list <tag> [<books>...]
+toku file add|list|remove|organize <book> [<path>|<format>] [--all] [--dry-run] [--copy]
+toku convert <book> --to <format> [--from <format>] [--force]   # optional; needs Calibre
 toku bulk tag|status|delete [--status <s>] [--tag <t>] [--dry-run]
 toku config [--edit]
 ```

--- a/docs/adr/011-file-management.md
+++ b/docs/adr/011-file-management.md
@@ -122,11 +122,20 @@ CREATE INDEX idx_files_checksum ON files(checksum);
 
 ### 5. Format conversion — optional Calibre shell-out
 
-- `toku convert` shells out to Calibre's `ebook-convert` CLI (#147). Building a converter
-  in Rust is a multi-month effort; Calibre's is mature, free, and battle-tested.
+- `toku convert <book> --to <format> [--from <format>] [--force]` shells out to Calibre's
+  `ebook-convert` CLI (#147). Building a converter in Rust is a multi-month effort; Calibre's
+  is mature, free, and battle-tested. The converter lives in `toku-files` (`Converter`), which
+  invokes the `ebook-convert` binary; the binary name is injectable so tests can substitute a
+  fake without a real Calibre install.
+- The output is written **next to the source file** (same stem, new extension) and
+  auto-associated with the book (provenance `calibre-convert`). When the book has a single
+  associated file, `--from` is inferred; with multiple files it is required. `--force` is
+  needed to overwrite an existing output file.
 - The dependency is **optional and never hard**: the command checks for `ebook-convert`
-  in `$PATH` and, if missing, prints installation guidance instead of failing the build or
-  blocking any other feature. Toku itself has no Calibre build/link dependency.
+  in `$PATH`   and, if missing, prints installation guidance (<https://calibre-ebook.com/download>)
+  and exits non-zero instead of failing the build or blocking any other feature. Toku itself
+  has no Calibre build/link dependency. Subprocess failures are surfaced with the captured
+  `ebook-convert` stderr.
 - **DRM-free files only.** Toku does not strip DRM and will not add DRM-removal tooling.
 
 ### 6. OPDS server — local-network-only by default


### PR DESCRIPTION
## Description

Adds `toku convert` — optional ebook format conversion by shelling out to Calibre's
`ebook-convert` (ROADMAP §6.2 / ADR-011 §5). Building a converter in Rust is out of scope;
Calibre's is mature, free, and battle-tested. The Calibre dependency is **optional and never
hard**.

**What's included**

- **`toku convert <book> --to <format> [--from <format>] [--force]`** (`toku-cli`): resolves the
  book, picks the source file (honours `--from`; auto-picks when the book has a single file,
  errors listing formats when ambiguous), rejects same-format conversion, writes the output next
  to the source file (same name, new extension), and guards an existing output behind `--force`.
- **New `convert` module in `toku-files`**: a `Converter` (default `ebook-convert`, injectable
  binary for tests) plus a `ConvertError` enum. Detects the binary via `--version`; a missing
  binary maps to `NotInstalled` with actionable install guidance, and non-zero exits map to
  `Subprocess { code, stderr }`.
- On success, the converted file is auto-associated with the book (SHA-256 + size recorded,
  provenance `calibre-convert`, `source_ref` pointing at the source path).
- Missing Calibre → clear guidance and a non-zero exit (no panic). Subprocess failures are
  surfaced with the captured `ebook-convert` stderr.
- **DRM-free files only** — no DRM stripping.
- Docs: CHANGELOG `[Unreleased]`, ADR-011 §5, and the ADR-003 command hierarchy (also adds the
  previously-missing `toku file` line).

## Related Issues

Closes #147

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI / infrastructure
- [ ] Other (describe below)

## Crate

- [ ] `toku-core` — Domain models, traits, state machine
- [ ] `toku-db` — SQLite persistence, migrations, FTS5
- [ ] `toku-import` — Importers (Goodreads, Calibre, StoryGraph)
- [ ] `toku-meta` — Metadata fetching (Open Library, Google Books)
- [x] `toku-cli` — CLI binary
- [ ] `toku-export` — Exporters (CSV, JSON, Markdown, BibTeX)
- [x] `docs/` — Documentation
- [x] `toku-files` — Ebook file management (conversion logic)

## Data Integrity Checklist

- [x] No user data is sent to any server without explicit opt-in
- [x] Import operations are idempotent (re-importing the same file creates no duplicates)
- [x] User edits to metadata are never overwritten by auto-enrichment
- [x] New fields track provenance (source + timestamp)
- [x] Export round-trip is preserved (if applicable)

## Checklist

- [x] I have read [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] `cargo fmt --check` passes
- [x] `cargo clippy --workspace -- -D warnings` passes
- [x] `cargo test --workspace` passes
- [x] I have updated documentation (if applicable)
