### PR TITLE
fix: re-sync internal dep versions and document the release flow

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -64,6 +64,19 @@ Cargo workspace with 9 crates:
 
 **Branch protection for this repo is managed via Terraform in `kafkade/github-infra` (`repo_toku.tf`).** The `required_status_checks` list must match the job names in `.github/workflows/ci.yml`. If you rename, add, or remove CI jobs that are used as merge gates (currently `Validate`), the corresponding IaC config must be updated or PRs will be permanently blocked. Always flag this when proposing workflow changes.
 
+## Releasing
+
+Releases follow a **two-phase, PR-based flow** driven by a machine-global, repo-agnostic helper (`rust-release.sh`, aliased to `release` — not tracked in-repo). Agents must respect the Git Policy above: perform the **prepare** file edits, but never commit, tag, or push.
+
+- **Phase 1 — prepare (in a feature branch / release PR).** `release prepare <major|minor|patch>` bumps `[workspace.package] version` and every internal `toku-*` path-dep version in `[workspace.dependencies]`, refreshes `Cargo.lock`, and stamps `CHANGELOG.md` (`[Unreleased] → [x.y.z] - <date>`, plus compare links). It does **not** commit, tag, or push — the resulting diff *is* the release PR. An agent may reproduce these edits by hand (equivalent to the script) and leave them uncommitted for review. The phase is idempotent: re-running when already prepared is a no-op.
+- **Phase 2 — tag (on the default branch, after the PR merges).** `release tag [--push]` verifies the version is already stamped, then creates the annotated `vX.Y.Z` tag at the merge commit and (with `--push`) pushes it. **Pushing the tag is the only trigger** for `.github/workflows/release.yml` (multi-target binary build + crates.io publish). This is a human/maintainer step — agents never tag or push.
+
+Conventions:
+
+- During normal work, only accumulate user-facing entries under `## [Unreleased]`; the version bump + changelog stamp happen solely at release time (Phase 1), never per-PR.
+- Because the crates are published to crates.io, `[workspace.dependencies]` path deps carry an explicit `version = "x.y.z"` (required to publish a path dep). These **must stay in lockstep** with `[workspace.package] version` — the helper keeps them synced on every `prepare`. Do not hand-edit one without the other; a lone drift stays invisible within a patch range (`^0.3.0` matches `0.3.x`) and only breaks at the next minor/major bump.
+- Before cutting, confirm the git tag matches `Cargo.toml` and that no CI job names changed (see CI / Infrastructure Dependency).
+
 ## Reference Documents
 
 - Full product roadmap: `ROADMAP.md`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -501,4 +501,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Export to Markdown: `toku export markdown` with books grouped by reading status and star ratings
 - Canonical backup: `toku export backup --output toku-backup.zip` with library data + cover images in a self-contained ZIP
 
-[Unreleased]: https://github.com/kafkade/toku/compare/v0.2.1...HEAD
+[Unreleased]: https://github.com/kafkade/toku/compare/v0.3.2...HEAD
+[0.3.2]: https://github.com/kafkade/toku/compare/v0.3.1...v0.3.2
+[0.3.1]: https://github.com/kafkade/toku/compare/v0.3.0...v0.3.1
+[0.3.0]: https://github.com/kafkade/toku/compare/v0.2.1...v0.3.0
+[0.2.1]: https://github.com/kafkade/toku/compare/v0.2.0...v0.2.1
+[0.2.0]: https://github.com/kafkade/toku/releases/tag/v0.2.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,14 +24,14 @@ license = "MIT"
 repository = "https://github.com/kafkade/toku"
 
 [workspace.dependencies]
-toku-core = { path = "crates/toku-core", version = "0.3.0" }
-toku-db = { path = "crates/toku-db", version = "0.3.0" }
-toku-meta = { path = "crates/toku-meta", version = "0.3.0" }
-toku-import = { path = "crates/toku-import", version = "0.3.0" }
-toku-export = { path = "crates/toku-export", version = "0.3.0" }
-toku-files = { path = "crates/toku-files", version = "0.3.0" }
-toku-web = { path = "crates/toku-web", version = "0.3.0" }
-toku-sync-client = { path = "crates/toku-sync-client", version = "0.3.0" }
+toku-core = { path = "crates/toku-core", version = "0.3.2" }
+toku-db = { path = "crates/toku-db", version = "0.3.2" }
+toku-meta = { path = "crates/toku-meta", version = "0.3.2" }
+toku-import = { path = "crates/toku-import", version = "0.3.2" }
+toku-export = { path = "crates/toku-export", version = "0.3.2" }
+toku-files = { path = "crates/toku-files", version = "0.3.2" }
+toku-web = { path = "crates/toku-web", version = "0.3.2" }
+toku-sync-client = { path = "crates/toku-sync-client", version = "0.3.2" }
 thiserror = "2"
 uuid = { version = "1", features = ["v7", "serde"] }
 chrono = { version = "0.4", default-features = false, features = ["std", "clock", "serde"] }


### PR DESCRIPTION
## Description

Running `release prepare minor` failed during the test step with:

```
error: failed to select a version for the requirement `toku-core = "^0.3.0"`
candidate versions found which didn't match: 0.4.0
required by package `toku-db v0.4.0`
```

Root cause: the workspace version had advanced to `0.3.2`, but the internal
`[workspace.dependencies]` pins were still hand-authored at `0.3.0`. Because
crates.io publishing requires those pins, cargo keeps them — and a caret range
(`^0.3.0`) silently matched every `0.3.x`, hiding the drift until the minor bump
made the crates `0.4.0`, which `^0.3.0` no longer matches.

### What's included

- **`Cargo.toml`** — Re-synced the 8 internal `toku-*` `[workspace.dependencies]`
  pins from `0.3.0` to `0.3.2` so they track the workspace version. This is the
  actual fix that unblocks `release prepare`.
- **`.github/copilot-instructions.md`** — Added a `## Releasing` section
  documenting the two-phase `rust-release.sh` flow (`prepare` / `tag`), the
  requirement that internal dep pins move in lockstep with the workspace
  version, and the drift gotcha above. This mirrors the convention already
  documented in the sibling repos.
- **`CHANGELOG.md`** — Fixed the compare links at the bottom, which were stuck at
  `v0.2.1`. Restored the full `[Unreleased]` + per-version link set through
  `v0.3.2`.

Recurrence prevention lives in the shared global `rust-release.sh` helper (its
`prepare` step now re-syncs every internal pin value-agnostically), matching how
the other Rust workspaces are maintained — no per-repo release tooling added.

## Related Issues

N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI / infrastructure
- [ ] Other (describe below)

## Crate

No crate source changed. The fix is to the workspace manifest's internal dep
pins (affects how all `toku-*` crates resolve each other) plus docs.

- [ ] `toku-core` — Domain models, traits, state machine
- [ ] `toku-db` — SQLite persistence, migrations, FTS5
- [ ] `toku-import` — Importers (Goodreads, Calibre, StoryGraph)
- [ ] `toku-meta` — Metadata fetching (Open Library, Google Books)
- [ ] `toku-cli` — CLI binary
- [ ] `toku-export` — Exporters (CSV, JSON, Markdown, BibTeX)
- [x] `docs/` — Documentation

## Data Integrity Checklist

N/A — this change touches only the workspace manifest's dependency pins and
documentation. No runtime behavior, data handling, import, or export path is
affected.

- [x] No user data is sent to any server without explicit opt-in
- [x] Import operations are idempotent (re-importing the same file creates no duplicates)
- [x] User edits to metadata are never overwritten by auto-enrichment
- [x] New fields track provenance (source + timestamp)
- [x] Export round-trip is preserved (if applicable)

## Checklist

- [x] I have read [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] `cargo fmt --check` passes
- [x] `cargo clippy --workspace -- -D warnings` passes
- [x] `cargo test --workspace` passes
- [x] I have updated documentation (if applicable)