### PR TITLE
fix(ci): add toku-files to the crates.io publish set for the 0.4.0 release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -155,7 +155,8 @@ jobs:
 
       # Publish crates in dependency order:
       # toku-core (no deps) → toku-db → toku-import, toku-meta, toku-export,
-      # toku-web, toku-sync-client → toku-cli
+      # toku-files → toku-web, toku-sync-client → toku-cli
+      # (toku-web and toku-cli depend on toku-files, so it must publish first.)
       # Polls crates.io index between publishes to avoid timing issues.
       - name: Publish workspace crates
         env:
@@ -189,6 +190,7 @@ jobs:
           publish_crate toku-import
           publish_crate toku-meta
           publish_crate toku-export
+          publish_crate toku-files
           publish_crate toku-web
           publish_crate toku-sync-client
           publish_crate toku-cli


### PR DESCRIPTION
## Description

Unblocks the tagged 0.4.0 crates.io publish. The `Publish to crates.io` job in
`.github/workflows/release.yml` publishes the workspace crates in dependency
order, but the new Phase 6 crate `toku-files` was missing from that list.

`toku-files` is a normal publishable library (declared in
`[workspace.dependencies]` with an explicit `version = "0.4.0"`, no
`publish = false`), and both `toku-web` and `toku-cli` now depend on it. Because
it was never published, `cargo publish -p toku-web` (and `-p toku-cli`) would
fail on the missing registry dependency once the `v0.4.0` tag triggered the
release workflow. This is the same class of bug PR #156 fixed for
`toku-web`/`toku-sync-client`, reintroduced this cycle when `toku-files` was
added.

**What's included**

- Add `publish_crate toku-files` to the publish sequence, after `toku-export`
  and before `toku-web`. It depends only on `toku-core` + `toku-db` (already
  published earlier in the sequence) and must precede `toku-web`/`toku-cli`,
  which consume it.
- Update the dependency-order comment above the step to reflect the correct
  ordering.

The 0.4.0 version bump and CHANGELOG roll are already on `main` (prepare commit),
so this PR is purely the workflow correction that makes the publish succeed.

**Sanity-check of the rest of the release workflow (no changes needed)**

- Docker multi-arch arm64 cross-compile fixes from #157/#158 are intact
  (`libc6-dev-arm64-cross` + glibc cross toolchain in `toku-sync/Dockerfile`).
- The required CI merge gate is still named `Validate`, so no
  `kafkade/github-infra` Terraform update is required.
- `toku-ffi` / `toku-sync` remain intentionally unpublished (FFI staticlib +
  Docker-shipped server); nothing published depends on them.

## Related Issues

Relates to #183

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [x] CI / infrastructure
- [ ] Other (describe below)

## Crate

N/A — CI release workflow only; no crate source is modified. (The fix ensures
`toku-files` gets published so `toku-web` and `toku-cli` can publish.)

- [ ] `toku-core` — Domain models, traits, state machine
- [ ] `toku-db` — SQLite persistence, migrations, FTS5
- [ ] `toku-import` — Importers (Goodreads, Calibre, StoryGraph)
- [ ] `toku-meta` — Metadata fetching (Open Library, Google Books)
- [ ] `toku-cli` — CLI binary
- [ ] `toku-export` — Exporters (CSV, JSON, Markdown, BibTeX)
- [ ] `docs/` — Documentation

## Data Integrity Checklist

N/A — CI workflow change; no user-data code paths are touched.

- [x] No user data is sent to any server without explicit opt-in
- [x] Import operations are idempotent (re-importing the same file creates no duplicates)
- [x] User edits to metadata are never overwritten by auto-enrichment
- [x] New fields track provenance (source + timestamp)
- [x] Export round-trip is preserved (if applicable)

## Checklist

- [x] I have read [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] `cargo fmt --check` passes
- [x] `cargo clippy --workspace -- -D warnings` passes
- [x] `cargo test --workspace` passes
- [x] I have updated documentation (if applicable) — N/A, workflow-only change