### PR TITLE
docs: mark Phase 6 (Ebook File Management) as delivered in ROADMAP

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -709,7 +709,7 @@ All statistics computed locally from SQLite queries. No server needed.
 
 **Recommendation**: Defer file management to Phase 6 (post-1.0). The MVP is a reading tracker, not a file manager. The architecture accommodates file management through the modular crate design.
 
-**Status**: Phase 6 is now planned and broken down into tracked GitHub issues under the **Phase 6: File Management** milestone (epic #154, sub-issues #147–#153). The four areas below — file association/disk organization, integrity & disk usage, format conversion, and the OPDS server — are committed deliverables. Implementation has not yet started; the critical path opens with ADR-011 (#151) → `toku-files` crate + schema (#153) → file association (#148).
+**Status**: ✅ **Delivered.** Phase 6 shipped in full under the **Phase 6: File Management** milestone (epic #154, sub-issues #147–#153, all closed and merged). The four areas below — file association/disk organization, integrity & disk usage, format conversion, and the OPDS server — are implemented in the `toku-files` crate. Foundations landed first (ADR-011 (#151), `toku-files` crate + `files` table schema (#153)), followed by file association (#148), disk organization (#152), integrity & usage (#149), format conversion (#147), and the OPDS server (#150).
 
 ### 6.1 — File Management (Phase 6)
 
@@ -1366,7 +1366,7 @@ Before committing to the architecture, validate:
 
 ---
 
-### Phase 6: File Management 🟡
+### Phase 6: File Management ✅
 
 **Theme**: "Calibre-grade ebook management."
 **Goal**: Optional management of the actual ebook files (`.epub`, `.pdf`, `.mobi`, `.azw3`) on disk, in a new `toku-files` crate (`toku-core` + `toku-db`, no network). Stays local-first; file binaries are explicitly **not** synced in Phase 7.
@@ -1381,7 +1381,7 @@ Before committing to the architecture, validate:
 
 **Foundations**: ADR-011 file-management architecture (#151), `toku-files` crate scaffold + `files` table schema (#153).
 
-**Status**: Planned and tracked under the **Phase 6: File Management** milestone (epic #154). Not yet started.
+**Status**: ✅ Delivered. Shipped under the **Phase 6: File Management** milestone (epic #154); all five deliverables and both foundations (#147–#153) are merged into the `toku-files` crate.
 
 **Dependencies**: Phase 3 (stable data model). Independent of sync — can proceed in parallel with the remaining Phase 7 work.
 


### PR DESCRIPTION
## Description

Wraps up **Epic #154 (Phase 6 — Ebook File Management)** by marking the phase as delivered in the roadmap. All seven Phase 6 sub-issues (#147–#153) are already closed and merged into `main` — the `toku-files` crate ships file association, disk organization, integrity/usage reporting, Calibre-based format conversion, and the OPDS server — but `ROADMAP.md` still described the phase as "not yet started." This is a documentation-only correction; no code changes.

### What's included

- **§6 Status paragraph**: rewritten from "Implementation has not yet started" to ✅ Delivered, referencing ADR-011 and the merged sub-issues (#147–#153).
- **Phase 6 roadmap header**: `🟡` → `✅`, matching the convention used for completed Phases 0–5.
- **Phase 6 Status line**: "Planned… Not yet started" → ✅ Delivered, noting the milestone and that all five deliverables plus both foundations are merged.

The 🟢/🟡 markers in the feature/complexity tables were intentionally left untouched — in those tables the emoji denotes *complexity*, not completion status.

## Related Issues

Closes #154

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI / infrastructure
- [ ] Other (describe below)

## Crate

- [x] `docs/` — Documentation (ROADMAP.md)

## Data Integrity Checklist

<!-- N/A — documentation-only change, no code or data paths touched -->

- [ ] No user data is sent to any server without explicit opt-in
- [ ] Import operations are idempotent (re-importing the same file creates no duplicates)
- [ ] User edits to metadata are never overwritten by auto-enrichment
- [ ] New fields track provenance (source + timestamp)
- [ ] Export round-trip is preserved (if applicable)

## Checklist

- [x] I have read [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] `cargo fmt --check` passes
- [ ] `cargo clippy --workspace -- -D warnings` passes <!-- N/A — no Rust code changed -->
- [ ] `cargo test --workspace` passes <!-- N/A — no Rust code changed -->
- [x] I have updated documentation (if applicable)
