### PR TITLE
feat(sync): emit sync ops for every frontend mutation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Sync now propagates ordinary edits incrementally. Every create/update/delete on a
+  syncable entity (books, reading sessions, progress, and tags) now stages a sync op
+  atomically with the write, in a single choke-point in the persistence layer, so all
+  frontends — the CLI, the FFI/mobile bindings, the web import wizard, and the Goodreads/
+  Calibre/StoryGraph importers — feed the op log by construction. Previously only bulk
+  delete and conflict resolution produced ops, so a normal edit never synced and only a
+  full `toku sync compact` snapshot moved state. Op emission remains a complete no-op until
+  a device identity is configured, preserving offline-first behavior: no sync setup means no
+  ops and no network. The FFI path now produces exactly the same ops as the CLI for
+  equivalent operations and no longer silently swallows op-write failures (#194)
+
 ## [0.4.0] - 2026-07-04
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5901,6 +5901,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tabled",
+ "tempfile",
  "tokio",
  "toku-core",
  "toku-db",

--- a/crates/toku-cli/Cargo.toml
+++ b/crates/toku-cli/Cargo.toml
@@ -53,3 +53,6 @@ apple-native-keyring-store = { version = "1", features = ["keychain"] }
 
 [target.'cfg(target_os = "windows")'.dependencies]
 windows-native-keyring-store = "1"
+
+[dev-dependencies]
+tempfile = "3"

--- a/crates/toku-cli/src/main.rs
+++ b/crates/toku-cli/src/main.rs
@@ -1095,7 +1095,7 @@ fn main() -> Result<()> {
             force,
         } => cmd_convert(&db, &repo, &book, &to, from.as_deref(), force),
         Commands::Export { target } => cmd_export(&db, &data_dir, target),
-        Commands::Bulk { action } => cmd_bulk(&db, &repo, action),
+        Commands::Bulk { action } => cmd_bulk(&repo, action),
         Commands::Stats {
             year,
             author,
@@ -3206,7 +3206,7 @@ fn resolve_bulk_books(
     Ok(filtered)
 }
 
-fn cmd_bulk(db: &toku_db::Database, repo: &BookRepository, action: BulkAction) -> Result<()> {
+fn cmd_bulk(repo: &BookRepository, action: BulkAction) -> Result<()> {
     match action {
         BulkAction::Tag {
             tag,
@@ -3318,29 +3318,13 @@ fn cmd_bulk(db: &toku_db::Database, repo: &BookRepository, action: BulkAction) -
             let verb = if dry_run { "Would delete" } else { "Deleting" };
             eprintln!("{verb} {} book(s):\n", books.len());
 
-            // If sync is configured, create delete ops for each book
-            let sync_repo = toku_db::SyncRepository::new(db);
-            let device_identity = sync_repo.get_device()?;
-
             for book in &books {
                 if dry_run {
                     eprintln!("  [dry-run] \"{}\"", book.title);
                 } else {
+                    // `delete_book` emits the Book Delete sync op atomically
+                    // with the write (no-op when sync isn't configured).
                     repo.delete_book(&book.id)?;
-
-                    if let Some(ref identity) = device_identity {
-                        let mut clock = toku_core::HybridClock::new(&identity.device_id);
-                        let op = toku_core::SyncOp::new(
-                            identity.device_id,
-                            clock.now(),
-                            toku_core::EntityType::Book,
-                            book.id,
-                            toku_core::OpType::Delete,
-                            None,
-                        );
-                        sync_repo.insert_op(&op)?;
-                    }
-
                     eprintln!("  ✗ \"{}\"", book.title);
                 }
             }

--- a/crates/toku-cli/tests/sync_emission_cli.rs
+++ b/crates/toku-cli/tests/sync_emission_cli.rs
@@ -1,0 +1,106 @@
+//! End-to-end CLI tests that drive the real `toku` binary and assert that
+//! ordinary commands emit sync ops (issue #194).
+//!
+//! These run the compiled binary via `CARGO_BIN_EXE_toku`, pointing it at a
+//! throwaway data directory. A device identity is seeded directly (equivalent
+//! to having run `toku sync init`) so the offline-first guard is satisfied and
+//! ops are emitted; the mutations themselves go through the real command path.
+
+use std::path::Path;
+use std::process::Command;
+
+use toku_db::{Database, SyncRepository};
+
+/// Seed a device identity in the CLI's database so op emission is enabled.
+fn seed_device(data_dir: &Path) {
+    let db = Database::open(&data_dir.join("toku.db")).expect("open db");
+    SyncRepository::new(&db)
+        .get_or_create_device("cli-test")
+        .expect("seed device");
+}
+
+fn count_ops(data_dir: &Path, entity_type: &str, op_type: &str) -> i64 {
+    let db = Database::open(&data_dir.join("toku.db")).expect("open db");
+    db.conn
+        .query_row(
+            "SELECT COUNT(*) FROM sync_ops WHERE entity_type = ?1 AND op_type = ?2",
+            [entity_type, op_type],
+            |r| r.get(0),
+        )
+        .expect("count ops")
+}
+
+fn total_ops(data_dir: &Path) -> i64 {
+    let db = Database::open(&data_dir.join("toku.db")).expect("open db");
+    db.conn
+        .query_row("SELECT COUNT(*) FROM sync_ops", [], |r| r.get(0))
+        .expect("count ops")
+}
+
+fn toku(data_dir: &Path, args: &[&str]) {
+    let status = Command::new(env!("CARGO_BIN_EXE_toku"))
+        .arg("--data-dir")
+        .arg(data_dir)
+        .args(args)
+        .status()
+        .expect("run toku");
+    assert!(status.success(), "toku {args:?} failed: {status}");
+}
+
+#[test]
+fn add_command_emits_book_create_op() {
+    let dir = tempfile::tempdir().unwrap();
+    seed_device(dir.path());
+
+    toku(
+        dir.path(),
+        &["add", "--title", "Dune", "--author", "Frank Herbert"],
+    );
+
+    assert_eq!(
+        count_ops(dir.path(), "book", "create"),
+        1,
+        "a real `toku add` must stage exactly one Book Create op"
+    );
+}
+
+#[test]
+fn add_without_device_emits_no_ops() {
+    // No seeded device — offline-first: the write must still work, but no ops.
+    let dir = tempfile::tempdir().unwrap();
+
+    toku(
+        dir.path(),
+        &["add", "--title", "Dune", "--author", "Frank Herbert"],
+    );
+
+    assert_eq!(
+        total_ops(dir.path()),
+        0,
+        "without a device identity no ops may be staged"
+    );
+}
+
+#[test]
+fn tag_command_emits_tag_op() {
+    let dir = tempfile::tempdir().unwrap();
+    seed_device(dir.path());
+
+    toku(
+        dir.path(),
+        &[
+            "add",
+            "--title",
+            "Neuromancer",
+            "--author",
+            "William Gibson",
+        ],
+    );
+    toku(dir.path(), &["tag", "add", "cyberpunk", "Neuromancer"]);
+
+    assert_eq!(
+        count_ops(dir.path(), "tag", "create"),
+        1,
+        "a real `toku tag add` must stage a Tag Create op"
+    );
+}

--- a/crates/toku-db/src/lib.rs
+++ b/crates/toku-db/src/lib.rs
@@ -8,6 +8,6 @@ mod sync_repo;
 pub use database::Database;
 pub use error::DbError;
 pub use merge::MergeEngine;
-pub use repo::BookRepository;
+pub use repo::{BookRepository, book_op_fields};
 pub use snapshot::SnapshotRepository;
 pub use sync_repo::{ConflictKeep, SyncConflict, SyncRepository};

--- a/crates/toku-db/src/repo.rs
+++ b/crates/toku-db/src/repo.rs
@@ -1,12 +1,12 @@
 use rusqlite::{OptionalExtension, params};
 use toku_core::{
-    Author, AuthorCount, Book, BookAuthor, BookSeries, ContributorRole, FilterCondition,
-    FilterExpr, FilterField, PaceRating, ReadingProgress, ReadingSession, ReadingStatus, Series,
-    Shelf, SmartFilter, Tag, TagCount, TagType, Work,
+    Author, AuthorCount, Book, BookAuthor, BookSeries, ContributorRole, EntityType,
+    FilterCondition, FilterExpr, FilterField, OpType, PaceRating, ReadingProgress, ReadingSession,
+    ReadingStatus, Series, Shelf, SmartFilter, Tag, TagCount, TagType, Work,
 };
 use uuid::Uuid;
 
-use crate::{Database, DbError};
+use crate::{Database, DbError, SyncRepository};
 
 /// Book persistence operations.
 pub struct BookRepository<'a> {
@@ -18,6 +18,31 @@ impl<'a> BookRepository<'a> {
         Self { db }
     }
 
+    /// Run a mutation together with its sync-op emission atomically.
+    ///
+    /// A transaction is opened only when the connection is not already inside a
+    /// caller-provided one — importers wrap whole batches in their own
+    /// `BEGIN IMMEDIATE`, and SQLite forbids nested `BEGIN`. In the nested case
+    /// the write and its op simply join the outer transaction. Either way the
+    /// row change and the emitted op commit (or roll back) together.
+    ///
+    /// The closure receives a [`SyncRepository`] bound to the same connection;
+    /// op emission is a no-op when no device identity is configured.
+    fn with_sync_txn<T>(
+        &self,
+        f: impl FnOnce(&SyncRepository) -> Result<T, DbError>,
+    ) -> Result<T, DbError> {
+        let sync = SyncRepository::new(self.db);
+        if self.db.conn.is_autocommit() {
+            let tx = self.db.conn.unchecked_transaction()?;
+            let out = f(&sync)?;
+            tx.commit()?;
+            Ok(out)
+        } else {
+            f(&sync)
+        }
+    }
+
     /// Insert a new book. Returns the book's ID.
     pub fn create_book(&self, book: &Book) -> Result<(), DbError> {
         let search_text = build_search_text(
@@ -26,31 +51,38 @@ impl<'a> BookRepository<'a> {
             book.description.as_deref(),
             &[],
         );
-        self.db.conn.execute(
-            "INSERT INTO books (id, title, subtitle, description, page_count, pub_date,
-             language, format, duration_minutes, cover_hash, work_id, status, rating,
-             created_at, updated_at, search_text)
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16)",
-            params![
-                book.id.to_string(),
-                book.title,
-                book.subtitle,
-                book.description,
-                book.page_count,
-                book.pub_date,
-                book.language,
-                book.format.as_str(),
-                book.duration_minutes,
-                book.cover_hash,
-                book.work_id.map(|u| u.to_string()),
-                book.status.as_str(),
-                book.rating,
-                book.created_at.to_rfc3339(),
-                book.updated_at.to_rfc3339(),
-                search_text,
-            ],
-        )?;
-        Ok(())
+        self.with_sync_txn(|sync| {
+            self.db.conn.execute(
+                "INSERT INTO books (id, title, subtitle, description, page_count, pub_date,
+                 language, format, duration_minutes, cover_hash, work_id, status, rating,
+                 created_at, updated_at, search_text)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16)",
+                params![
+                    book.id.to_string(),
+                    book.title,
+                    book.subtitle,
+                    book.description,
+                    book.page_count,
+                    book.pub_date,
+                    book.language,
+                    book.format.as_str(),
+                    book.duration_minutes,
+                    book.cover_hash,
+                    book.work_id.map(|u| u.to_string()),
+                    book.status.as_str(),
+                    book.rating,
+                    book.created_at.to_rfc3339(),
+                    book.updated_at.to_rfc3339(),
+                    search_text,
+                ],
+            )?;
+            sync.emit_local_op(
+                EntityType::Book,
+                book.id,
+                OpType::Create,
+                Some(book_op_fields(book)),
+            )
+        })
     }
 
     /// Retrieve a book by its UUID.
@@ -163,11 +195,16 @@ impl<'a> BookRepository<'a> {
     /// Soft-delete a book by ID. Sets `deleted_at` instead of removing the row.
     pub fn delete_book(&self, id: &Uuid) -> Result<bool, DbError> {
         let now = chrono::Utc::now().to_rfc3339();
-        let rows = self.db.conn.execute(
-            "UPDATE books SET deleted_at = ?1, updated_at = ?1 WHERE id = ?2 AND deleted_at IS NULL",
-            params![now, id.to_string()],
-        )?;
-        Ok(rows > 0)
+        self.with_sync_txn(|sync| {
+            let rows = self.db.conn.execute(
+                "UPDATE books SET deleted_at = ?1, updated_at = ?1 WHERE id = ?2 AND deleted_at IS NULL",
+                params![now, id.to_string()],
+            )?;
+            if rows > 0 {
+                sync.emit_local_op(EntityType::Book, *id, OpType::Delete, None)?;
+            }
+            Ok(rows > 0)
+        })
     }
 
     /// Retrieve a book by ID, including soft-deleted books.
@@ -448,67 +485,116 @@ impl<'a> BookRepository<'a> {
 
     /// Update a book's reading status.
     pub fn update_book_status(&self, id: &Uuid, status: ReadingStatus) -> Result<bool, DbError> {
-        let rows = self.db.conn.execute(
-            "UPDATE books SET status = ?1, updated_at = ?2 WHERE id = ?3 AND deleted_at IS NULL",
-            params![
-                status.as_str(),
-                chrono::Utc::now().to_rfc3339(),
-                id.to_string(),
-            ],
-        )?;
-        Ok(rows > 0)
+        self.with_sync_txn(|sync| {
+            let rows = self.db.conn.execute(
+                "UPDATE books SET status = ?1, updated_at = ?2 WHERE id = ?3 AND deleted_at IS NULL",
+                params![
+                    status.as_str(),
+                    chrono::Utc::now().to_rfc3339(),
+                    id.to_string(),
+                ],
+            )?;
+            if rows > 0 {
+                sync.emit_local_op(
+                    EntityType::Book,
+                    *id,
+                    OpType::Update,
+                    Some(serde_json::json!({ "status": status.as_str() })),
+                )?;
+            }
+            Ok(rows > 0)
+        })
     }
 
     /// Update a book's rating.
     pub fn update_book_rating(&self, id: &Uuid, rating: i32) -> Result<bool, DbError> {
-        let rows = self.db.conn.execute(
-            "UPDATE books SET rating = ?1, updated_at = ?2 WHERE id = ?3 AND deleted_at IS NULL",
-            params![rating, chrono::Utc::now().to_rfc3339(), id.to_string(),],
-        )?;
-        Ok(rows > 0)
+        self.with_sync_txn(|sync| {
+            let rows = self.db.conn.execute(
+                "UPDATE books SET rating = ?1, updated_at = ?2 WHERE id = ?3 AND deleted_at IS NULL",
+                params![rating, chrono::Utc::now().to_rfc3339(), id.to_string(),],
+            )?;
+            if rows > 0 {
+                sync.emit_local_op(
+                    EntityType::Book,
+                    *id,
+                    OpType::Update,
+                    Some(serde_json::json!({ "rating": rating })),
+                )?;
+            }
+            Ok(rows > 0)
+        })
     }
 
     /// Insert a new reading session.
     pub fn create_reading_session(&self, session: &ReadingSession) -> Result<(), DbError> {
-        self.db.conn.execute(
-            "INSERT INTO reading_sessions (id, book_id, started_at, finished_at,
-             start_page, end_page, rating, notes, created_at)
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)",
-            params![
-                session.id.to_string(),
-                session.book_id.to_string(),
-                session.started_at.to_rfc3339(),
-                session.finished_at.map(|d| d.to_rfc3339()),
-                session.start_page,
-                session.end_page,
-                session.rating,
-                session.notes,
-                session.created_at.to_rfc3339(),
-            ],
-        )?;
-        Ok(())
+        self.with_sync_txn(|sync| {
+            self.db.conn.execute(
+                "INSERT INTO reading_sessions (id, book_id, started_at, finished_at,
+                 start_page, end_page, rating, notes, created_at)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)",
+                params![
+                    session.id.to_string(),
+                    session.book_id.to_string(),
+                    session.started_at.to_rfc3339(),
+                    session.finished_at.map(|d| d.to_rfc3339()),
+                    session.start_page,
+                    session.end_page,
+                    session.rating,
+                    session.notes,
+                    session.created_at.to_rfc3339(),
+                ],
+            )?;
+            sync.emit_local_op(
+                EntityType::Session,
+                session.id,
+                OpType::Create,
+                Some(serde_json::json!({
+                    "book_id": session.book_id.to_string(),
+                    "started_at": session.started_at.to_rfc3339(),
+                    "finished_at": session.finished_at.map(|d| d.to_rfc3339()),
+                    "start_page": session.start_page,
+                    "end_page": session.end_page,
+                    "rating": session.rating,
+                    "notes": session.notes,
+                })),
+            )
+        })
     }
 
     // --- Reading progress operations ---
 
     /// Insert a reading progress entry.
     pub fn log_progress(&self, progress: &ReadingProgress) -> Result<(), DbError> {
-        self.db.conn.execute(
-            "INSERT INTO reading_progress (id, book_id, session_id, progress_type,
-             value, note, logged_at, created_at)
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
-            params![
-                progress.id.to_string(),
-                progress.book_id.to_string(),
-                progress.session_id.map(|u| u.to_string()),
-                progress.progress_type.as_str(),
-                progress.value,
-                progress.note,
-                progress.logged_at.to_rfc3339(),
-                progress.created_at.to_rfc3339(),
-            ],
-        )?;
-        Ok(())
+        self.with_sync_txn(|sync| {
+            self.db.conn.execute(
+                "INSERT INTO reading_progress (id, book_id, session_id, progress_type,
+                 value, note, logged_at, created_at)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
+                params![
+                    progress.id.to_string(),
+                    progress.book_id.to_string(),
+                    progress.session_id.map(|u| u.to_string()),
+                    progress.progress_type.as_str(),
+                    progress.value,
+                    progress.note,
+                    progress.logged_at.to_rfc3339(),
+                    progress.created_at.to_rfc3339(),
+                ],
+            )?;
+            sync.emit_local_op(
+                EntityType::Progress,
+                progress.id,
+                OpType::Create,
+                Some(serde_json::json!({
+                    "book_id": progress.book_id.to_string(),
+                    "progress_type": progress.progress_type.as_str(),
+                    "value": progress.value,
+                    "session_id": progress.session_id.map(|u| u.to_string()),
+                    "logged_at": progress.logged_at.to_rfc3339(),
+                    "note": progress.note,
+                })),
+            )
+        })
     }
 
     /// Get all progress entries for a book, ordered by `logged_at` DESC.
@@ -900,27 +986,82 @@ impl<'a> BookRepository<'a> {
         self.get_book(book_id)?;
         let tag = self.create_typed_tag(tag_name, tag_type)?;
 
-        self.db.conn.execute(
-            "INSERT OR IGNORE INTO book_tags (book_id, tag_id) VALUES (?1, ?2)",
-            params![book_id.to_string(), tag.id.to_string()],
-        )?;
-
-        Ok(())
+        self.with_sync_txn(|sync| {
+            let rows = self.db.conn.execute(
+                "INSERT OR IGNORE INTO book_tags (book_id, tag_id) VALUES (?1, ?2)",
+                params![book_id.to_string(), tag.id.to_string()],
+            )?;
+            if rows > 0 {
+                sync.emit_local_op(
+                    EntityType::Tag,
+                    *book_id,
+                    OpType::Create,
+                    Some(serde_json::json!({
+                        "tag_name": tag.name,
+                        "tag_type": tag_type.as_str(),
+                    })),
+                )?;
+            }
+            Ok(())
+        })
     }
 
     /// Set the pace rating for a book. Removes any existing pace tag first.
     pub fn set_book_pace(&self, book_id: &Uuid, pace: PaceRating) -> Result<(), DbError> {
         self.get_book(book_id)?;
 
-        // Remove existing pace tags
-        self.db.conn.execute(
-            "DELETE FROM book_tags WHERE book_id = ?1
-             AND tag_id IN (SELECT id FROM tags WHERE tag_type = 'pace')",
-            params![book_id.to_string()],
-        )?;
+        self.with_sync_txn(|sync| {
+            // Capture the names of the pace tags currently on the book so the
+            // removal can emit a Tag Delete op for each (merge matches by name).
+            let existing: Vec<String> = {
+                let mut stmt = self.db.conn.prepare(
+                    "SELECT t.name FROM tags t
+                     JOIN book_tags bt ON bt.tag_id = t.id
+                     WHERE bt.book_id = ?1 AND t.tag_type = 'pace'",
+                )?;
+                let names =
+                    stmt.query_map(params![book_id.to_string()], |row| row.get::<_, String>(0))?;
+                names.filter_map(|r| r.ok()).collect()
+            };
 
-        // Add new pace tag
-        self.add_typed_tag_to_book(book_id, pace.as_str(), TagType::Pace)
+            let removed = self.db.conn.execute(
+                "DELETE FROM book_tags WHERE book_id = ?1
+                 AND tag_id IN (SELECT id FROM tags WHERE tag_type = 'pace')",
+                params![book_id.to_string()],
+            )?;
+            if removed > 0 {
+                for name in &existing {
+                    sync.emit_local_op(
+                        EntityType::Tag,
+                        *book_id,
+                        OpType::Delete,
+                        Some(serde_json::json!({
+                            "tag_name": name,
+                            "tag_type": TagType::Pace.as_str(),
+                        })),
+                    )?;
+                }
+            }
+
+            // Add the new pace tag in the same transaction.
+            let tag = self.create_typed_tag(pace.as_str(), TagType::Pace)?;
+            let added = self.db.conn.execute(
+                "INSERT OR IGNORE INTO book_tags (book_id, tag_id) VALUES (?1, ?2)",
+                params![book_id.to_string(), tag.id.to_string()],
+            )?;
+            if added > 0 {
+                sync.emit_local_op(
+                    EntityType::Tag,
+                    *book_id,
+                    OpType::Create,
+                    Some(serde_json::json!({
+                        "tag_name": tag.name,
+                        "tag_type": TagType::Pace.as_str(),
+                    })),
+                )?;
+            }
+            Ok(())
+        })
     }
 
     /// Remove a general tag from a book.
@@ -935,19 +1076,31 @@ impl<'a> BookRepository<'a> {
         tag_name: &str,
         tag_type: TagType,
     ) -> Result<(), DbError> {
-        let rows = self.db.conn.execute(
-            "DELETE FROM book_tags WHERE book_id = ?1
-             AND tag_id IN (SELECT id FROM tags WHERE name = ?2 AND tag_type = ?3)",
-            params![book_id.to_string(), tag_name, tag_type.as_str()],
-        )?;
+        self.with_sync_txn(|sync| {
+            let rows = self.db.conn.execute(
+                "DELETE FROM book_tags WHERE book_id = ?1
+                 AND tag_id IN (SELECT id FROM tags WHERE name = ?2 AND tag_type = ?3)",
+                params![book_id.to_string(), tag_name, tag_type.as_str()],
+            )?;
 
-        if rows == 0 {
-            return Err(DbError::NotFound(format!(
-                "tag '{tag_name}' ({tag_type}) not on this book"
-            )));
-        }
+            if rows == 0 {
+                return Err(DbError::NotFound(format!(
+                    "tag '{tag_name}' ({tag_type}) not on this book"
+                )));
+            }
 
-        Ok(())
+            sync.emit_local_op(
+                EntityType::Tag,
+                *book_id,
+                OpType::Delete,
+                Some(serde_json::json!({
+                    "tag_name": tag_name,
+                    "tag_type": tag_type.as_str(),
+                })),
+            )?;
+
+            Ok(())
+        })
     }
 
     /// Get all tags for a book.
@@ -1918,6 +2071,15 @@ impl<'a> BookRepository<'a> {
             params![removed_id.to_string()],
         )?;
 
+        // Emit a sync op tombstoning the removed book, in the same transaction
+        // so the merge and its op commit atomically. No-op without a device.
+        SyncRepository::new(self.db).emit_local_op(
+            EntityType::Book,
+            *removed_id,
+            OpType::Delete,
+            None,
+        )?;
+
         tx.commit()?;
 
         // 13. Recompute search_text outside the transaction
@@ -1925,6 +2087,31 @@ impl<'a> BookRepository<'a> {
 
         Ok(())
     }
+}
+
+/// Builds the sync-op field payload for a book Create op.
+///
+/// Mirrors the schema consumed by [`crate::merge`] (`BOOK_FIELDS`): enums are
+/// serialized via their string form, numbers as integers. `work_id` is omitted
+/// intentionally — Work rows are not synced yet, so shipping the reference would
+/// dangle on the receiving device.
+///
+/// Exposed so importers (which insert books via raw SQL to also persist source
+/// IDs) can emit the exact same Book Create op as [`BookRepository::create_book`].
+pub fn book_op_fields(book: &Book) -> serde_json::Value {
+    serde_json::json!({
+        "title": book.title,
+        "subtitle": book.subtitle,
+        "description": book.description,
+        "page_count": book.page_count,
+        "pub_date": book.pub_date,
+        "language": book.language,
+        "format": book.format.as_str(),
+        "duration_minutes": book.duration_minutes,
+        "cover_hash": book.cover_hash,
+        "status": book.status.as_str(),
+        "rating": book.rating,
+    })
 }
 
 /// Build the denormalized search_text from book fields and author names.

--- a/crates/toku-db/src/sync_repo.rs
+++ b/crates/toku-db/src/sync_repo.rs
@@ -77,6 +77,101 @@ impl<'a> SyncRepository<'a> {
         Ok(())
     }
 
+    /// Emit a local sync op for a frontend mutation and stage it for push.
+    ///
+    /// This is the single choke-point through which every domain mutation
+    /// records its op. It is a **no-op when no device identity is configured**,
+    /// preserving the offline-first guarantee: op creation never requires sync
+    /// setup or network access.
+    ///
+    /// The op is stored in plaintext — `fields` are encrypted later, at push
+    /// time (see `toku-sync-client`). The HLC is seeded past the highest local
+    /// HLC so emitted ops are monotonic. For book fields, local provenance is
+    /// recorded (mirroring the merge engine) so that a later pull of a staler
+    /// remote edit cannot clobber this local write.
+    ///
+    /// Errors propagate to the caller so a failed op rolls back the enclosing
+    /// transaction: sync correctness must not be silently dropped.
+    pub fn emit_local_op(
+        &self,
+        entity_type: EntityType,
+        entity_id: Uuid,
+        op_type: OpType,
+        fields: Option<serde_json::Value>,
+    ) -> Result<(), DbError> {
+        let Some(identity) = self.get_device()? else {
+            return Ok(());
+        };
+
+        let hlc = self.next_local_hlc(&identity.device_id)?;
+
+        // Record local field provenance for book create/update writes so that
+        // subsequent merges (pulled remote edits) respect this write's recency.
+        // Session/Progress/Tag entities are append-only or immutable and carry
+        // no per-field HLC bookkeeping, so they need no provenance here.
+        if entity_type == EntityType::Book
+            && matches!(op_type, OpType::Create | OpType::Update)
+            && let Some(obj) = fields.as_ref().and_then(|f| f.as_object())
+        {
+            let hlc_str = hlc.to_canonical();
+            let book_id = entity_id.to_string();
+            for field_name in obj.keys() {
+                self.upsert_book_provenance(&book_id, field_name, &hlc_str)?;
+            }
+        }
+
+        let op = SyncOp::new(
+            identity.device_id,
+            hlc,
+            entity_type,
+            entity_id,
+            op_type,
+            fields,
+        );
+        self.insert_op(&op)
+    }
+
+    /// Build the next monotonic local HLC, seeded past the highest HLC already
+    /// present in the local op log (across all devices). This guarantees each
+    /// emitted op sorts after every existing one, avoiding same-millisecond
+    /// collisions that could otherwise drop a rapid second edit on the peer.
+    fn next_local_hlc(&self, device_id: &Uuid) -> Result<HlcTimestamp, DbError> {
+        let mut clock = HybridClock::new(device_id);
+        let max_hlc: Option<String> = self
+            .db
+            .conn
+            .query_row("SELECT MAX(hlc) FROM sync_ops", [], |row| row.get(0))
+            .optional()?
+            .flatten();
+
+        if let Some(max) = max_hlc
+            && let Ok(remote) = HlcTimestamp::from_str(&max)
+        {
+            return Ok(clock.update(&remote));
+        }
+        Ok(clock.now())
+    }
+
+    /// Upsert book field provenance with the given sync HLC. Mirrors the merge
+    /// engine's provenance write so local and remote edits share identical LWW
+    /// bookkeeping. On conflict only `sync_hlc` advances, leaving any existing
+    /// metadata `source` (e.g. from an importer) untouched.
+    fn upsert_book_provenance(
+        &self,
+        book_id: &str,
+        field_name: &str,
+        hlc: &str,
+    ) -> Result<(), DbError> {
+        self.db.conn.execute(
+            "INSERT INTO metadata_provenance (book_id, field_name, source, source_date, is_user_override, sync_hlc)
+             VALUES (?1, ?2, 'sync', ?3, 0, ?3)
+             ON CONFLICT (book_id, field_name) DO UPDATE SET sync_hlc = ?3
+             WHERE sync_hlc IS NULL OR sync_hlc < ?3",
+            params![book_id, field_name, hlc],
+        )?;
+        Ok(())
+    }
+
     /// Get all ops that have not been pushed yet, ordered by HLC.
     pub fn get_unpushed_ops(&self) -> Result<Vec<SyncOp>, DbError> {
         let mut stmt = self.db.conn.prepare(

--- a/crates/toku-db/tests/sync_emission.rs
+++ b/crates/toku-db/tests/sync_emission.rs
@@ -1,0 +1,312 @@
+//! Integration tests for the sync-op emission choke-point in `BookRepository`.
+//!
+//! Every create/update/delete on a syncable entity (Book, Session, Progress,
+//! Tag) must stage exactly one `SyncOp`, atomically with the write, and must be
+//! a complete no-op when no device identity is configured (offline-first).
+
+use toku_core::{
+    Book, EntityType, OpType, PaceRating, ProgressType, ReadingProgress, ReadingSession,
+    ReadingStatus, SyncOp, TagType,
+};
+use toku_db::{BookRepository, Database, SyncRepository};
+
+fn db_with_device() -> Database {
+    let db = Database::open_in_memory().unwrap();
+    SyncRepository::new(&db)
+        .get_or_create_device("test-device")
+        .unwrap();
+    db
+}
+
+fn ops(db: &Database) -> Vec<SyncOp> {
+    SyncRepository::new(db).get_unpushed_ops().unwrap()
+}
+
+fn ops_for(db: &Database, entity_type: EntityType) -> Vec<SyncOp> {
+    ops(db)
+        .into_iter()
+        .filter(|o| o.entity_type == entity_type)
+        .collect()
+}
+
+fn make_book(title: &str) -> Book {
+    Book::new(title)
+}
+
+// ── Book ────────────────────────────────────────────────────────────────
+
+#[test]
+fn create_book_emits_one_book_create_op() {
+    let db = db_with_device();
+    let repo = BookRepository::new(&db);
+
+    let mut book = make_book("Dune");
+    book.rating = Some(8);
+    book.page_count = Some(412);
+    repo.create_book(&book).unwrap();
+
+    let book_ops = ops_for(&db, EntityType::Book);
+    assert_eq!(book_ops.len(), 1, "expected exactly one Book op");
+    let op = &book_ops[0];
+    assert_eq!(op.op_type, OpType::Create);
+    assert_eq!(op.entity_id, book.id);
+
+    let fields = op.fields.as_ref().expect("create op must carry fields");
+    assert_eq!(fields["title"], "Dune");
+    assert_eq!(fields["rating"], 8);
+    assert_eq!(fields["page_count"], 412);
+    assert_eq!(fields["status"], "want-to-read");
+    // work_id is intentionally omitted (Work rows are not synced yet).
+    assert!(fields.get("work_id").is_none());
+}
+
+#[test]
+fn update_status_emits_one_update_op_and_records_provenance() {
+    let db = db_with_device();
+    let repo = BookRepository::new(&db);
+
+    let book = make_book("Dune");
+    repo.create_book(&book).unwrap();
+
+    assert!(
+        repo.update_book_status(&book.id, ReadingStatus::Reading)
+            .unwrap()
+    );
+
+    let update_ops: Vec<_> = ops_for(&db, EntityType::Book)
+        .into_iter()
+        .filter(|o| o.op_type == OpType::Update)
+        .collect();
+    assert_eq!(update_ops.len(), 1);
+    assert_eq!(update_ops[0].fields.as_ref().unwrap()["status"], "reading");
+
+    // Provenance for the status field must be recorded so a staler remote edit
+    // can't clobber this local write on the next pull.
+    let sync_hlc: Option<String> = db
+        .conn
+        .query_row(
+            "SELECT sync_hlc FROM metadata_provenance WHERE book_id = ?1 AND field_name = 'status'",
+            [book.id.to_string()],
+            |r| r.get(0),
+        )
+        .unwrap();
+    assert!(sync_hlc.is_some(), "status provenance sync_hlc must be set");
+}
+
+#[test]
+fn update_rating_emits_one_update_op() {
+    let db = db_with_device();
+    let repo = BookRepository::new(&db);
+
+    let book = make_book("Dune");
+    repo.create_book(&book).unwrap();
+
+    assert!(repo.update_book_rating(&book.id, 10).unwrap());
+
+    let update_ops: Vec<_> = ops_for(&db, EntityType::Book)
+        .into_iter()
+        .filter(|o| o.op_type == OpType::Update)
+        .collect();
+    assert_eq!(update_ops.len(), 1);
+    assert_eq!(update_ops[0].fields.as_ref().unwrap()["rating"], 10);
+}
+
+#[test]
+fn delete_book_emits_one_delete_op() {
+    let db = db_with_device();
+    let repo = BookRepository::new(&db);
+
+    let book = make_book("Dune");
+    repo.create_book(&book).unwrap();
+
+    assert!(repo.delete_book(&book.id).unwrap());
+
+    let delete_ops: Vec<_> = ops_for(&db, EntityType::Book)
+        .into_iter()
+        .filter(|o| o.op_type == OpType::Delete)
+        .collect();
+    assert_eq!(delete_ops.len(), 1);
+    assert_eq!(delete_ops[0].entity_id, book.id);
+    assert!(delete_ops[0].fields.is_none());
+}
+
+#[test]
+fn delete_missing_book_emits_no_op() {
+    let db = db_with_device();
+    let repo = BookRepository::new(&db);
+
+    let missing = uuid::Uuid::now_v7();
+    assert!(!repo.delete_book(&missing).unwrap());
+    assert_eq!(ops(&db).len(), 0);
+}
+
+// ── Offline-first guard ──────────────────────────────────────────────────
+
+#[test]
+fn no_device_means_no_ops_but_write_succeeds() {
+    // No device identity configured — op creation must be a complete no-op,
+    // while the underlying write still happens.
+    let db = Database::open_in_memory().unwrap();
+    let repo = BookRepository::new(&db);
+
+    let book = make_book("Dune");
+    repo.create_book(&book).unwrap();
+    repo.update_book_status(&book.id, ReadingStatus::Reading)
+        .unwrap();
+    repo.update_book_rating(&book.id, 7).unwrap();
+    repo.delete_book(&book.id).unwrap();
+
+    assert_eq!(ops(&db).len(), 0, "offline mode must not stage any ops");
+    // The write path itself must not be blocked by the absence of sync.
+    assert!(repo.get_book_including_deleted(&book.id).is_ok());
+}
+
+// ── Atomicity ────────────────────────────────────────────────────────────
+
+#[test]
+fn failed_op_rolls_back_the_write() {
+    let db = db_with_device();
+    let repo = BookRepository::new(&db);
+
+    // Force any op insert to fail; the enclosing transaction must roll back the
+    // book write too, so neither the row nor the op survives.
+    db.conn
+        .execute_batch(
+            "CREATE TRIGGER fail_ops BEFORE INSERT ON sync_ops
+             BEGIN SELECT RAISE(ABORT, 'boom'); END;",
+        )
+        .unwrap();
+
+    let book = make_book("Dune");
+    let result = repo.create_book(&book);
+    assert!(result.is_err(), "create_book should surface the op failure");
+
+    // Drop the trigger so the assertion queries work.
+    db.conn.execute_batch("DROP TRIGGER fail_ops").unwrap();
+
+    assert!(
+        repo.get_book(&book.id).is_err(),
+        "book write must be rolled back with the failed op"
+    );
+    assert_eq!(ops(&db).len(), 0, "no op should have been committed");
+}
+
+// ── Session / Progress ───────────────────────────────────────────────────
+
+#[test]
+fn create_session_emits_session_create_op() {
+    let db = db_with_device();
+    let repo = BookRepository::new(&db);
+
+    let book = make_book("Dune");
+    repo.create_book(&book).unwrap();
+
+    let mut session = ReadingSession::new(book.id);
+    session.start_page = Some(1);
+    session.end_page = Some(50);
+    repo.create_reading_session(&session).unwrap();
+
+    let session_ops = ops_for(&db, EntityType::Session);
+    assert_eq!(session_ops.len(), 1);
+    let op = &session_ops[0];
+    assert_eq!(op.op_type, OpType::Create);
+    assert_eq!(op.entity_id, session.id);
+    let fields = op.fields.as_ref().unwrap();
+    assert_eq!(fields["book_id"], book.id.to_string());
+    assert_eq!(fields["start_page"], 1);
+    assert_eq!(fields["end_page"], 50);
+}
+
+#[test]
+fn log_progress_emits_progress_create_op() {
+    let db = db_with_device();
+    let repo = BookRepository::new(&db);
+
+    let book = make_book("Dune");
+    repo.create_book(&book).unwrap();
+
+    let progress = ReadingProgress::new(book.id, ProgressType::Page, 120);
+    repo.log_progress(&progress).unwrap();
+
+    let progress_ops = ops_for(&db, EntityType::Progress);
+    assert_eq!(progress_ops.len(), 1);
+    let op = &progress_ops[0];
+    assert_eq!(op.op_type, OpType::Create);
+    assert_eq!(op.entity_id, progress.id);
+    let fields = op.fields.as_ref().unwrap();
+    assert_eq!(fields["book_id"], book.id.to_string());
+    assert_eq!(fields["progress_type"], "page");
+    assert_eq!(fields["value"], 120);
+}
+
+// ── Tags ─────────────────────────────────────────────────────────────────
+
+#[test]
+fn add_and_remove_tag_emit_create_then_delete_ops() {
+    let db = db_with_device();
+    let repo = BookRepository::new(&db);
+
+    let book = make_book("Dune");
+    repo.create_book(&book).unwrap();
+
+    repo.add_typed_tag_to_book(&book.id, "sci-fi", TagType::General)
+        .unwrap();
+
+    let tag_ops = ops_for(&db, EntityType::Tag);
+    assert_eq!(tag_ops.len(), 1);
+    assert_eq!(tag_ops[0].op_type, OpType::Create);
+    // Tag ops are book-scoped associations: entity_id is the book id.
+    assert_eq!(tag_ops[0].entity_id, book.id);
+    assert_eq!(tag_ops[0].fields.as_ref().unwrap()["tag_name"], "sci-fi");
+    assert_eq!(tag_ops[0].fields.as_ref().unwrap()["tag_type"], "general");
+
+    repo.remove_typed_tag_from_book(&book.id, "sci-fi", TagType::General)
+        .unwrap();
+
+    let tag_ops = ops_for(&db, EntityType::Tag);
+    assert_eq!(tag_ops.len(), 2);
+    assert_eq!(tag_ops[1].op_type, OpType::Delete);
+    assert_eq!(tag_ops[1].fields.as_ref().unwrap()["tag_name"], "sci-fi");
+}
+
+#[test]
+fn adding_same_tag_twice_emits_only_one_op() {
+    let db = db_with_device();
+    let repo = BookRepository::new(&db);
+
+    let book = make_book("Dune");
+    repo.create_book(&book).unwrap();
+
+    repo.add_typed_tag_to_book(&book.id, "sci-fi", TagType::General)
+        .unwrap();
+    // Second add is a no-op association (INSERT OR IGNORE) → no extra op.
+    repo.add_typed_tag_to_book(&book.id, "sci-fi", TagType::General)
+        .unwrap();
+
+    assert_eq!(ops_for(&db, EntityType::Tag).len(), 1);
+}
+
+#[test]
+fn set_pace_replaces_tag_with_delete_then_create() {
+    let db = db_with_device();
+    let repo = BookRepository::new(&db);
+
+    let book = make_book("Dune");
+    repo.create_book(&book).unwrap();
+
+    repo.set_book_pace(&book.id, PaceRating::Fast).unwrap();
+    // First set: no existing pace tag, so only a Create.
+    let tag_ops = ops_for(&db, EntityType::Tag);
+    assert_eq!(tag_ops.len(), 1);
+    assert_eq!(tag_ops[0].op_type, OpType::Create);
+    assert_eq!(tag_ops[0].fields.as_ref().unwrap()["tag_name"], "fast");
+
+    repo.set_book_pace(&book.id, PaceRating::Slow).unwrap();
+    // Second set: remove old "fast" (Delete) + add "slow" (Create).
+    let tag_ops = ops_for(&db, EntityType::Tag);
+    assert_eq!(tag_ops.len(), 3);
+    assert_eq!(tag_ops[1].op_type, OpType::Delete);
+    assert_eq!(tag_ops[1].fields.as_ref().unwrap()["tag_name"], "fast");
+    assert_eq!(tag_ops[2].op_type, OpType::Create);
+    assert_eq!(tag_ops[2].fields.as_ref().unwrap()["tag_name"], "slow");
+}

--- a/crates/toku-ffi/src/lib.rs
+++ b/crates/toku-ffi/src/lib.rs
@@ -32,12 +32,11 @@ use std::path::Path;
 use std::str::FromStr;
 
 use serde::Serialize;
-use serde_json::json;
 use toku_core::{
-    Author, Book, ContributorRole, CurrentlyReadingInput, EntityType, HybridClock, OpType,
-    ProgressType, ReadingProgress, ReadingStatus, StatsInput, SyncOp, compute_stats,
+    Author, Book, ContributorRole, CurrentlyReadingInput, ProgressType, ReadingProgress,
+    ReadingStatus, StatsInput, compute_stats,
 };
-use toku_db::{BookRepository, Database, SyncRepository};
+use toku_db::{BookRepository, Database};
 
 // ── Status codes ────────────────────────────────────────────────────────
 
@@ -176,36 +175,6 @@ fn rust_string_to_c(s: &str) -> *mut c_char {
     match CString::new(s) {
         Ok(cs) => cs.into_raw(),
         Err(_) => std::ptr::null_mut(),
-    }
-}
-
-// ── Helper: append a sync op for a local mutation ───────────────────────
-
-/// Best-effort: append a sync op so a local mutation flows through the op-log to
-/// other devices (the same op-log the phone uses).
-///
-/// Op creation is guarded on a configured device identity, mirroring the CLI: when
-/// sync has not been set up there is no device, so nothing is recorded. Any failure
-/// is swallowed — a missing or partial sync setup must never block the primary write.
-fn record_sync_op(
-    db: &Database,
-    entity_type: EntityType,
-    entity_id: uuid::Uuid,
-    op_type: OpType,
-    fields: Option<serde_json::Value>,
-) {
-    let sync_repo = SyncRepository::new(db);
-    if let Ok(Some(identity)) = sync_repo.get_device() {
-        let mut clock = HybridClock::new(&identity.device_id);
-        let op = SyncOp::new(
-            identity.device_id,
-            clock.now(),
-            entity_type,
-            entity_id,
-            op_type,
-            fields,
-        );
-        let _ = sync_repo.insert_op(&op);
     }
 }
 
@@ -568,13 +537,8 @@ pub unsafe extern "C" fn toku_update_book_status(
 
         match repo.update_book_status(&uuid, reading_status) {
             Ok(true) => {
-                record_sync_op(
-                    &handle.db,
-                    EntityType::Book,
-                    uuid,
-                    OpType::Update,
-                    Some(json!({ "status": reading_status.as_str() })),
-                );
+                // `update_book_status` emits the Book Update sync op atomically
+                // with the write, identical to the CLI path.
                 TokuStatus::Ok
             }
             Ok(false) => {
@@ -634,13 +598,8 @@ pub unsafe extern "C" fn toku_update_book_rating(
 
         match repo.update_book_rating(&uuid, actual_rating) {
             Ok(true) => {
-                record_sync_op(
-                    &handle.db,
-                    EntityType::Book,
-                    uuid,
-                    OpType::Update,
-                    Some(json!({ "rating": actual_rating })),
-                );
+                // `update_book_rating` emits the Book Update sync op atomically
+                // with the write, identical to the CLI path.
                 TokuStatus::Ok
             }
             Ok(false) => {
@@ -738,20 +697,8 @@ pub unsafe extern "C" fn toku_log_progress(
             return TokuStatus::ErrorDb;
         }
 
-        record_sync_op(
-            &handle.db,
-            EntityType::Progress,
-            progress.id,
-            OpType::Create,
-            Some(json!({
-                "book_id": progress.book_id.to_string(),
-                "progress_type": ptype.as_str(),
-                "value": value,
-                "session_id": progress.session_id.map(|s| s.to_string()),
-                "logged_at": progress.logged_at.to_rfc3339(),
-            })),
-        );
-
+        // `log_progress` emits the Progress Create sync op atomically with the
+        // write, identical to the CLI path.
         TokuStatus::Ok
     }))
 }
@@ -1587,6 +1534,8 @@ pub unsafe extern "C" fn toku_free_string(s: *mut c_char) {
 mod tests {
     use super::*;
     use std::ffi::CString;
+    use toku_core::EntityType;
+    use toku_db::SyncRepository;
 
     fn open_memory_db() -> *mut TokuDb {
         let db = Database::open_in_memory().unwrap();
@@ -2010,6 +1959,59 @@ mod tests {
         );
 
         unsafe { toku_close(db) };
+    }
+
+    /// Parity: an FFI status update must emit an op with byte-identical fields
+    /// to the equivalent direct `BookRepository` (CLI) call. Both go through the
+    /// same repo choke-point, so this guards against future divergence.
+    #[test]
+    fn ffi_status_op_matches_repo_op() {
+        use toku_core::OpType;
+
+        fn update_op_fields<F: FnOnce(*mut TokuDb, &str)>(mutate: F) -> Option<serde_json::Value> {
+            let db = open_memory_db();
+            let id = add_test_book(db, "Parity", None);
+            {
+                let handle = unsafe { &*db };
+                SyncRepository::new(&handle.db)
+                    .get_or_create_device("dev")
+                    .unwrap();
+            }
+            mutate(db, &id);
+            let handle = unsafe { &*db };
+            let ops = SyncRepository::new(&handle.db).get_unpushed_ops().unwrap();
+            let fields = ops
+                .into_iter()
+                .find(|op| op.entity_type == EntityType::Book && op.op_type == OpType::Update)
+                .expect("a Book Update op")
+                .fields;
+            unsafe { toku_close(db) };
+            fields
+        }
+
+        // FFI path: go through the C ABI entry point.
+        let ffi_fields = update_op_fields(|db, id| {
+            let id_c = CString::new(id).unwrap();
+            let status_c = CString::new("reading").unwrap();
+            let r = unsafe { toku_update_book_status(db, id_c.as_ptr(), status_c.as_ptr()) };
+            assert!(matches!(r, TokuStatus::Ok));
+        });
+
+        // CLI-equivalent path: call the repository method directly.
+        let repo_fields = update_op_fields(|db, id| {
+            let handle = unsafe { &*db };
+            let repo = BookRepository::new(&handle.db);
+            let uuid = uuid::Uuid::parse_str(id).unwrap();
+            assert!(
+                repo.update_book_status(&uuid, ReadingStatus::Reading)
+                    .unwrap()
+            );
+        });
+
+        assert_eq!(
+            ffi_fields, repo_fields,
+            "FFI status op fields must match the repo/CLI op fields exactly"
+        );
     }
 
     #[test]

--- a/crates/toku-import/src/calibre.rs
+++ b/crates/toku-import/src/calibre.rs
@@ -3,8 +3,8 @@ use std::path::Path;
 
 use chrono::Utc;
 use rusqlite::{Connection, OpenFlags, params};
-use toku_core::{Author, Book, BookFormat, ContributorRole, Isbn};
-use toku_db::{BookRepository, Database};
+use toku_core::{Author, Book, BookFormat, ContributorRole, EntityType, Isbn, OpType};
+use toku_db::{BookRepository, Database, SyncRepository};
 use uuid::Uuid;
 
 use crate::ImportError;
@@ -208,7 +208,10 @@ fn import_single_book(
         }
     }
 
-    // Insert book with calibre_id
+    // Insert book with calibre_id, atomically with its Book Create sync op.
+    // Calibre imports each book independently (no outer transaction), so open
+    // one here; nested repo mutations join it via `is_autocommit()`.
+    let tx = db.conn.unchecked_transaction()?;
     db.conn.execute(
         "INSERT INTO books (id, title, subtitle, description, page_count, pub_date,
          language, format, duration_minutes, cover_hash, work_id, status, rating,
@@ -293,6 +296,18 @@ fn import_single_book(
     if book.pub_date.is_some() {
         set_provenance(&db.conn, &book.id, "pub_date", "calibre_import")?;
     }
+
+    // Emit the Book Create sync op after provenance is written so the importer's
+    // `source` labels survive (emit only advances `sync_hlc`). No-op without a
+    // device; commits atomically with the book insert above.
+    SyncRepository::new(db).emit_local_op(
+        EntityType::Book,
+        book.id,
+        OpType::Create,
+        Some(toku_db::book_op_fields(&book)),
+    )?;
+
+    tx.commit()?;
 
     Ok(book.id)
 }

--- a/crates/toku-import/src/goodreads.rs
+++ b/crates/toku-import/src/goodreads.rs
@@ -4,8 +4,10 @@ use std::path::Path;
 use chrono::Utc;
 use csv::ReaderBuilder;
 use rusqlite::params;
-use toku_core::{Author, Book, BookFormat, ContributorRole, Isbn, ReadingStatus};
-use toku_db::{BookRepository, Database};
+use toku_core::{
+    Author, Book, BookFormat, ContributorRole, EntityType, Isbn, OpType, ReadingStatus,
+};
+use toku_db::{BookRepository, Database, SyncRepository};
 use uuid::Uuid;
 
 use crate::ImportError;
@@ -429,6 +431,16 @@ fn import_rows(
         if book.pub_date.is_some() {
             set_provenance(&db.conn, &book.id, "pub_date", "goodreads_import")?;
         }
+
+        // Emit the Book Create sync op after provenance is written so the
+        // importer's `source` labels survive (emit only advances `sync_hlc`).
+        // Runs inside the importer's transaction; no-op without a device.
+        SyncRepository::new(db).emit_local_op(
+            EntityType::Book,
+            book.id,
+            OpType::Create,
+            Some(toku_db::book_op_fields(&book)),
+        )?;
 
         if let Some(ref id) = gr_id {
             existing_gr_ids.insert(id.clone(), book.id);

--- a/crates/toku-import/src/storygraph.rs
+++ b/crates/toku-import/src/storygraph.rs
@@ -5,9 +5,10 @@ use chrono::Utc;
 use csv::ReaderBuilder;
 use rusqlite::params;
 use toku_core::{
-    Author, Book, BookFormat, ContributorRole, Isbn, ReadingSession, ReadingStatus, TagType,
+    Author, Book, BookFormat, ContributorRole, EntityType, Isbn, OpType, ReadingSession,
+    ReadingStatus, TagType,
 };
-use toku_db::{BookRepository, Database};
+use toku_db::{BookRepository, Database, SyncRepository};
 use uuid::Uuid;
 
 use crate::ImportError;
@@ -467,6 +468,16 @@ fn import_rows(
         if book.rating.is_some() {
             set_provenance(&db.conn, &book.id, "rating", "storygraph_import")?;
         }
+
+        // Emit the Book Create sync op after provenance is written so the
+        // importer's `source` labels survive (emit only advances `sync_hlc`).
+        // Runs inside the importer's transaction; no-op without a device.
+        SyncRepository::new(db).emit_local_op(
+            EntityType::Book,
+            book.id,
+            OpType::Create,
+            Some(toku_db::book_op_fields(&book)),
+        )?;
 
         // Update dedup maps
         let key = format!(

--- a/crates/toku-sync/tests/harness/mod.rs
+++ b/crates/toku-sync/tests/harness/mod.rs
@@ -26,7 +26,10 @@ use std::sync::Once;
 use chrono::{DateTime, Utc};
 use tempfile::TempDir;
 use tokio::runtime::Runtime;
-use toku_core::{EntityType, HybridClock, OpType, SyncOp};
+use toku_core::{
+    Book, EntityType, HybridClock, OpType, ProgressType, ReadingProgress, ReadingSession,
+    ReadingStatus, SyncOp, TagType,
+};
 use toku_db::{BookRepository, Database, MergeEngine, SyncRepository};
 use toku_sync::build_router;
 use toku_sync::db::SyncDatabase;
@@ -287,6 +290,79 @@ impl SimulatedDevice {
         self.emit(book_id, OpType::Delete, None, at);
     }
 
+    // ── Real-frontend mutations ───────────────────────────────────────────────
+    //
+    // These drive the product's `BookRepository` directly. Because the device
+    // has a configured identity (from enrollment), every write funnels through
+    // the same op-emission choke-point the CLI and FFI use — so these exercise
+    // real command paths, not hand-staged ops. The op is emitted atomically
+    // with the write and staged for the next push.
+
+    /// Create a book through the real repository. Returns the new book id.
+    pub fn repo_add_book(&self, title: &str) -> Uuid {
+        let db = self.open_db();
+        let book = Book::new(title);
+        let id = book.id;
+        BookRepository::new(&db)
+            .create_book(&book)
+            .expect("repo create_book");
+        id
+    }
+
+    /// Set a book's status through the real repository.
+    pub fn repo_set_status(&self, book_id: Uuid, status: ReadingStatus) {
+        let db = self.open_db();
+        BookRepository::new(&db)
+            .update_book_status(&book_id, status)
+            .expect("repo update_book_status");
+    }
+
+    /// Set a book's rating through the real repository.
+    pub fn repo_set_rating(&self, book_id: Uuid, rating: i32) {
+        let db = self.open_db();
+        BookRepository::new(&db)
+            .update_book_rating(&book_id, rating)
+            .expect("repo update_book_rating");
+    }
+
+    /// Soft-delete a book through the real repository.
+    pub fn repo_delete_book(&self, book_id: Uuid) {
+        let db = self.open_db();
+        BookRepository::new(&db)
+            .delete_book(&book_id)
+            .expect("repo delete_book");
+    }
+
+    /// Log a reading session through the real repository. Returns its id.
+    pub fn repo_log_session(&self, book_id: Uuid) -> Uuid {
+        let db = self.open_db();
+        let session = ReadingSession::new(book_id);
+        let id = session.id;
+        BookRepository::new(&db)
+            .create_reading_session(&session)
+            .expect("repo create_reading_session");
+        id
+    }
+
+    /// Log a page-progress entry through the real repository. Returns its id.
+    pub fn repo_log_progress(&self, book_id: Uuid, value: i32) -> Uuid {
+        let db = self.open_db();
+        let progress = ReadingProgress::new(book_id, ProgressType::Page, value);
+        let id = progress.id;
+        BookRepository::new(&db)
+            .log_progress(&progress)
+            .expect("repo log_progress");
+        id
+    }
+
+    /// Add a general tag to a book through the real repository.
+    pub fn repo_add_tag(&self, book_id: Uuid, name: &str) {
+        let db = self.open_db();
+        BookRepository::new(&db)
+            .add_typed_tag_to_book(&book_id, name, TagType::General)
+            .expect("repo add_typed_tag_to_book");
+    }
+
     // ── Sync ─────────────────────────────────────────────────────────────────
 
     /// Push all locally-pending ops to the server.
@@ -335,6 +411,37 @@ impl SimulatedDevice {
             .get_book(&book_id)
             .ok()
             .map(|b| b.status.to_string())
+    }
+
+    /// Number of reading sessions recorded locally for a book.
+    pub fn session_count(&self, book_id: Uuid) -> usize {
+        let db = self.open_db();
+        db.conn
+            .query_row(
+                "SELECT COUNT(*) FROM reading_sessions WHERE book_id = ?1",
+                [book_id.to_string()],
+                |r| r.get::<_, i64>(0),
+            )
+            .expect("count sessions") as usize
+    }
+
+    /// The most recent progress value recorded locally for a book, if any.
+    pub fn latest_progress(&self, book_id: Uuid) -> Option<i32> {
+        let db = self.open_db();
+        BookRepository::new(&db)
+            .get_latest_progress(&book_id)
+            .ok()
+            .flatten()
+            .map(|p| p.value)
+    }
+
+    /// True when the book carries a tag with the given name locally.
+    pub fn has_tag(&self, book_id: Uuid, name: &str) -> bool {
+        let db = self.open_db();
+        BookRepository::new(&db)
+            .get_book_tags(&book_id)
+            .map(|tags| tags.iter().any(|t| t.name == name))
+            .unwrap_or(false)
     }
 
     /// Number of ops staged locally that have not yet been pushed.

--- a/crates/toku-sync/tests/sync_real_emission.rs
+++ b/crates/toku-sync/tests/sync_real_emission.rs
@@ -1,0 +1,167 @@
+//! Multi-device round-trip tests driven by **real frontend commands**.
+//!
+//! Unlike `sync_multi_device.rs` (which hand-builds ops to pin explicit HLC
+//! times for deterministic LWW), these tests mutate through the product's
+//! `BookRepository` — the exact code path the CLI and FFI use. They assert that
+//! ordinary edits (add book, set status/rating, delete, log session/progress,
+//! add tag) emit ops and round-trip to a second device. This is the acceptance
+//! criterion for issue #194: real commands produce ops that propagate.
+
+mod harness;
+
+use harness::{SimulatedDevice, TestServer};
+use toku_core::ReadingStatus;
+
+/// Adding a book through the real repository emits exactly one op that
+/// propagates to a second device.
+#[test]
+fn real_add_book_round_trips() {
+    let server = TestServer::start();
+    let lib = "real-01";
+
+    let a = SimulatedDevice::register(&server, lib, "device-a", None);
+    let b = SimulatedDevice::register(&server, lib, "device-b", None);
+
+    let book = a.repo_add_book("Piranesi");
+    assert!(
+        a.book_exists(book),
+        "A has the book immediately after the write"
+    );
+    assert_eq!(a.pending_ops(), 1, "exactly one op staged by create_book");
+
+    assert_eq!(a.push().accepted, 1);
+    let pulled = b.pull();
+    assert_eq!(pulled.applied, 1);
+
+    assert!(b.book_exists(book));
+    assert_eq!(b.book_title(book).as_deref(), Some("Piranesi"));
+}
+
+/// Status and rating updates round-trip and materialize on the peer.
+#[test]
+fn real_status_and_rating_round_trip() {
+    let server = TestServer::start();
+    let lib = "real-02";
+
+    let a = SimulatedDevice::register(&server, lib, "device-a", None);
+    let b = SimulatedDevice::register(&server, lib, "device-b", None);
+
+    let book = a.repo_add_book("Dune");
+    a.repo_set_status(book, ReadingStatus::Reading);
+    a.repo_set_rating(book, 9);
+    assert_eq!(a.pending_ops(), 3, "create + status + rating");
+
+    a.push();
+    b.pull();
+
+    assert_eq!(b.book_status(book).as_deref(), Some("reading"));
+    assert_eq!(b.book_rating(book), Some(9));
+}
+
+/// A delete performed via the real repository tombstones the book on the peer.
+#[test]
+fn real_delete_round_trips() {
+    let server = TestServer::start();
+    let lib = "real-03";
+
+    let a = SimulatedDevice::register(&server, lib, "device-a", None);
+    let b = SimulatedDevice::register(&server, lib, "device-b", None);
+
+    let book = a.repo_add_book("Ephemeral");
+    a.push();
+    b.pull();
+    assert!(b.book_exists(book));
+
+    a.repo_delete_book(book);
+    a.push();
+    b.pull();
+
+    assert!(!b.book_exists(book), "delete op must propagate to B");
+}
+
+/// A reading session logged through the real repository round-trips.
+#[test]
+fn real_session_round_trips() {
+    let server = TestServer::start();
+    let lib = "real-04";
+
+    let a = SimulatedDevice::register(&server, lib, "device-a", None);
+    let b = SimulatedDevice::register(&server, lib, "device-b", None);
+
+    let book = a.repo_add_book("Hyperion");
+    a.repo_log_session(book);
+
+    a.push();
+    b.pull();
+
+    assert!(b.book_exists(book));
+    assert_eq!(b.session_count(book), 1, "session op must propagate to B");
+}
+
+/// A progress entry logged through the real repository round-trips.
+#[test]
+fn real_progress_round_trips() {
+    let server = TestServer::start();
+    let lib = "real-05";
+
+    let a = SimulatedDevice::register(&server, lib, "device-a", None);
+    let b = SimulatedDevice::register(&server, lib, "device-b", None);
+
+    let book = a.repo_add_book("Cryptonomicon");
+    a.repo_log_progress(book, 250);
+
+    a.push();
+    b.pull();
+
+    assert_eq!(
+        b.latest_progress(book),
+        Some(250),
+        "progress must propagate to B"
+    );
+}
+
+/// A tag added through the real repository round-trips.
+#[test]
+fn real_tag_round_trips() {
+    let server = TestServer::start();
+    let lib = "real-06";
+
+    let a = SimulatedDevice::register(&server, lib, "device-a", None);
+    let b = SimulatedDevice::register(&server, lib, "device-b", None);
+
+    let book = a.repo_add_book("Neuromancer");
+    a.repo_add_tag(book, "cyberpunk");
+
+    a.push();
+    b.pull();
+
+    assert!(b.book_exists(book));
+    assert!(b.has_tag(book, "cyberpunk"), "tag op must propagate to B");
+}
+
+/// Everything together: a full edit session on A converges on B in one sync.
+#[test]
+fn real_full_edit_session_converges() {
+    let server = TestServer::start();
+    let lib = "real-07";
+
+    let a = SimulatedDevice::register(&server, lib, "device-a", None);
+    let b = SimulatedDevice::register(&server, lib, "device-b", None);
+
+    let book = a.repo_add_book("The Dispossessed");
+    a.repo_set_status(book, ReadingStatus::Reading);
+    a.repo_log_session(book);
+    a.repo_log_progress(book, 100);
+    a.repo_add_tag(book, "utopia");
+    a.repo_set_rating(book, 10);
+
+    a.push();
+    b.pull();
+
+    assert_eq!(b.book_title(book).as_deref(), Some("The Dispossessed"));
+    assert_eq!(b.book_status(book).as_deref(), Some("reading"));
+    assert_eq!(b.book_rating(book), Some(10));
+    assert_eq!(b.session_count(book), 1);
+    assert_eq!(b.latest_progress(book), Some(100));
+    assert!(b.has_tag(book, "utopia"));
+}


### PR DESCRIPTION
## Description

Wires every frontend mutation into the sync op log so ordinary edits propagate incrementally via push/pull. Previously the sync server and crypto existed, but client frontends never fed the op log: only bulk delete and conflict resolution produced ops, so a normal edit (add book, log a session, set status/rating, add a tag) never synced — only a full `toku sync compact` snapshot moved state.

This introduces a single choke-point in the persistence layer so ops can't be forgotten per call-site, and every create/update/delete on a syncable entity now stages exactly one op **atomically with the write**.

### What's included

- **Choke-point in `toku-db`.** New `SyncRepository::emit_local_op` (plus `next_local_hlc` and `upsert_book_provenance`) builds a plaintext `SyncOp`, seeds a monotonic HLC, records per-field book provenance, and propagates errors instead of swallowing them. A new `BookRepository::with_sync_txn` helper opens a transaction when the connection is in autocommit, or joins the caller's open transaction otherwise (importers run inside `BEGIN IMMEDIATE`), guaranteeing the op and the write commit or roll back together.
- **Wired mutations.** create/delete book, update status, update rating, create reading session, log progress, add/remove tag, set pace, and `merge_books` (emits a Delete op for the merged-away book). Ops are only emitted when a row actually changed.
- **Importers.** Goodreads, Calibre, and StoryGraph emit a Book Create op after their provenance writes (so importer source labels survive), covering the web import wizard path.
- **FFI parity.** The FFI status/rating/progress paths now rely on the same repository choke-point, so mobile mutations produce byte-identical ops to the CLI, and op-write failures are no longer silently swallowed.
- **Offline-first preserved.** Op emission is a complete no-op until a device identity is configured — no sync setup means no ops and no network for core mutations.

### Removed redundant emission

The old hand-rolled op emission at the CLI bulk-delete site and the FFI `record_sync_op` helper are removed, since the choke-point now covers them.

### Tests

- `toku-db/tests/sync_emission.rs` — exactly-one-op per entity, the no-device no-op guard, and atomic rollback when the op write fails.
- `toku-sync/tests/sync_real_emission.rs` — two-device A→B round-trips driven by real repository commands through the real orchestrator + merge + crypto.
- `toku-cli/tests/sync_emission_cli.rs` — drives the compiled `toku` binary and asserts ops are staged.
- `toku-ffi` — `ffi_status_op_matches_repo_op` asserts the FFI op fields exactly match the repository/CLI path.

## Related Issues

Closes #194. Relates to #207 (tracking epic). Follow-up filed as #208 for extending op emission to Author, Shelf, Work, ISBN, and Series (deferred — requires an op-protocol/merge expansion).

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI / infrastructure
- [ ] Other (describe below)

## Crate

- [ ] `toku-core` — Domain models, traits, state machine
- [x] `toku-db` — SQLite persistence, migrations, FTS5
- [x] `toku-import` — Importers (Goodreads, Calibre, StoryGraph)
- [ ] `toku-meta` — Metadata fetching (Open Library, Google Books)
- [x] `toku-cli` — CLI binary
- [ ] `toku-export` — Exporters (CSV, JSON, Markdown, BibTeX)
- [ ] `docs/` — Documentation

_Also touches `toku-ffi` (C FFI bindings) and `toku-sync` test harness._

## Data Integrity Checklist

- [x] No user data is sent to any server without explicit opt-in — op emission is a no-op until a device identity is configured; encryption still happens at push time.
- [x] Import operations are idempotent (re-importing the same file creates no duplicates) — importer dedup via source IDs is unchanged; emission runs after existing provenance writes.
- [x] User edits to metadata are never overwritten by auto-enrichment — emit uses `INSERT ... ON CONFLICT` that only advances `sync_hlc`, preserving the existing metadata `source`.
- [x] New fields track provenance (source + timestamp) — local writes record per-field provenance with the op's HLC.
- [ ] Export round-trip is preserved (if applicable) — N/A, no export paths changed.

## Checklist

- [x] I have read [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] `cargo fmt --check` passes
- [x] `cargo clippy --workspace -- -D warnings` passes
- [x] `cargo test --workspace` passes (539 tests)
- [ ] I have updated documentation (if applicable) — CHANGELOG `[Unreleased]` updated; no other docs affected.