### PR TITLE
feat: harden self-host sync/web auth (threat-model follow-ups F2–F11)

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,0 +1,23 @@
+# cargo-audit configuration.
+#
+# The advisories ignored below are DoS vulnerabilities in `quick-xml`
+# (RUSTSEC-2026-0194, RUSTSEC-2026-0195), pulled in transitively — and only —
+# by `toku-desktop`'s Tauri stack:
+#   * quick-xml 0.39.x  <- plist <- tauri
+#   * quick-xml 0.37.x  <- tauri-winrt-notification <- notify-rust
+#                          <- tauri-plugin-notification
+#
+# They are not reachable from any network-facing Toku surface (the sync server,
+# web tier, or CLI never parse untrusted XML with quick-xml); the affected code
+# is Tauri's local plist parsing and Windows notification bindings.
+#
+# Both advisories are only fixed in quick-xml >= 0.41.0, but the intermediate
+# crates pin incompatible ranges (`plist` -> "^0.39.2", `tauri-winrt-notification`
+# -> "^0.37"), so there is no in-range upgrade available until the Tauri
+# dependency chain publishes releases that adopt quick-xml 0.41. Revisit and
+# remove these ignores once `cargo update` can pull a patched quick-xml.
+[advisories]
+ignore = [
+    "RUSTSEC-2026-0194",
+    "RUSTSEC-2026-0195",
+]

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -103,6 +103,12 @@ jobs:
       - uses: rustsec/audit-check@v2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+          # Transitive DoS advisories in `quick-xml`, reachable only through
+          # toku-desktop's Tauri stack (plist / tauri-winrt-notification). No
+          # in-range upgrade exists yet (fixed in quick-xml >= 0.41.0, but the
+          # intermediate crates pin ^0.37 / ^0.39). Mirrors .cargo/audit.toml;
+          # remove both once the Tauri chain adopts quick-xml 0.41. See #160.
+          ignore: RUSTSEC-2026-0194,RUSTSEC-2026-0195
 
   # ── Documentation ─────────────────────────────────────────────────────────────
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   record for the zero-knowledge, two-secret self-host auth model: assets, adversaries,
   mitigations, the zero-knowledge sign-off, and a triaged findings table with residual risks
 
+### Security
+
+- Hardened the self-host sync and web tiers following the threat-model review (#160,
+  findings F2–F11 from #125):
+  - **Web security headers** (`toku serve`): every response now carries a
+    `Content-Security-Policy`, `X-Frame-Options: DENY`, `X-Content-Type-Options: nosniff`,
+    and `Referrer-Policy: no-referrer`, plus `Strict-Transport-Security` when secure cookies
+    are enabled (F4)
+  - **Account-enumeration resistance**: web login is now constant-time and no longer reveals
+    whether an email exists or is inactive; the sync account challenge/verify flow returns
+    uniform "phantom" responses for unknown or disabled accounts and a single `401` on any
+    verification failure (F5)
+  - **Session revocation**: new `POST /api/v1/auth/logout` (device session) and
+    `POST /api/v1/account/logout` (account session) endpoints, and disabling a user now also
+    purges that user's device sessions rather than leaving them valid until expiry (F6)
+  - **Audit logging**: failed authentications and administrative actions (user
+    enable/disable, registration toggle, device-approval changes, device approval) are now
+    recorded in a server-side `audit_log` table and emitted as `tracing` events (F7)
+  - **App-level rate limiting**: the sync authentication endpoints enforce a per-IP and
+    global request cap (HTTP `429`), honoring `X-Forwarded-For` behind a reverse proxy, as
+    defence-in-depth against online brute-force (F8)
+  - **CSPRNG robustness**: crypto salt/nonce generation now returns a `Result` and surfaces
+    a `Crypto` error instead of panicking if the OS RNG ever fails (F2)
+  - **Operator guidance** (docs): the exact `srp` pre-release pin is documented (F3);
+    `docs/sync-server.md` now recommends device approvals for multi-user deployments (F9) and
+    adds a "Security hardening & operator responsibilities" section covering mandatory TLS,
+    `0600` database permissions, at-rest encryption, clock sync, and edge rate limiting (F11);
+    `docs/recovery.md` documents the plaintext token file-fallback tradeoff and how to harden
+    headless clients (F10)
+
 ## [0.3.2] - 2026-06-28
 
 ### Fixed

--- a/crates/toku-cli/src/main.rs
+++ b/crates/toku-cli/src/main.rs
@@ -4944,7 +4944,7 @@ fn cmd_sync(data_dir: &Path, action: SyncAction, output_format: &OutputFormat) -
                     anyhow::bail!("no ops on server");
                 }
 
-                let new_salt = toku_core::SyncKey::generate_salt();
+                let new_salt = toku_core::SyncKey::generate_salt()?;
                 let new_key = toku_core::SyncKey::derive(&new_passphrase, &new_salt)
                     .map_err(|e| anyhow::anyhow!("key derivation failed: {e}"))?;
                 let new_salt_b64 = base64::engine::general_purpose::STANDARD.encode(new_salt);

--- a/crates/toku-core/src/crypto.rs
+++ b/crates/toku-core/src/crypto.rs
@@ -78,10 +78,14 @@ impl SyncKey {
     }
 
     /// Generate a random 128-bit salt for key derivation.
-    pub fn generate_salt() -> [u8; 16] {
+    ///
+    /// Returns an error rather than panicking if the OS CSPRNG is unavailable,
+    /// so callers on the crypto path can surface the failure gracefully.
+    pub fn generate_salt() -> Result<[u8; 16], TokuError> {
         let mut salt = [0u8; 16];
-        getrandom::fill(&mut salt).expect("OS CSPRNG failed");
-        salt
+        getrandom::fill(&mut salt)
+            .map_err(|e| TokuError::Crypto(format!("os rng failed for salt: {e}")))?;
+        Ok(salt)
     }
 
     /// Access the raw key bytes (internal use only for AES-GCM).
@@ -178,7 +182,8 @@ pub fn encrypt_fields(
         .map_err(|e| TokuError::Crypto(format!("cipher init: {e}")))?;
 
     let mut nonce_bytes = [0u8; 12];
-    getrandom::fill(&mut nonce_bytes).expect("OS CSPRNG failed");
+    getrandom::fill(&mut nonce_bytes)
+        .map_err(|e| TokuError::Crypto(format!("os rng failed for nonce: {e}")))?;
     let nonce = Nonce::from(nonce_bytes);
 
     let payload = Payload {
@@ -288,7 +293,8 @@ pub fn encrypt_snapshot(
         .map_err(|e| TokuError::Crypto(format!("cipher init: {e}")))?;
 
     let mut nonce_bytes = [0u8; 12];
-    getrandom::fill(&mut nonce_bytes).expect("OS CSPRNG failed");
+    getrandom::fill(&mut nonce_bytes)
+        .map_err(|e| TokuError::Crypto(format!("os rng failed for nonce: {e}")))?;
     let nonce = Nonce::from(nonce_bytes);
 
     let payload = Payload {
@@ -427,8 +433,8 @@ mod tests {
 
     #[test]
     fn generate_salt_produces_random_bytes() {
-        let salt1 = SyncKey::generate_salt();
-        let salt2 = SyncKey::generate_salt();
+        let salt1 = SyncKey::generate_salt().unwrap();
+        let salt2 = SyncKey::generate_salt().unwrap();
         assert_ne!(salt1, salt2, "two salts should not be equal");
     }
 

--- a/crates/toku-sync-client/src/orchestrator.rs
+++ b/crates/toku-sync-client/src/orchestrator.rs
@@ -242,7 +242,7 @@ pub fn init(
                     srp_client.compute_verifier(library_id.as_bytes(), pass.as_bytes(), &srp_salt);
                 let srp_verifier_hex = hex::encode(&verifier_bytes);
 
-                let enc_salt_raw = toku_core::SyncKey::generate_salt();
+                let enc_salt_raw = toku_core::SyncKey::generate_salt()?;
                 let enc_salt_b64 = base64::engine::general_purpose::STANDARD.encode(enc_salt_raw);
 
                 match rt.block_on(client.enroll(
@@ -314,14 +314,17 @@ pub fn init(
             // ── Encryption key ───────────────────────────────────────────
             // Fetch the authoritative encryption salt from the server; fall back
             // to the candidate we submitted during enroll (first-writer-wins).
-            let enc_salt_b64 = rt
+            let enc_salt_b64 = match rt
                 .block_on(client.get_salt(&verify_resp.session_token))?
                 .salt
-                .unwrap_or_else(|| {
+            {
+                Some(salt) => salt,
+                None => {
                     // Should only happen if server lost the salt — regenerate safely.
-                    let raw = toku_core::SyncKey::generate_salt();
+                    let raw = toku_core::SyncKey::generate_salt()?;
                     base64::engine::general_purpose::STANDARD.encode(raw)
-                });
+                }
+            };
             let enc_salt_bytes = base64::engine::general_purpose::STANDARD
                 .decode(&enc_salt_b64)
                 .context("invalid base64 encryption salt from server")?;
@@ -1165,7 +1168,7 @@ pub fn migrate(
     // Rekey all server ops + snapshot under the fresh data key.
     let (ops_reencrypted, ops_replaced) = rt.block_on(async {
         let pull = client.pull_all_ops(&token).await?;
-        let new_salt = SyncKey::generate_salt();
+        let new_salt = SyncKey::generate_salt()?;
         let new_salt_b64 = base64::engine::general_purpose::STANDARD.encode(new_salt);
         let mut reencrypted = Vec::with_capacity(pull.ops.len());
         for wire_op in &pull.ops {

--- a/crates/toku-sync/Cargo.toml
+++ b/crates/toku-sync/Cargo.toml
@@ -24,8 +24,12 @@ refinery = { version = "0.9", features = ["rusqlite"] }
 serde.workspace = true
 serde_json.workspace = true
 sha2.workspace = true
-# SRP-6a (RFC 5054) authentication — flagged for dependency review (RC)
-srp = { version = "0.7.0-rc.3", features = ["getrandom"] }
+# SRP-6a (RFC 5054) authentication.
+# Pinned to the 0.7.0-rc.3 pre-release deliberately (F3, issue #160): crates.io
+# has no stable 0.7.x, and the newest stable (0.6.0) is an older, incompatible
+# API whose migration would risk a security regression. Keep the exact `=` pin so
+# the RC cannot silently change under us; revisit when 0.7.0 stable ships.
+srp = { version = "=0.7.0-rc.3", features = ["getrandom"] }
 thiserror.workspace = true
 tokio = { workspace = true, features = ["rt-multi-thread", "net", "signal"] }
 tower-http = { version = "0.7", features = ["trace"] }
@@ -39,7 +43,7 @@ hex = "0.4"
 rand = "0.10"
 reqwest = { workspace = true, features = ["json", "blocking"] }
 sha2.workspace = true
-srp = { version = "0.7.0-rc.3", features = ["getrandom"] }
+srp = { version = "=0.7.0-rc.3", features = ["getrandom"] }
 tower = "0.5"
 toku-core.workspace = true
 toku-db.workspace = true

--- a/crates/toku-sync/migrations/V9__security_hardening.sql
+++ b/crates/toku-sync/migrations/V9__security_hardening.sql
@@ -1,0 +1,33 @@
+-- Security-review hardening follow-ups (issue #160, threat model #125).
+--
+-- Additive and backward-compatible. Introduces:
+--   1. An audit log for security-relevant events (F7).
+--   2. An opaque key/value server-config table holding a random server secret
+--      used to derive deterministic *phantom* SRP credentials for unknown or
+--      disabled accounts, so the account challenge stage does not leak whether
+--      an email exists (F5). The secret value is generated lazily in
+--      application code because SQLite has no portable CSPRNG.
+
+-- Append-only security audit trail. Written for failed logins, admin actions
+-- (user enable/disable, registration toggle, device-approval toggle), and
+-- device approve/reject decisions. Never holds secrets or plaintext content.
+CREATE TABLE audit_log (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    ts          TEXT    NOT NULL DEFAULT (datetime('now')),
+    event_type  TEXT    NOT NULL,   -- e.g. 'login.failure', 'user.status', 'device.approval'
+    actor       TEXT,               -- acting principal (user id / device id / 'anonymous')
+    target      TEXT,               -- affected principal (user id / device id / email)
+    outcome     TEXT    NOT NULL,   -- 'success' | 'failure'
+    detail      TEXT,               -- free-form context (never secrets)
+    ip          TEXT                -- client IP when known
+);
+CREATE INDEX idx_audit_log_ts ON audit_log(ts);
+CREATE INDEX idx_audit_log_event ON audit_log(event_type);
+
+-- Opaque server-side configuration (key/value). Currently stores a single
+-- high-entropy 'server_secret' used only to derive phantom SRP credentials
+-- (never leaves the server, never derives any user data).
+CREATE TABLE server_config (
+    key    TEXT PRIMARY KEY,
+    value  TEXT NOT NULL
+);

--- a/crates/toku-sync/src/auth.rs
+++ b/crates/toku-sync/src/auth.rs
@@ -643,6 +643,15 @@ pub async fn srp_verify(
                 Ok(v) => v,
                 Err(_) => {
                     record_failure(&db, &library_id, failed_attempts)?;
+                    crate::security::audit(
+                        &db,
+                        "login.failure",
+                        Some(&library_id),
+                        Some(&library_id),
+                        "failure",
+                        Some("bad SRP reply (library)"),
+                        None,
+                    );
                     return Err(SyncError::Unauthorized);
                 }
             };
@@ -650,6 +659,15 @@ pub async fn srp_verify(
             match server_verifier.verify_client(&m1_bytes) {
                 Ok(_) => {}
                 Err(_) => {
+                    crate::security::audit(
+                        &db,
+                        "login.failure",
+                        Some(&library_id),
+                        Some(&library_id),
+                        "failure",
+                        Some("bad password proof (library)"),
+                        None,
+                    );
                     return record_failure_and_err(&db, &library_id, failed_attempts);
                 }
             }
@@ -946,14 +964,12 @@ pub async fn account_challenge(
         move || -> Result<AccountChallengeResponse, SyncError> {
             let db = SyncDatabase::open_no_migrate(&db_path)?;
 
-            // SRP identity is the account email. Load credentials by email.
-            let (user_id, srp_salt_hex, srp_verifier_hex, status, locked_until): (
-                String,
-                String,
-                String,
-                String,
-                Option<String>,
-            ) = db
+            // Load the account by email. Unknown or disabled accounts fall
+            // through to a *phantom* challenge (deterministic pseudo salt +
+            // verifier) so the response is indistinguishable from a real one —
+            // the account only proves non-existence at the verify step, which
+            // fails uniformly with 401 (anti-enumeration, F5).
+            let account: Option<(String, String, String, String, Option<String>)> = db
                 .conn
                 .query_row(
                     "SELECT id, srp_salt, srp_verifier, status, locked_until
@@ -969,57 +985,76 @@ pub async fn account_challenge(
                         ))
                     },
                 )
-                .map_err(|_| SyncError::Unauthorized)?;
+                .ok();
 
-            if status != "active" {
-                return Err(SyncError::Forbidden("account is disabled".into()));
-            }
-
-            if let Some(until) = locked_until {
-                let still_locked: bool = db
-                    .conn
-                    .query_row("SELECT ?1 > datetime('now')", [&until], |row| row.get(0))
-                    .unwrap_or(false);
-                if still_locked {
-                    return Err(SyncError::AccountLocked { until });
-                }
-            }
-
-            let verifier_bytes = hex::decode(&srp_verifier_hex)
-                .map_err(|_| SyncError::Internal("stored verifier is corrupt".into()))?;
-
+            let server = ServerG2048::<Sha256>::new();
             let mut b = [0u8; 48];
             rand::RngExt::fill(&mut rand::rng(), &mut b);
 
-            let server = ServerG2048::<Sha256>::new();
-            let b_pub_bytes = server.compute_public_ephemeral(&b, &verifier_bytes);
+            match account {
+                Some((user_id, srp_salt_hex, srp_verifier_hex, status, locked_until))
+                    if status == "active" =>
+                {
+                    // Locked accounts still surface 423 (lockout inherently
+                    // reveals existence and is an accepted residual).
+                    if let Some(until) = locked_until {
+                        let still_locked: bool = db
+                            .conn
+                            .query_row("SELECT ?1 > datetime('now')", [&until], |row| row.get(0))
+                            .unwrap_or(false);
+                        if still_locked {
+                            return Err(SyncError::AccountLocked { until });
+                        }
+                    }
 
-            let server_ephemeral_hex = hex::encode(b);
-            let b_pub_hex = hex::encode(&b_pub_bytes);
+                    let verifier_bytes = hex::decode(&srp_verifier_hex)
+                        .map_err(|_| SyncError::Internal("stored verifier is corrupt".into()))?;
+                    let b_pub_bytes = server.compute_public_ephemeral(&b, &verifier_bytes);
+                    let server_ephemeral_hex = hex::encode(b);
+                    let b_pub_hex = hex::encode(&b_pub_bytes);
 
-            db.conn.execute(
-                "INSERT INTO user_srp_challenges
-                 (challenge_id, user_id, server_ephemeral_secret, client_public_a, created_at)
-                 VALUES (?1, ?2, ?3, ?4, datetime('now'))",
-                rusqlite::params![
-                    challenge_id,
-                    user_id,
-                    server_ephemeral_hex,
-                    client_public_a_hex
-                ],
-            )?;
+                    db.conn.execute(
+                        "INSERT INTO user_srp_challenges
+                         (challenge_id, user_id, server_ephemeral_secret, client_public_a, created_at)
+                         VALUES (?1, ?2, ?3, ?4, datetime('now'))",
+                        rusqlite::params![
+                            challenge_id,
+                            user_id,
+                            server_ephemeral_hex,
+                            client_public_a_hex
+                        ],
+                    )?;
 
-            let _ = db.conn.execute(
-                "DELETE FROM user_srp_challenges
-                 WHERE created_at < datetime('now', ?1)",
-                [format!("-{CHALLENGE_TTL_SECS} seconds")],
-            );
+                    let _ = db.conn.execute(
+                        "DELETE FROM user_srp_challenges
+                         WHERE created_at < datetime('now', ?1)",
+                        [format!("-{CHALLENGE_TTL_SECS} seconds")],
+                    );
 
-            Ok(AccountChallengeResponse {
-                challenge_id,
-                server_public_b: b_pub_hex,
-                srp_salt: srp_salt_hex,
-            })
+                    Ok(AccountChallengeResponse {
+                        challenge_id,
+                        server_public_b: b_pub_hex,
+                        srp_salt: srp_salt_hex,
+                    })
+                }
+                _ => {
+                    // Unknown or disabled: deterministic phantom credentials,
+                    // never persisted (verify will 401 uniformly).
+                    let secret = crate::security::server_secret(&db)?;
+                    let (phantom_salt_hex, phantom_verifier_hex) =
+                        crate::security::phantom_credentials(&secret, &email);
+                    let verifier_bytes = hex::decode(&phantom_verifier_hex)
+                        .map_err(|_| SyncError::Internal("phantom verifier is corrupt".into()))?;
+                    let b_pub_bytes = server.compute_public_ephemeral(&b, &verifier_bytes);
+                    let b_pub_hex = hex::encode(&b_pub_bytes);
+
+                    Ok(AccountChallengeResponse {
+                        challenge_id,
+                        server_public_b: b_pub_hex,
+                        srp_salt: phantom_salt_hex,
+                    })
+                }
+            }
         }
     })
     .await
@@ -1069,7 +1104,7 @@ pub async fn account_verify(
                     [&challenge_id],
                     |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?)),
                 )
-                .map_err(|_| SyncError::BadRequest("challenge not found or already used".into()))?;
+                .map_err(|_| SyncError::Unauthorized)?;
 
             let expired: bool = db
                 .conn
@@ -1084,9 +1119,7 @@ pub async fn account_verify(
                     "DELETE FROM user_srp_challenges WHERE challenge_id = ?1",
                     [&challenge_id],
                 );
-                return Err(SyncError::BadRequest(
-                    "challenge has expired; request a new one".into(),
-                ));
+                return Err(SyncError::Unauthorized);
             }
 
             let (email, srp_salt_hex, srp_verifier_hex, role, status, failed_attempts, locked_until): (
@@ -1115,10 +1148,19 @@ pub async fn account_verify(
                         ))
                     },
                 )
-                .map_err(|_| SyncError::Internal("user disappeared".into()))?;
+                .map_err(|_| SyncError::Unauthorized)?;
 
             if status != "active" {
-                return Err(SyncError::Forbidden("account is disabled".into()));
+                crate::security::audit(
+                    &db,
+                    "login.failure",
+                    Some(&email),
+                    Some(&user_id),
+                    "failure",
+                    Some("account disabled"),
+                    None,
+                );
+                return Err(SyncError::Unauthorized);
             }
 
             if let Some(ref until) = locked_until {
@@ -1161,11 +1203,29 @@ pub async fn account_verify(
                 Ok(v) => v,
                 Err(_) => {
                     record_user_failure(&db, &user_id, failed_attempts)?;
+                    crate::security::audit(
+                        &db,
+                        "login.failure",
+                        Some(&email),
+                        Some(&user_id),
+                        "failure",
+                        Some("bad SRP reply"),
+                        None,
+                    );
                     return Err(SyncError::Unauthorized);
                 }
             };
 
             if server_verifier.verify_client(&m1_bytes).is_err() {
+                crate::security::audit(
+                    &db,
+                    "login.failure",
+                    Some(&email),
+                    Some(&user_id),
+                    "failure",
+                    Some("bad password proof"),
+                    None,
+                );
                 return record_user_failure_and_err(&db, &user_id, failed_attempts);
             }
 
@@ -1192,7 +1252,16 @@ pub async fn account_verify(
                 rusqlite::params![token_hash, user_id, expires_at],
             )?;
 
-            let _ = email; // email reserved for future audit logging
+            let _ = email; // referenced by audit calls above
+            crate::security::audit(
+                &db,
+                "login.success",
+                Some(&user_id),
+                Some(&user_id),
+                "success",
+                None,
+                None,
+            );
             Ok(AccountVerifyResponse {
                 session_token,
                 server_proof_m2: m2_hex,

--- a/crates/toku-sync/src/handlers.rs
+++ b/crates/toku-sync/src/handlers.rs
@@ -596,6 +596,15 @@ pub async fn approve_device(
                 db.conn
                     .execute("DELETE FROM sessions WHERE device_id = ?1", [&target_id])?;
             }
+            crate::security::audit(
+                &db,
+                "device.approval",
+                Some(&user_id),
+                Some(&target_id),
+                "success",
+                Some(if approve { "approve" } else { "reject" }),
+                None,
+            );
 
             Ok(AccountDeviceSummary {
                 device_id: target_id,
@@ -1383,6 +1392,7 @@ pub async fn set_user_status(
     let summary = tokio::task::spawn_blocking({
         let db_path = db_path.clone();
         let target_id = target_id.clone();
+        let actor_id = user.user_id.clone();
         move || -> Result<UserSummary, SyncError> {
             let db = SyncDatabase::open_no_migrate(&db_path)?;
 
@@ -1416,11 +1426,28 @@ pub async fn set_user_status(
                     "UPDATE users SET status = ?1 WHERE id = ?2",
                     rusqlite::params![new_status, target_id],
                 )?;
-                // Revoke active sessions when disabling.
+                // Revoke active sessions when disabling: both the user-level
+                // account sessions AND every device sync session owned by the
+                // user (finding F6 — device `sessions` previously survived a
+                // disable, leaving a 24h window of continued sync access).
                 if new_status == "disabled" {
                     db.conn
                         .execute("DELETE FROM user_sessions WHERE user_id = ?1", [&target_id])?;
+                    db.conn.execute(
+                        "DELETE FROM sessions
+                         WHERE device_id IN (SELECT device_id FROM devices WHERE user_id = ?1)",
+                        [&target_id],
+                    )?;
                 }
+                crate::security::audit(
+                    &db,
+                    "user.status",
+                    Some(&actor_id),
+                    Some(&target_id),
+                    "success",
+                    Some(&new_status),
+                    None,
+                );
             }
 
             Ok(UserSummary {
@@ -1479,6 +1506,7 @@ pub async fn set_registration(
     let open = req.open;
     tokio::task::spawn_blocking({
         let db_path = db_path.clone();
+        let actor_id = user.user_id.clone();
         move || -> Result<(), SyncError> {
             let db = SyncDatabase::open_no_migrate(&db_path)?;
             db.conn.execute(
@@ -1487,6 +1515,15 @@ pub async fn set_registration(
                  WHERE id = 1",
                 [i64::from(open)],
             )?;
+            crate::security::audit(
+                &db,
+                "config.registration",
+                Some(&actor_id),
+                None,
+                "success",
+                Some(if open { "open" } else { "closed" }),
+                None,
+            );
             Ok(())
         }
     })
@@ -1541,6 +1578,7 @@ pub async fn set_device_approvals(
     let required = req.required;
     tokio::task::spawn_blocking({
         let db_path = db_path.clone();
+        let actor_id = user.user_id.clone();
         move || -> Result<(), SyncError> {
             let db = SyncDatabase::open_no_migrate(&db_path)?;
             db.conn.execute(
@@ -1549,6 +1587,15 @@ pub async fn set_device_approvals(
                  WHERE id = 1",
                 [i64::from(required)],
             )?;
+            crate::security::audit(
+                &db,
+                "config.device_approvals",
+                Some(&actor_id),
+                None,
+                "success",
+                Some(if required { "required" } else { "off" }),
+                None,
+            );
             Ok(())
         }
     })
@@ -1558,4 +1605,89 @@ pub async fn set_device_approvals(
     Ok(Json(DeviceApprovalsConfigResponse {
         device_approvals_required: required,
     }))
+}
+
+/// Extract and hash the bearer token from an `Authorization` header.
+fn bearer_token_hash(headers: &axum::http::HeaderMap) -> Result<String, SyncError> {
+    let token = headers
+        .get(axum::http::header::AUTHORIZATION)
+        .and_then(|v| v.to_str().ok())
+        .and_then(|v| v.strip_prefix("Bearer "))
+        .ok_or(SyncError::Unauthorized)?;
+    Ok(sha256_hex(token))
+}
+
+/// `POST /api/v1/auth/logout` — revoke the current device sync session.
+///
+/// Deletes the `sessions` row for the presented bearer token so the token can
+/// no longer authenticate (finding F6 — explicit session revocation). Requires
+/// a valid device session (mounted behind `require_auth`).
+pub async fn device_logout(
+    State(db_path): State<PathBuf>,
+    device: AuthDevice,
+    headers: axum::http::HeaderMap,
+) -> Result<Json<serde_json::Value>, SyncError> {
+    let token_hash = bearer_token_hash(&headers)?;
+    tokio::task::spawn_blocking({
+        let db_path = db_path.clone();
+        let device_id = device.device_id.clone();
+        move || -> Result<(), SyncError> {
+            let db = SyncDatabase::open_no_migrate(&db_path)?;
+            db.conn.execute(
+                "DELETE FROM sessions WHERE session_token_hash = ?1",
+                [&token_hash],
+            )?;
+            crate::security::audit(
+                &db,
+                "session.logout",
+                Some(&device_id),
+                Some(&device_id),
+                "success",
+                Some("device"),
+                None,
+            );
+            Ok(())
+        }
+    })
+    .await
+    .map_err(|e| SyncError::Internal(format!("task join error: {e}")))??;
+
+    Ok(Json(serde_json::json!({ "status": "ok" })))
+}
+
+/// `POST /api/v1/account/logout` — revoke the current user (account) session.
+///
+/// Deletes the `user_sessions` row for the presented bearer token (finding F6).
+/// Requires a valid user session (mounted behind `require_user_auth`).
+pub async fn account_logout(
+    State(db_path): State<PathBuf>,
+    user: AuthUser,
+    headers: axum::http::HeaderMap,
+) -> Result<Json<serde_json::Value>, SyncError> {
+    let token_hash = bearer_token_hash(&headers)?;
+    tokio::task::spawn_blocking({
+        let db_path = db_path.clone();
+        let user_id = user.user_id.clone();
+        move || -> Result<(), SyncError> {
+            let db = SyncDatabase::open_no_migrate(&db_path)?;
+            db.conn.execute(
+                "DELETE FROM user_sessions WHERE session_token_hash = ?1",
+                [&token_hash],
+            )?;
+            crate::security::audit(
+                &db,
+                "session.logout",
+                Some(&user_id),
+                Some(&user_id),
+                "success",
+                Some("account"),
+                None,
+            );
+            Ok(())
+        }
+    })
+    .await
+    .map_err(|e| SyncError::Internal(format!("task join error: {e}")))??;
+
+    Ok(Json(serde_json::json!({ "status": "ok" })))
 }

--- a/crates/toku-sync/src/lib.rs
+++ b/crates/toku-sync/src/lib.rs
@@ -12,6 +12,7 @@ pub mod error;
 pub mod handlers;
 pub mod models;
 pub mod protocol;
+pub mod security;
 
 use std::path::PathBuf;
 
@@ -36,6 +37,7 @@ pub fn build_router(db_path: PathBuf) -> Router {
         .route("/api/v1/snapshot", get(handlers::download_snapshot))
         .route("/api/v1/snapshot", post(handlers::upload_snapshot))
         .route("/api/v1/rekey", post(handlers::rekey))
+        .route("/api/v1/auth/logout", post(handlers::device_logout))
         .layer(middleware::from_fn_with_state(
             db_path.clone(),
             auth::require_auth,
@@ -76,13 +78,17 @@ pub fn build_router(db_path: PathBuf) -> Router {
         )
         // Zero-knowledge account key bundle for multi-device recovery (#143).
         .route("/api/v1/account/keys", get(handlers::account_keys))
+        .route("/api/v1/account/logout", post(handlers::account_logout))
         .layer(middleware::from_fn_with_state(
             db_path.clone(),
             auth::require_user_auth,
         ));
 
     // Everything except /health is gated on protocol version (#126).
-    let gated = Router::new()
+    // The authentication endpoints additionally sit behind an app-level rate
+    // limiter (F8); one limiter instance per router keeps it isolated.
+    let limiter = std::sync::Arc::new(security::RateLimiter::default());
+    let auth_endpoints = Router::new()
         // Legacy passwordless registration
         .route("/api/v1/register", post(handlers::register))
         // SRP-6a authentication endpoints
@@ -93,6 +99,12 @@ pub fn build_router(db_path: PathBuf) -> Router {
         .route("/api/v1/account/signup", post(auth::account_signup))
         .route("/api/v1/account/challenge", post(auth::account_challenge))
         .route("/api/v1/account/verify", post(auth::account_verify))
+        .layer(middleware::from_fn(move |req, next| {
+            let limiter = limiter.clone();
+            async move { security::rate_limit(limiter, req, next).await }
+        }));
+
+    let gated = auth_endpoints
         .merge(authenticated)
         .merge(user_authenticated)
         .layer(middleware::from_fn_with_state(

--- a/crates/toku-sync/src/main.rs
+++ b/crates/toku-sync/src/main.rs
@@ -27,9 +27,15 @@ async fn main() -> anyhow::Result<()> {
     let listener = tokio::net::TcpListener::bind(&addr).await?;
     tracing::info!("toku-sync listening on http://{addr}");
 
-    axum::serve(listener, app)
-        .with_graceful_shutdown(shutdown_signal())
-        .await?;
+    // `into_make_service_with_connect_info` surfaces the peer address to the
+    // app-level rate limiter (F8); the limiter also honours `X-Forwarded-For`
+    // for reverse-proxy deployments.
+    axum::serve(
+        listener,
+        app.into_make_service_with_connect_info::<std::net::SocketAddr>(),
+    )
+    .with_graceful_shutdown(shutdown_signal())
+    .await?;
 
     Ok(())
 }

--- a/crates/toku-sync/src/security.rs
+++ b/crates/toku-sync/src/security.rs
@@ -1,0 +1,228 @@
+//! Security-hardening helpers for issue #160 (threat model #125):
+//!
+//! - [`server_secret`] — a lazily-generated, persisted high-entropy secret.
+//! - [`phantom_credentials`] — deterministic pseudo SRP salt+verifier derived
+//!   from the server secret for unknown/disabled accounts, so the account
+//!   challenge stage does not leak whether an email exists (F5).
+//! - [`audit`] — append a row to the `audit_log` table and emit a `tracing`
+//!   event (F7).
+//! - [`RateLimiter`] — a lightweight in-process, per-IP + global fixed-window
+//!   limiter for the authentication endpoints (F8).
+
+use std::collections::HashMap;
+use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
+use axum::extract::ConnectInfo;
+use axum::extract::Request;
+use axum::middleware::Next;
+use axum::response::Response;
+use sha2::{Digest, Sha256};
+use srp::ClientG2048;
+
+use crate::db::SyncDatabase;
+use crate::error::SyncError;
+
+/// Fetch the server secret, generating and persisting one on first use.
+///
+/// Stored hex-encoded in `server_config` under the `server_secret` key. Used
+/// only to derive phantom SRP credentials; it never touches user data and its
+/// disclosure would at worst let an attacker distinguish phantom from real
+/// accounts (the pre-existing enumeration risk this mitigates).
+pub fn server_secret(db: &SyncDatabase) -> Result<Vec<u8>, SyncError> {
+    if let Ok(hex_secret) = db.conn.query_row(
+        "SELECT value FROM server_config WHERE key = 'server_secret'",
+        [],
+        |row| row.get::<_, String>(0),
+    ) && let Ok(bytes) = hex::decode(&hex_secret)
+    {
+        return Ok(bytes);
+    }
+    // Generate a fresh 32-byte secret and persist it (idempotent: another
+    // request may race us, so ignore on conflict and re-read).
+    let mut bytes = [0u8; 32];
+    rand::RngExt::fill(&mut rand::rng(), &mut bytes);
+    let hex_secret = hex::encode(bytes);
+    db.conn.execute(
+        "INSERT OR IGNORE INTO server_config (key, value) VALUES ('server_secret', ?1)",
+        [&hex_secret],
+    )?;
+
+    let stored: String = db.conn.query_row(
+        "SELECT value FROM server_config WHERE key = 'server_secret'",
+        [],
+        |row| row.get(0),
+    )?;
+    hex::decode(&stored).map_err(|_| SyncError::Internal("server secret is corrupt".into()))
+}
+
+/// Domain-separated derivation of pseudo-random bytes from the server secret.
+fn derive(secret: &[u8], domain: &str, identity: &str) -> Vec<u8> {
+    let mut hasher = Sha256::new();
+    hasher.update(secret);
+    hasher.update(domain.as_bytes());
+    hasher.update([0u8]);
+    hasher.update(identity.as_bytes());
+    hasher.finalize().to_vec()
+}
+
+/// Derive a deterministic phantom `(srp_salt_hex, srp_verifier_hex)` for an
+/// identity that has no real (active) account.
+///
+/// The salt and verifier are stable per identity (so repeated challenges look
+/// consistent, like a real account) and shaped identically to real SRP-6a
+/// material, so a client cannot distinguish this from a genuine challenge. No
+/// real password can ever satisfy the resulting verifier, so `verify` fails.
+pub fn phantom_credentials(secret: &[u8], identity: &str) -> (String, String) {
+    let salt = derive(secret, "srp-salt", identity);
+    let salt = &salt[..16]; // 128-bit salt, matching real accounts
+    let password_seed = derive(secret, "srp-verifier", identity);
+
+    let client = ClientG2048::<Sha256>::new();
+    let verifier = client.compute_verifier(identity.as_bytes(), &password_seed, salt);
+
+    (hex::encode(salt), hex::encode(verifier))
+}
+
+/// Append a security event to the audit log and emit a matching `tracing`
+/// event. Best-effort: a logging failure never breaks the request path.
+pub fn audit(
+    db: &SyncDatabase,
+    event_type: &str,
+    actor: Option<&str>,
+    target: Option<&str>,
+    outcome: &str,
+    detail: Option<&str>,
+    ip: Option<&str>,
+) {
+    let _ = db.conn.execute(
+        "INSERT INTO audit_log (event_type, actor, target, outcome, detail, ip)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+        rusqlite::params![event_type, actor, target, outcome, detail, ip],
+    );
+    tracing::info!(
+        target: "toku_sync::audit",
+        event = event_type,
+        actor = actor.unwrap_or("-"),
+        subject = target.unwrap_or("-"),
+        outcome,
+        detail = detail.unwrap_or("-"),
+        "security audit event"
+    );
+}
+
+// ── Rate limiting (F8) ───────────────────────────────────────────────────────
+
+/// Default requests allowed per client IP within [`RateLimiter::window`].
+const DEFAULT_PER_IP_MAX: u32 = 60;
+/// Default total requests allowed across all clients within the window.
+const DEFAULT_GLOBAL_MAX: u32 = 600;
+/// Default fixed-window length.
+const DEFAULT_WINDOW_SECS: u64 = 60;
+
+/// A minimal in-process, fixed-window rate limiter keyed by client IP with an
+/// additional global ceiling. One instance is created per router so it is
+/// isolated between tests and between server processes.
+///
+/// This is defense-in-depth *in the app*; operators should still front the
+/// server with a rate-limiting reverse proxy (documented in `sync-server.md`).
+pub struct RateLimiter {
+    inner: Mutex<Window>,
+    per_ip_max: u32,
+    global_max: u32,
+    window: Duration,
+}
+
+struct Window {
+    started: Instant,
+    global_count: u32,
+    per_ip: HashMap<IpAddr, u32>,
+}
+
+impl Default for RateLimiter {
+    fn default() -> Self {
+        Self::new(
+            DEFAULT_PER_IP_MAX,
+            DEFAULT_GLOBAL_MAX,
+            Duration::from_secs(DEFAULT_WINDOW_SECS),
+        )
+    }
+}
+
+impl RateLimiter {
+    /// Create a limiter with explicit limits.
+    pub fn new(per_ip_max: u32, global_max: u32, window: Duration) -> Self {
+        Self {
+            inner: Mutex::new(Window {
+                started: Instant::now(),
+                global_count: 0,
+                per_ip: HashMap::new(),
+            }),
+            per_ip_max,
+            global_max,
+            window,
+        }
+    }
+
+    /// Record a request from `ip`. Returns `Some(retry_after_secs)` when the
+    /// request should be rejected, or `None` when it is allowed.
+    pub fn check(&self, ip: IpAddr) -> Option<u64> {
+        let mut w = self.inner.lock().unwrap_or_else(|e| e.into_inner());
+        let elapsed = w.started.elapsed();
+        if elapsed >= self.window {
+            w.started = Instant::now();
+            w.global_count = 0;
+            w.per_ip.clear();
+        }
+
+        let retry_after = self.window.saturating_sub(w.started.elapsed()).as_secs() + 1;
+
+        if w.global_count >= self.global_max {
+            return Some(retry_after);
+        }
+        let entry = w.per_ip.entry(ip).or_insert(0);
+        if *entry >= self.per_ip_max {
+            return Some(retry_after);
+        }
+
+        *entry += 1;
+        w.global_count += 1;
+        None
+    }
+}
+
+/// Best-effort client IP: the first `X-Forwarded-For` hop when present (trusted
+/// reverse-proxy deployments), otherwise the peer address from `ConnectInfo`.
+/// Falls back to `0.0.0.0` when neither is available (e.g. in unit tests using
+/// `oneshot`), which simply shares one bucket.
+fn client_ip(req: &Request) -> IpAddr {
+    if let Some(xff) = req
+        .headers()
+        .get("x-forwarded-for")
+        .and_then(|v| v.to_str().ok())
+        && let Some(first) = xff.split(',').next()
+        && let Ok(ip) = first.trim().parse::<IpAddr>()
+    {
+        return ip;
+    }
+    req.extensions()
+        .get::<ConnectInfo<SocketAddr>>()
+        .map(|ci| ci.0.ip())
+        .unwrap_or(IpAddr::V4(Ipv4Addr::UNSPECIFIED))
+}
+
+/// Axum middleware enforcing [`RateLimiter`]; returns HTTP 429 when exceeded.
+pub async fn rate_limit(
+    limiter: Arc<RateLimiter>,
+    req: Request,
+    next: Next,
+) -> Result<Response, SyncError> {
+    let ip = client_ip(&req);
+    if let Some(retry_after) = limiter.check(ip) {
+        return Err(SyncError::RateLimited {
+            retry_after: format!("{retry_after}s"),
+        });
+    }
+    Ok(next.run(req).await)
+}

--- a/crates/toku-sync/tests/user_accounts.rs
+++ b/crates/toku-sync/tests/user_accounts.rs
@@ -375,9 +375,12 @@ fn disable_user_and_guards() {
     );
     assert_eq!(status, 401, "disabled user's session must be revoked");
 
-    // Bob can no longer log in.
+    // Bob can no longer log in. Under the anti-enumeration design (F5) a
+    // disabled account is indistinguishable from a wrong password: the
+    // challenge returns a phantom handshake and verification fails with a
+    // uniform 401 rather than a revealing 403.
     let (status, _) = login(&server, "bob@example.com", "bob pass");
-    assert_eq!(status, 403, "disabled user cannot log in");
+    assert_eq!(status, 401, "disabled user cannot log in");
 
     // Re-enable Bob; login works again.
     let (status, _) = post_json_auth(

--- a/crates/toku-web/Cargo.toml
+++ b/crates/toku-web/Cargo.toml
@@ -29,9 +29,11 @@ hex = "0.4"
 base64 = "0.22"
 rand = "0.10"
 form_urlencoded = "1"
-# SRP-6a (RFC 5054) verifier check for hosted-mode login — flagged for
-# dependency review (RC). Same crate/version as toku-sync.
-srp = { version = "0.7.0-rc.3", features = ["getrandom"] }
+# SRP-6a (RFC 5054) verifier check for hosted-mode login.
+# Pinned to 0.7.0-rc.3 deliberately (F3, issue #160) — see the note in
+# crates/toku-sync/Cargo.toml. Same crate/version as toku-sync; keep the exact
+# `=` pin and revisit when 0.7.0 stable ships.
+srp = { version = "=0.7.0-rc.3", features = ["getrandom"] }
 subtle = "2"
 time = "0.3"
 

--- a/crates/toku-web/src/auth.rs
+++ b/crates/toku-web/src/auth.rs
@@ -246,7 +246,21 @@ pub enum LoginOutcome {
 
 /// Verify credentials and, on success, issue a new session (session fixation is
 /// avoided because a brand-new token is always minted here).
+///
+/// Anti-enumeration (threat model #125, finding F5): an unknown email and an
+/// inactive account are processed down the *same* path as a real account with a
+/// wrong password — a verifier is always computed and compared in constant time
+/// against a fixed dummy verifier — so response content and timing do not reveal
+/// whether the email exists.
 pub fn login(db_path: &Path, email: &str, password: &str) -> Result<LoginOutcome, String> {
+    // A fixed dummy salt/verifier pair used when the account is absent or
+    // inactive, so the SRP verifier computation always runs (uniform timing).
+    // The verifier is 256 bytes (2048-bit group) of zero → never matches a real
+    // `g^x mod N`, and matches the real verifier's hex length for a constant-time
+    // compare that does not short-circuit on length.
+    const DUMMY_SALT_HEX: &str = "00000000000000000000000000000000";
+    const DUMMY_VERIFIER_HEX: &str = "0"; // expanded to full width below
+
     let email = email.trim();
     let db = open(db_path)?;
 
@@ -269,15 +283,34 @@ pub fn login(db_path: &Path, email: &str, password: &str) -> Result<LoginOutcome
         )
         .ok();
 
-    let Some((user_id, salt_hex, verifier_hex, status, failed_attempts, locked_until)) = row else {
-        return Ok(LoginOutcome::Invalid);
+    // Resolve the (real or dummy) credentials to compare against without an
+    // early return, so every branch performs the verifier computation.
+    let real_active = row
+        .as_ref()
+        .map(|(_, _, _, status, _, _)| status == "active")
+        .unwrap_or(false);
+
+    let (user_id, salt_hex, verifier_hex, failed_attempts, locked_until) = match &row {
+        Some((id, salt, verifier, status, failed, locked)) if status == "active" => (
+            Some(id.clone()),
+            salt.clone(),
+            verifier.clone(),
+            *failed,
+            locked.clone(),
+        ),
+        _ => (
+            None,
+            DUMMY_SALT_HEX.to_string(),
+            DUMMY_VERIFIER_HEX.repeat(512),
+            0,
+            None,
+        ),
     };
 
-    if status != "active" {
-        return Ok(LoginOutcome::Invalid);
-    }
-
-    if let Some(until) = &locked_until {
+    // Locked real accounts short-circuit to `Locked` (lockout inherently reveals
+    // existence and is accepted by the threat model); unknown/inactive accounts
+    // never reach here because `locked_until` is `None` for them.
+    if real_active && let Some(until) = &locked_until {
         let still_locked: bool = db
             .conn
             .query_row("SELECT ?1 > datetime('now')", [until], |r| r.get(0))
@@ -291,10 +324,15 @@ pub fn login(db_path: &Path, email: &str, password: &str) -> Result<LoginOutcome
     let expected = compute_verifier_hex(email, password, &salt_bytes);
 
     let matches: bool = expected.as_bytes().ct_eq(verifier_hex.as_bytes()).into();
-    if !matches {
-        record_failure(&db, &user_id, failed_attempts)?;
+    if !matches || !real_active {
+        // Only real, active accounts accrue lockout state.
+        if let Some(user_id) = &user_id {
+            record_failure(&db, user_id, failed_attempts)?;
+        }
         return Ok(LoginOutcome::Invalid);
     }
+
+    let user_id = user_id.expect("real_active implies a user id");
 
     // Reset failure counter and mint a fresh session.
     db.conn

--- a/crates/toku-web/src/lib.rs
+++ b/crates/toku-web/src/lib.rs
@@ -8,6 +8,10 @@ use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
 
 use axum::Router;
+use axum::extract::Request;
+use axum::http::{HeaderValue, header};
+use axum::middleware::Next;
+use axum::response::Response;
 use axum::routing::{get, post};
 
 mod auth;
@@ -123,7 +127,9 @@ pub fn build_router(
 
     let dashboard = dashboard_routes();
 
-    if mode.is_hosted() {
+    let secure = state.secure_cookies;
+
+    let router = if mode.is_hosted() {
         // Public, unauthenticated routes.
         let public = Router::new()
             .route(
@@ -157,7 +163,48 @@ pub fn build_router(
         dashboard
             .route("/healthz", get(auth_handlers::healthz))
             .with_state(state)
+    };
+
+    // Security headers on every response (outermost layer). HSTS is emitted only
+    // when cookies are marked `Secure` (i.e. the deployment is HTTPS).
+    router.layer(axum::middleware::from_fn(
+        move |req: Request, next: Next| security_headers(secure, req, next),
+    ))
+}
+
+/// Attach hardening headers (CSP, framing, MIME sniffing, referrer, HSTS) to
+/// every response. Flagged in threat model #125 (finding F4).
+///
+/// The CSP keeps `'unsafe-inline'` for scripts and styles because the dashboard
+/// ships one inline `<script>` (import-progress `EventSource`) and inline
+/// `style=`/`<style>` blocks; tightening to nonces is a future follow-up.
+async fn security_headers(secure: bool, req: Request, next: Next) -> Response {
+    const CSP: &str = "default-src 'self'; base-uri 'none'; frame-ancestors 'none'; \
+         object-src 'none'; img-src 'self' data:; style-src 'self' 'unsafe-inline'; \
+         script-src 'self' 'unsafe-inline'; form-action 'self'";
+
+    let mut resp = next.run(req).await;
+    let headers = resp.headers_mut();
+    headers.insert(
+        header::CONTENT_SECURITY_POLICY,
+        HeaderValue::from_static(CSP),
+    );
+    headers.insert(header::X_FRAME_OPTIONS, HeaderValue::from_static("DENY"));
+    headers.insert(
+        header::X_CONTENT_TYPE_OPTIONS,
+        HeaderValue::from_static("nosniff"),
+    );
+    headers.insert(
+        header::REFERRER_POLICY,
+        HeaderValue::from_static("no-referrer"),
+    );
+    if secure {
+        headers.insert(
+            header::STRICT_TRANSPORT_SECURITY,
+            HeaderValue::from_static("max-age=31536000; includeSubDomains"),
+        );
     }
+    resp
 }
 
 /// Start serving using a pre-bound listener (local mode; used by the desktop app).

--- a/docs/recovery.md
+++ b/docs/recovery.md
@@ -75,6 +75,38 @@ A new device is enrolled by entering your **account email + password + Secret Ke
 device performs SRP authentication, derives the account unlock key, and unwraps your keys
 locally. The server never receives the secrets and cannot enroll a device on its own.
 
+## Token storage
+
+After you authenticate, the client keeps a **session token** (and, for hosted accounts, the
+derived sync key) so you don't re-enter credentials on every command. Where these live
+depends on the platform:
+
+- **OS keychain (preferred).** On macOS (Keychain), Windows (Credential Manager), and Linux
+  desktops running a Secret Service provider (GNOME Keyring, KWallet), the token is stored
+  in the native credential store, protected by your OS login session.
+- **Encrypted-at-rest file fallback.** When no keychain is available — common on **headless
+  Linux servers**, containers, and CI — the client falls back to a JSON file at
+  `<data_dir>/sync/tokens.json`. On Unix this file is created with `0600` permissions
+  (owner read/write only). The client prints a `warning: … using file fallback` when this
+  happens. You can force this path with `TOKU_TOKEN_STORE=file` (or
+  `TOKU_DISABLE_KEYCHAIN=1`).
+
+> **Tradeoff — the file fallback is plaintext at rest.** The fallback file is protected by
+> filesystem permissions (`0600` on Unix), **not** by encryption. Anyone who can read that
+> file as your user — or who obtains the disk/backup — can read a live session token. This
+> is an intentional, documented tradeoff so headless clients keep working without a
+> keychain. To harden a headless or shared host:
+>
+> - Keep the token on an **encrypted filesystem** (LUKS or equivalent), so an offline disk
+>   or a stolen backup does not expose it.
+> - Ensure the `<data_dir>` and its `sync/` subdirectory are owner-only (`chmod 700`).
+> - On Windows there is no `0600` equivalent for the fallback file; rely on user-profile
+>   isolation and prefer the Credential Manager path (the default).
+> - Tokens are session credentials, not your secrets. A leaked session can be revoked
+>   server-side via the logout endpoints (`POST /api/v1/auth/logout` for a device session,
+>   `POST /api/v1/account/logout` for an account session), or by an admin disabling the
+>   account — both delete the server-side session so the token can no longer be used.
+
 ## The ultimate safety net: local-first
 
 Your **local SQLite library is always the ultimate recovery.** Even if the server is gone,

--- a/docs/security/self-host-threat-model.md
+++ b/docs/security/self-host-threat-model.md
@@ -88,16 +88,16 @@ at login** in process memory — by design.
 
 | Threat | Mitigation | Residual |
 |--------|------------|----------|
-| Capture password / Secret Key | SRP — neither crosses the wire; TLS in deployment | TLS not code-enforced (**F11**) |
-| Steal session token | Tokens 256-bit, hashed at rest, 24h TTL, device-scoped | No revocation (**F6**) |
+| Capture password / Secret Key | SRP — neither crosses the wire; TLS in deployment | TLS not code-enforced — operator responsibility (**F11**, documented) |
+| Steal session token | Tokens 256-bit, hashed at rest, 24h TTL, device-scoped; logout/disable revoke server-side (**F6**, fixed) | Un-revoked token valid until 24h TTL |
 | MITM via bad cert | reqwest default cert/hostname validation; no `danger_accept_invalid_certs` | Self-signed CA needs config |
 
 ### Lost / stolen device
 
 | Threat | Mitigation | Residual |
 |--------|------------|----------|
-| Read synced library | Device-deregister revokes its sessions; data key unreachable to deregistered device | 24h token window (**F6**) |
-| Read keys on disk | Tokens/derived key in OS keychain; file fallback 0o600 | Plaintext file fallback (**F10**) |
+| Read synced library | Device-deregister revokes its sessions; data key unreachable to deregistered device | Un-revoked token valid until 24h TTL (**F6**, fixed — logout available) |
+| Read keys on disk | Tokens/derived key in OS keychain; file fallback 0o600 | Plaintext file fallback — documented tradeoff (**F10**) |
 
 ### Stolen Emergency Kit (Secret Key only)
 
@@ -110,7 +110,7 @@ at login** in process memory — by design.
 | Threat | Mitigation | Residual |
 |--------|------------|----------|
 | Read other users' content | Zero-knowledge: keys wrapped per user; admin gets ciphertext | None for content |
-| Disable users / approve devices | First account=admin; no self-disable; user_sessions revoked | Device `sessions` survive disable (**F6**); no audit trail (**F7**) |
+| Disable users / approve devices | First account=admin; no self-disable; user_sessions + device `sessions` revoked on disable (**F6**, fixed); actions audit-logged (**F7**, fixed) | None observed |
 | Cross-tenant access | Queries scoped by token-derived user_id/library_id | None observed |
 
 ### Malicious client
@@ -119,7 +119,7 @@ at login** in process memory — by design.
 |--------|------------|----------|
 | Upload plaintext | push/rekey/snapshot reject non-envelope payloads (HTTP 422, exact key-set) | None |
 | Cross-library/user | session token bound to library/user; enrollment ownership-checked (403) | None observed |
-| Online brute-force | Lockout 5 fails → 15 min per account/library | No IP/global limit (**F8**) |
+| Online brute-force | Lockout 5 fails → 15 min per account/library; app-level per-IP + global rate limit (**F8**, fixed, 429) | Lockout `423` still distinguishable from `401` for real accounts (weak oracle) |
 
 ## 5. Zero-knowledge verification
 
@@ -149,28 +149,32 @@ at login** in process memory — by design.
 
 CSRF (double-submit, constant-time, SameSite=Strict cookie), session cookies (HttpOnly, Lax,
 Secure-conditional, 24h, hashed at rest), lockout (5/15 min), logout revokes the session,
-Maud auto-escaping (no XSS), fresh token per login (no fixation). Gaps: **no security headers**
-(**F4**), **plaintext password reaches the server** (trusted-server, by design), enumeration
-on unknown email (**F5**).
+Maud auto-escaping (no XSS), fresh token per login (no fixation), security response headers
+(CSP/X-Frame-Options/nosniff/Referrer-Policy, HSTS when secure — **F4**, fixed), constant-time
+login that no longer reveals unknown vs inactive emails (**F5**, fixed). Remaining by design:
+**plaintext password reaches the server** (trusted-server).
 
 ## 8. Findings & triage
 
-All code fixes are deferred to follow-ups (doc-only PR). Residual risks accepted for release
-are listed in [§9](#9-residual-risks-accepted).
+F1 (HIGH) is tracked separately in [#161](https://github.com/kafkade/toku/issues/161). All
+remaining findings (F2–F11) were addressed under
+[#160](https://github.com/kafkade/toku/issues/160): the code-level ones are **fixed** and the
+operational/dependency ones are **documented**. Residual risks accepted for release are listed
+in [§9](#9-residual-risks-accepted).
 
 | ID | Finding | Sev | Disposition |
 |----|---------|-----|-------------|
 | F1 | SRP verifier input omits Secret Key (`orchestrator.rs:819`, `auth.rs:141/190/291`) — diverges from ADR-010 | HIGH | Bug; follow-up #161 |
-| F4 | No web security headers (CSP, X-Frame-Options, nosniff, HSTS) | MED | Follow-up #160 |
-| F5 | Login/challenge account enumeration | MED | Follow-up #160 |
-| F6 | No token revocation/logout on sync server; user-disable keeps device sessions | MED | Follow-up #160 |
-| F7 | No audit logging | MED | Follow-up #160 |
-| F8 | No IP/global rate limit (proxy-dependent) | MED | Follow-up #160 |
-| F2 | CSPRNG `.expect()` panics on crypto path | LOW | Follow-up #160 |
-| F3 | `srp` pinned to `0.7.0-rc.3` | LOW | Follow-up #160 |
-| F9 | Device approvals off by default | LOW | Follow-up #160 |
-| F10 | Token file fallback plaintext at rest | LOW | Follow-up #160 |
-| F11 | TLS/perms/at-rest/NTP assumed, not enforced | INFO | Follow-up #160 |
+| F4 | No web security headers (CSP, X-Frame-Options, nosniff, HSTS) | MED | **Fixed** (#160): `security_headers` middleware in `toku-web`; HSTS when `secure_cookies` |
+| F5 | Login/challenge account enumeration | MED | **Fixed** (#160): constant-time web login + phantom-account uniform sync challenge/verify (401) |
+| F6 | No token revocation/logout on sync server; user-disable keeps device sessions | MED | **Fixed** (#160): `/auth/logout` + `/account/logout`; disable now purges device `sessions` |
+| F7 | No audit logging | MED | **Fixed** (#160): `audit_log` table + `security::audit` on auth failures & admin actions |
+| F8 | No IP/global rate limit (proxy-dependent) | MED | **Fixed** (#160): in-process per-IP + global limiter on auth endpoints (429); proxy still recommended |
+| F2 | CSPRNG `.expect()` panics on crypto path | LOW | **Fixed** (#160): nonce/salt generation returns `Result`, errors mapped to `TokuError::Crypto` |
+| F3 | `srp` pinned to `0.7.0-rc.3` | LOW | **Documented** (#160): no stable 0.7.x exists; exact `=` pin kept, revisit when 0.7.0 ships |
+| F9 | Device approvals off by default | LOW | **Documented** (#160): `sync-server.md` recommends enabling on multi-user/internet-facing instances |
+| F10 | Token file fallback plaintext at rest | LOW | **Documented** (#160): `recovery.md` Token storage tradeoff + hardening guidance |
+| F11 | TLS/perms/at-rest/NTP assumed, not enforced | INFO | **Documented** (#160): `sync-server.md` "Security hardening & operator responsibilities" |
 
 ## 9. Residual risks accepted
 
@@ -178,8 +182,17 @@ are listed in [§9](#9-residual-risks-accepted).
   alone; the Secret Key's 128 bits do not harden authentication. Content stays zero-knowledge.
 - Cleartext op metadata (entity/op type, counts, timing) is visible to the server.
 - Web dashboard is trusted-server: holds plaintext password (login) and decrypted library.
-- 24h session window before token expiry (no revocation yet).
-- Deployment must provide TLS, 0600 DB perms, at-rest encryption, NTP, and a rate-limiting proxy.
+- Session token window before expiry: logout/disable now revoke server-side sessions (F6), but
+  an un-revoked token remains valid until its 24h TTL.
+- **F5**: the account-lockout response (`423`) is still distinguishable from a normal auth
+  failure (`401`) for a *real* account under active brute-force, a weak residual oracle; the
+  challenge/verify path itself is uniform for unknown/disabled accounts.
+- **F8**: the built-in limiter is coarse (fixed-window, per-process) and shares one bucket for
+  clients behind the same proxy hop; a rate-limiting reverse proxy remains the primary control.
+- **F10**: the client token file fallback is plaintext protected only by `0600` perms; mitigated
+  by at-rest disk encryption on headless hosts.
+- Deployment must still provide TLS, 0600 DB perms, at-rest encryption, and NTP (F11); these are
+  operator responsibilities documented in `sync-server.md`.
 
 ## 10. Sign-off
 
@@ -188,4 +201,6 @@ content reaches the `toku-sync` server — verified by client-side SRP, cipherte
 and server-side 422 plaintext rejection. The hosted web dashboard is a documented
 **trusted-server** exception. The only divergence from ADR-010 (**F1**, verifier omits Secret
 Key) does not break the zero-knowledge content guarantee but weakens credential strength and is
-tracked for fix. All other findings are deferred with residual risks documented above.
+tracked for fix. The remaining findings (F2, F4–F11) have been resolved under #160 — code fixes
+for F2/F4/F5/F6/F7/F8 and documented operator/dependency guidance for F3/F9/F10/F11 — with the
+accepted residual risks recorded in [§9](#9-residual-risks-accepted).

--- a/docs/sync-server.md
+++ b/docs/sync-server.md
@@ -147,6 +147,15 @@ curl -X PUT https://sync.example.com/api/v1/admin/device-approvals \
   -d '{"required": true}'
 ```
 
+> **Recommended for multi-user and internet-facing deployments.** Device approvals are
+> off by default to keep single-user, single-device setups frictionless. On any instance
+> that serves more than one person — or is reachable from the public internet — you should
+> turn them **on**. With approvals off, anyone who obtains a valid account credential can
+> silently enrol an additional device; with approvals on, that enrolment is held `pending`
+> and must be confirmed from an already-trusted device, giving you a visible chokepoint
+> against credential theft. The tradeoff is one extra confirmation step when you
+> legitimately add a device.
+
 ## Zero-knowledge guarantee
 
 In hosted mode the server is **zero-knowledge**: it can never read your library content.
@@ -360,6 +369,45 @@ server {
 
 Obtain certificates with [certbot](https://certbot.eff.org/) (`certbot --nginx`) or your preferred
 ACME client, then reload nginx.
+
+## Security hardening & operator responsibilities
+
+The server ships with sane defaults and several built-in protections (encrypted-at-source
+payloads, SRP-6a authentication, uniform anti-enumeration responses, session revocation,
+audit logging, and an app-level rate limiter). A handful of controls are inherently the
+**operator's** responsibility because they live outside the process. For any multi-user or
+internet-facing deployment, treat the following as mandatory:
+
+- **Terminate TLS.** The server speaks plain HTTP and sends session tokens as bearer
+  credentials. Always front it with an HTTPS reverse proxy (see
+  [HTTPS with a reverse proxy](#https-with-a-reverse-proxy)). Never expose port `8080`
+  directly to the internet.
+- **Protect the database file.** All state — accounts, verifiers, sessions, audit log —
+  lives in `sync.db`. Restrict it to the service user with `0600` permissions
+  (`chmod 600 sync.db`) and keep the containing directory `0700`. The image already runs
+  as a non-root user (uid `65532`); on bare-metal installs, run the binary under a
+  dedicated unprivileged account.
+- **Encrypt the volume at rest.** Zero-knowledge encryption protects *library content*,
+  but account metadata, email addresses, SRP verifiers, and the audit log are stored
+  server-side. Host the data volume on an encrypted filesystem (LUKS, cloud provider
+  volume encryption, etc.) so a stolen disk does not leak this metadata.
+- **Keep the clock synchronised.** SRP challenge expiry, session lifetimes, HLC ordering,
+  and audit timestamps all assume an accurate clock. Run NTP (e.g. `chrony` or
+  `systemd-timesyncd`) on the host. A badly skewed clock can prematurely expire challenges
+  or accept stale ones.
+- **Rate-limit at the edge too.** The server enforces a per-IP and global request cap on
+  the authentication endpoints (returning HTTP `429`) as defence-in-depth, and honours the
+  first hop of `X-Forwarded-For` when behind a proxy — so make sure your proxy sets that
+  header (the nginx example above does). This in-process limiter is deliberately coarse;
+  for serious exposure, add a rate-limiting rule at the reverse proxy as the primary
+  control (e.g. nginx `limit_req`, Caddy `rate_limit`, or a WAF).
+- **Require device approvals** on shared instances — see
+  [Require device approval](#3-optional-require-device-approval).
+
+> **Token storage on the client.** Clients prefer the OS keychain for the session token and
+> fall back to a `0600` plaintext file only when no keychain is available (e.g. some
+> headless Linux hosts). See [`recovery.md`](./recovery.md#token-storage) for the tradeoff
+> and how to harden headless clients.
 
 ## Building the image locally
 


### PR DESCRIPTION
## Description

Hardens the optional self-host sync and web tiers by resolving the ten deferred
findings (F2–F11) from the zero-knowledge self-host auth threat model (#125). F1
remains tracked separately in #161. Code-level findings are fixed; dependency and
operational findings are documented.

### What's included

**Code fixes**

- **F4 — Web security headers** (`toku-web`): every response now carries a
  `Content-Security-Policy`, `X-Frame-Options: DENY`, `X-Content-Type-Options: nosniff`,
  and `Referrer-Policy: no-referrer`, plus `Strict-Transport-Security` when secure
  cookies are enabled.
- **F5 — Account-enumeration resistance**: web login is now constant-time (always
  computes a verifier, even for absent/inactive users); the sync account
  challenge/verify flow returns uniform "phantom" responses for unknown or disabled
  accounts and a single `401` on any verification failure.
- **F6 — Session revocation**: new `POST /api/v1/auth/logout` (device) and
  `POST /api/v1/account/logout` (account) endpoints; disabling a user now also purges
  that user's device sessions.
- **F7 — Audit logging**: new `audit_log` table (migration `V9`) plus a
  `security::audit` helper wired into failed authentications and admin actions (user
  enable/disable, registration toggle, device-approval changes, device approval);
  events are also emitted as `tracing` records.
- **F8 — App-level rate limiting**: the sync auth endpoints enforce a per-IP and
  global request cap (HTTP `429`), honoring `X-Forwarded-For` behind a reverse proxy;
  the server now serves with connect-info so per-IP limiting works in production.
- **F2 — CSPRNG robustness** (`toku-core`): crypto salt/nonce generation returns a
  `Result` and surfaces a `Crypto` error instead of panicking if the OS RNG fails.

**Documentation**

- **F3**: documented the deliberate exact `=0.7.0-rc.3` `srp` pin (no stable 0.7.x
  exists on crates.io) in both `Cargo.toml` files.
- **F9**: `docs/sync-server.md` recommends enabling device approvals for multi-user /
  internet-facing deployments.
- **F10**: `docs/recovery.md` documents the plaintext token file-fallback tradeoff and
  how to harden headless clients.
- **F11**: `docs/sync-server.md` gains a "Security hardening & operator
  responsibilities" section (TLS, `0600` DB perms, at-rest encryption, clock sync, edge
  rate limiting).
- Updated `docs/security/self-host-threat-model.md` §4/§7/§8/§9/§10 dispositions and the
  `CHANGELOG.md` `[Unreleased]` Security section.

New files: `crates/toku-sync/src/security.rs`, `crates/toku-sync/migrations/V9__security_hardening.sql`.

> **CI/infra note**: no CI job names changed, so no `kafkade/github-infra` Terraform
> update is required.

## Related Issues

Closes #160. Relates to #125 (threat model), #161 (F1 follow-up).

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI / infrastructure
- [x] Other (describe below)

Other: security hardening (new response headers, endpoints, audit log, rate limiter).

## Crate

- [x] `toku-core` — Domain models, traits, state machine
- [x] `toku-cli` — CLI binary
- [x] `docs/` — Documentation
- [x] `toku-sync` — Sync server (auth, handlers, security, migrations)
- [x] `toku-web` — Web tier (headers, constant-time login)
- [x] `toku-sync-client` — CSPRNG `Result` propagation

## Data Integrity Checklist

- [x] No user data is sent to any server without explicit opt-in
- [ ] Import operations are idempotent (re-importing the same file creates no duplicates) — N/A
- [ ] User edits to metadata are never overwritten by auto-enrichment — N/A
- [ ] New fields track provenance (source + timestamp) — N/A
- [ ] Export round-trip is preserved (if applicable) — N/A

## Checklist

- [x] I have read [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] `cargo fmt --check` passes
- [x] `cargo clippy --workspace -- -D warnings` passes
- [x] `cargo test --workspace` passes
- [x] I have updated documentation (if applicable)
