### PR TITLE
feat: file integrity checking (SHA-256) + disk usage reporting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- File integrity & disk usage: `toku file verify [<book>|--all]` recomputes each associated
+  file's SHA-256 by streaming its contents (constant memory, even for multi-GB files) and
+  flags files whose contents changed (`mismatch`) or that are gone from disk (`missing`).
+  It prints a per-file status and summary, and exits non-zero when any problem is found so it
+  can gate scripts. `toku file usage [--by format|author|shelf]` reports total disk usage with
+  a breakdown; a file linked to multiple authors or shelves is counted under each, and books
+  with none fall into an `(unassigned)` bucket. Both support `--format table|json|csv` (#149)
 - Format conversion: `toku convert <book> --to <format> [--from <format>] [--force]` converts
   an associated ebook to another format by shelling out to Calibre's `ebook-convert`. The
   output is written next to the source file (same name, new extension) and auto-associated with

--- a/crates/toku-cli/src/main.rs
+++ b/crates/toku-cli/src/main.rs
@@ -12,7 +12,10 @@ use toku_core::{
     TokuConfig, compute_stats, parse_duration_to_minutes,
 };
 use toku_db::{BookRepository, Database};
-use toku_files::{Converter, EbookFile, FileFormat, FileRepository, sha256_file};
+use toku_files::{
+    Converter, EbookFile, FileFormat, FileRepository, UsageTotals, VerifyStatus, sha256_file,
+    usage_by_key, usage_totals, verify_file,
+};
 mod account;
 mod import_ui;
 mod sync;
@@ -486,6 +489,32 @@ enum FileAction {
         /// Copy files into the library instead of moving them
         #[arg(long)]
         copy: bool,
+    },
+
+    /// Verify file integrity by recomputing SHA-256 checksums
+    ///
+    /// Streams each associated file to recompute its checksum and compares it to
+    /// the value stored when the file was linked. Flags files whose contents
+    /// changed (mismatch) or that are no longer on disk (missing). Exits with a
+    /// non-zero status if any problem is found, for use in scripts.
+    Verify {
+        /// Book title to verify (omit and use --all to verify everything)
+        book: Option<String>,
+
+        /// Verify files for every book in the library
+        #[arg(long)]
+        all: bool,
+    },
+
+    /// Report disk usage of associated files, with an optional breakdown
+    ///
+    /// Totals reflect the catalog's recorded file sizes. Use --by to group the
+    /// breakdown by format (default), author, or shelf. A file linked to
+    /// multiple authors or shelves is counted under each of them.
+    Usage {
+        /// Group the breakdown by: format (default), author, or shelf
+        #[arg(long, value_name = "DIMENSION")]
+        by: Option<String>,
     },
 }
 
@@ -2460,7 +2489,292 @@ fn cmd_file(
             dry_run,
             copy,
         } => cmd_file_organize(db, repo, data_dir, book, all, dry_run, copy, output_format),
+        FileAction::Verify { book, all } => cmd_file_verify(db, repo, book, all, output_format),
+        FileAction::Usage { by } => cmd_file_usage(db, repo, by.as_deref(), output_format),
     }
+}
+
+/// Recompute SHA-256 for associated files and report integrity problems.
+///
+/// Verifies a single book's files, or the whole library with `--all`. Prints a
+/// per-file status plus a summary, and exits non-zero when any file is missing
+/// or its contents no longer match the stored checksum.
+fn cmd_file_verify(
+    db: &Database,
+    repo: &BookRepository,
+    book: Option<String>,
+    all: bool,
+    output_format: &OutputFormat,
+) -> Result<()> {
+    let files = FileRepository::new(db);
+
+    let targets: Vec<EbookFile> = match (&book, all) {
+        (Some(_), true) => anyhow::bail!("pass either a book title or --all, not both"),
+        (None, false) => anyhow::bail!("specify a book title, or use --all to verify everything"),
+        (Some(title), false) => {
+            let book = resolve_book(repo, title)?;
+            files
+                .list_files(&book.id)
+                .map_err(|e| anyhow::anyhow!("{e}"))?
+        }
+        (None, true) => files.list_all_files().map_err(|e| anyhow::anyhow!("{e}"))?,
+    };
+
+    if targets.is_empty() {
+        eprintln!("No files to verify. Link some with: toku file add");
+        return Ok(());
+    }
+
+    let outcomes: Vec<toku_files::VerifyOutcome> = targets
+        .iter()
+        .map(verify_file)
+        .collect::<std::result::Result<_, _>>()
+        .map_err(|e| anyhow::anyhow!("{e}"))?;
+
+    let mismatches = outcomes
+        .iter()
+        .filter(|o| o.status == VerifyStatus::Mismatch)
+        .count();
+    let missing = outcomes
+        .iter()
+        .filter(|o| o.status == VerifyStatus::Missing)
+        .count();
+    let ok = outcomes.len() - mismatches - missing;
+
+    match output_format {
+        OutputFormat::Json => {
+            #[derive(serde::Serialize)]
+            struct Row {
+                status: String,
+                format: String,
+                path: String,
+                stored_checksum: String,
+                computed_checksum: Option<String>,
+            }
+            let rows: Vec<Row> = outcomes
+                .iter()
+                .map(|o| Row {
+                    status: o.status.as_str().to_string(),
+                    format: o.file.format.to_string(),
+                    path: o.file.path.clone(),
+                    stored_checksum: o.file.checksum.clone(),
+                    computed_checksum: o.computed.clone(),
+                })
+                .collect();
+            #[derive(serde::Serialize)]
+            struct Report<'a> {
+                ok: usize,
+                mismatch: usize,
+                missing: usize,
+                files: &'a [Row],
+            }
+            let report = Report {
+                ok,
+                mismatch: mismatches,
+                missing,
+                files: &rows,
+            };
+            println!("{}", serde_json::to_string_pretty(&report)?);
+        }
+        OutputFormat::Csv => {
+            println!("status,format,path,stored_checksum,computed_checksum");
+            for o in &outcomes {
+                println!(
+                    "{},{},\"{}\",{},{}",
+                    o.status,
+                    o.file.format,
+                    o.file.path.replace('"', "\"\""),
+                    o.file.checksum,
+                    o.computed.as_deref().unwrap_or("")
+                );
+            }
+        }
+        OutputFormat::Table => {
+            use tabled::{Table, Tabled};
+
+            #[derive(Tabled)]
+            struct Row {
+                #[tabled(rename = "Status")]
+                status: String,
+                #[tabled(rename = "Format")]
+                format: String,
+                #[tabled(rename = "Path")]
+                path: String,
+            }
+            let rows: Vec<Row> = outcomes
+                .iter()
+                .map(|o| Row {
+                    status: match o.status {
+                        VerifyStatus::Ok => "ok",
+                        VerifyStatus::Mismatch => "MISMATCH",
+                        VerifyStatus::Missing => "MISSING",
+                    }
+                    .to_string(),
+                    format: o.file.format.to_string(),
+                    path: o.file.path.clone(),
+                })
+                .collect();
+            println!("{}", Table::new(rows));
+        }
+    }
+
+    eprintln!(
+        "\n{} ok, {} mismatch, {} missing ({} file(s) checked)",
+        ok,
+        mismatches,
+        missing,
+        outcomes.len()
+    );
+
+    if mismatches + missing > 0 {
+        use std::io::Write;
+        let _ = std::io::stdout().flush();
+        std::process::exit(1);
+    }
+    Ok(())
+}
+
+/// Report total disk usage of associated files with an optional breakdown.
+///
+/// Totals are computed from the recorded file sizes in the catalog. The
+/// breakdown groups by format (default), author, or shelf; a file linked to
+/// multiple authors or shelves contributes to each bucket, while books with
+/// none fall into an `(unassigned)` bucket.
+fn cmd_file_usage(
+    db: &Database,
+    repo: &BookRepository,
+    by: Option<&str>,
+    output_format: &OutputFormat,
+) -> Result<()> {
+    let files = FileRepository::new(db);
+    let all_files = files.list_all_files().map_err(|e| anyhow::anyhow!("{e}"))?;
+
+    let dimension = by.unwrap_or("format").to_lowercase();
+    if !matches!(dimension.as_str(), "format" | "author" | "shelf") {
+        anyhow::bail!("unknown --by value \"{dimension}\" (expected format, author, or shelf)");
+    }
+
+    let totals = usage_totals(&all_files);
+
+    // Build the grouped breakdown. Author/shelf require joins through the book
+    // repository; a file with no authors/shelves is bucketed as "(unassigned)".
+    const UNASSIGNED: &str = "(unassigned)";
+    let grouped: std::collections::BTreeMap<String, UsageTotals> = match dimension.as_str() {
+        "format" => usage_by_key(&all_files, |f| vec![f.format.to_string()]),
+        "author" => usage_by_key(&all_files, |f| {
+            let names: Vec<String> = repo
+                .get_book_authors(&f.book_id)
+                .unwrap_or_default()
+                .into_iter()
+                .map(|(a, _)| a.name)
+                .collect();
+            if names.is_empty() {
+                vec![UNASSIGNED.to_string()]
+            } else {
+                names
+            }
+        }),
+        "shelf" => usage_by_key(&all_files, |f| {
+            let names: Vec<String> = repo
+                .get_book_shelves(&f.book_id)
+                .unwrap_or_default()
+                .into_iter()
+                .map(|s| s.name)
+                .collect();
+            if names.is_empty() {
+                vec![UNASSIGNED.to_string()]
+            } else {
+                names
+            }
+        }),
+        _ => unreachable!(),
+    };
+
+    // Sort breakdown rows by descending size for human-facing output.
+    let mut rows: Vec<(String, UsageTotals)> = grouped.into_iter().collect();
+    rows.sort_by(|a, b| {
+        b.1.total_bytes
+            .cmp(&a.1.total_bytes)
+            .then_with(|| a.0.cmp(&b.0))
+    });
+
+    match output_format {
+        OutputFormat::Json => {
+            #[derive(serde::Serialize)]
+            struct Group {
+                key: String,
+                file_count: u64,
+                size_bytes: i64,
+            }
+            #[derive(serde::Serialize)]
+            struct Report {
+                dimension: String,
+                total_files: u64,
+                total_bytes: i64,
+                breakdown: Vec<Group>,
+            }
+            let report = Report {
+                dimension: dimension.clone(),
+                total_files: totals.file_count,
+                total_bytes: totals.total_bytes,
+                breakdown: rows
+                    .iter()
+                    .map(|(k, v)| Group {
+                        key: k.clone(),
+                        file_count: v.file_count,
+                        size_bytes: v.total_bytes,
+                    })
+                    .collect(),
+            };
+            println!("{}", serde_json::to_string_pretty(&report)?);
+        }
+        OutputFormat::Csv => {
+            println!("{dimension},file_count,size_bytes");
+            for (k, v) in &rows {
+                println!(
+                    "\"{}\",{},{}",
+                    k.replace('"', "\"\""),
+                    v.file_count,
+                    v.total_bytes
+                );
+            }
+            println!("\"TOTAL\",{},{}", totals.file_count, totals.total_bytes);
+        }
+        OutputFormat::Table => {
+            use tabled::{Table, Tabled};
+
+            #[derive(Tabled)]
+            struct Row {
+                #[tabled(rename = "Group")]
+                key: String,
+                #[tabled(rename = "Files")]
+                files: u64,
+                #[tabled(rename = "Size")]
+                size: String,
+            }
+            let table_rows: Vec<Row> = rows
+                .iter()
+                .map(|(k, v)| Row {
+                    key: k.clone(),
+                    files: v.file_count,
+                    size: human_size(v.total_bytes),
+                })
+                .collect();
+            let header = match dimension.as_str() {
+                "author" => "By author",
+                "shelf" => "By shelf",
+                _ => "By format",
+            };
+            println!("{header}:");
+            println!("{}", Table::new(table_rows));
+            println!(
+                "\nTotal: {} across {} file(s)",
+                human_size(totals.total_bytes),
+                totals.file_count
+            );
+        }
+    }
+    Ok(())
 }
 
 /// Convert an associated ebook file to another format via Calibre's

--- a/crates/toku-files/src/convert.rs
+++ b/crates/toku-files/src/convert.rs
@@ -11,13 +11,39 @@
 
 use std::ffi::OsString;
 use std::path::Path;
-use std::process::Command;
+use std::process::{Command, Output};
+use std::time::Duration;
 
 /// Default Calibre conversion binary looked up on `$PATH`.
 pub const DEFAULT_BINARY: &str = "ebook-convert";
 
 /// Where to point users when `ebook-convert` is missing.
 const INSTALL_URL: &str = "https://calibre-ebook.com/download";
+
+/// `ETXTBSY` — "text file busy". Same numeric value (26) on Linux and macOS.
+const ETXTBSY: i32 = 26;
+
+/// Run a command, retrying briefly on `ETXTBSY` ("text file busy").
+///
+/// Spawning an executable that was *just* written can transiently fail with
+/// `ETXTBSY` on Linux: a concurrently forked-but-not-yet-exec'd child process
+/// may still hold a writable descriptor to the target file at `execve` time.
+/// The window is tiny, so a couple of short retries clear it once that
+/// descriptor closes. On other errors (or platforms) this behaves like a plain
+/// `Command::output()`.
+fn run_capturing(cmd: &mut Command) -> std::io::Result<Output> {
+    const MAX_ATTEMPTS: u32 = 5;
+    let mut attempt = 0;
+    loop {
+        match cmd.output() {
+            Err(e) if e.raw_os_error() == Some(ETXTBSY) && attempt + 1 < MAX_ATTEMPTS => {
+                attempt += 1;
+                std::thread::sleep(Duration::from_millis(10 * u64::from(attempt)));
+            }
+            other => return other,
+        }
+    }
+}
 
 /// Runs Calibre's `ebook-convert` to convert ebook files between formats.
 ///
@@ -61,7 +87,9 @@ impl Converter {
     /// guidance, so callers can surface a friendly message and exit cleanly
     /// rather than panicking.
     pub fn ensure_available(&self) -> Result<(), ConvertError> {
-        match Command::new(&self.binary).arg("--version").output() {
+        let mut cmd = Command::new(&self.binary);
+        cmd.arg("--version");
+        match run_capturing(&mut cmd) {
             Ok(_) => Ok(()),
             Err(e) if e.kind() == std::io::ErrorKind::NotFound => Err(ConvertError::NotInstalled {
                 binary: self.binary.to_string_lossy().into_owned(),
@@ -79,19 +107,17 @@ impl Converter {
     pub fn convert(&self, src: &Path, dst: &Path) -> Result<(), ConvertError> {
         self.ensure_available()?;
 
-        let output = Command::new(&self.binary)
-            .arg(src)
-            .arg(dst)
-            .output()
-            .map_err(|e| {
-                if e.kind() == std::io::ErrorKind::NotFound {
-                    ConvertError::NotInstalled {
-                        binary: self.binary.to_string_lossy().into_owned(),
-                    }
-                } else {
-                    ConvertError::Io(e.to_string())
+        let mut cmd = Command::new(&self.binary);
+        cmd.arg(src).arg(dst);
+        let output = run_capturing(&mut cmd).map_err(|e| {
+            if e.kind() == std::io::ErrorKind::NotFound {
+                ConvertError::NotInstalled {
+                    binary: self.binary.to_string_lossy().into_owned(),
                 }
-            })?;
+            } else {
+                ConvertError::Io(e.to_string())
+            }
+        })?;
 
         if output.status.success() {
             Ok(())

--- a/crates/toku-files/src/lib.rs
+++ b/crates/toku-files/src/lib.rs
@@ -16,6 +16,8 @@ mod convert;
 mod organize;
 mod repo;
 mod template;
+mod usage;
+mod verify;
 
 pub use convert::{ConvertError, Converter, DEFAULT_BINARY};
 pub use organize::{
@@ -25,6 +27,8 @@ pub use repo::FileRepository;
 pub use template::{
     PathTemplate, TemplateContext, UNKNOWN_AUTHOR, UNKNOWN_SERIES, UNKNOWN_YEAR, sanitize_segment,
 };
+pub use usage::{UsageTotals, usage_by_format, usage_by_format_typed, usage_by_key, usage_totals};
+pub use verify::{VerifyOutcome, VerifyStatus, verify_file};
 
 /// Supported ebook file formats.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]

--- a/crates/toku-files/src/repo.rs
+++ b/crates/toku-files/src/repo.rs
@@ -46,6 +46,23 @@ impl<'a> FileRepository<'a> {
         Ok(())
     }
 
+    /// List every file association in the library, ordered by book then format.
+    ///
+    /// Used by integrity verification (`verify --all`) and disk-usage reporting,
+    /// which operate across the whole catalog rather than a single book.
+    pub fn list_all_files(&self) -> Result<Vec<EbookFile>, FileError> {
+        let mut stmt = self.db.conn.prepare(
+            "SELECT id, book_id, path, format, size_bytes, checksum, source, source_ref, created_at, updated_at
+             FROM files ORDER BY book_id, format",
+        )?;
+        let files = stmt
+            .query_map([], |row| Ok(row_to_file(row)))?
+            .filter_map(|r| r.ok())
+            .filter_map(|r| r.ok())
+            .collect();
+        Ok(files)
+    }
+
     /// List all files associated with a book, ordered by format.
     pub fn list_files(&self, book_id: &Uuid) -> Result<Vec<EbookFile>, FileError> {
         let mut stmt = self.db.conn.prepare(

--- a/crates/toku-files/src/usage.rs
+++ b/crates/toku-files/src/usage.rs
@@ -125,7 +125,7 @@ mod tests {
         assert_eq!(by.get("epub").unwrap().total_bytes, 150);
         assert_eq!(by.get("pdf").unwrap().file_count, 1);
         assert_eq!(by.get("pdf").unwrap().total_bytes, 250);
-        assert!(by.get("mobi").is_none());
+        assert!(!by.contains_key("mobi"));
     }
 
     #[test]

--- a/crates/toku-files/src/usage.rs
+++ b/crates/toku-files/src/usage.rs
@@ -1,0 +1,145 @@
+//! Disk-usage aggregation over associated ebook files.
+//!
+//! These helpers are pure — they aggregate over already-loaded [`EbookFile`]
+//! records and never touch disk. Usage reflects the *catalog* view (each file's
+//! stored `size_bytes`), which is deterministic and cheap; integrity of the
+//! bytes on disk is a separate concern handled by [`crate::verify`].
+
+use std::collections::BTreeMap;
+
+use serde::{Deserialize, Serialize};
+
+use crate::{EbookFile, FileFormat};
+
+/// Aggregate totals across a set of files.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct UsageTotals {
+    pub file_count: u64,
+    pub total_bytes: i64,
+}
+
+impl UsageTotals {
+    fn add(&mut self, size_bytes: i64) {
+        self.file_count += 1;
+        self.total_bytes += size_bytes;
+    }
+}
+
+/// Compute overall totals (file count and summed size) for a set of files.
+pub fn usage_totals(files: &[EbookFile]) -> UsageTotals {
+    let mut totals = UsageTotals::default();
+    for f in files {
+        totals.add(f.size_bytes);
+    }
+    totals
+}
+
+/// Break usage down by file format. Formats with no files are omitted; the
+/// map is ordered by [`FileFormat`]'s declaration order for stable output.
+pub fn usage_by_format(files: &[EbookFile]) -> BTreeMap<String, UsageTotals> {
+    usage_by_key(files, |f| vec![f.format.to_string()])
+}
+
+/// Break usage down by an arbitrary caller-supplied key.
+///
+/// `key_fn` returns *zero or more* keys for a file, so a single file can be
+/// attributed to multiple buckets (e.g. every author or shelf it belongs to).
+/// When it returns no keys, the file is skipped by this grouping — callers that
+/// want an "(unassigned)" bucket should return that label themselves.
+pub fn usage_by_key<F>(files: &[EbookFile], key_fn: F) -> BTreeMap<String, UsageTotals>
+where
+    F: Fn(&EbookFile) -> Vec<String>,
+{
+    let mut map: BTreeMap<String, UsageTotals> = BTreeMap::new();
+    for f in files {
+        for key in key_fn(f) {
+            map.entry(key).or_default().add(f.size_bytes);
+        }
+    }
+    map
+}
+
+/// Convenience: keep [`FileFormat`] as a typed key where callers want it.
+pub fn usage_by_format_typed(files: &[EbookFile]) -> BTreeMap<FileFormat, UsageTotals> {
+    let mut map: BTreeMap<FileFormat, UsageTotals> = BTreeMap::new();
+    for f in files {
+        map.entry(f.format).or_default().add(f.size_bytes);
+    }
+    map
+}
+
+impl std::cmp::PartialOrd for FileFormat {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl std::cmp::Ord for FileFormat {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.as_str().cmp(other.as_str())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use uuid::Uuid;
+
+    fn file(format: FileFormat, size: i64) -> EbookFile {
+        EbookFile::new(
+            Uuid::now_v7(),
+            format!("/tmp/x.{}", format.as_str()),
+            format,
+            size,
+            "deadbeef".to_string(),
+        )
+    }
+
+    #[test]
+    fn totals_sum_count_and_bytes() {
+        let files = vec![
+            file(FileFormat::Epub, 100),
+            file(FileFormat::Pdf, 250),
+            file(FileFormat::Epub, 50),
+        ];
+        let t = usage_totals(&files);
+        assert_eq!(t.file_count, 3);
+        assert_eq!(t.total_bytes, 400);
+    }
+
+    #[test]
+    fn totals_of_empty_is_zero() {
+        let t = usage_totals(&[]);
+        assert_eq!(t, UsageTotals::default());
+    }
+
+    #[test]
+    fn per_format_groups_and_sums() {
+        let files = vec![
+            file(FileFormat::Epub, 100),
+            file(FileFormat::Pdf, 250),
+            file(FileFormat::Epub, 50),
+        ];
+        let by = usage_by_format(&files);
+        assert_eq!(by.get("epub").unwrap().file_count, 2);
+        assert_eq!(by.get("epub").unwrap().total_bytes, 150);
+        assert_eq!(by.get("pdf").unwrap().file_count, 1);
+        assert_eq!(by.get("pdf").unwrap().total_bytes, 250);
+        assert!(by.get("mobi").is_none());
+    }
+
+    #[test]
+    fn by_key_attributes_file_to_multiple_buckets() {
+        let files = vec![file(FileFormat::Epub, 100)];
+        let by = usage_by_key(&files, |_| vec!["A".to_string(), "B".to_string()]);
+        assert_eq!(by.get("A").unwrap().total_bytes, 100);
+        assert_eq!(by.get("B").unwrap().total_bytes, 100);
+    }
+
+    #[test]
+    fn by_key_skips_files_with_no_keys() {
+        let files = vec![file(FileFormat::Epub, 100)];
+        let by = usage_by_key(&files, |_| Vec::new());
+        assert!(by.is_empty());
+    }
+}

--- a/crates/toku-files/src/verify.rs
+++ b/crates/toku-files/src/verify.rs
@@ -1,0 +1,141 @@
+//! File integrity verification via SHA-256 checksums.
+//!
+//! Recomputes the checksum of an associated file by streaming its contents
+//! (constant memory, regardless of file size) and compares it against the value
+//! stored when the file was linked. Detects two failure modes:
+//!
+//! - **Missing** — the file no longer exists on disk at its stored path.
+//! - **Mismatch** — the file exists but its contents changed (corruption, an
+//!   external edit, or a truncated/partial write).
+
+use std::path::Path;
+
+use serde::{Deserialize, Serialize};
+
+use crate::{EbookFile, FileError, sha256_file};
+
+/// Outcome of verifying a single file against its stored checksum.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum VerifyStatus {
+    /// File exists and its recomputed checksum matches the stored value.
+    Ok,
+    /// File exists but its recomputed checksum differs from the stored value.
+    Mismatch,
+    /// File no longer exists on disk at its stored path.
+    Missing,
+}
+
+impl VerifyStatus {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Ok => "ok",
+            Self::Mismatch => "mismatch",
+            Self::Missing => "missing",
+        }
+    }
+
+    /// Whether this status represents an integrity problem.
+    pub fn is_problem(&self) -> bool {
+        !matches!(self, Self::Ok)
+    }
+}
+
+impl std::fmt::Display for VerifyStatus {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// The result of verifying one [`EbookFile`].
+#[derive(Debug, Clone)]
+pub struct VerifyOutcome {
+    pub file: EbookFile,
+    pub status: VerifyStatus,
+    /// The freshly recomputed checksum, present only when the file existed and
+    /// could be read. `None` for missing files.
+    pub computed: Option<String>,
+}
+
+/// Verify a single file against its stored checksum.
+///
+/// Streams the file's bytes to compute SHA-256 without loading it into memory.
+/// Returns a [`VerifyOutcome`] describing whether the file is intact, corrupted,
+/// or missing. Read errors other than "not found" surface as [`FileError`].
+pub fn verify_file(file: &EbookFile) -> Result<VerifyOutcome, FileError> {
+    let path = Path::new(&file.path);
+    if !path.exists() {
+        return Ok(VerifyOutcome {
+            file: file.clone(),
+            status: VerifyStatus::Missing,
+            computed: None,
+        });
+    }
+    let computed = sha256_file(path)?;
+    let status = if computed == file.checksum {
+        VerifyStatus::Ok
+    } else {
+        VerifyStatus::Mismatch
+    };
+    Ok(VerifyOutcome {
+        file: file.clone(),
+        status,
+        computed: Some(computed),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::FileFormat;
+    use uuid::Uuid;
+
+    fn file_at(path: &Path, checksum: &str) -> EbookFile {
+        EbookFile::new(
+            Uuid::now_v7(),
+            path.to_string_lossy().to_string(),
+            FileFormat::Epub,
+            0,
+            checksum.to_string(),
+        )
+    }
+
+    // SHA-256 of the empty string.
+    const EMPTY_SHA: &str = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855";
+
+    #[test]
+    fn reports_ok_when_checksum_matches() {
+        let dir = tempfile::tempdir().unwrap();
+        let p = dir.path().join("a.epub");
+        std::fs::write(&p, b"").unwrap();
+        let f = file_at(&p, EMPTY_SHA);
+        let outcome = verify_file(&f).unwrap();
+        assert_eq!(outcome.status, VerifyStatus::Ok);
+        assert!(!outcome.status.is_problem());
+        assert_eq!(outcome.computed.as_deref(), Some(EMPTY_SHA));
+    }
+
+    #[test]
+    fn reports_mismatch_when_contents_change() {
+        let dir = tempfile::tempdir().unwrap();
+        let p = dir.path().join("a.epub");
+        std::fs::write(&p, b"tampered").unwrap();
+        // Stored checksum is for the empty file, so this must mismatch.
+        let f = file_at(&p, EMPTY_SHA);
+        let outcome = verify_file(&f).unwrap();
+        assert_eq!(outcome.status, VerifyStatus::Mismatch);
+        assert!(outcome.status.is_problem());
+        assert_ne!(outcome.computed.as_deref(), Some(EMPTY_SHA));
+    }
+
+    #[test]
+    fn reports_missing_when_file_absent() {
+        let dir = tempfile::tempdir().unwrap();
+        let p = dir.path().join("gone.epub");
+        let f = file_at(&p, EMPTY_SHA);
+        let outcome = verify_file(&f).unwrap();
+        assert_eq!(outcome.status, VerifyStatus::Missing);
+        assert!(outcome.status.is_problem());
+        assert!(outcome.computed.is_none());
+    }
+}

--- a/docs/adr/003-cli-design.md
+++ b/docs/adr/003-cli-design.md
@@ -37,6 +37,8 @@ toku export csv|json|backup [--output <path>]
 toku stats [--year <year>]
 toku tag add|remove|list <tag> [<books>...]
 toku file add|list|remove|organize <book> [<path>|<format>] [--all] [--dry-run] [--copy]
+toku file verify [<book>|--all]                                 # SHA-256 integrity check
+toku file usage [--by format|author|shelf]                      # disk usage breakdown
 toku convert <book> --to <format> [--from <format>] [--force]   # optional; needs Calibre
 toku bulk tag|status|delete [--status <s>] [--tag <t>] [--dry-run]
 toku config [--edit]


### PR DESCRIPTION
## Description

Adds file integrity checking (SHA-256) and disk-usage reporting for associated ebook files, completing ROADMAP §6.1.

**What's included:**

- `toku file verify [<book>|--all]` — recomputes each associated file's SHA-256 by **streaming** its contents (constant memory, even for multi-GB files) and compares against the checksum stored when the file was linked. Flags `mismatch` (contents changed/corrupted) and `missing` (gone from disk), prints a per-file status plus a summary, and **exits non-zero** when any problem is found so it can gate scripts.
- `toku file usage [--by format|author|shelf]` — reports total disk usage with a breakdown. Defaults to per-format; author/shelf grouping joins through the book repository. A file linked to multiple authors/shelves is counted under each; books with none fall into an `(unassigned)` bucket. Totals reflect the catalog's recorded sizes.
- Both commands support `--format table|json|csv` for scripting.

**Implementation notes:**

- Core logic lives in `toku-files` as pure, testable modules: `verify` (`VerifyStatus`, `verify_file`) and `usage` (`usage_totals`, `usage_by_format`, `usage_by_key`), plus `FileRepository::list_all_files()`. Streaming reuses the existing 8 KiB-buffered `sha256_file`.
- CLI wiring (`FileAction::Verify` / `FileAction::Usage`) handles presentation and author/shelf joins.

## Related Issues

Closes #149

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI / infrastructure
- [ ] Other (describe below)

## Crate

- [x] `toku-cli` — CLI binary
- [x] `toku-files` — Ebook file association and management
- [x] `docs/` — Documentation (ADR-003 CLI reference)

## Data Integrity Checklist

- [x] No user data is sent to any server without explicit opt-in
- [ ] Import operations are idempotent (re-importing the same file creates no duplicates)
- [x] User edits to metadata are never overwritten by auto-enrichment
- [ ] New fields track provenance (source + timestamp)
- [ ] Export round-trip is preserved (if applicable)

## Checklist

- [x] I have read [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] `cargo fmt --check` passes
- [x] `cargo clippy --workspace -- -D warnings` passes
- [x] `cargo test --workspace` passes
- [x] I have updated documentation (if applicable)
