### PR TITLE
feat: OPDS catalog server for e-readers (toku opds serve)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- OPDS server: `toku opds serve [--host <addr>] [--port <n>]` serves the library as an
+  OPDS 1.2 (Atom) catalog so e-reader apps (KOReader, Moon+ Reader, etc.) can browse and
+  download associated ebook files. Provides a root navigation feed with browse-by-author,
+  browse-by-series, and browse-by-shelf sub-catalogs, an "All Books" acquisition feed, and
+  OpenSearch-powered search (`/opds/search?q=`). Acquisition feeds list only books that have
+  associated files (honoring `toku file add`); each entry carries per-format download links,
+  cover/thumbnail links, and metadata (author, ISBN, language, description). Downloads stream
+  the exact on-disk file recorded for that association. Local-first (no external calls) and
+  LAN-facing by default (binds `0.0.0.0` so e-readers on your network can reach it; use
+  `--host 127.0.0.1` to restrict to this machine). Optional HTTP Basic auth is gated by a new
+  `[opds]` config section: `toku opds set-password <username>` prompts for a password and
+  stores a salted hash; `toku opds disable` clears it (#150)
 - File integrity & disk usage: `toku file verify [<book>|--all]` recomputes each associated
   file's SHA-256 by streaming its contents (constant memory, even for multi-GB files) and
   flags files whose contents changed (`mismatch`) or that are gone from disk (`missing`).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6111,6 +6111,7 @@ dependencies = [
  "tokio-stream",
  "toku-core",
  "toku-db",
+ "toku-files",
  "toku-import",
  "tower",
  "urlencoding",

--- a/README.md
+++ b/README.md
@@ -70,6 +70,8 @@ their ever-growing libraries.
 - 🌐 Web dashboard (`toku serve`) with statistics, import wizard, library views, and dark mode
   — loopback-only by default, or run authenticated for network access
   ([hosted mode & auth](docs/web-auth.md))
+- 📚 OPDS catalog server (`toku opds serve`) so e-readers (KOReader, Moon+ Reader, etc.) can
+  browse and download your associated ebook files over the local network — optional HTTP Basic auth
 - 🍎 macOS app (SwiftUI) with sidebar navigation, sortable table/grid views, and Swift Charts
 - 📱 iOS app (iPhone + iPad) with cover grid, barcode scanner, and reading progress updates
 - 🪟 Windows desktop app (Tauri v2) wrapping the web UI in a native window with system tray

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -453,7 +453,7 @@ Rejected alternatives:
 | Markdown | Blog posts, reading lists | Phase 2 | 🟢 |
 | ZIP backup (canonical) | Full backup/migration | Phase 2 | 🟡 |
 | BibTeX | Academic citations | Phase 3 | 🟡 |
-| OPDS | E-reader catalog | Phase 6 | 🟡 |
+| OPDS | E-reader catalog | Phase 6 | 🟢 |
 | HTML | Static reading list site | Phase 3 | 🟡 |
 
 ### 3.3 — Book Metadata Sources
@@ -729,9 +729,9 @@ DRM note: Only DRM-free files are supported. No DRM stripping.
 
 ### 6.3 — OPDS Server (Phase 6)
 
-- Serve the library as an OPDS catalog for e-readers (KOReader, Moon+ Reader) 🟡
-- Local network only by default
-- Optional basic authentication
+- Serve the library as an OPDS catalog for e-readers (KOReader, Moon+ Reader) 🟢
+- Local network only by default 🟢
+- Optional basic authentication 🟢
 
 ### 6.4 — Architecture Note
 

--- a/crates/toku-cli/src/main.rs
+++ b/crates/toku-cli/src/main.rs
@@ -272,6 +272,18 @@ enum Commands {
         insecure_cookies: bool,
     },
 
+    /// Serve the library as an OPDS catalog for e-readers (KOReader, etc.)
+    ///
+    /// Exposes associated ebook files over OPDS so e-reader apps can browse and
+    /// download them. Local-first and LAN-facing: it makes no external calls and
+    /// serves only your local library. Binds all interfaces by default so
+    /// e-readers on your network can reach it; guard it with optional HTTP Basic
+    /// auth via `toku opds set-password`.
+    Opds {
+        #[command(subcommand)]
+        action: OpdsAction,
+    },
+
     /// Manage work grouping (link editions of the same creative work)
     Work {
         #[command(subcommand)]
@@ -441,6 +453,31 @@ enum TagAction {
 
     /// List all tags with book counts
     List,
+}
+
+#[derive(Subcommand)]
+enum OpdsAction {
+    /// Start the OPDS catalog server
+    Serve {
+        /// Port to listen on
+        #[arg(long, short, default_value = "3001")]
+        port: u16,
+
+        /// Host to bind. Defaults to 0.0.0.0 so e-readers on your local network
+        /// can reach the catalog; use 127.0.0.1 to restrict to this machine.
+        #[arg(long, default_value = "0.0.0.0")]
+        host: String,
+    },
+
+    /// Enable HTTP Basic auth by setting a username + password (prompts for the
+    /// password, stores a salted hash in the `[opds]` config section)
+    SetPassword {
+        /// Username for HTTP Basic auth
+        username: String,
+    },
+
+    /// Disable HTTP Basic auth (clears the `[opds]` credentials)
+    Disable,
 }
 
 #[derive(Subcommand)]
@@ -963,6 +1000,9 @@ fn main() -> Result<()> {
                     .map_err(|e| anyhow::anyhow!("{e}"))
             });
         }
+        Commands::Opds { action } => {
+            return cmd_opds(&data_dir, action);
+        }
         Commands::Sync { action } => {
             return cmd_sync(&data_dir, action.clone(), &cli.format);
         }
@@ -1067,6 +1107,7 @@ fn main() -> Result<()> {
         Commands::Config { .. }
         | Commands::Completions { .. }
         | Commands::Serve { .. }
+        | Commands::Opds { .. }
         | Commands::Sync { .. }
         | Commands::Account { .. } => {
             unreachable!()
@@ -1113,6 +1154,68 @@ fn cmd_config(data_dir: &Path, show_path: bool, open_edit: bool) -> Result<()> {
     let toml_str = toml::to_string_pretty(&config).context("failed to serialize config")?;
     println!("{toml_str}");
     Ok(())
+}
+
+/// Handle `toku opds` — serve the OPDS catalog or manage its auth credentials.
+fn cmd_opds(data_dir: &Path, action: &OpdsAction) -> Result<()> {
+    match action {
+        OpdsAction::Serve { port, host } => {
+            let config = TokuConfig::load(data_dir).context("failed to load config")?;
+            let auth = if config.opds.auth_enabled() {
+                Some(config.opds.clone())
+            } else {
+                None
+            };
+            let db_path = data_dir.join("toku.db");
+            let host = host.clone();
+            let port = *port;
+            let rt = tokio::runtime::Builder::new_multi_thread()
+                .enable_all()
+                .build()
+                .context("failed to build tokio runtime")?;
+            rt.block_on(async move {
+                toku_web::serve_opds(db_path, &host, port, auth)
+                    .await
+                    .map_err(|e| anyhow::anyhow!("{e}"))
+            })
+        }
+        OpdsAction::SetPassword { username } => {
+            let username = username.trim();
+            if username.is_empty() {
+                anyhow::bail!("username cannot be empty");
+            }
+            let password = read_password_prompt("OPDS password: ")?;
+            if password.is_empty() {
+                anyhow::bail!("password cannot be empty");
+            }
+            let confirm = read_password_prompt("Confirm OPDS password: ")?;
+            if password != confirm {
+                anyhow::bail!("passwords do not match");
+            }
+            let mut config = TokuConfig::load(data_dir).context("failed to load config")?;
+            config.opds.username = Some(username.to_string());
+            config.opds.password_hash = Some(toku_core::OpdsConfig::hash_password(&password));
+            config.save(data_dir).context("failed to save config")?;
+            eprintln!("OPDS HTTP Basic auth enabled for user '{username}'.");
+            eprintln!(
+                "The catalog will now require this login. Restart `toku opds serve` to apply."
+            );
+            Ok(())
+        }
+        OpdsAction::Disable => {
+            let mut config = TokuConfig::load(data_dir).context("failed to load config")?;
+            let was_enabled = config.opds.auth_enabled();
+            config.opds.username = None;
+            config.opds.password_hash = None;
+            config.save(data_dir).context("failed to save config")?;
+            if was_enabled {
+                eprintln!("OPDS HTTP Basic auth disabled. Restart `toku opds serve` to apply.");
+            } else {
+                eprintln!("OPDS HTTP Basic auth was not enabled.");
+            }
+            Ok(())
+        }
+    }
 }
 
 #[allow(clippy::too_many_arguments)]

--- a/crates/toku-core/src/config.rs
+++ b/crates/toku-core/src/config.rs
@@ -18,6 +18,111 @@ pub struct TokuConfig {
     pub sync: Option<SyncConfig>,
     /// Ebook file management configuration (disk organization).
     pub files: FilesConfig,
+    /// OPDS server configuration (optional HTTP Basic auth).
+    pub opds: OpdsConfig,
+}
+
+/// OPDS server configuration stored in `config.toml` under `[opds]`.
+///
+/// Controls the optional HTTP Basic authentication that guards the OPDS
+/// catalog served by `toku opds`. Authentication is enabled only when *both*
+/// `username` and `password_hash` are set — otherwise the catalog is served
+/// without a login prompt (the local-network default).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
+#[serde(default)]
+pub struct OpdsConfig {
+    /// HTTP Basic auth username. `None` disables authentication.
+    pub username: Option<String>,
+    /// Salted password hash, formatted `sha256$<salt_hex>$<hash_hex>`.
+    /// `None` disables authentication.
+    pub password_hash: Option<String>,
+}
+
+impl OpdsConfig {
+    /// True when both a username and password hash are configured, meaning
+    /// the OPDS server should require HTTP Basic authentication.
+    pub fn auth_enabled(&self) -> bool {
+        self.username.as_deref().is_some_and(|u| !u.is_empty())
+            && self.password_hash.as_deref().is_some_and(|h| !h.is_empty())
+    }
+
+    /// Hash a plaintext password with a fresh random 16-byte salt, producing a
+    /// `sha256$<salt_hex>$<hash_hex>` string suitable for `password_hash`.
+    pub fn hash_password(password: &str) -> String {
+        let mut salt = [0u8; 16];
+        getrandom::fill(&mut salt).expect("system RNG must be available");
+        format!(
+            "sha256${}${}",
+            hex_encode(&salt),
+            sha256_salted(&salt, password)
+        )
+    }
+
+    /// Constant-time verification of a plaintext password against the stored
+    /// `sha256$<salt_hex>$<hash_hex>` hash. Returns false on any malformed hash.
+    pub fn verify_password(&self, password: &str) -> bool {
+        let Some(hash) = self.password_hash.as_deref() else {
+            return false;
+        };
+        verify_password_hash(hash, password)
+    }
+}
+
+/// Verify a plaintext password against a `sha256$<salt_hex>$<hash_hex>` string,
+/// in constant time. Returns false for any malformed or non-matching input.
+pub fn verify_password_hash(stored: &str, password: &str) -> bool {
+    let mut parts = stored.splitn(3, '$');
+    let (Some(scheme), Some(salt_hex), Some(hash_hex)) = (parts.next(), parts.next(), parts.next())
+    else {
+        return false;
+    };
+    if scheme != "sha256" {
+        return false;
+    }
+    let Some(salt) = hex_decode(salt_hex) else {
+        return false;
+    };
+    let expected = sha256_salted(&salt, password);
+    constant_time_eq(expected.as_bytes(), hash_hex.as_bytes())
+}
+
+/// SHA-256 of `salt || password`, hex-encoded.
+fn sha256_salted(salt: &[u8], password: &str) -> String {
+    use sha2::{Digest, Sha256};
+    let mut hasher = Sha256::new();
+    hasher.update(salt);
+    hasher.update(password.as_bytes());
+    hex_encode(&hasher.finalize())
+}
+
+fn hex_encode(bytes: &[u8]) -> String {
+    let mut s = String::with_capacity(bytes.len() * 2);
+    for b in bytes {
+        s.push_str(&format!("{b:02x}"));
+    }
+    s
+}
+
+fn hex_decode(s: &str) -> Option<Vec<u8>> {
+    if !s.len().is_multiple_of(2) {
+        return None;
+    }
+    (0..s.len())
+        .step_by(2)
+        .map(|i| u8::from_str_radix(&s[i..i + 2], 16).ok())
+        .collect()
+}
+
+/// Length-independent constant-time byte comparison.
+fn constant_time_eq(a: &[u8], b: &[u8]) -> bool {
+    if a.len() != b.len() {
+        return false;
+    }
+    let mut diff = 0u8;
+    for (x, y) in a.iter().zip(b.iter()) {
+        diff |= x ^ y;
+    }
+    diff == 0
 }
 
 /// File-management configuration stored in `config.toml` under `[files]`.
@@ -69,6 +174,7 @@ impl Default for TokuConfig {
             metadata_source: "openlibrary".to_string(),
             sync: None,
             files: FilesConfig::default(),
+            opds: OpdsConfig::default(),
         }
     }
 }
@@ -139,6 +245,7 @@ mod tests {
             metadata_source: "google".to_string(),
             sync: None,
             files: FilesConfig::default(),
+            opds: OpdsConfig::default(),
         };
         cfg.save(&dir).expect("save should succeed");
 
@@ -146,6 +253,72 @@ mod tests {
         assert_eq!(loaded, cfg);
 
         // Clean up
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn opds_auth_disabled_by_default() {
+        let cfg = TokuConfig::default();
+        assert!(!cfg.opds.auth_enabled());
+    }
+
+    #[test]
+    fn opds_auth_enabled_only_with_both_fields() {
+        let mut opds = OpdsConfig {
+            username: Some("reader".to_string()),
+            password_hash: None,
+        };
+        assert!(!opds.auth_enabled());
+        opds.password_hash = Some(OpdsConfig::hash_password("s3cret"));
+        assert!(opds.auth_enabled());
+    }
+
+    #[test]
+    fn opds_password_hash_roundtrips() {
+        let opds = OpdsConfig {
+            username: Some("reader".to_string()),
+            password_hash: Some(OpdsConfig::hash_password("correct horse battery staple")),
+        };
+        assert!(opds.verify_password("correct horse battery staple"));
+        assert!(!opds.verify_password("wrong password"));
+    }
+
+    #[test]
+    fn opds_password_hash_uses_random_salt() {
+        let a = OpdsConfig::hash_password("same");
+        let b = OpdsConfig::hash_password("same");
+        // Different salts ⇒ different stored hashes, but both verify.
+        assert_ne!(a, b);
+        assert!(verify_password_hash(&a, "same"));
+        assert!(verify_password_hash(&b, "same"));
+    }
+
+    #[test]
+    fn opds_verify_rejects_malformed_hash() {
+        assert!(!verify_password_hash("", "x"));
+        assert!(!verify_password_hash("notahash", "x"));
+        assert!(!verify_password_hash("md5$aa$bb", "x"));
+        assert!(!verify_password_hash("sha256$zz$bb", "x"));
+    }
+
+    #[test]
+    fn opds_config_roundtrips_through_toml() {
+        let dir = std::env::temp_dir().join("toku-test-config-opds");
+        let _ = std::fs::remove_dir_all(&dir);
+
+        let cfg = TokuConfig {
+            opds: OpdsConfig {
+                username: Some("reader".to_string()),
+                password_hash: Some(OpdsConfig::hash_password("hunter2")),
+            },
+            ..TokuConfig::default()
+        };
+        cfg.save(&dir).expect("save should succeed");
+
+        let loaded = TokuConfig::load(&dir).expect("load should succeed");
+        assert_eq!(loaded, cfg);
+        assert!(loaded.opds.verify_password("hunter2"));
+
         let _ = std::fs::remove_dir_all(&dir);
     }
 }

--- a/crates/toku-db/src/repo.rs
+++ b/crates/toku-db/src/repo.rs
@@ -325,6 +325,63 @@ impl<'a> BookRepository<'a> {
         Ok(results)
     }
 
+    /// List every series that has at least one (non-deleted) book, with the
+    /// number of books in each. Ordered by series name.
+    pub fn list_series(&self) -> Result<Vec<(Series, usize)>, DbError> {
+        let mut stmt = self.db.conn.prepare(
+            "SELECT s.id, s.name, s.total_books, COUNT(DISTINCT b.id) AS cnt
+             FROM series s
+             JOIN book_series bs ON bs.series_id = s.id
+             JOIN books b ON b.id = bs.book_id AND b.deleted_at IS NULL
+             GROUP BY s.id, s.name, s.total_books
+             HAVING cnt > 0
+             ORDER BY s.name COLLATE NOCASE",
+        )?;
+
+        let rows = stmt
+            .query_map([], |row| {
+                let id_str: String = row.get(0)?;
+                let name: String = row.get(1)?;
+                let total_books: Option<i32> = row.get(2)?;
+                let count: i64 = row.get(3)?;
+                Ok((
+                    Series {
+                        id: Uuid::parse_str(&id_str).unwrap_or_default(),
+                        name,
+                        total_books,
+                    },
+                    count as usize,
+                ))
+            })?
+            .filter_map(|r| r.ok())
+            .collect();
+
+        Ok(rows)
+    }
+
+    /// List all (non-deleted) books in a series, matched case-insensitively by
+    /// series name. Ordered by reading position when available, then title.
+    pub fn list_books_in_series(&self, series_name: &str) -> Result<Vec<Book>, DbError> {
+        let mut stmt = self.db.conn.prepare(
+            "SELECT b.id, b.title, b.subtitle, b.description, b.page_count, b.pub_date,
+                    b.language, b.format, b.duration_minutes, b.cover_hash, b.work_id,
+                    b.status, b.rating, b.created_at, b.updated_at
+             FROM books b
+             JOIN book_series bs ON bs.book_id = b.id
+             JOIN series s ON s.id = bs.series_id
+             WHERE LOWER(s.name) = LOWER(?1) AND b.deleted_at IS NULL
+             ORDER BY CAST(bs.position AS REAL), b.title COLLATE NOCASE",
+        )?;
+
+        let books = stmt
+            .query_map(params![series_name], |row| Ok(row_to_book(row)))?
+            .filter_map(|r| r.ok())
+            .filter_map(|r| r.ok())
+            .collect();
+
+        Ok(books)
+    }
+
     /// Store an ISBN linked to a book.
     pub fn add_isbn(&self, isbn: &str, book_id: &Uuid) -> Result<(), DbError> {
         self.db.conn.execute(
@@ -2189,6 +2246,50 @@ mod tests {
         assert_eq!(books.len(), 2);
         assert_eq!(books[0].title, "Dune");
         assert_eq!(books[1].title, "Neuromancer");
+    }
+
+    #[test]
+    fn lists_series_and_books_in_series() {
+        let db = test_db();
+        let repo = BookRepository::new(&db);
+
+        let mut b1 = Book::new("Dune Messiah");
+        b1.id = Uuid::now_v7();
+        let mut b2 = Book::new("Dune");
+        b2.id = Uuid::now_v7();
+        repo.create_book(&b1).unwrap();
+        repo.create_book(&b2).unwrap();
+
+        let series_id = Uuid::now_v7();
+        db.conn
+            .execute(
+                "INSERT INTO series (id, name, total_books) VALUES (?1, ?2, ?3)",
+                params![series_id.to_string(), "Dune", 2],
+            )
+            .unwrap();
+        db.conn
+            .execute(
+                "INSERT INTO book_series (book_id, series_id, position) VALUES (?1, ?2, ?3)",
+                params![b1.id.to_string(), series_id.to_string(), "2"],
+            )
+            .unwrap();
+        db.conn
+            .execute(
+                "INSERT INTO book_series (book_id, series_id, position) VALUES (?1, ?2, ?3)",
+                params![b2.id.to_string(), series_id.to_string(), "1"],
+            )
+            .unwrap();
+
+        let series = repo.list_series().unwrap();
+        assert_eq!(series.len(), 1);
+        assert_eq!(series[0].0.name, "Dune");
+        assert_eq!(series[0].1, 2);
+
+        // Ordered by numeric position: Dune (1) before Dune Messiah (2).
+        let books = repo.list_books_in_series("dune").unwrap();
+        assert_eq!(books.len(), 2);
+        assert_eq!(books[0].title, "Dune");
+        assert_eq!(books[1].title, "Dune Messiah");
     }
 
     #[test]

--- a/crates/toku-files/src/repo.rs
+++ b/crates/toku-files/src/repo.rs
@@ -77,6 +77,21 @@ impl<'a> FileRepository<'a> {
         Ok(files)
     }
 
+    /// Find a file association by its unique id. Returns `None` if no such
+    /// record exists. Used by the OPDS server to resolve an acquisition link
+    /// to the exact on-disk path stored for that file.
+    pub fn get_file(&self, id: &Uuid) -> Result<Option<EbookFile>, FileError> {
+        let mut stmt = self.db.conn.prepare(
+            "SELECT id, book_id, path, format, size_bytes, checksum, source, source_ref, created_at, updated_at
+             FROM files WHERE id = ?1",
+        )?;
+        let mut rows = stmt
+            .query_map(params![id.to_string()], |row| Ok(row_to_file(row)))?
+            .filter_map(|r| r.ok())
+            .filter_map(|r| r.ok());
+        Ok(rows.next())
+    }
+
     /// Find a file linked to a book by exact checksum.
     pub fn find_by_checksum(
         &self,

--- a/crates/toku-web/Cargo.toml
+++ b/crates/toku-web/Cargo.toml
@@ -11,6 +11,7 @@ repository.workspace = true
 toku-core.workspace = true
 toku-db.workspace = true
 toku-import.workspace = true
+toku-files.workspace = true
 thiserror.workspace = true
 chrono.workspace = true
 serde.workspace = true

--- a/crates/toku-web/src/lib.rs
+++ b/crates/toku-web/src/lib.rs
@@ -21,12 +21,15 @@ pub mod import_handlers;
 mod import_views;
 pub mod library_handlers;
 mod library_views;
+pub mod opds;
+mod opds_xml;
 mod sync_handlers;
 mod sync_status;
 mod views;
 
 pub use auth::WebMode;
 pub use error::WebError;
+pub use opds::serve_opds;
 
 /// Shared application state for Axum handlers.
 #[derive(Clone)]

--- a/crates/toku-web/src/opds.rs
+++ b/crates/toku-web/src/opds.rs
@@ -1,0 +1,620 @@
+//! OPDS catalog server — serves the library to e-readers (KOReader, Moon+
+//! Reader, etc.) as an OPDS 1.2 (Atom) feed.
+//!
+//! This is a **local-first, LAN-facing** surface: it makes no external calls
+//! and serves only the local database and the ebook files already associated
+//! with books via `toku file add`. It is deliberately independent from the
+//! dashboard's hosted-mode (SRP) auth — the only protection here is an optional
+//! HTTP Basic auth guard, enabled through the `[opds]` config section.
+
+use std::collections::HashMap;
+use std::path::PathBuf;
+
+use axum::Router;
+use axum::body::Body;
+use axum::extract::{Path, Query, State};
+use axum::http::{StatusCode, header};
+use axum::middleware::Next;
+use axum::response::{IntoResponse, Response};
+use axum::routing::get;
+use toku_core::{Book, ContributorRole, OpdsConfig};
+use toku_db::{BookRepository, Database};
+use toku_files::{EbookFile, FileRepository};
+
+use crate::error::WebError;
+use crate::opds_xml::{
+    self, ACQUISITION_TYPE, AcqEntry, AcqLink, NAVIGATION_TYPE, NavEntry, OPDS_ROOT,
+    OPENSEARCH_TYPE,
+};
+
+/// Shared state for the OPDS router.
+#[derive(Clone)]
+pub struct OpdsState {
+    pub db_path: PathBuf,
+    pub covers_dir: PathBuf,
+    /// Optional HTTP Basic auth credentials. `None` when auth is disabled.
+    pub auth: Option<OpdsConfig>,
+}
+
+/// Everything the feeds need about one book, gathered in a single pass.
+struct BookBundle {
+    book: Book,
+    authors: Vec<String>,
+    isbns: Vec<String>,
+    series: Vec<String>,
+    shelves: Vec<String>,
+    files: Vec<EbookFile>,
+}
+
+// ── Router / serving ─────────────────────────────────────────────────────────
+
+/// Build the Axum router for the OPDS catalog.
+pub fn build_opds_router(state: OpdsState) -> Router {
+    let router = Router::new()
+        .route(OPDS_ROOT, get(root_feed))
+        .route(&format!("{OPDS_ROOT}/all"), get(all_feed))
+        .route(&format!("{OPDS_ROOT}/authors"), get(authors_feed))
+        .route(&format!("{OPDS_ROOT}/authors/{{name}}"), get(author_feed))
+        .route(&format!("{OPDS_ROOT}/shelves"), get(shelves_feed))
+        .route(&format!("{OPDS_ROOT}/shelves/{{name}}"), get(shelf_feed))
+        .route(&format!("{OPDS_ROOT}/series"), get(series_feed))
+        .route(
+            &format!("{OPDS_ROOT}/series/{{name}}"),
+            get(series_detail_feed),
+        )
+        .route(&format!("{OPDS_ROOT}/search"), get(search_feed))
+        .route(&format!("{OPDS_ROOT}/opensearch.xml"), get(opensearch))
+        .route(&format!("{OPDS_ROOT}/download/{{file_id}}"), get(download))
+        .route(&format!("{OPDS_ROOT}/cover/{{hash}}"), get(cover))
+        .route("/healthz", get(|| async { "ok" }));
+
+    if state.auth.is_some() {
+        router
+            .route_layer(axum::middleware::from_fn_with_state(
+                state.clone(),
+                basic_auth,
+            ))
+            .with_state(state)
+    } else {
+        router.with_state(state)
+    }
+}
+
+/// Serve the OPDS catalog on `{host}:{port}`.
+///
+/// Runs database migrations once at startup, then serves the catalog. Unlike
+/// the dashboard, the OPDS server may bind non-loopback addresses by design —
+/// e-readers reach it over the LAN. Exposure beyond the LAN remains the user's
+/// network/firewall responsibility (see ADR-011).
+pub async fn serve_opds(
+    db_path: PathBuf,
+    host: &str,
+    port: u16,
+    auth: Option<OpdsConfig>,
+) -> Result<(), WebError> {
+    Database::open(&db_path)
+        .map_err(|e| WebError::Internal(format!("failed to open database: {e}")))?;
+
+    let covers_dir = db_path
+        .parent()
+        .unwrap_or_else(|| std::path::Path::new("."))
+        .join("covers");
+
+    let state = OpdsState {
+        db_path,
+        covers_dir,
+        auth,
+    };
+
+    let addr = format!("{host}:{port}");
+    let listener = tokio::net::TcpListener::bind(&addr)
+        .await
+        .map_err(|e| WebError::Internal(format!("failed to bind {addr}: {e}")))?;
+
+    let auth_note = if state.auth.is_some() {
+        " (HTTP Basic auth required)"
+    } else {
+        ""
+    };
+    eprintln!("Toku OPDS catalog → http://{addr}{OPDS_ROOT}{auth_note}");
+
+    let app = build_opds_router(state);
+    axum::serve(listener, app)
+        .await
+        .map_err(|e| WebError::Internal(format!("server error: {e}")))?;
+    Ok(())
+}
+
+// ── Auth middleware ──────────────────────────────────────────────────────────
+
+/// HTTP Basic auth guard. Mounted only when `[opds]` credentials are set.
+async fn basic_auth(
+    State(state): State<OpdsState>,
+    req: axum::extract::Request,
+    next: Next,
+) -> Response {
+    let Some(cfg) = &state.auth else {
+        return next.run(req).await;
+    };
+
+    if let Some((user, pass)) = extract_basic_credentials(&req) {
+        let user_ok = cfg.username.as_deref() == Some(user.as_str());
+        // Always run the (constant-time) password verification to avoid leaking
+        // whether the username was correct via timing.
+        let pass_ok = cfg.verify_password(&pass);
+        if user_ok && pass_ok {
+            return next.run(req).await;
+        }
+    }
+
+    (
+        StatusCode::UNAUTHORIZED,
+        [(
+            header::WWW_AUTHENTICATE,
+            "Basic realm=\"Toku OPDS\", charset=\"UTF-8\"",
+        )],
+        "Unauthorized",
+    )
+        .into_response()
+}
+
+/// Parse a `Authorization: Basic <base64(user:pass)>` header.
+fn extract_basic_credentials(req: &axum::extract::Request) -> Option<(String, String)> {
+    use base64::Engine;
+    let header = req.headers().get(header::AUTHORIZATION)?.to_str().ok()?;
+    let encoded = header
+        .strip_prefix("Basic ")
+        .or_else(|| header.strip_prefix("basic "))?;
+    let decoded = base64::engine::general_purpose::STANDARD
+        .decode(encoded.trim())
+        .ok()?;
+    let decoded = String::from_utf8(decoded).ok()?;
+    let (user, pass) = decoded.split_once(':')?;
+    Some((user.to_string(), pass.to_string()))
+}
+
+// ── Handlers ─────────────────────────────────────────────────────────────────
+
+/// `GET /opds` — root navigation feed.
+async fn root_feed() -> Response {
+    let updated = now_rfc3339();
+    let entries = vec![
+        NavEntry {
+            title: "All Books".into(),
+            href: format!("{OPDS_ROOT}/all"),
+            content: Some("Every book with a downloadable file".into()),
+            acquisition: true,
+        },
+        NavEntry {
+            title: "By Author".into(),
+            href: format!("{OPDS_ROOT}/authors"),
+            content: Some("Browse by author".into()),
+            acquisition: false,
+        },
+        NavEntry {
+            title: "By Series".into(),
+            href: format!("{OPDS_ROOT}/series"),
+            content: Some("Browse by series".into()),
+            acquisition: false,
+        },
+        NavEntry {
+            title: "By Shelf".into(),
+            href: format!("{OPDS_ROOT}/shelves"),
+            content: Some("Browse by shelf".into()),
+            acquisition: false,
+        },
+    ];
+    let feed = opds_xml::navigation_feed(
+        "urn:toku:opds",
+        "Toku Library",
+        OPDS_ROOT,
+        &updated,
+        &entries,
+    );
+    feed_response(NAVIGATION_TYPE, feed)
+}
+
+/// `GET /opds/all` — acquisition feed of every book with files.
+async fn all_feed(State(state): State<OpdsState>) -> Result<Response, WebError> {
+    let bundles = load_bundles(&state.db_path).await?;
+    let entries = bundles.iter().map(bundle_to_entry).collect::<Vec<_>>();
+    let feed = opds_xml::acquisition_feed(
+        "urn:toku:opds:all",
+        "All Books",
+        &format!("{OPDS_ROOT}/all"),
+        &now_rfc3339(),
+        &entries,
+    );
+    Ok(feed_response(ACQUISITION_TYPE, feed))
+}
+
+/// `GET /opds/authors` — navigation feed of authors (with book counts).
+async fn authors_feed(State(state): State<OpdsState>) -> Result<Response, WebError> {
+    let bundles = load_bundles(&state.db_path).await?;
+    let entries = grouped_nav(&bundles, "authors", |b| b.authors.clone());
+    let feed = opds_xml::navigation_feed(
+        "urn:toku:opds:authors",
+        "Authors",
+        &format!("{OPDS_ROOT}/authors"),
+        &now_rfc3339(),
+        &entries,
+    );
+    Ok(feed_response(NAVIGATION_TYPE, feed))
+}
+
+/// `GET /opds/authors/{name}` — acquisition feed for one author.
+async fn author_feed(
+    State(state): State<OpdsState>,
+    Path(name): Path<String>,
+) -> Result<Response, WebError> {
+    let bundles = load_bundles(&state.db_path).await?;
+    let matches = filter_bundles(&bundles, &name, |b| &b.authors);
+    let entries = matches
+        .iter()
+        .map(|b| bundle_to_entry(b))
+        .collect::<Vec<_>>();
+    let feed = opds_xml::acquisition_feed(
+        &format!("urn:toku:opds:author:{name}"),
+        &name,
+        &format!("{OPDS_ROOT}/authors/{}", urlencoding::encode(&name)),
+        &now_rfc3339(),
+        &entries,
+    );
+    Ok(feed_response(ACQUISITION_TYPE, feed))
+}
+
+/// `GET /opds/series` — navigation feed of series.
+async fn series_feed(State(state): State<OpdsState>) -> Result<Response, WebError> {
+    let bundles = load_bundles(&state.db_path).await?;
+    let entries = grouped_nav(&bundles, "series", |b| b.series.clone());
+    let feed = opds_xml::navigation_feed(
+        "urn:toku:opds:series",
+        "Series",
+        &format!("{OPDS_ROOT}/series"),
+        &now_rfc3339(),
+        &entries,
+    );
+    Ok(feed_response(NAVIGATION_TYPE, feed))
+}
+
+/// `GET /opds/series/{name}` — acquisition feed for one series.
+async fn series_detail_feed(
+    State(state): State<OpdsState>,
+    Path(name): Path<String>,
+) -> Result<Response, WebError> {
+    let bundles = load_bundles(&state.db_path).await?;
+    let matches = filter_bundles(&bundles, &name, |b| &b.series);
+    let entries = matches
+        .iter()
+        .map(|b| bundle_to_entry(b))
+        .collect::<Vec<_>>();
+    let feed = opds_xml::acquisition_feed(
+        &format!("urn:toku:opds:series:{name}"),
+        &name,
+        &format!("{OPDS_ROOT}/series/{}", urlencoding::encode(&name)),
+        &now_rfc3339(),
+        &entries,
+    );
+    Ok(feed_response(ACQUISITION_TYPE, feed))
+}
+
+/// `GET /opds/shelves` — navigation feed of shelves.
+async fn shelves_feed(State(state): State<OpdsState>) -> Result<Response, WebError> {
+    let bundles = load_bundles(&state.db_path).await?;
+    let entries = grouped_nav(&bundles, "shelves", |b| b.shelves.clone());
+    let feed = opds_xml::navigation_feed(
+        "urn:toku:opds:shelves",
+        "Shelves",
+        &format!("{OPDS_ROOT}/shelves"),
+        &now_rfc3339(),
+        &entries,
+    );
+    Ok(feed_response(NAVIGATION_TYPE, feed))
+}
+
+/// `GET /opds/shelves/{name}` — acquisition feed for one shelf.
+async fn shelf_feed(
+    State(state): State<OpdsState>,
+    Path(name): Path<String>,
+) -> Result<Response, WebError> {
+    let bundles = load_bundles(&state.db_path).await?;
+    let matches = filter_bundles(&bundles, &name, |b| &b.shelves);
+    let entries = matches
+        .iter()
+        .map(|b| bundle_to_entry(b))
+        .collect::<Vec<_>>();
+    let feed = opds_xml::acquisition_feed(
+        &format!("urn:toku:opds:shelf:{name}"),
+        &name,
+        &format!("{OPDS_ROOT}/shelves/{}", urlencoding::encode(&name)),
+        &now_rfc3339(),
+        &entries,
+    );
+    Ok(feed_response(ACQUISITION_TYPE, feed))
+}
+
+#[derive(serde::Deserialize)]
+struct SearchParams {
+    q: Option<String>,
+}
+
+/// `GET /opds/search?q=` — acquisition feed of search results (files only).
+async fn search_feed(
+    State(state): State<OpdsState>,
+    Query(params): Query<SearchParams>,
+) -> Result<Response, WebError> {
+    let query = params.q.unwrap_or_default();
+    let bundles = load_bundles(&state.db_path).await?;
+
+    let entries = if query.trim().is_empty() {
+        Vec::new()
+    } else {
+        let db_path = state.db_path.clone();
+        let q = query.clone();
+        let ids = tokio::task::spawn_blocking(move || -> Result<Vec<String>, WebError> {
+            let db = Database::open_no_migrate(&db_path)?;
+            let repo = BookRepository::new(&db);
+            Ok(repo
+                .search_books_filtered(&q, None, None, None)?
+                .into_iter()
+                .map(|b| b.id.to_string())
+                .collect())
+        })
+        .await
+        .map_err(|e| WebError::Internal(e.to_string()))??;
+
+        let idset: std::collections::HashSet<String> = ids.into_iter().collect();
+        bundles
+            .iter()
+            .filter(|b| idset.contains(&b.book.id.to_string()))
+            .map(bundle_to_entry)
+            .collect()
+    };
+
+    let feed = opds_xml::acquisition_feed(
+        "urn:toku:opds:search",
+        &format!("Search: {query}"),
+        &format!("{OPDS_ROOT}/search?q={}", urlencoding::encode(&query)),
+        &now_rfc3339(),
+        &entries,
+    );
+    Ok(feed_response(ACQUISITION_TYPE, feed))
+}
+
+/// `GET /opds/opensearch.xml` — OpenSearch description document.
+async fn opensearch() -> Response {
+    feed_response(OPENSEARCH_TYPE, opds_xml::opensearch_description())
+}
+
+/// `GET /opds/download/{file_id}` — stream an associated ebook file from disk.
+async fn download(
+    State(state): State<OpdsState>,
+    Path(file_id): Path<String>,
+) -> Result<Response, WebError> {
+    let id = uuid::Uuid::parse_str(&file_id)
+        .map_err(|_| WebError::NotFound("invalid file id".into()))?;
+    let db_path = state.db_path.clone();
+
+    let file = tokio::task::spawn_blocking(move || -> Result<Option<EbookFile>, WebError> {
+        let db = Database::open_no_migrate(&db_path)?;
+        let repo = FileRepository::new(&db);
+        repo.get_file(&id)
+            .map_err(|e| WebError::Internal(e.to_string()))
+    })
+    .await
+    .map_err(|e| WebError::Internal(e.to_string()))??
+    .ok_or_else(|| WebError::NotFound("file not found".into()))?;
+
+    // Serve only the exact stored path — never a client-supplied path.
+    let path = PathBuf::from(&file.path);
+    let data = tokio::task::spawn_blocking(move || std::fs::read(&path))
+        .await
+        .map_err(|e| WebError::Internal(e.to_string()))?
+        .map_err(|_| WebError::NotFound("file missing on disk".into()))?;
+
+    let filename = std::path::Path::new(&file.path)
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or("book")
+        .to_string();
+    let disposition = format!(
+        "attachment; filename=\"{}\"",
+        filename.replace('"', "").replace(['\r', '\n'], "")
+    );
+
+    Ok((
+        [
+            (
+                header::CONTENT_TYPE,
+                opds_xml::format_mime(file.format).to_string(),
+            ),
+            (header::CONTENT_DISPOSITION, disposition),
+        ],
+        Body::from(data),
+    )
+        .into_response())
+}
+
+/// `GET /opds/cover/{hash}` — serve a cover image from disk.
+async fn cover(
+    State(state): State<OpdsState>,
+    Path(hash): Path<String>,
+) -> Result<Response, WebError> {
+    if hash.is_empty() || hash.len() > 64 || !hash.chars().all(|c| c.is_ascii_hexdigit()) {
+        return Err(WebError::NotFound("invalid cover hash".into()));
+    }
+    let path = state.covers_dir.join(format!("{hash}.jpg"));
+    let data = tokio::task::spawn_blocking(move || std::fs::read(path))
+        .await
+        .map_err(|e| WebError::Internal(e.to_string()))?
+        .map_err(|_| WebError::NotFound("cover not found".into()))?;
+
+    Ok((
+        [
+            (header::CONTENT_TYPE, "image/jpeg"),
+            (header::CACHE_CONTROL, "public, max-age=31536000, immutable"),
+        ],
+        data,
+    )
+        .into_response())
+}
+
+// ── Data gathering ───────────────────────────────────────────────────────────
+
+/// Load every book that has ≥1 associated file, with the metadata the feeds
+/// need. Runs the blocking DB work off the async runtime.
+async fn load_bundles(db_path: &std::path::Path) -> Result<Vec<BookBundle>, WebError> {
+    let db_path = db_path.to_path_buf();
+    tokio::task::spawn_blocking(move || gather_bundles(&db_path))
+        .await
+        .map_err(|e| WebError::Internal(e.to_string()))?
+}
+
+fn gather_bundles(db_path: &std::path::Path) -> Result<Vec<BookBundle>, WebError> {
+    let db = Database::open_no_migrate(db_path)?;
+    let repo = BookRepository::new(&db);
+    let file_repo = FileRepository::new(&db);
+
+    // Group all files by book.
+    let mut files_by_book: HashMap<String, Vec<EbookFile>> = HashMap::new();
+    for f in file_repo
+        .list_all_files()
+        .map_err(|e| WebError::Internal(e.to_string()))?
+    {
+        files_by_book
+            .entry(f.book_id.to_string())
+            .or_default()
+            .push(f);
+    }
+
+    let mut bundles = Vec::new();
+    for book in repo.list_books()? {
+        let Some(files) = files_by_book.remove(&book.id.to_string()) else {
+            continue; // no files → not served over OPDS
+        };
+
+        let authors = repo
+            .get_book_authors(&book.id)
+            .unwrap_or_default()
+            .into_iter()
+            .filter(|(_, ba)| ba.role == ContributorRole::Author)
+            .map(|(a, _)| a.name)
+            .collect();
+        let isbns = repo.get_book_isbns(&book.id).unwrap_or_default();
+        let series = repo
+            .get_book_series(&book.id)
+            .unwrap_or_default()
+            .into_iter()
+            .map(|(s, _)| s.name)
+            .collect();
+        let shelves = repo
+            .get_book_shelves(&book.id)
+            .unwrap_or_default()
+            .into_iter()
+            .map(|s| s.name)
+            .collect();
+
+        bundles.push(BookBundle {
+            book,
+            authors,
+            isbns,
+            series,
+            shelves,
+            files,
+        });
+    }
+
+    // Stable ordering by title for deterministic feeds.
+    bundles.sort_by(|a, b| {
+        a.book
+            .title
+            .to_lowercase()
+            .cmp(&b.book.title.to_lowercase())
+    });
+    Ok(bundles)
+}
+
+/// Convert a book bundle into an OPDS acquisition entry.
+fn bundle_to_entry(b: &BookBundle) -> AcqEntry {
+    let mut files = b.files.clone();
+    files.sort_by_key(|f| f.format.as_str());
+    let links = files
+        .iter()
+        .map(|f| AcqLink {
+            href: format!("{OPDS_ROOT}/download/{}", f.id),
+            mime: opds_xml::format_mime(f.format).to_string(),
+        })
+        .collect();
+
+    let cover_href = b
+        .book
+        .cover_hash
+        .as_ref()
+        .map(|h| format!("{OPDS_ROOT}/cover/{h}"));
+
+    AcqEntry {
+        id: format!("urn:uuid:{}", b.book.id),
+        title: b.book.title.clone(),
+        authors: b.authors.clone(),
+        updated: b.book.updated_at.to_rfc3339(),
+        summary: b.book.description.clone(),
+        language: b.book.language.clone(),
+        isbns: b.isbns.clone(),
+        publisher_year: b.book.pub_date.clone(),
+        cover_href,
+        links,
+    }
+}
+
+/// Build a navigation feed grouping bundles by a multi-valued key (author,
+/// series, shelf), producing one nav entry per distinct value with a count.
+fn grouped_nav(
+    bundles: &[BookBundle],
+    segment: &str,
+    key: impl Fn(&BookBundle) -> Vec<String>,
+) -> Vec<NavEntry> {
+    let mut counts: HashMap<String, usize> = HashMap::new();
+    for b in bundles {
+        for value in key(b) {
+            if value.trim().is_empty() {
+                continue;
+            }
+            *counts.entry(value).or_default() += 1;
+        }
+    }
+    let mut names: Vec<(String, usize)> = counts.into_iter().collect();
+    names.sort_by_key(|(name, _)| name.to_lowercase());
+
+    names
+        .into_iter()
+        .map(|(name, count)| NavEntry {
+            title: name.clone(),
+            href: format!("{OPDS_ROOT}/{segment}/{}", urlencoding::encode(&name)),
+            content: Some(format!("{count} book{}", if count == 1 { "" } else { "s" })),
+            acquisition: true,
+        })
+        .collect()
+}
+
+/// Filter bundles whose multi-valued key contains `name` (case-insensitive).
+fn filter_bundles<'a>(
+    bundles: &'a [BookBundle],
+    name: &str,
+    key: impl Fn(&BookBundle) -> &Vec<String>,
+) -> Vec<&'a BookBundle> {
+    let needle = name.to_lowercase();
+    bundles
+        .iter()
+        .filter(|b| key(b).iter().any(|v| v.to_lowercase() == needle))
+        .collect()
+}
+
+// ── Small helpers ────────────────────────────────────────────────────────────
+
+fn now_rfc3339() -> String {
+    chrono::Utc::now().to_rfc3339()
+}
+
+fn feed_response(content_type: &str, body: String) -> Response {
+    ([(header::CONTENT_TYPE, content_type.to_string())], body).into_response()
+}

--- a/crates/toku-web/src/opds_xml.rs
+++ b/crates/toku-web/src/opds_xml.rs
@@ -1,0 +1,323 @@
+//! OPDS 1.2 (Atom) feed construction for the e-reader catalog.
+//!
+//! Feeds are hand-built as strings (with strict XML escaping) to avoid pulling
+//! in an XML crate. Two feed kinds exist per the OPDS spec: **navigation**
+//! feeds (menus that link to other feeds) and **acquisition** feeds (lists of
+//! books with download links).
+
+use toku_files::FileFormat;
+
+/// MIME type for an OPDS navigation feed.
+pub const NAVIGATION_TYPE: &str = "application/atom+xml;profile=opds-catalog;kind=navigation";
+/// MIME type for an OPDS acquisition feed.
+pub const ACQUISITION_TYPE: &str = "application/atom+xml;profile=opds-catalog;kind=acquisition";
+/// MIME type for an OpenSearch description document.
+pub const OPENSEARCH_TYPE: &str = "application/opensearchdescription+xml";
+
+/// Root path all OPDS routes hang off of.
+pub const OPDS_ROOT: &str = "/opds";
+
+/// Map an ebook [`FileFormat`] to the MIME type used for its acquisition link
+/// and download response.
+pub fn format_mime(format: FileFormat) -> &'static str {
+    match format {
+        FileFormat::Epub => "application/epub+zip",
+        FileFormat::Pdf => "application/pdf",
+        FileFormat::Mobi => "application/x-mobipocket-ebook",
+        FileFormat::Azw3 => "application/vnd.amazon.ebook",
+    }
+}
+
+/// An entry in a navigation feed: a link to another feed.
+pub struct NavEntry {
+    pub title: String,
+    pub href: String,
+    pub content: Option<String>,
+    /// True when the target is an acquisition feed (a book list) rather than a
+    /// nested navigation feed.
+    pub acquisition: bool,
+}
+
+/// A single download link within an acquisition entry.
+pub struct AcqLink {
+    pub href: String,
+    pub mime: String,
+}
+
+/// A book entry in an acquisition feed.
+pub struct AcqEntry {
+    /// Stable identifier, e.g. `urn:uuid:<book id>`.
+    pub id: String,
+    pub title: String,
+    pub authors: Vec<String>,
+    /// RFC 3339 timestamp of the book's last update.
+    pub updated: String,
+    pub summary: Option<String>,
+    pub language: Option<String>,
+    pub isbns: Vec<String>,
+    pub publisher_year: Option<String>,
+    /// Cover image href (served from `/opds/cover/{hash}`), if any.
+    pub cover_href: Option<String>,
+    /// One acquisition link per associated ebook file.
+    pub links: Vec<AcqLink>,
+}
+
+/// Escape a string for inclusion in XML text or attribute values.
+fn xml_escape(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    for c in s.chars() {
+        match c {
+            '&' => out.push_str("&amp;"),
+            '<' => out.push_str("&lt;"),
+            '>' => out.push_str("&gt;"),
+            '"' => out.push_str("&quot;"),
+            '\'' => out.push_str("&apos;"),
+            // Strip control chars that are illegal in XML 1.0.
+            c if (c as u32) < 0x20 && c != '\t' && c != '\n' && c != '\r' => {}
+            c => out.push(c),
+        }
+    }
+    out
+}
+
+fn feed_header(
+    out: &mut String,
+    id: &str,
+    title: &str,
+    self_href: &str,
+    self_type: &str,
+    updated: &str,
+) {
+    out.push_str("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n");
+    out.push_str(
+        "<feed xmlns=\"http://www.w3.org/2005/Atom\" \
+         xmlns:opds=\"http://opds-spec.org/2010/catalog\" \
+         xmlns:dc=\"http://purl.org/dc/terms/\">\n",
+    );
+    out.push_str(&format!("  <id>{}</id>\n", xml_escape(id)));
+    out.push_str(&format!("  <title>{}</title>\n", xml_escape(title)));
+    out.push_str(&format!("  <updated>{}</updated>\n", xml_escape(updated)));
+    out.push_str(&format!(
+        "  <link rel=\"self\" href=\"{}\" type=\"{}\"/>\n",
+        xml_escape(self_href),
+        xml_escape(self_type),
+    ));
+    out.push_str(&format!(
+        "  <link rel=\"start\" href=\"{OPDS_ROOT}\" type=\"{NAVIGATION_TYPE}\"/>\n",
+    ));
+    out.push_str(&format!(
+        "  <link rel=\"search\" href=\"{OPDS_ROOT}/opensearch.xml\" type=\"{OPENSEARCH_TYPE}\"/>\n",
+    ));
+}
+
+/// Build a navigation feed from a list of sub-feed links.
+pub fn navigation_feed(
+    id: &str,
+    title: &str,
+    self_href: &str,
+    updated: &str,
+    entries: &[NavEntry],
+) -> String {
+    let mut out = String::new();
+    feed_header(&mut out, id, title, self_href, NAVIGATION_TYPE, updated);
+
+    for e in entries {
+        let link_type = if e.acquisition {
+            ACQUISITION_TYPE
+        } else {
+            NAVIGATION_TYPE
+        };
+        out.push_str("  <entry>\n");
+        out.push_str(&format!("    <title>{}</title>\n", xml_escape(&e.title)));
+        out.push_str(&format!(
+            "    <id>{}</id>\n",
+            xml_escape(&format!("{id}:{}", e.href))
+        ));
+        out.push_str(&format!("    <updated>{}</updated>\n", xml_escape(updated)));
+        if let Some(content) = &e.content {
+            out.push_str(&format!(
+                "    <content type=\"text\">{}</content>\n",
+                xml_escape(content)
+            ));
+        }
+        out.push_str(&format!(
+            "    <link rel=\"subsection\" href=\"{}\" type=\"{}\"/>\n",
+            xml_escape(&e.href),
+            link_type,
+        ));
+        out.push_str("  </entry>\n");
+    }
+
+    out.push_str("</feed>\n");
+    out
+}
+
+/// Build an acquisition feed from a list of book entries.
+pub fn acquisition_feed(
+    id: &str,
+    title: &str,
+    self_href: &str,
+    updated: &str,
+    entries: &[AcqEntry],
+) -> String {
+    let mut out = String::new();
+    feed_header(&mut out, id, title, self_href, ACQUISITION_TYPE, updated);
+
+    for e in entries {
+        out.push_str("  <entry>\n");
+        out.push_str(&format!("    <title>{}</title>\n", xml_escape(&e.title)));
+        out.push_str(&format!("    <id>{}</id>\n", xml_escape(&e.id)));
+        out.push_str(&format!(
+            "    <updated>{}</updated>\n",
+            xml_escape(&e.updated)
+        ));
+        for author in &e.authors {
+            out.push_str("    <author>\n");
+            out.push_str(&format!("      <name>{}</name>\n", xml_escape(author)));
+            out.push_str("    </author>\n");
+        }
+        if let Some(lang) = &e.language {
+            out.push_str(&format!(
+                "    <dc:language>{}</dc:language>\n",
+                xml_escape(lang)
+            ));
+        }
+        if let Some(year) = &e.publisher_year {
+            out.push_str(&format!(
+                "    <dc:issued>{}</dc:issued>\n",
+                xml_escape(year)
+            ));
+        }
+        for isbn in &e.isbns {
+            out.push_str(&format!(
+                "    <dc:identifier>urn:isbn:{}</dc:identifier>\n",
+                xml_escape(isbn)
+            ));
+        }
+        if let Some(summary) = &e.summary {
+            out.push_str(&format!(
+                "    <summary type=\"text\">{}</summary>\n",
+                xml_escape(summary)
+            ));
+        }
+        if let Some(cover) = &e.cover_href {
+            out.push_str(&format!(
+                "    <link rel=\"http://opds-spec.org/image\" href=\"{}\" type=\"image/jpeg\"/>\n",
+                xml_escape(cover)
+            ));
+            out.push_str(&format!(
+                "    <link rel=\"http://opds-spec.org/image/thumbnail\" href=\"{}\" type=\"image/jpeg\"/>\n",
+                xml_escape(cover)
+            ));
+        }
+        for link in &e.links {
+            out.push_str(&format!(
+                "    <link rel=\"http://opds-spec.org/acquisition\" href=\"{}\" type=\"{}\"/>\n",
+                xml_escape(&link.href),
+                xml_escape(&link.mime),
+            ));
+        }
+        out.push_str("  </entry>\n");
+    }
+
+    out.push_str("</feed>\n");
+    out
+}
+
+/// Build the OpenSearch description document advertising the search endpoint.
+pub fn opensearch_description() -> String {
+    format!(
+        "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n\
+         <OpenSearchDescription xmlns=\"http://a9.com/-/spec/opensearch/1.1/\">\n\
+         \x20 <ShortName>Toku</ShortName>\n\
+         \x20 <Description>Search the Toku library</Description>\n\
+         \x20 <InputEncoding>UTF-8</InputEncoding>\n\
+         \x20 <Url type=\"{ACQUISITION_TYPE}\" \
+         template=\"{OPDS_ROOT}/search?q={{searchTerms}}\"/>\n\
+         </OpenSearchDescription>\n",
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn escapes_xml_special_chars() {
+        assert_eq!(
+            xml_escape("a & b <c> \"d\" 'e'"),
+            "a &amp; b &lt;c&gt; &quot;d&quot; &apos;e&apos;"
+        );
+    }
+
+    #[test]
+    fn strips_illegal_control_chars() {
+        assert_eq!(xml_escape("a\u{0}b\u{1}c"), "abc");
+        assert_eq!(xml_escape("keep\ttabs\nnewlines"), "keep\ttabs\nnewlines");
+    }
+
+    #[test]
+    fn navigation_feed_has_expected_shape() {
+        let feed = navigation_feed(
+            "urn:toku:opds",
+            "Toku Library",
+            "/opds",
+            "2024-01-01T00:00:00Z",
+            &[NavEntry {
+                title: "By Author".into(),
+                href: "/opds/authors".into(),
+                content: Some("Browse by author".into()),
+                acquisition: false,
+            }],
+        );
+        assert!(feed.contains("<feed"));
+        assert!(feed.contains("profile=opds-catalog;kind=navigation"));
+        assert!(feed.contains("rel=\"subsection\" href=\"/opds/authors\""));
+        assert!(feed.contains("rel=\"search\""));
+    }
+
+    #[test]
+    fn acquisition_feed_includes_download_and_cover() {
+        let feed = acquisition_feed(
+            "urn:toku:opds:all",
+            "All Books",
+            "/opds/all",
+            "2024-01-01T00:00:00Z",
+            &[AcqEntry {
+                id: "urn:uuid:1234".into(),
+                title: "Dune".into(),
+                authors: vec!["Frank Herbert".into()],
+                updated: "2024-01-01T00:00:00Z".into(),
+                summary: Some("Desert planet".into()),
+                language: Some("en".into()),
+                isbns: vec!["9780441172719".into()],
+                publisher_year: None,
+                cover_href: Some("/opds/cover/abc".into()),
+                links: vec![AcqLink {
+                    href: "/opds/download/file1".into(),
+                    mime: "application/epub+zip".into(),
+                }],
+            }],
+        );
+        assert!(feed.contains("<name>Frank Herbert</name>"));
+        assert!(feed.contains("urn:isbn:9780441172719"));
+        assert!(
+            feed.contains("rel=\"http://opds-spec.org/acquisition\" href=\"/opds/download/file1\"")
+        );
+        assert!(feed.contains("rel=\"http://opds-spec.org/image\""));
+    }
+
+    #[test]
+    fn format_mime_maps_all_variants() {
+        assert_eq!(format_mime(FileFormat::Epub), "application/epub+zip");
+        assert_eq!(format_mime(FileFormat::Pdf), "application/pdf");
+        assert_eq!(
+            format_mime(FileFormat::Mobi),
+            "application/x-mobipocket-ebook"
+        );
+        assert_eq!(
+            format_mime(FileFormat::Azw3),
+            "application/vnd.amazon.ebook"
+        );
+    }
+}

--- a/crates/toku-web/tests/opds.rs
+++ b/crates/toku-web/tests/opds.rs
@@ -1,0 +1,270 @@
+//! Integration tests for the OPDS catalog server (issue #150).
+//!
+//! These drive the OPDS router end to end via `tower::ServiceExt::oneshot`,
+//! covering feed shape, browse-by-* grouping, search, downloads that honor file
+//! associations, and the optional HTTP Basic auth guard.
+
+use axum::Router;
+use axum::body::Body;
+use axum::http::{Request, StatusCode, header};
+use base64::Engine as _;
+use http_body_util::BodyExt;
+use tower::ServiceExt;
+
+use toku_core::{Book, OpdsConfig};
+use toku_db::{BookRepository, Database};
+use toku_files::{EbookFile, FileFormat, FileRepository, sha256_file};
+use toku_web::opds::{OpdsState, build_opds_router};
+
+struct TestEnv {
+    _dir: tempfile::TempDir,
+    db_path: std::path::PathBuf,
+    covers_dir: std::path::PathBuf,
+}
+
+/// Build a library with one book that has an associated epub file and one book
+/// with no files. Returns the env plus the added file's id.
+fn setup_env() -> (TestEnv, String) {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let db_path = dir.path().join("toku.db");
+    let covers_dir = dir.path().join("covers");
+    std::fs::create_dir_all(&covers_dir).expect("covers dir");
+
+    let db = Database::open(&db_path).expect("migrate db");
+    let repo = BookRepository::new(&db);
+
+    // Book with a file.
+    let mut dune = Book::new("Dune");
+    dune.description = Some("Desert planet".into());
+    dune.language = Some("en".into());
+    repo.create_book(&dune).expect("create dune");
+    let author = toku_core::Author::new("Frank Herbert");
+    repo.add_book_author(&author, &dune.id, toku_core::ContributorRole::Author, 0)
+        .expect("add author");
+    repo.add_isbn("9780441172719", &dune.id).expect("add isbn");
+    repo.create_shelf("Favorites").expect("create shelf");
+    repo.add_book_to_shelf(&dune.id, "Favorites")
+        .expect("add to shelf");
+
+    // Book without any file — must NOT appear in acquisition feeds.
+    let neuromancer = Book::new("Neuromancer");
+    repo.create_book(&neuromancer).expect("create neuromancer");
+
+    // Associate a real file on disk with Dune.
+    let epub_path = dir.path().join("dune.epub");
+    std::fs::write(&epub_path, b"epub-bytes").expect("write epub");
+    let checksum = sha256_file(&epub_path).expect("checksum");
+    let file = EbookFile::new(
+        dune.id,
+        epub_path.to_string_lossy().into_owned(),
+        FileFormat::Epub,
+        10,
+        checksum,
+    );
+    let file_id = file.id.to_string();
+    FileRepository::new(&db).add_file(&file).expect("add file");
+
+    (
+        TestEnv {
+            _dir: dir,
+            db_path,
+            covers_dir,
+        },
+        file_id,
+    )
+}
+
+fn router(env: &TestEnv, auth: Option<OpdsConfig>) -> Router {
+    build_opds_router(OpdsState {
+        db_path: env.db_path.clone(),
+        covers_dir: env.covers_dir.clone(),
+        auth,
+    })
+}
+
+async fn get(router: Router, uri: &str) -> (StatusCode, String, Option<String>) {
+    let resp = router
+        .oneshot(
+            Request::builder()
+                .uri(uri)
+                .body(Body::empty())
+                .expect("request"),
+        )
+        .await
+        .expect("response");
+    let status = resp.status();
+    let content_type = resp
+        .headers()
+        .get(header::CONTENT_TYPE)
+        .and_then(|v| v.to_str().ok())
+        .map(|s| s.to_string());
+    let body = resp.into_body().collect().await.expect("body").to_bytes();
+    (
+        status,
+        String::from_utf8_lossy(&body).into_owned(),
+        content_type,
+    )
+}
+
+#[tokio::test]
+async fn root_feed_is_navigation_with_subsections() {
+    let (env, _) = setup_env();
+    let (status, body, ct) = get(router(&env, None), "/opds").await;
+    assert_eq!(status, StatusCode::OK);
+    assert!(ct.unwrap().contains("kind=navigation"));
+    assert!(body.contains("<title>All Books</title>"));
+    assert!(body.contains("href=\"/opds/authors\""));
+    assert!(body.contains("href=\"/opds/series\""));
+    assert!(body.contains("href=\"/opds/shelves\""));
+    assert!(body.contains("rel=\"search\""));
+}
+
+#[tokio::test]
+async fn all_feed_only_lists_books_with_files() {
+    let (env, file_id) = setup_env();
+    let (status, body, ct) = get(router(&env, None), "/opds/all").await;
+    assert_eq!(status, StatusCode::OK);
+    assert!(ct.unwrap().contains("kind=acquisition"));
+    assert!(body.contains("<title>Dune</title>"));
+    assert!(body.contains("<name>Frank Herbert</name>"));
+    assert!(body.contains("urn:isbn:9780441172719"));
+    assert!(body.contains(&format!("/opds/download/{file_id}")));
+    // Neuromancer has no file and must be excluded.
+    assert!(!body.contains("Neuromancer"));
+}
+
+#[tokio::test]
+async fn browse_by_author_shelf_and_series() {
+    let (env, _) = setup_env();
+
+    let (_, authors, _) = get(router(&env, None), "/opds/authors").await;
+    assert!(authors.contains("<title>Frank Herbert</title>"));
+    assert!(authors.contains("href=\"/opds/authors/Frank%20Herbert\""));
+
+    let (_, author_detail, _) = get(router(&env, None), "/opds/authors/Frank%20Herbert").await;
+    assert!(author_detail.contains("<title>Dune</title>"));
+
+    let (_, shelves, _) = get(router(&env, None), "/opds/shelves").await;
+    assert!(shelves.contains("<title>Favorites</title>"));
+
+    let (_, shelf_detail, _) = get(router(&env, None), "/opds/shelves/Favorites").await;
+    assert!(shelf_detail.contains("<title>Dune</title>"));
+
+    // No series configured → empty (but valid) navigation feed.
+    let (status, series, _) = get(router(&env, None), "/opds/series").await;
+    assert_eq!(status, StatusCode::OK);
+    assert!(series.contains("<title>Series</title>"));
+}
+
+#[tokio::test]
+async fn search_matches_and_excludes_fileless_books() {
+    let (env, _) = setup_env();
+
+    let (status, hit, _) = get(router(&env, None), "/opds/search?q=Dune").await;
+    assert_eq!(status, StatusCode::OK);
+    assert!(hit.contains("<title>Dune</title>"));
+
+    // Neuromancer matches text but has no file, so it is not downloadable.
+    let (_, miss, _) = get(router(&env, None), "/opds/search?q=Neuromancer").await;
+    assert!(!miss.contains("<title>Neuromancer</title>"));
+
+    // Empty query yields a valid, empty feed.
+    let (status, empty, _) = get(router(&env, None), "/opds/search?q=").await;
+    assert_eq!(status, StatusCode::OK);
+    assert!(empty.contains("<feed"));
+}
+
+#[tokio::test]
+async fn download_serves_associated_file_bytes() {
+    let (env, file_id) = setup_env();
+    let resp = router(&env, None)
+        .oneshot(
+            Request::builder()
+                .uri(format!("/opds/download/{file_id}"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    assert_eq!(
+        resp.headers().get(header::CONTENT_TYPE).unwrap(),
+        "application/epub+zip"
+    );
+    let disposition = resp
+        .headers()
+        .get(header::CONTENT_DISPOSITION)
+        .unwrap()
+        .to_str()
+        .unwrap()
+        .to_string();
+    assert!(disposition.contains("dune.epub"));
+    let body = resp.into_body().collect().await.unwrap().to_bytes();
+    assert_eq!(&body[..], b"epub-bytes");
+}
+
+#[tokio::test]
+async fn download_unknown_file_is_404() {
+    let (env, _) = setup_env();
+    let unknown = uuid::Uuid::now_v7();
+    let (status, _, _) = get(router(&env, None), &format!("/opds/download/{unknown}")).await;
+    assert_eq!(status, StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn opensearch_document_is_served() {
+    let (env, _) = setup_env();
+    let (status, body, ct) = get(router(&env, None), "/opds/opensearch.xml").await;
+    assert_eq!(status, StatusCode::OK);
+    assert!(ct.unwrap().contains("opensearchdescription"));
+    assert!(body.contains("template=\"/opds/search?q={searchTerms}\""));
+}
+
+fn auth_config() -> OpdsConfig {
+    OpdsConfig {
+        username: Some("reader".into()),
+        password_hash: Some(OpdsConfig::hash_password("lanpass")),
+    }
+}
+
+#[tokio::test]
+async fn auth_required_when_configured() {
+    let (env, _) = setup_env();
+    let (status, _, _) = get(router(&env, Some(auth_config())), "/opds").await;
+    assert_eq!(status, StatusCode::UNAUTHORIZED);
+}
+
+#[tokio::test]
+async fn auth_rejects_wrong_password() {
+    let (env, _) = setup_env();
+    let creds = base64::engine::general_purpose::STANDARD.encode("reader:wrong");
+    let resp = router(&env, Some(auth_config()))
+        .oneshot(
+            Request::builder()
+                .uri("/opds")
+                .header(header::AUTHORIZATION, format!("Basic {creds}"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+    assert!(resp.headers().contains_key(header::WWW_AUTHENTICATE));
+}
+
+#[tokio::test]
+async fn auth_accepts_correct_credentials() {
+    let (env, _) = setup_env();
+    let creds = base64::engine::general_purpose::STANDARD.encode("reader:lanpass");
+    let resp = router(&env, Some(auth_config()))
+        .oneshot(
+            Request::builder()
+                .uri("/opds")
+                .header(header::AUTHORIZATION, format!("Basic {creds}"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+}


### PR DESCRIPTION
## Description

Adds an **OPDS 1.2 (Atom) catalog server** so e-reader apps (KOReader, Moon+ Reader, etc.) can browse the Toku library and download associated ebook files directly over the local network. OPDS handling lives in the `toku-web` crate and is exposed through a new dedicated `toku opds` CLI command.

### What's included

- **`toku opds serve [--host <addr>] [--port <n>]`** — starts the catalog at `/opds`. Binds `0.0.0.0:3001` by default so e-readers on the LAN can reach it (distinct from the `toku serve` dashboard on 3000); pass `--host 127.0.0.1` to restrict to this machine.
- **Catalog structure** — a root navigation feed with browse-by-author, browse-by-series, and browse-by-shelf sub-catalogs, an "All Books" acquisition feed, and OpenSearch-powered search (`/opds/search?q=`).
- **Acquisition feeds** list only books that have associated files (honoring `toku file add`). Each entry carries per-format download links, cover/thumbnail links, and metadata (author, ISBN, language, description).
- **Downloads** stream the exact on-disk file recorded for that association by file ID — never a client-supplied path — with the correct MIME type and `Content-Disposition`.
- **Optional HTTP Basic auth** gated by a new `[opds]` config section. `toku opds set-password <username>` prompts for a password and stores a salted SHA-256 hash; `toku opds disable` clears it. Auth is off unless both username and hash are present; comparison is constant-time.
- **Supporting changes**: `OpdsConfig` + password hashing in `toku-core`; `list_series` / `list_books_in_series` in `toku-db`; `get_file` lookup in `toku-files`.

Local-first is preserved — the server makes no external calls and serves only the local database and on-disk files.

## Related Issues

Closes #150

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI / infrastructure
- [ ] Other (describe below)

## Crate

- [x] `toku-core` — Domain models, traits, state machine
- [x] `toku-db` — SQLite persistence, migrations, FTS5
- [ ] `toku-import` — Importers (Goodreads, Calibre, StoryGraph)
- [ ] `toku-meta` — Metadata fetching (Open Library, Google Books)
- [x] `toku-cli` — CLI binary
- [ ] `toku-export` — Exporters (CSV, JSON, Markdown, BibTeX)
- [x] `docs/` — Documentation
- [x] `toku-web` — OPDS server + feeds (new `opds` / `opds_xml` modules)
- [x] `toku-files` — file lookup for acquisition/download

## Data Integrity Checklist

- [x] No user data is sent to any server without explicit opt-in
- [x] Import operations are idempotent (re-importing the same file creates no duplicates)
- [x] User edits to metadata are never overwritten by auto-enrichment
- [x] New fields track provenance (source + timestamp)
- [x] Export round-trip is preserved (if applicable)

## Checklist

- [x] I have read [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] `cargo fmt --check` passes
- [x] `cargo clippy --workspace -- -D warnings` passes
- [x] `cargo test --workspace` passes
- [x] I have updated documentation (if applicable)
