### PR TITLE
feat(sync): upload existing state on first opt-in + wire/expose new-device bootstrap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Opting into sync now uploads the library you already have. On `toku sync signup` (and on a
+  `toku sync enroll` that creates a fresh library), Toku backfills your existing books,
+  reading sessions, progress, and tags into the sync log and pushes them automatically — no
+  manual `toku sync compact` needed to seed the server. The command reports how many items
+  were uploaded and warns about what sync does not cover yet (ebook file binaries, and
+  authors/shelves/works/series/ISBNs — tracked in #208). The backfill is idempotent and only
+  ever runs at the opt-in boundary, so offline, sync-disabled use never touches the network
+  (#199)
+- New devices restore automatically. Enrolling a device into an existing library now
+  bootstraps it (applies the latest server snapshot, then pulls remaining ops) as part of
+  `toku sync enroll`; a device that enrolls while approval is required restores on its first
+  `toku sync login` after approval. A new `toku sync bootstrap [--reset-cursor]` command
+  exposes the same restore path for manual re-provisioning and recovery. Your local SQLite
+  database remains the primary recovery (#199)
+
 ### Changed
 
 - Sync now propagates ordinary edits incrementally. Every create/update/delete on a

--- a/crates/toku-cli/src/main.rs
+++ b/crates/toku-cli/src/main.rs
@@ -800,6 +800,14 @@ enum SyncAction {
     /// Pull remote changes from the sync server
     Pull,
 
+    /// Restore this device's library from the server (new-device provisioning /
+    /// recovery): download and apply the latest snapshot, then pull remaining ops
+    Bootstrap {
+        /// Discard the local pull cursor and re-sync from scratch (full re-download)
+        #[arg(long)]
+        reset_cursor: bool,
+    },
+
     /// List all devices registered to this library
     Devices,
 
@@ -4234,6 +4242,31 @@ fn read_secret_key() -> Result<toku_core::SecretKey> {
     toku_core::SecretKey::parse(&raw).map_err(|e| anyhow::anyhow!("invalid Secret Key: {e}"))
 }
 
+/// Print, to stderr, what a first-opt-in backfill uploaded and — always — the
+/// classes of data sync does not cover, so the user's "what reached the server"
+/// mental model stays correct (ADR-013 D2: non-silent by construction).
+fn report_backfill(report: &sync::orchestrator::BackfillReport) {
+    if report.ops_total == 0 {
+        eprintln!("Existing library: nothing new to upload (already staged or empty).");
+    } else {
+        eprintln!(
+            "Uploaded your existing library: {} book(s), {} session(s), \
+             {} progress entr{}, {} tag(s) \u{2014} {} ops ({} accepted).",
+            report.books,
+            report.sessions,
+            report.progress,
+            if report.progress == 1 { "y" } else { "ies" },
+            report.tags,
+            report.ops_total,
+            report.pushed,
+        );
+    }
+    eprintln!(
+        "Note: sync does not cover ebook file binaries (they stay on this device), \
+         nor authors, shelves, works, series, or ISBNs yet (tracked in #208)."
+    );
+}
+
 /// Render an Emergency Kit, choosing the format from the output path's extension
 /// (`.pdf`/`.html`, else text). With no path the plain-text kit is printed.
 fn render_emergency_kit(kit: &toku_core::EmergencyKit, out: Option<&Path>) -> Result<()> {
@@ -4420,6 +4453,14 @@ fn cmd_sync(data_dir: &Path, action: SyncAction, output_format: &OutputFormat) -
                             "server": outcome.server,
                             "device_status": outcome.device_status,
                             "secret_key": outcome.secret_key,
+                            "backfill": {
+                                "books": outcome.backfill.books,
+                                "sessions": outcome.backfill.sessions,
+                                "progress": outcome.backfill.progress,
+                                "tags": outcome.backfill.tags,
+                                "ops_total": outcome.backfill.ops_total,
+                                "pushed": outcome.backfill.pushed,
+                            },
                         }))?
                     );
                 }
@@ -4433,6 +4474,8 @@ fn cmd_sync(data_dir: &Path, action: SyncAction, output_format: &OutputFormat) -
                         outcome.device_name, outcome.device_id, outcome.device_status
                     );
                     eprintln!("  Library: {}", outcome.library_id);
+                    eprintln!();
+                    report_backfill(&outcome.backfill);
                     eprintln!();
                     eprintln!("⚠  Your Secret Key is shown only once:");
                     eprintln!("     {}", outcome.secret_key);
@@ -4463,6 +4506,12 @@ fn cmd_sync(data_dir: &Path, action: SyncAction, output_format: &OutputFormat) -
                             "role": outcome.role,
                             "server": outcome.server,
                             "data_key_unlocked": outcome.data_key_unlocked,
+                            "bootstrap": outcome.bootstrap.as_ref().map(|b| serde_json::json!({
+                                "snapshot_applied": b.snapshot_applied,
+                                "snapshot_books": b.snapshot_books,
+                                "pulled": b.pulled,
+                                "applied": b.applied,
+                            })),
                         }))?
                     );
                 }
@@ -4473,6 +4522,17 @@ fn cmd_sync(data_dir: &Path, action: SyncAction, output_format: &OutputFormat) -
                             "note: the encryption key was not unlocked (the server's account-keys \
                              endpoint is unavailable). Sync of encrypted data may not work yet."
                         );
+                    }
+                    if let Some(bootstrap) = &outcome.bootstrap {
+                        if bootstrap.snapshot_applied {
+                            eprintln!(
+                                "Restored your library: applied a server snapshot ({} books), \
+                                 then pulled {} more ops.",
+                                bootstrap.snapshot_books, bootstrap.pulled
+                            );
+                        } else {
+                            eprintln!("Restored your library: pulled {} ops.", bootstrap.pulled);
+                        }
                     }
                 }
             }
@@ -4514,6 +4574,20 @@ fn cmd_sync(data_dir: &Path, action: SyncAction, output_format: &OutputFormat) -
                             "device_name": outcome.device_name,
                             "server": outcome.server,
                             "device_status": outcome.device_status,
+                            "backfill": outcome.backfill.as_ref().map(|b| serde_json::json!({
+                                "books": b.books,
+                                "sessions": b.sessions,
+                                "progress": b.progress,
+                                "tags": b.tags,
+                                "ops_total": b.ops_total,
+                                "pushed": b.pushed,
+                            })),
+                            "bootstrap": outcome.bootstrap.as_ref().map(|b| serde_json::json!({
+                                "snapshot_applied": b.snapshot_applied,
+                                "snapshot_books": b.snapshot_books,
+                                "pulled": b.pulled,
+                                "applied": b.applied,
+                            })),
                         }))?
                     );
                 }
@@ -4525,8 +4599,23 @@ fn cmd_sync(data_dir: &Path, action: SyncAction, output_format: &OutputFormat) -
                     if outcome.device_status == "pending" {
                         eprintln!(
                             "This device is pending approval by an existing trusted device. \
-                             Once approved, run `toku sync login` to activate it."
+                             Once approved, run `toku sync login` to activate it \u{2014} it will \
+                             restore your library then."
                         );
+                    }
+                    if let Some(backfill) = &outcome.backfill {
+                        report_backfill(backfill);
+                    }
+                    if let Some(bootstrap) = &outcome.bootstrap {
+                        if bootstrap.snapshot_applied {
+                            eprintln!(
+                                "Restored your library: applied a server snapshot ({} books), \
+                                 then pulled {} more ops.",
+                                bootstrap.snapshot_books, bootstrap.pulled
+                            );
+                        } else {
+                            eprintln!("Restored your library: pulled {} ops.", bootstrap.pulled);
+                        }
                     }
                 }
             }
@@ -4676,6 +4765,51 @@ fn cmd_sync(data_dir: &Path, action: SyncAction, output_format: &OutputFormat) -
                         eprintln!("Nothing to pull already up to date");
                     } else {
                         eprintln!("Pulled {} ops", outcome.pulled);
+                    }
+                }
+            }
+            Ok(())
+        }
+
+        SyncAction::Bootstrap { reset_cursor } => {
+            let outcome = sync::orchestrator::bootstrap(data_dir, reset_cursor)?;
+
+            match output_format {
+                OutputFormat::Json => {
+                    println!(
+                        "{}",
+                        serde_json::to_string_pretty(&serde_json::json!({
+                            "snapshot_applied": outcome.snapshot_applied,
+                            "snapshot_books": outcome.snapshot_books,
+                            "pulled": outcome.pulled,
+                            "applied": outcome.applied,
+                            "reset_cursor": reset_cursor,
+                        }))?
+                    );
+                }
+                OutputFormat::Csv => {
+                    println!("snapshot_applied,snapshot_books,pulled,applied");
+                    println!(
+                        "{},{},{},{}",
+                        outcome.snapshot_applied,
+                        outcome.snapshot_books,
+                        outcome.pulled,
+                        outcome.applied
+                    );
+                }
+                OutputFormat::Table => {
+                    if reset_cursor {
+                        eprintln!("Reset pull cursor; re-syncing from scratch.");
+                    }
+                    if outcome.snapshot_applied {
+                        eprintln!(
+                            "Applied server snapshot ({} books), then pulled {} ops.",
+                            outcome.snapshot_books, outcome.pulled
+                        );
+                    } else if outcome.pulled == 0 {
+                        eprintln!("Already up to date nothing to restore.");
+                    } else {
+                        eprintln!("No snapshot on server; pulled {} ops.", outcome.pulled);
                     }
                 }
             }

--- a/crates/toku-cli/tests/sync_emission_cli.rs
+++ b/crates/toku-cli/tests/sync_emission_cli.rs
@@ -104,3 +104,48 @@ fn tag_command_emits_tag_op() {
         "a real `toku tag add` must stage a Tag Create op"
     );
 }
+
+/// Run `toku` capturing stdout+status (for arg-parsing/help smoke tests).
+fn toku_output(data_dir: &Path, args: &[&str]) -> std::process::Output {
+    Command::new(env!("CARGO_BIN_EXE_toku"))
+        .arg("--data-dir")
+        .arg(data_dir)
+        .args(args)
+        .output()
+        .expect("run toku")
+}
+
+#[test]
+fn sync_bootstrap_command_is_wired_with_reset_cursor_flag() {
+    // The new recovery verb (#199, ADR-013 D3) must be a real subcommand that
+    // parses `--reset-cursor`. `--help` exercises the clap surface without
+    // needing a configured sync server.
+    let dir = tempfile::tempdir().unwrap();
+    let out = toku_output(dir.path(), &["sync", "bootstrap", "--help"]);
+    assert!(
+        out.status.success(),
+        "`toku sync bootstrap --help` should succeed"
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("--reset-cursor"),
+        "bootstrap help must document --reset-cursor; got:\n{stdout}"
+    );
+}
+
+#[test]
+fn sync_bootstrap_without_config_errors_gracefully() {
+    // With no sync configured, bootstrap must fail with a clean error (non-zero
+    // exit), never panic — no `unwrap()` in the user-facing path.
+    let dir = tempfile::tempdir().unwrap();
+    let out = toku_output(dir.path(), &["sync", "bootstrap"]);
+    assert!(
+        !out.status.success(),
+        "bootstrap without sync configured should exit non-zero"
+    );
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        !stderr.contains("panicked"),
+        "bootstrap must not panic; stderr:\n{stderr}"
+    );
+}

--- a/crates/toku-db/migrations/V19__sync_device_bootstrap.sql
+++ b/crates/toku-db/migrations/V19__sync_device_bootstrap.sql
@@ -1,0 +1,8 @@
+-- Track whether this device has completed its initial sync bootstrap.
+--
+-- Set once the device has either backfilled its existing state (first opt-in
+-- on signup / fresh-library enroll) or restored a prior library from the
+-- server (new-device enroll / deferred post-approval login). This is a
+-- device-local marker (never synced) so routine logins don't repeatedly
+-- re-run bootstrap. See ADR-013 (D3).
+ALTER TABLE sync_device ADD COLUMN bootstrapped_at TEXT;

--- a/crates/toku-db/src/backfill.rs
+++ b/crates/toku-db/src/backfill.rs
@@ -1,0 +1,213 @@
+//! First-opt-in op-backfill (#199, ADR-013 D2).
+//!
+//! When a user opts into sync, every syncable row created *before* opt-in has no
+//! op in the log — a device identity is created *by* opt-in, and #194's
+//! op-emission is a no-op until then. Backfill closes that boundary: it
+//! synthesizes `Create` ops for the existing rows of the syncable entity types
+//! (Book, Session, Progress, Tag — the exact set #194 covers) and stages them so
+//! the normal push pipeline uploads them.
+//!
+//! Design notes:
+//!
+//! * **Same ops as ongoing sync.** Ops are emitted through the same
+//!   [`SyncRepository::emit_local_op`] choke-point normal mutations use, with
+//!   field payloads built by the shared `*_op_fields` helpers — there is no
+//!   second, divergent "snapshot subset" that could drift from the op stream
+//!   (the failure ADR-013 flags with `compact`).
+//! * **Dependency order.** Books are emitted before Sessions/Progress/Tags so
+//!   the monotonic HLC guarantees a parent Book Create sorts before the child
+//!   ops that reference it on the receiving device.
+//! * **Idempotent.** An entity that already has a `Create` op is skipped, so
+//!   re-running backfill (or backfilling a library that already emitted some ops
+//!   through ongoing edits) never duplicates.
+//! * **Live rows only.** Soft-deleted books (and their children) are skipped —
+//!   there is nothing on the server for a pre-opt-in tombstone to delete.
+
+use std::collections::HashSet;
+
+use toku_core::{EntityType, OpType};
+
+use crate::repo::{book_op_fields, progress_op_fields, session_op_fields, tag_op_fields};
+use crate::{BookRepository, Database, DbError, SyncRepository};
+
+/// Per-entity tally of ops synthesized by [`backfill_sync_ops`].
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct BackfillCounts {
+    pub books: usize,
+    pub sessions: usize,
+    pub progress: usize,
+    pub tags: usize,
+}
+
+impl BackfillCounts {
+    /// Total ops synthesized across all entity types.
+    pub fn total(&self) -> usize {
+        self.books + self.sessions + self.progress + self.tags
+    }
+}
+
+/// Synthesize `Create` ops for existing syncable rows that don't already have
+/// one, staging them for the next push. Returns a per-entity tally.
+///
+/// A no-op that returns zero counts when no device identity is configured: op
+/// emission requires a device (offline-first), and the caller only invokes this
+/// at the opt-in boundary once a device exists. Runs in a single transaction so
+/// a partial failure rolls back cleanly and can be retried.
+pub fn backfill_sync_ops(db: &Database) -> Result<BackfillCounts, DbError> {
+    let sync = SyncRepository::new(db);
+
+    // Offline-first: without a device, emit_local_op is a no-op, so there is
+    // nothing honest to count. Bail early rather than report phantom ops.
+    if sync.get_device()?.is_none() {
+        return Ok(BackfillCounts::default());
+    }
+
+    if db.conn.is_autocommit() {
+        let tx = db.conn.unchecked_transaction()?;
+        let counts = backfill_inner(db, &sync)?;
+        tx.commit()?;
+        Ok(counts)
+    } else {
+        backfill_inner(db, &sync)
+    }
+}
+
+fn backfill_inner(db: &Database, sync: &SyncRepository) -> Result<BackfillCounts, DbError> {
+    let existing = ExistingCreateOps::load(db)?;
+    let repo = BookRepository::new(db);
+    let mut counts = BackfillCounts::default();
+
+    // Live books first so their Create ops sort ahead of child ops by HLC.
+    let books = repo.list_books()?;
+    let live_book_ids: HashSet<String> = books.iter().map(|b| b.id.to_string()).collect();
+    for book in &books {
+        if existing.books.contains(&book.id.to_string()) {
+            continue;
+        }
+        sync.emit_local_op(
+            EntityType::Book,
+            book.id,
+            OpType::Create,
+            Some(book_op_fields(book)),
+        )?;
+        counts.books += 1;
+    }
+
+    // Reading sessions belonging to a live book.
+    for session in repo.list_reading_sessions()? {
+        if !live_book_ids.contains(&session.book_id.to_string()) {
+            continue;
+        }
+        if existing.sessions.contains(&session.id.to_string()) {
+            continue;
+        }
+        sync.emit_local_op(
+            EntityType::Session,
+            session.id,
+            OpType::Create,
+            Some(session_op_fields(&session)),
+        )?;
+        counts.sessions += 1;
+    }
+
+    // Reading progress and tags are read per book (both are keyed on the book).
+    for book in &books {
+        for progress in repo.get_reading_log(&book.id)? {
+            if existing.progress.contains(&progress.id.to_string()) {
+                continue;
+            }
+            sync.emit_local_op(
+                EntityType::Progress,
+                progress.id,
+                OpType::Create,
+                Some(progress_op_fields(&progress)),
+            )?;
+            counts.progress += 1;
+        }
+
+        let book_id = book.id.to_string();
+        for tag in repo.get_book_tags(&book.id)? {
+            let key = (
+                book_id.clone(),
+                tag.name.clone(),
+                tag.tag_type.as_str().to_string(),
+            );
+            if existing.tags.contains(&key) {
+                continue;
+            }
+            sync.emit_local_op(
+                EntityType::Tag,
+                book.id,
+                OpType::Create,
+                Some(tag_op_fields(&tag.name, tag.tag_type)),
+            )?;
+            counts.tags += 1;
+        }
+    }
+
+    Ok(counts)
+}
+
+/// The set of entities that already carry a `Create` op, used to make backfill
+/// idempotent. Book/Session/Progress are keyed by `entity_id`; Tag is keyed by
+/// `(book_id, tag_name, tag_type)` since many tag ops share one book id.
+struct ExistingCreateOps {
+    books: HashSet<String>,
+    sessions: HashSet<String>,
+    progress: HashSet<String>,
+    tags: HashSet<(String, String, String)>,
+}
+
+impl ExistingCreateOps {
+    fn load(db: &Database) -> Result<Self, DbError> {
+        let mut out = Self {
+            books: HashSet::new(),
+            sessions: HashSet::new(),
+            progress: HashSet::new(),
+            tags: HashSet::new(),
+        };
+
+        let mut stmt = db.conn.prepare(
+            "SELECT entity_type, entity_id, fields_json
+             FROM sync_ops WHERE op_type = 'create'",
+        )?;
+        let rows = stmt.query_map([], |row| {
+            let entity_type: String = row.get(0)?;
+            let entity_id: String = row.get(1)?;
+            let fields_json: Option<String> = row.get(2)?;
+            Ok((entity_type, entity_id, fields_json))
+        })?;
+
+        for row in rows {
+            let (entity_type, entity_id, fields_json) = row?;
+            match entity_type.as_str() {
+                "book" => {
+                    out.books.insert(entity_id);
+                }
+                "session" => {
+                    out.sessions.insert(entity_id);
+                }
+                "progress" => {
+                    out.progress.insert(entity_id);
+                }
+                "tag" => {
+                    if let Some((name, ty)) = tag_key_from_fields(fields_json.as_deref()) {
+                        out.tags.insert((entity_id, name, ty));
+                    }
+                }
+                _ => {}
+            }
+        }
+
+        Ok(out)
+    }
+}
+
+/// Extract `(tag_name, tag_type)` from a Tag op's `fields_json`, if present.
+fn tag_key_from_fields(fields_json: Option<&str>) -> Option<(String, String)> {
+    let raw = fields_json?;
+    let value: serde_json::Value = serde_json::from_str(raw).ok()?;
+    let name = value.get("tag_name")?.as_str()?.to_string();
+    let ty = value.get("tag_type")?.as_str()?.to_string();
+    Some((name, ty))
+}

--- a/crates/toku-db/src/lib.rs
+++ b/crates/toku-db/src/lib.rs
@@ -1,3 +1,4 @@
+mod backfill;
 mod database;
 mod error;
 mod merge;
@@ -5,9 +6,12 @@ mod repo;
 mod snapshot;
 mod sync_repo;
 
+pub use backfill::{BackfillCounts, backfill_sync_ops};
 pub use database::Database;
 pub use error::DbError;
 pub use merge::MergeEngine;
-pub use repo::{BookRepository, book_op_fields};
+pub use repo::{
+    BookRepository, book_op_fields, progress_op_fields, session_op_fields, tag_op_fields,
+};
 pub use snapshot::SnapshotRepository;
 pub use sync_repo::{ConflictKeep, SyncConflict, SyncRepository};

--- a/crates/toku-db/src/repo.rs
+++ b/crates/toku-db/src/repo.rs
@@ -548,15 +548,7 @@ impl<'a> BookRepository<'a> {
                 EntityType::Session,
                 session.id,
                 OpType::Create,
-                Some(serde_json::json!({
-                    "book_id": session.book_id.to_string(),
-                    "started_at": session.started_at.to_rfc3339(),
-                    "finished_at": session.finished_at.map(|d| d.to_rfc3339()),
-                    "start_page": session.start_page,
-                    "end_page": session.end_page,
-                    "rating": session.rating,
-                    "notes": session.notes,
-                })),
+                Some(session_op_fields(session)),
             )
         })
     }
@@ -585,14 +577,7 @@ impl<'a> BookRepository<'a> {
                 EntityType::Progress,
                 progress.id,
                 OpType::Create,
-                Some(serde_json::json!({
-                    "book_id": progress.book_id.to_string(),
-                    "progress_type": progress.progress_type.as_str(),
-                    "value": progress.value,
-                    "session_id": progress.session_id.map(|u| u.to_string()),
-                    "logged_at": progress.logged_at.to_rfc3339(),
-                    "note": progress.note,
-                })),
+                Some(progress_op_fields(progress)),
             )
         })
     }
@@ -996,10 +981,7 @@ impl<'a> BookRepository<'a> {
                     EntityType::Tag,
                     *book_id,
                     OpType::Create,
-                    Some(serde_json::json!({
-                        "tag_name": tag.name,
-                        "tag_type": tag_type.as_str(),
-                    })),
+                    Some(tag_op_fields(&tag.name, tag_type)),
                 )?;
             }
             Ok(())
@@ -1035,10 +1017,7 @@ impl<'a> BookRepository<'a> {
                         EntityType::Tag,
                         *book_id,
                         OpType::Delete,
-                        Some(serde_json::json!({
-                            "tag_name": name,
-                            "tag_type": TagType::Pace.as_str(),
-                        })),
+                        Some(tag_op_fields(name, TagType::Pace)),
                     )?;
                 }
             }
@@ -1054,10 +1033,7 @@ impl<'a> BookRepository<'a> {
                     EntityType::Tag,
                     *book_id,
                     OpType::Create,
-                    Some(serde_json::json!({
-                        "tag_name": tag.name,
-                        "tag_type": TagType::Pace.as_str(),
-                    })),
+                    Some(tag_op_fields(&tag.name, TagType::Pace)),
                 )?;
             }
             Ok(())
@@ -1093,10 +1069,7 @@ impl<'a> BookRepository<'a> {
                 EntityType::Tag,
                 *book_id,
                 OpType::Delete,
-                Some(serde_json::json!({
-                    "tag_name": tag_name,
-                    "tag_type": tag_type.as_str(),
-                })),
+                Some(tag_op_fields(tag_name, tag_type)),
             )?;
 
             Ok(())
@@ -2111,6 +2084,52 @@ pub fn book_op_fields(book: &Book) -> serde_json::Value {
         "cover_hash": book.cover_hash,
         "status": book.status.as_str(),
         "rating": book.rating,
+    })
+}
+
+/// Builds the sync-op field payload for a reading-session Create op.
+///
+/// Mirrors the schema consumed by [`crate::merge`] (`merge_session`). Exposed so
+/// the first-opt-in backfill (#199) can synthesize the exact same Session Create
+/// op as [`BookRepository::create_reading_session`].
+pub fn session_op_fields(session: &ReadingSession) -> serde_json::Value {
+    serde_json::json!({
+        "book_id": session.book_id.to_string(),
+        "started_at": session.started_at.to_rfc3339(),
+        "finished_at": session.finished_at.map(|d| d.to_rfc3339()),
+        "start_page": session.start_page,
+        "end_page": session.end_page,
+        "rating": session.rating,
+        "notes": session.notes,
+    })
+}
+
+/// Builds the sync-op field payload for a reading-progress Create op.
+///
+/// Mirrors the schema consumed by [`crate::merge`] (`merge_progress`). Exposed so
+/// the first-opt-in backfill (#199) can synthesize the exact same Progress Create
+/// op as [`BookRepository::log_progress`].
+pub fn progress_op_fields(progress: &ReadingProgress) -> serde_json::Value {
+    serde_json::json!({
+        "book_id": progress.book_id.to_string(),
+        "progress_type": progress.progress_type.as_str(),
+        "value": progress.value,
+        "session_id": progress.session_id.map(|u| u.to_string()),
+        "logged_at": progress.logged_at.to_rfc3339(),
+        "note": progress.note,
+    })
+}
+
+/// Builds the sync-op field payload for a book-tag Create/Delete op.
+///
+/// Mirrors the schema consumed by [`crate::merge`] (`merge_tag`): a Tag op is
+/// keyed on the book id (the op's `entity_id`) plus the tag's `name`/`type`.
+/// Exposed so the first-opt-in backfill (#199) can synthesize the exact same Tag
+/// Create op as [`BookRepository::add_typed_tag_to_book`].
+pub fn tag_op_fields(tag_name: &str, tag_type: TagType) -> serde_json::Value {
+    serde_json::json!({
+        "tag_name": tag_name,
+        "tag_type": tag_type.as_str(),
     })
 }
 

--- a/crates/toku-db/src/sync_repo.rs
+++ b/crates/toku-db/src/sync_repo.rs
@@ -342,6 +342,41 @@ impl<'a> SyncRepository<'a> {
         Ok(())
     }
 
+    /// Clear a sync cursor so the next sync starts from scratch. Used by
+    /// `toku sync bootstrap --reset-cursor` to force a full re-pull.
+    pub fn clear_cursor(&self, key: &str) -> Result<(), DbError> {
+        self.db
+            .conn
+            .execute("DELETE FROM sync_cursors WHERE key = ?1", params![key])?;
+        Ok(())
+    }
+
+    /// Record that this device has completed its initial sync bootstrap
+    /// (backfill on first opt-in, or restore on new-device enroll / deferred
+    /// login). Device-local; never synced. See ADR-013 (D3).
+    pub fn mark_bootstrapped(&self) -> Result<(), DbError> {
+        self.db.conn.execute(
+            "UPDATE sync_device SET bootstrapped_at = ?1 WHERE bootstrapped_at IS NULL",
+            params![chrono::Utc::now().to_rfc3339()],
+        )?;
+        Ok(())
+    }
+
+    /// Whether this device has already completed its initial sync bootstrap.
+    /// Returns `false` when no device identity exists yet.
+    pub fn is_bootstrapped(&self) -> Result<bool, DbError> {
+        let result: Option<Option<String>> = self
+            .db
+            .conn
+            .query_row(
+                "SELECT bootstrapped_at FROM sync_device LIMIT 1",
+                [],
+                |row| row.get(0),
+            )
+            .optional()?;
+        Ok(matches!(result, Some(Some(_))))
+    }
+
     /// Insert a sync op received from the server.
     ///
     /// Remote ops are stored with `pushed_at` set to now (they don't need

--- a/crates/toku-sync-client/src/orchestrator.rs
+++ b/crates/toku-sync-client/src/orchestrator.rs
@@ -82,6 +82,20 @@ pub struct BootstrapOutcome {
     pub applied: usize,
 }
 
+/// Report of a first-opt-in op-backfill (#199, ADR-013 D2): how many pre-existing
+/// rows were staged as ops and how they fared on push.
+#[derive(Debug, Clone, Serialize)]
+pub struct BackfillReport {
+    pub books: usize,
+    pub sessions: usize,
+    pub progress: usize,
+    pub tags: usize,
+    /// Total ops synthesized across all entity types.
+    pub ops_total: usize,
+    /// Ops accepted by the server on the backfill push.
+    pub pushed: usize,
+}
+
 /// Outcome of [`signup`].
 #[derive(Debug, Clone, Serialize)]
 pub struct SignupOutcome {
@@ -97,6 +111,9 @@ pub struct SignupOutcome {
     /// The formatted Secret Key — surfaced **once** so the caller can render an
     /// Emergency Kit. Never persisted to disk by the orchestrator.
     pub secret_key: String,
+    /// First-opt-in backfill of pre-existing local state (D2). Always present
+    /// for signup since the first device always creates a fresh library.
+    pub backfill: BackfillReport,
 }
 
 /// Outcome of [`login`].
@@ -109,6 +126,9 @@ pub struct LoginOutcome {
     /// Whether the leaf data key was unwrapped and stored (requires the #143
     /// `GET /api/v1/account/keys` endpoint).
     pub data_key_unlocked: bool,
+    /// Present when this login triggered a deferred new-device bootstrap — i.e.
+    /// the first login after an approval-pending device was approved (D3).
+    pub bootstrap: Option<BootstrapOutcome>,
 }
 
 /// Outcome of [`enroll`].
@@ -122,6 +142,14 @@ pub struct EnrollOutcome {
     pub server: String,
     /// `active` (synced immediately) or `pending` (awaiting approval).
     pub device_status: String,
+    /// First-opt-in backfill of pre-existing local state (D2). Present only when
+    /// this enroll created a **fresh** library from a device that already held
+    /// local data; `None` when joining an existing library.
+    pub backfill: Option<BackfillReport>,
+    /// New-device bootstrap result (D3). Present when an active device session
+    /// was minted and bootstrap ran; `None` for approval-pending devices (whose
+    /// bootstrap is deferred to the first post-approval login).
+    pub bootstrap: Option<BootstrapOutcome>,
 }
 
 /// Outcome of [`migrate`].
@@ -536,7 +564,11 @@ pub fn pull(data_dir: &Path) -> anyhow::Result<PullOutcome> {
 ///
 /// When no snapshot exists the server still holds the full op log, so this is
 /// equivalent to a plain [`pull`].
-pub fn bootstrap(data_dir: &Path) -> anyhow::Result<BootstrapOutcome> {
+///
+/// When `reset_cursor` is set the local pull cursor is cleared first, forcing a
+/// full re-download of the snapshot and a re-pull from op #1 — the recovery path
+/// for a device whose local state is suspect (`toku sync bootstrap --reset-cursor`).
+pub fn bootstrap(data_dir: &Path, reset_cursor: bool) -> anyhow::Result<BootstrapOutcome> {
     let rt = build_runtime()?;
     let token_store = TokenStore::new(data_dir);
     let config = toku_core::TokuConfig::load(data_dir).unwrap_or_default();
@@ -544,6 +576,13 @@ pub fn bootstrap(data_dir: &Path) -> anyhow::Result<BootstrapOutcome> {
     let server = &sync_config.server;
     let token = require_token(&token_store, server)?;
     let client = SyncClient::new(server)?;
+
+    if reset_cursor {
+        let db = open_db(data_dir)?;
+        SyncRepository::new(&db)
+            .clear_cursor("pull_cursor")
+            .context("failed to reset pull cursor")?;
+    }
 
     let mut snapshot_applied = false;
     let mut snapshot_books = 0usize;
@@ -575,6 +614,10 @@ pub fn bootstrap(data_dir: &Path) -> anyhow::Result<BootstrapOutcome> {
     // Pull whatever the server still retains (post-snapshot ops, or the full
     // op log if no snapshot existed) and materialize it on top of the snapshot.
     let pulled = pull(data_dir)?;
+
+    // Record that this device has completed a bootstrap so a later routine
+    // `login` does not re-run the deferred new-device restore (D3).
+    mark_bootstrapped(data_dir)?;
 
     Ok(BootstrapOutcome {
         snapshot_applied,
@@ -788,6 +831,52 @@ fn finalize_device(
     Ok(())
 }
 
+/// Record that this device has completed a bootstrap.
+fn mark_bootstrapped(data_dir: &Path) -> anyhow::Result<()> {
+    let db = open_db(data_dir)?;
+    SyncRepository::new(&db)
+        .mark_bootstrapped()
+        .context("failed to record bootstrap state")?;
+    Ok(())
+}
+
+/// Whether this device has already completed a bootstrap.
+fn is_bootstrapped(data_dir: &Path) -> anyhow::Result<bool> {
+    let db = open_db(data_dir)?;
+    Ok(SyncRepository::new(&db).is_bootstrapped()?)
+}
+
+/// First-opt-in op-backfill (#199, ADR-013 D2): synthesize `Create` ops for every
+/// pre-existing syncable row and push them through the normal pipeline.
+///
+/// Layered at the opt-in boundary — after `finalize_device` has configured the
+/// device identity, token, and data key, and before the caller returns — not
+/// inside `push`. Idempotent: re-running never duplicates (see
+/// [`toku_db::backfill_sync_ops`]). Returns a report so the caller can tell the
+/// user exactly what reached the server.
+fn run_backfill(data_dir: &Path) -> anyhow::Result<BackfillReport> {
+    let counts = {
+        let db = open_db(data_dir)?;
+        toku_db::backfill_sync_ops(&db).context("failed to backfill pre-existing state")?
+    };
+
+    // Drain the freshly-staged ops (plus any already pending) to the server.
+    let pushed = if counts.total() > 0 {
+        push(data_dir)?.accepted
+    } else {
+        0
+    };
+
+    Ok(BackfillReport {
+        books: counts.books,
+        sessions: counts.sessions,
+        progress: counts.progress,
+        tags: counts.tags,
+        ops_total: counts.total(),
+        pushed,
+    })
+}
+
 /// Reconstruct the account key hierarchy from a server key bundle and unwrap the
 /// leaf data key with the password + Secret Key.
 ///
@@ -893,6 +982,14 @@ pub fn signup(
         &data_key,
     )?;
 
+    // First opt-in: backfill any pre-existing local library so it reaches the
+    // server without a manual `compact` (D2). The first device always owns a
+    // fresh, active library, so this always runs. A successful backfill also
+    // counts as this device's bootstrap (nothing to restore from an empty
+    // server), so a later routine `login` won't re-run the deferred restore.
+    let backfill = run_backfill(data_dir)?;
+    mark_bootstrapped(data_dir)?;
+
     Ok(SignupOutcome {
         user_id: signup.user_id,
         email: signup.email,
@@ -903,6 +1000,7 @@ pub fn signup(
         server: server.to_string(),
         device_status: enroll.status,
         secret_key: secret_key.format(),
+        backfill,
     })
 }
 
@@ -948,7 +1046,11 @@ pub fn login(
         }
     }
 
-    // Refresh this device's session token if we know our device id.
+    // Refresh this device's session token if we know our device id. Track
+    // whether a device session is available so we can run a deferred new-device
+    // bootstrap below (D3): an approval-pending device has no session at enroll
+    // time, so its bootstrap waits for the first post-approval login.
+    let mut device_session_ready = false;
     if let Some(sync_config) = toku_core::TokuConfig::load(data_dir)
         .unwrap_or_default()
         .sync
@@ -958,6 +1060,15 @@ pub fn login(
             rt.block_on(client.create_device_session(&verify.session_token, &sync_config.device_id))
     {
         token_store.store(server, &session.session_token)?;
+        device_session_ready = true;
+    }
+
+    // Deferred bootstrap: the first login that mints a device session for a
+    // device that has never bootstrapped restores the prior library. Idempotent
+    // and gated on the `bootstrapped` marker so routine logins don't re-run it.
+    let mut bootstrap_result = None;
+    if data_key_unlocked && device_session_ready && !is_bootstrapped(data_dir)? {
+        bootstrap_result = Some(bootstrap(data_dir, false)?);
     }
 
     Ok(LoginOutcome {
@@ -966,6 +1077,7 @@ pub fn login(
         role: verify.role,
         server: server.to_string(),
         data_key_unlocked,
+        bootstrap: bootstrap_result,
     })
 }
 
@@ -1020,6 +1132,28 @@ pub fn enroll(
         &data_key,
     )?;
 
+    let is_active = enroll.session_token.is_some();
+    // A fresh library (caller passed no library_id) created from a device that
+    // already holds local data is a first opt-in: backfill it (D2). Joining an
+    // existing library instead restores from the server via bootstrap (D3).
+    let fresh_library = library_id.is_none();
+
+    let mut backfill = None;
+    let mut bootstrap_result = None;
+    if is_active {
+        if fresh_library {
+            // Nothing on the server yet — push local state up. A self-pull would
+            // only re-fetch our own just-pushed ops, so we skip bootstrap and
+            // just record that this device is provisioned.
+            backfill = Some(run_backfill(data_dir)?);
+            mark_bootstrapped(data_dir)?;
+        } else {
+            // Joining an existing library: restore the prior state through the
+            // normal new-device bootstrap path.
+            bootstrap_result = Some(bootstrap(data_dir, false)?);
+        }
+    }
+
     Ok(EnrollOutcome {
         user_id: verify.user_id,
         email: email.to_string(),
@@ -1028,6 +1162,8 @@ pub fn enroll(
         device_name,
         server: server.to_string(),
         device_status: enroll.status,
+        backfill,
+        bootstrap: bootstrap_result,
     })
 }
 

--- a/crates/toku-sync/tests/first_optin_backfill.rs
+++ b/crates/toku-sync/tests/first_optin_backfill.rs
@@ -1,0 +1,559 @@
+//! First-opt-in op-backfill (#199, ADR-013 D2) + new-device bootstrap wiring (D3).
+//!
+//! These drive the **real** `toku-sync-client` orchestrator (`signup`/`enroll`/
+//! `login`/`push`/`bootstrap`) — the logic behind the `toku sync …` subcommands —
+//! against a real in-process `toku-sync` server, using the **real**
+//! `BookRepository` to seed library state (no hand-staged ops). They assert the
+//! two ADR-013 decisions this issue implements:
+//!
+//! * **D2 — first opt-in uploads existing state.** Rows created *before* opt-in
+//!   have no op (a device identity is minted *by* opt-in, and #194's emission is a
+//!   no-op until then). On `signup` (and a fresh-library `enroll`) the client
+//!   backfills `Create` ops for every pre-existing syncable row and pushes them —
+//!   so a brand-new device restores the full library **without a manual
+//!   `compact`**.
+//! * **D3 — new-device bootstrap is wired + exposed.** An active `enroll` runs
+//!   bootstrap automatically; an approval-pending device defers it to the first
+//!   post-approval `login`. Bootstrap restores from a server snapshot after
+//!   compaction, falling back to an op-log pull when none exists.
+
+mod harness;
+
+use std::path::Path;
+use std::sync::Once;
+
+use harness::TestServer;
+use tempfile::TempDir;
+use toku_core::{
+    Book, HybridClock, ProgressType, ReadingProgress, ReadingSession, SecretKey, SyncKey, TagType,
+    encrypt_snapshot,
+};
+use toku_db::{BookRepository, Database, SnapshotRepository, SyncRepository};
+use uuid::Uuid;
+
+static INIT_ENV: Once = Once::new();
+
+/// Force the file-backed token store so tests never touch the OS keychain.
+fn use_file_token_store() {
+    INIT_ENV.call_once(|| {
+        // SAFETY: set once, before any orchestrator call spawns threads.
+        unsafe {
+            std::env::set_var("TOKU_TOKEN_STORE", "file");
+        }
+    });
+}
+
+fn rt() -> tokio::runtime::Runtime {
+    tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("build runtime")
+}
+
+fn data_dir() -> TempDir {
+    tempfile::tempdir().expect("create client data dir")
+}
+
+fn open_db(dir: &Path) -> Database {
+    Database::open(&dir.join("toku.db")).expect("open device db")
+}
+
+// ── Seeding via the real repository ───────────────────────────────────────────
+//
+// Before opt-in there is no device identity, so these writes stage **zero** ops
+// (offline-first: emission is a no-op without a device). After opt-in the same
+// calls emit ops through the #194 choke-point.
+
+fn seed_book(dir: &Path, title: &str) -> Uuid {
+    let db = open_db(dir);
+    let book = Book::new(title);
+    let id = book.id;
+    BookRepository::new(&db)
+        .create_book(&book)
+        .expect("create_book");
+    id
+}
+
+fn seed_session(dir: &Path, book_id: Uuid) -> Uuid {
+    let db = open_db(dir);
+    let session = ReadingSession::new(book_id);
+    let id = session.id;
+    BookRepository::new(&db)
+        .create_reading_session(&session)
+        .expect("create_reading_session");
+    id
+}
+
+fn seed_progress(dir: &Path, book_id: Uuid, value: i32) -> Uuid {
+    let db = open_db(dir);
+    let progress = ReadingProgress::new(book_id, ProgressType::Page, value);
+    let id = progress.id;
+    BookRepository::new(&db)
+        .log_progress(&progress)
+        .expect("log_progress");
+    id
+}
+
+fn seed_tag(dir: &Path, book_id: Uuid, name: &str) {
+    let db = open_db(dir);
+    BookRepository::new(&db)
+        .add_typed_tag_to_book(&book_id, name, TagType::General)
+        .expect("add_typed_tag_to_book");
+}
+
+// ── Local-state readers ───────────────────────────────────────────────────────
+
+fn pending_ops(dir: &Path) -> usize {
+    let db = open_db(dir);
+    SyncRepository::new(&db)
+        .get_unpushed_ops()
+        .expect("read unpushed ops")
+        .len()
+}
+
+fn book_count(dir: &Path) -> usize {
+    let db = open_db(dir);
+    BookRepository::new(&db)
+        .list_books()
+        .expect("list books")
+        .len()
+}
+
+fn book_titles(dir: &Path) -> Vec<String> {
+    let db = open_db(dir);
+    let mut titles: Vec<String> = BookRepository::new(&db)
+        .list_books()
+        .expect("list books")
+        .into_iter()
+        .map(|b| b.title)
+        .collect();
+    titles.sort();
+    titles
+}
+
+fn session_count(dir: &Path, book_id: Uuid) -> i64 {
+    let db = open_db(dir);
+    db.conn
+        .query_row(
+            "SELECT COUNT(*) FROM reading_sessions WHERE book_id = ?1",
+            [book_id.to_string()],
+            |r| r.get(0),
+        )
+        .expect("count sessions")
+}
+
+fn latest_progress(dir: &Path, book_id: Uuid) -> Option<i32> {
+    let db = open_db(dir);
+    BookRepository::new(&db)
+        .get_latest_progress(&book_id)
+        .expect("get_latest_progress")
+        .map(|p| p.value)
+}
+
+fn has_tag(dir: &Path, book_id: Uuid, name: &str) -> bool {
+    let db = open_db(dir);
+    BookRepository::new(&db)
+        .get_book_tags(&book_id)
+        .map(|tags| tags.iter().any(|t| t.name == name))
+        .unwrap_or(false)
+}
+
+/// Reproduce `toku sync compact`: export a snapshot, encrypt it client-side, and
+/// upload it (which prunes the pre-snapshot op history on the server). Kept as a
+/// manual maintenance step (ADR-013) so the after-compaction restore path stays
+/// exercised end-to-end.
+fn compact(dir: &Path, server: &TestServer) {
+    let db = open_db(dir);
+    let sync_repo = SyncRepository::new(&db);
+    let snapshot_repo = SnapshotRepository::new(&db);
+    let device = sync_repo
+        .get_device()
+        .expect("get_device")
+        .expect("device identity");
+    let hlc = HybridClock::new(&device.device_id).now().to_canonical();
+
+    let store = toku_sync_client::TokenStore::new(dir);
+    let token = store
+        .load(server.base_url())
+        .expect("load token")
+        .expect("device token");
+    let key_bytes = store
+        .load_sync_key(server.base_url())
+        .expect("load sync key")
+        .expect("sync key");
+    let key = SyncKey::from_exported_bytes(&key_bytes).expect("valid sync key");
+
+    let snapshot = snapshot_repo
+        .export_snapshot(device.device_id, &hlc)
+        .expect("export snapshot");
+    let json = serde_json::to_string(&snapshot).expect("serialize snapshot");
+    let envelope = encrypt_snapshot(&key, &json).expect("encrypt snapshot");
+    let blob = serde_json::to_string(&envelope).expect("serialize envelope");
+
+    let client = toku_sync_client::SyncClient::new(server.base_url()).expect("client");
+    rt().block_on(client.upload_snapshot(&token, &blob, &hlc))
+        .expect("upload snapshot");
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+/// AC#1: a fresh library that opts in via `signup` uploads its pre-existing state
+/// automatically — a brand-new device restores everything WITHOUT a manual
+/// `compact`.
+#[test]
+fn fresh_signup_backfills_existing_library_without_compact() {
+    use_file_token_store();
+    let server = TestServer::start();
+    let dir_a = data_dir();
+    let secret = SecretKey::generate().expect("generate secret key");
+
+    // Seed BEFORE opt-in: no device identity yet, so these stage zero ops.
+    let dune = seed_book(dir_a.path(), "Dune");
+    let earthsea = seed_book(dir_a.path(), "A Wizard of Earthsea");
+    seed_session(dir_a.path(), dune);
+    seed_progress(dir_a.path(), dune, 42);
+    seed_tag(dir_a.path(), earthsea, "fantasy");
+    assert_eq!(
+        pending_ops(dir_a.path()),
+        0,
+        "pre-opt-in writes must stage no ops (offline-first no-op)"
+    );
+
+    let signup = toku_sync_client::signup(
+        dir_a.path(),
+        server.base_url(),
+        "owner@example.com",
+        "owner-password",
+        &secret,
+        Some("laptop".to_string()),
+    )
+    .expect("signup should succeed");
+
+    // D2: one backfilled + pushed op per pre-existing syncable row.
+    let bf = &signup.backfill;
+    assert_eq!(bf.books, 2, "both books backfilled");
+    assert_eq!(bf.sessions, 1, "the session backfilled");
+    assert_eq!(bf.progress, 1, "the progress entry backfilled");
+    assert_eq!(bf.tags, 1, "the tag backfilled");
+    assert_eq!(bf.ops_total, 5);
+    assert_eq!(bf.pushed, 5, "all backfilled ops accepted by the server");
+
+    // Prove the state reached the server WITHOUT a manual compact: a brand-new
+    // device restores the full library through the orchestrator's bootstrap.
+    let dir_b = data_dir();
+    let enroll = toku_sync_client::enroll(
+        dir_b.path(),
+        server.base_url(),
+        "owner@example.com",
+        "owner-password",
+        &secret,
+        Some("phone".to_string()),
+        Some(signup.library_id.clone()),
+    )
+    .expect("enroll should succeed");
+
+    assert!(
+        enroll.bootstrap.is_some(),
+        "an active enroll must auto-bootstrap (D3)"
+    );
+    assert!(
+        enroll.backfill.is_none(),
+        "joining an existing library must not backfill"
+    );
+    assert_eq!(book_count(dir_b.path()), 2, "both books restored");
+    assert_eq!(
+        book_titles(dir_b.path()),
+        vec!["A Wizard of Earthsea".to_string(), "Dune".to_string()]
+    );
+    assert_eq!(session_count(dir_b.path(), dune), 1, "session restored");
+    assert_eq!(
+        latest_progress(dir_b.path(), dune),
+        Some(42),
+        "progress restored"
+    );
+    assert!(has_tag(dir_b.path(), earthsea, "fantasy"), "tag restored");
+}
+
+/// AC#2: a new device restores full prior state via the auto-wired bootstrap.
+/// Here the data is written *after* opt-in (normal ongoing ops) and pushed; the
+/// enrolling device converges via the bootstrap op-log pull (no snapshot yet).
+#[test]
+fn new_device_enroll_restores_full_prior_state() {
+    use_file_token_store();
+    let server = TestServer::start();
+    let dir_a = data_dir();
+    let secret = SecretKey::generate().expect("generate secret key");
+
+    let signup = toku_sync_client::signup(
+        dir_a.path(),
+        server.base_url(),
+        "owner@example.com",
+        "owner-password",
+        &secret,
+        Some("laptop".to_string()),
+    )
+    .expect("signup should succeed");
+    assert_eq!(
+        signup.backfill.ops_total, 0,
+        "fresh library has nothing to backfill"
+    );
+
+    // Ongoing mutations after opt-in emit ops through the normal path.
+    let book = seed_book(dir_a.path(), "The Left Hand of Darkness");
+    seed_session(dir_a.path(), book);
+    seed_progress(dir_a.path(), book, 100);
+    seed_tag(dir_a.path(), book, "sci-fi");
+    let pushed = toku_sync_client::push(dir_a.path()).expect("push");
+    assert!(pushed.accepted >= 4, "ongoing ops pushed: {pushed:?}");
+
+    let dir_b = data_dir();
+    let enroll = toku_sync_client::enroll(
+        dir_b.path(),
+        server.base_url(),
+        "owner@example.com",
+        "owner-password",
+        &secret,
+        Some("phone".to_string()),
+        Some(signup.library_id.clone()),
+    )
+    .expect("enroll should succeed");
+
+    let bootstrap = enroll.bootstrap.expect("active enroll auto-bootstraps");
+    assert!(
+        !bootstrap.snapshot_applied,
+        "no compaction ran, so bootstrap falls back to an op-log pull"
+    );
+    assert_eq!(book_count(dir_b.path()), 1);
+    assert_eq!(
+        book_titles(dir_b.path()),
+        vec!["The Left Hand of Darkness".to_string()]
+    );
+    assert_eq!(session_count(dir_b.path(), book), 1);
+    assert_eq!(latest_progress(dir_b.path(), book), Some(100));
+    assert!(has_tag(dir_b.path(), book, "sci-fi"));
+}
+
+/// AC#3: enrollment after compaction restores the full library from the server
+/// snapshot (the op history has been pruned), then converges via the tail pull.
+#[test]
+fn enroll_after_compaction_restores_via_snapshot() {
+    use_file_token_store();
+    let server = TestServer::start();
+    let dir_a = data_dir();
+    let secret = SecretKey::generate().expect("generate secret key");
+
+    let signup = toku_sync_client::signup(
+        dir_a.path(),
+        server.base_url(),
+        "owner@example.com",
+        "owner-password",
+        &secret,
+        Some("laptop".to_string()),
+    )
+    .expect("signup should succeed");
+
+    let dune = seed_book(dir_a.path(), "Dune");
+    let hyperion = seed_book(dir_a.path(), "Hyperion");
+    seed_session(dir_a.path(), dune);
+    seed_progress(dir_a.path(), dune, 55);
+    seed_tag(dir_a.path(), hyperion, "sci-fi");
+    toku_sync_client::push(dir_a.path()).expect("push");
+
+    // Compact: upload an encrypted snapshot and prune the op history server-side.
+    compact(dir_a.path(), &server);
+
+    let dir_b = data_dir();
+    let enroll = toku_sync_client::enroll(
+        dir_b.path(),
+        server.base_url(),
+        "owner@example.com",
+        "owner-password",
+        &secret,
+        Some("phone".to_string()),
+        Some(signup.library_id.clone()),
+    )
+    .expect("enroll should succeed");
+
+    let bootstrap = enroll.bootstrap.expect("active enroll auto-bootstraps");
+    assert!(
+        bootstrap.snapshot_applied,
+        "after compaction the server serves a snapshot"
+    );
+    assert_eq!(bootstrap.snapshot_books, 2, "snapshot carried both books");
+    assert_eq!(
+        book_count(dir_b.path()),
+        2,
+        "full library restored from snapshot"
+    );
+    assert_eq!(session_count(dir_b.path(), dune), 1);
+    assert_eq!(latest_progress(dir_b.path(), dune), Some(55));
+    assert!(has_tag(dir_b.path(), hyperion, "sci-fi"));
+}
+
+/// Backfill is idempotent: re-running it after opt-in synthesizes no new ops
+/// (every pre-existing row already carries a Create op).
+#[test]
+fn backfill_is_idempotent() {
+    use_file_token_store();
+    let server = TestServer::start();
+    let dir = data_dir();
+    let secret = SecretKey::generate().expect("generate secret key");
+
+    seed_book(dir.path(), "Dune");
+    let signup = toku_sync_client::signup(
+        dir.path(),
+        server.base_url(),
+        "owner@example.com",
+        "owner-password",
+        &secret,
+        Some("laptop".to_string()),
+    )
+    .expect("signup should succeed");
+    assert_eq!(signup.backfill.books, 1);
+
+    // A second backfill pass must find nothing new.
+    let db = open_db(dir.path());
+    let again = toku_db::backfill_sync_ops(&db).expect("re-run backfill");
+    assert_eq!(
+        again.total(),
+        0,
+        "re-running backfill must not duplicate ops"
+    );
+}
+
+/// D3 defer: an approval-pending device does not bootstrap at enroll time; the
+/// deferred bootstrap runs on the first post-approval `login`.
+#[test]
+fn pending_device_defers_bootstrap_until_post_approval_login() {
+    use_file_token_store();
+    let server = TestServer::start();
+    let dir_a = data_dir();
+    let secret = SecretKey::generate().expect("generate secret key");
+
+    let signup = toku_sync_client::signup(
+        dir_a.path(),
+        server.base_url(),
+        "owner@example.com",
+        "owner-password",
+        &secret,
+        Some("laptop".to_string()),
+    )
+    .expect("signup should succeed");
+
+    // Seed + push some state to restore later.
+    let book = seed_book(dir_a.path(), "Neuromancer");
+    seed_progress(dir_a.path(), book, 77);
+    toku_sync_client::push(dir_a.path()).expect("push");
+
+    // Enable the device-approval gate (admin, via the owner's user session).
+    let admin_token = toku_sync_client::TokenStore::new(dir_a.path())
+        .load_user_session(server.base_url())
+        .expect("load user session")
+        .expect("owner user session");
+    let (status, _) = put_auth(
+        &format!("{}/api/v1/admin/device-approvals", server.base_url()),
+        &admin_token,
+        &serde_json::json!({ "required": true }),
+    );
+    assert_eq!(status, 200, "enabling device approvals should succeed");
+
+    // Enroll a second device into the existing library: held pending, no session.
+    let dir_b = data_dir();
+    let enroll = toku_sync_client::enroll(
+        dir_b.path(),
+        server.base_url(),
+        "owner@example.com",
+        "owner-password",
+        &secret,
+        Some("phone".to_string()),
+        Some(signup.library_id.clone()),
+    )
+    .expect("enroll should succeed");
+    assert_eq!(
+        enroll.device_status, "pending",
+        "second device is held pending"
+    );
+    assert!(
+        enroll.bootstrap.is_none(),
+        "a pending device must defer bootstrap (no session yet)"
+    );
+    assert_eq!(book_count(dir_b.path()), 0, "nothing restored yet");
+
+    // Owner approves the pending device.
+    let (status, _) = post_auth(
+        &format!(
+            "{}/api/v1/devices/{}/approval",
+            server.base_url(),
+            enroll.device_id
+        ),
+        &admin_token,
+        &serde_json::json!({ "decision": "approve" }),
+    );
+    assert_eq!(status, 200, "approval should succeed");
+
+    // First post-approval login mints a session and runs the deferred bootstrap.
+    let login = toku_sync_client::login(
+        dir_b.path(),
+        server.base_url(),
+        "owner@example.com",
+        "owner-password",
+        &secret,
+    )
+    .expect("login should succeed");
+    assert!(
+        login.bootstrap.is_some(),
+        "the first post-approval login runs the deferred bootstrap (D3)"
+    );
+    assert_eq!(
+        book_count(dir_b.path()),
+        1,
+        "state restored after approval+login"
+    );
+    assert_eq!(latest_progress(dir_b.path(), book), Some(77));
+
+    // A subsequent login must NOT re-bootstrap (gated by the local marker).
+    let login2 = toku_sync_client::login(
+        dir_b.path(),
+        server.base_url(),
+        "owner@example.com",
+        "owner-password",
+        &secret,
+    )
+    .expect("second login should succeed");
+    assert!(
+        login2.bootstrap.is_none(),
+        "an already-bootstrapped device must not re-run bootstrap on routine login"
+    );
+}
+
+// ── Minimal authenticated HTTP helpers (admin approval endpoints) ─────────────
+
+fn put_auth(url: &str, bearer: &str, body: &serde_json::Value) -> (u16, serde_json::Value) {
+    rt().block_on(async {
+        let resp = reqwest::Client::new()
+            .put(url)
+            .bearer_auth(bearer)
+            .json(body)
+            .send()
+            .await
+            .expect("send request");
+        let status = resp.status().as_u16();
+        let val: serde_json::Value = resp.json().await.unwrap_or(serde_json::Value::Null);
+        (status, val)
+    })
+}
+
+fn post_auth(url: &str, bearer: &str, body: &serde_json::Value) -> (u16, serde_json::Value) {
+    rt().block_on(async {
+        let resp = reqwest::Client::new()
+            .post(url)
+            .bearer_auth(bearer)
+            .json(body)
+            .send()
+            .await
+            .expect("send request");
+        let status = resp.status().as_u16();
+        let val: serde_json::Value = resp.json().await.unwrap_or(serde_json::Value::Null);
+        (status, val)
+    })
+}

--- a/crates/toku-sync/tests/harness/mod.rs
+++ b/crates/toku-sync/tests/harness/mod.rs
@@ -378,7 +378,7 @@ impl SimulatedDevice {
     /// Bootstrap from a server snapshot (falling back to a full op-log pull
     /// when no snapshot exists).
     pub fn bootstrap(&self) -> toku_sync_client::BootstrapOutcome {
-        toku_sync_client::bootstrap(self.data_dir()).expect("bootstrap")
+        toku_sync_client::bootstrap(self.data_dir(), false).expect("bootstrap")
     }
 
     // ── State readers (assert against materialized tables) ────────────────────

--- a/docs/recovery.md
+++ b/docs/recovery.md
@@ -75,6 +75,41 @@ A new device is enrolled by entering your **account email + password + Secret Ke
 device performs SRP authentication, derives the account unlock key, and unwraps your keys
 locally. The server never receives the secrets and cannot enroll a device on its own.
 
+### First opt-in uploads your existing library
+
+When you first opt into sync from a device that already has a local library — `toku sync
+signup`, or `toku sync enroll` that creates a fresh library — Toku automatically **backfills**
+your existing books, reading sessions, progress, and tags into the sync log and pushes them.
+You do **not** need to run `toku sync compact` to seed the server; opt-in reports how many
+items were uploaded. (Compaction is only a maintenance step that snapshots and prunes old
+op history.)
+
+Sync does **not** cover ebook file binaries (they stay on the device — see
+[ADR-011](adr/011-file-management.md)) or authors, shelves, works, series, and ISBNs yet
+(tracked in [#208](https://github.com/kafkade/toku/issues/208)); the CLI warns about this at
+opt-in.
+
+### Restoring a device (bootstrap)
+
+When a device joins an **existing** library, Toku **bootstraps** it automatically: it
+downloads and applies the latest server snapshot (if one exists after a `compact`), then
+pulls any remaining op history. A device that enrolls while **approval is required** stays
+pending and has nothing to restore yet — its bootstrap runs on the first `toku sync login`
+after an existing device approves it.
+
+You can also trigger this manually — for re-provisioning, or to recover a device whose local
+state drifted:
+
+```sh
+toku sync bootstrap                 # apply the latest snapshot, then pull remaining ops
+toku sync bootstrap --reset-cursor  # discard the local pull cursor and re-sync from scratch
+```
+
+`--reset-cursor` forces a full re-download (snapshot + full op tail) — useful if the local
+pull cursor is ahead of a freshly restored server, or after a server-side reset. Because your
+**local SQLite database stays the primary recovery** (see below), bootstrap is a convenience
+for re-provisioning from the server, not a replacement for keeping an offline backup.
+
 ## Token storage
 
 After you authenticate, the client keeps a **session token** (and, for hosted accounts, the


### PR DESCRIPTION
## Description

Opting into sync now uploads the library you already have, and new devices restore their full library automatically — no manual `toku sync compact` required.

Previously, `signup`/`enroll` only stored credentials, identity, and config; push only sent rows that were already in the op log. Since op emission is a no-op until a device identity exists, every book, session, progress entry, and tag created *before* opt-in had no op and never reached the server — the only way to upload existing state was a manual `toku sync compact` (a snapshot subset). And on a fresh device there was no way to restore from a snapshot: the restore routine existed in the client but was never invoked and had no command.

**What's included**

- **First opt-in uploads existing state (automatic op-backfill).** On `toku sync signup`, and on a `toku sync enroll` that creates a fresh library, the client now synthesizes `Create` ops for every existing syncable row (books, reading sessions, progress, tags) and pushes them through the normal zero-knowledge pipeline. The ops go through the *same* op-emission choke-point as ordinary edits (shared field-builder helpers guarantee byte-identical payloads), so backfilled state merges cleanly with future edits. The backfill is idempotent (rows that already have a `Create` op are skipped) and reports how many items were uploaded, plus a warning about what sync does not cover yet (ebook file binaries, and authors/shelves/works/series/ISBNs — tracked in #208).
- **New-device restore (bootstrap) is wired and exposed.** Enrolling into an existing library now automatically restores prior state (apply the latest server snapshot if one exists, then pull the remaining op history). A device enrolled while approval is required stays pending and restores on its first `toku sync login` after approval — gated by a device-local marker so routine logins never re-run it. A new `toku sync bootstrap [--reset-cursor]` command exposes the same restore path for manual re-provisioning and recovery; `--reset-cursor` discards the local pull cursor and re-syncs from scratch.
- **Offline-first preserved.** Backfill and bootstrap only run at the sync opt-in boundary. With no device identity configured, backfill is a complete no-op and nothing touches the network.
- **Schema:** new migration `V19__sync_device_bootstrap.sql` adds a device-local `bootstrapped_at` column to `sync_device` (never synced) to gate the deferred bootstrap.
- **Docs:** `docs/recovery.md` gains a first-opt-in-upload and bootstrap/recovery section; `CHANGELOG.md` updated.

**Tests**

New orchestrator-level integration tests drive the real client against an in-process sync server, seeding library state through the real repository (no hand-staged ops): fresh-signup upload without a manual compact, new-device enroll restore, enroll-after-compaction restore via snapshot, backfill idempotency, and pending-device deferral until post-approval login. Two real-binary CLI smoke tests cover the new `bootstrap` command's argument parsing and graceful failure without sync configured.

## Related Issues

Closes #199

Relates to #207 (on-device-first assessment epic), #208 (deferred entity coverage), and #194 (op-emission choke-point this builds on).

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI / infrastructure
- [ ] Other (describe below)

## Crate

- [ ] `toku-core` — Domain models, traits, state machine
- [x] `toku-db` — SQLite persistence, migrations, FTS5
- [ ] `toku-import` — Importers (Goodreads, Calibre, StoryGraph)
- [ ] `toku-meta` — Metadata fetching (Open Library, Google Books)
- [x] `toku-cli` — CLI binary
- [ ] `toku-export` — Exporters (CSV, JSON, Markdown, BibTeX)
- [x] `docs/` — Documentation

<!-- Also touches `toku-sync-client` (backfill/bootstrap orchestration) and adds integration tests in `toku-sync`; these crates are not listed above. -->

## Data Integrity Checklist

- [x] No user data is sent to any server without explicit opt-in — backfill/bootstrap run only at the sync opt-in boundary (signup/enroll/login); with no device identity, op emission is a complete no-op and nothing touches the network.
- [x] Import operations are idempotent (re-importing the same file creates no duplicates) — the backfill is idempotent: rows that already carry a `Create` op are skipped, so re-running never duplicates ops.
- [x] User edits to metadata are never overwritten by auto-enrichment — backfill only synthesizes `Create` ops for rows with no existing op; it never rewrites existing state, and merge is last-writer-wins on HLC as before.
- [ ] New fields track provenance (source + timestamp) — N/A: no new user-facing metadata fields; synthesized ops carry the same provenance as ordinary mutations.
- [ ] Export round-trip is preserved (if applicable) — N/A: no export format changes.

## Checklist

- [x] I have read [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] `cargo fmt --check` passes
- [x] `cargo clippy --workspace -- -D warnings` passes
- [x] `cargo test --workspace` passes
- [x] I have updated documentation (if applicable)

---

**Note for reviewers:** enrolling into an *existing* library from a device that already holds local rows does **not** backfill those local rows (they stay local); the command warns instead. This matches the issue's scope (backfill applies to signup + fresh-library enroll). Reconciling join-with-local-rows would be a follow-up. No CI job names changed, so no Terraform `required_status_checks` update is needed.