### PR TITLE
docs: refresh README + docs for 1.0 (version, feature set, platform matrix)

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -2,7 +2,7 @@
 
 ## Project Overview
 
-Toku (読く — Japanese for "to read") is a private, offline-first personal book manager. It combines the metadata depth of Calibre, the reading tracking of Goodreads, and the analytics of StoryGraph — without any social features. Phases 0–5 are complete (CLI, imports, analytics, web dashboard, native apps). Phase 6 (file management) and Phase 7 (sync) are next.
+Toku (読く — Japanese for "to read") is a private, offline-first personal book manager. It combines the metadata depth of Calibre, the reading tracking of Goodreads, and the analytics of StoryGraph — without any social features. Phases 0–7 are complete (CLI, imports, analytics, web dashboard, native apps, file management, and sync). A watchOS companion app is planned (tracked in #178).
 
 ## Non-Negotiable Constraints
 
@@ -16,17 +16,20 @@ Every code contribution, architecture decision, and feature design must uphold t
 
 ## Architecture
 
-Cargo workspace with 9 crates:
+Cargo workspace with 12 crates:
 
 - `toku-core/` — Domain models, traits, state machine, statistics engine. Pure Rust, no I/O. Compiles to native, WASM, FFI.
 - `toku-db/` — SQLite persistence, schema migrations (refinery), FTS5 full-text search.
 - `toku-import/` — Import implementations: Goodreads CSV, Calibre metadata.db, StoryGraph.
 - `toku-meta/` — Metadata fetching: Open Library API (primary), Google Books (fallback). Cover image downloading.
+- `toku-files/` — Ebook file management: association, SHA-256 integrity verification, disk organization, and format conversion (via Calibre's `ebook-convert`).
 - `toku-cli/` — CLI binary (clap v4). The main entry point.
 - `toku-export/` — Export implementations: CSV, JSON, Markdown, BibTeX, canonical backup.
 - `toku-ffi/` — C FFI bindings for Swift/Kotlin via `cbindgen`. Used by macOS and iOS apps.
-- `toku-web/` — Axum + maud web server. Library views, statistics dashboard, import wizard. Started via `toku serve`.
+- `toku-web/` — Axum + maud web server. Library views, statistics dashboard, import wizard, OPDS catalog. Started via `toku serve`.
 - `toku-desktop/` — Tauri v2 Windows desktop app wrapping the web UI.
+- `toku-sync/` — Self-hostable, zero-knowledge sync relay server (stores only client-encrypted ciphertext).
+- `toku-sync-client/` — Client-side sync engine: end-to-end encryption, HLC-based conflict resolution, and op propagation.
 
 ### Data Boundary Rule
 

--- a/README.md
+++ b/README.md
@@ -20,8 +20,11 @@ toku stats --year 2025                 # See your reading stats
 toku browse                            # Interactive TUI browser
 ```
 
-> **Status**: Active development (v0.2.1) — full-featured CLI, web dashboard,
-> macOS/iOS apps, and Windows desktop app. Phases 0–5 complete.
+> **Status**: Active development (v0.4.0) — full-featured CLI, web dashboard, OPDS
+> catalog server, optional end-to-end-encrypted multi-device sync, ebook file
+> management, and native macOS/iOS/Windows apps. Phases 0–7 complete.
+> See the [platform support matrix](#platform-support) for what's production-ready
+> vs. in beta vs. planned.
 
 ---
 
@@ -52,8 +55,9 @@ their ever-growing libraries.
   Your library is for you.
 - **Import everything.** Bring your Goodreads, Calibre, or StoryGraph history. Years of
   reading data should transfer in seconds.
-- **CLI-first.** A fast, scriptable command-line tool. Web, iOS, macOS, and Windows
-  interfaces are planned for later — built on the same core library.
+- **CLI-first.** A fast, scriptable command-line tool. The web dashboard, iOS, macOS, and
+  Windows apps are built on the same core library — the CLI stays the primary, canonical
+  interface.
 - **Open source.** MIT licensed. Contributions welcome.
 
 ## Features
@@ -67,6 +71,10 @@ their ever-growing libraries.
 - 🔍 Full-text search across your entire library (titles, authors, descriptions)
 - 🖥️ Interactive TUI browser with split-pane layout, filters, and live detail view
 - 🔄 Bulk operations for tagging, status changes, and deletions across filtered sets
+- 📚 Ebook file management — associate `.epub`/`.pdf`/`.mobi`/`.azw3` files with books
+  (`toku file add`), verify integrity by SHA-256 (`toku file verify`), report disk usage
+  (`toku file usage`), organize files into a managed library by a path template
+  (`toku file organize`), and convert formats via Calibre's `ebook-convert` (`toku convert`)
 - 🌐 Web dashboard (`toku serve`) with statistics, import wizard, library views, and dark mode
   — loopback-only by default, or run authenticated for network access
   ([hosted mode & auth](docs/web-auth.md))
@@ -80,16 +88,41 @@ their ever-growing libraries.
 - 🔑 Account Secret Key + printable Emergency Kit for zero-knowledge sync
   ([recovery guide](docs/recovery.md))
 
+## Platform support
+
+Toku ships several interfaces built on the same Rust core library. Not all are at the same
+maturity level:
+
+| Platform | Status | Notes |
+|---|---|---|
+| **CLI** (`toku`) | ✅ Production | The primary, canonical interface. Every feature lands here first. |
+| **Web dashboard** (`toku serve`) | ✅ Production | Statistics, import wizard, library views, dark mode. Loopback-only by default; [hosted mode & auth](docs/web-auth.md) for network access. |
+| **OPDS catalog** (`toku opds serve`) | ✅ Production | Serves associated ebook files to e-reader apps over the local network. |
+| **Sync relay** (`toku-sync`) | ✅ Production | Optional, self-hostable, end-to-end encrypted. See the [self-hosting guide](docs/self-hosting.md). |
+| **macOS app** (SwiftUI) | 🟡 Beta | Native sidebar, sortable table/grid views, Swift Charts. |
+| **iOS app** (iPhone + iPad) | 🟡 Beta | Cover grid, barcode scanner, reading progress updates. |
+| **Windows desktop** (Tauri v2) | 🟡 Beta | Wraps the web UI in a native window with system tray. |
+| **watchOS app** | ⏳ Planned | Not yet shipped — tracked in [#178](https://github.com/kafkade/toku/issues/178). |
+
+## Documentation
+
+- [Self-hosting the sync server](docs/self-hosting.md) — overview and quick start
+- [Sync server deployment guide](docs/sync-server.md) — full Docker/reverse-proxy reference
+- [Web dashboard hosted mode & authentication](docs/web-auth.md)
+- [Account recovery: Secret Key & Emergency Kit](docs/recovery.md)
+- [Self-hosting threat model](docs/security/self-host-threat-model.md) — security & privacy analysis
+
 ## Tech Stack
 
 - **Language**: Rust
 - **Database**: SQLite with FTS5
 - **CLI**: clap v4
 - **Web**: Axum + maud (server-side rendered HTML with inline SVG charts)
+- **Sync**: self-hostable relay server with end-to-end encryption (zero-knowledge)
 - **Desktop**: Tauri v2 (Windows)
 - **Mobile/macOS**: SwiftUI via Rust FFI (`toku-ffi` crate)
-- **Architecture**: Cargo workspace with 9 crates — core, database, import, export,
-  metadata, CLI, FFI, web, and desktop
+- **Architecture**: Cargo workspace with 12 crates — core, database, metadata, import,
+  export, files, CLI, FFI, web, desktop, and the sync server and client
 
 ## License
 

--- a/docs/sync-server.md
+++ b/docs/sync-server.md
@@ -27,7 +27,7 @@ The server is now listening on `http://localhost:8080`. Check it:
 
 ```bash
 curl http://localhost:8080/health
-# {"status":"ok","version":"0.2.1"}
+# {"status":"ok","version":"0.4.0"}
 ```
 
 ### Docker Compose
@@ -253,7 +253,7 @@ After recreating, confirm the new version is healthy:
 
 ```bash
 curl https://sync.example.com/health
-# {"status":"ok","version":"0.3.2","protocol_version":2,"min_protocol":1}
+# {"status":"ok","version":"0.4.0","protocol_version":2,"min_protocol":1}
 ```
 
 > **Back up before upgrading.** Take a copy of `sync.db` (see [Data persistence](#data-persistence))
@@ -261,7 +261,7 @@ curl https://sync.example.com/health
 > automatically on start and are forward-only.
 >
 > **Pin a tag for production.** `:latest` is convenient but moves underneath you. For
-> reproducible upgrades, pin a specific version (e.g. `ghcr.io/kafkade/toku-sync:0.3.2`)
+> reproducible upgrades, pin a specific version (e.g. `ghcr.io/kafkade/toku-sync:0.4.0`)
 > and bump it deliberately. Both `MAJOR.MINOR` and full `MAJOR.MINOR.PATCH` tags are
 > published alongside `latest`.
 


### PR DESCRIPTION
## Description

Refreshes the user-facing documentation so it matches the shipped product ahead of 1.0. The README's status line and feature story were stale, and there was no clear signal about which interfaces are production-ready vs. in beta vs. planned.

**What's included:**

- **README status/version** — `v0.2.1` / "Phases 0–5 complete" → **`v0.4.0`** / "Phases 0–7 complete", reworded to reflect that sync, file management, and the OPDS catalog have shipped.
- **Platform support matrix** — new section stating CLI ✅ production, Web ✅ production, OPDS ✅ production, Sync relay ✅ production, macOS/iOS/Windows 🟡 beta, and watchOS ⏳ planned (links #178). No implication that watchOS ships.
- **Features** — added an ebook file-management bullet (`toku file add/verify/usage/organize`, `toku convert`), which was previously undocumented.
- **Documentation section** — README now links `docs/self-hosting.md`, `docs/sync-server.md`, `docs/web-auth.md`, `docs/recovery.md`, and `docs/security/self-host-threat-model.md`.
- **Tech Stack** — fixed the CLI-first principle (dropped stale "planned for later"), added Sync, and corrected the crate count from 9 to **12** with an accurate list.
- **Docs sweep** — updated stale illustrative version strings (`0.2.1` / `0.3.2` → `0.4.0`, including the pinned image tag) in `docs/sync-server.md`, and refreshed the "Phases 0–5 complete" language and 9-crate list in `.github/copilot-instructions.md`.

Uses **v0.4.0** (the actual current repo version) rather than the issue's "v0.3.2", which was itself stale. `ROADMAP.md` is intentionally left untouched (historical planning tables, out of scope).

## Related Issues

Closes #184

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI / infrastructure
- [ ] Other (describe below)

## Crate

- [ ] `toku-core` — Domain models, traits, state machine
- [ ] `toku-db` — SQLite persistence, migrations, FTS5
- [ ] `toku-import` — Importers (Goodreads, Calibre, StoryGraph)
- [ ] `toku-meta` — Metadata fetching (Open Library, Google Books)
- [ ] `toku-cli` — CLI binary
- [ ] `toku-export` — Exporters (CSV, JSON, Markdown, BibTeX)
- [x] `docs/` — Documentation

(Also touches `README.md` and `.github/copilot-instructions.md`.)

## Data Integrity Checklist

- [x] No user data is sent to any server without explicit opt-in — N/A, docs only
- [x] Import operations are idempotent (re-importing the same file creates no duplicates) — N/A, docs only
- [x] User edits to metadata are never overwritten by auto-enrichment — N/A, docs only
- [x] New fields track provenance (source + timestamp) — N/A, docs only
- [x] Export round-trip is preserved (if applicable) — N/A, docs only

## Checklist

- [x] I have read [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] `cargo fmt --check` passes (no Rust changed)
- [x] `cargo clippy --workspace -- -D warnings` passes (no Rust changed — unaffected)
- [x] `cargo test --workspace` passes (no Rust changed — unaffected)
- [x] I have updated documentation (if applicable) — markdownlint clean across all 30 files