### PR TITLE
feat: canonical lossless backup export + `toku import backup` restore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Canonical, lossless backups. `toku export backup` now writes a versioned,
+  self-describing archive (JSON-in-ZIP) that captures your **entire** library —
+  books (including audiobook durations, works, and soft-delete tombstones),
+  contributors and their roles, every ISBN, tags with their types, shelves
+  (including smart-shelf definitions), series, reading sessions and progress,
+  notes, reviews, ratings, per-field metadata provenance, user settings, import
+  history, and your cover images and ebook files as content-addressed binaries.
+  Nothing is flattened or dropped, so your data stays fully portable and
+  yours — no lock-in (#200)
+- Restore from a backup with `toku import backup <archive.zip>`. By default it
+  **merges** into your current library without ever clobbering a newer edit:
+  books match by id, then Goodreads/Calibre id, then ISBN; reading sessions and
+  progress are append-only; notes and reviews resolve last-writer-wins by clock
+  while respecting deletions; covers and files de-duplicate by checksum; and
+  re-running the same restore is a no-op. Use `--replace` for a verbatim
+  disaster-recovery restore into a cleared library, `--dry-run` to preview what
+  would change, and `--format table|json|csv` for the summary. Everything works
+  fully offline (#200)
+- Optional encrypted backups. Pass `--encrypt` to `toku export backup` to seal
+  the archive with your library data key (AES-256-GCM); `toku import backup`
+  transparently decrypts it. Unencrypted plaintext remains the default offline
+  artifact (#200)
+
 - Opting into sync now uploads the library you already have. On `toku sync signup` (and on a
   `toku sync enroll` that creates a fresh library), Toku backfills your existing books,
   reading sessions, progress, and tags into the sync log and pushes them automatically — no

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5971,6 +5971,7 @@ version = "0.4.0"
 dependencies = [
  "chrono",
  "csv",
+ "rusqlite",
  "serde",
  "serde_json",
  "tempfile",

--- a/crates/toku-cli/src/main.rs
+++ b/crates/toku-cli/src/main.rs
@@ -359,6 +359,21 @@ enum ImportSource {
         /// Import ID (shown after a successful import)
         import_id: String,
     },
+
+    /// Restore from a canonical lossless backup (`.zip`)
+    Backup {
+        /// Path to the backup ZIP created by `toku export backup`
+        path: PathBuf,
+
+        /// Replace the current library verbatim (disaster recovery) instead of
+        /// the default additive, precedence-respecting merge
+        #[arg(long)]
+        replace: bool,
+
+        /// Preview what would be restored without writing
+        #[arg(long)]
+        dry_run: bool,
+    },
 }
 
 #[derive(Subcommand)]
@@ -715,6 +730,11 @@ enum ExportTarget {
         /// Output file path (required)
         #[arg(long, short)]
         output: PathBuf,
+
+        /// Seal the backup with the configured library data key (AES-256-GCM).
+        /// Requires an enrolled sync key; the default is an unencrypted archive.
+        #[arg(long)]
+        encrypt: bool,
     },
 }
 
@@ -1091,7 +1111,7 @@ fn main() -> Result<()> {
             tag.as_deref(),
             &cli.format,
         ),
-        Commands::Import { source } => cmd_import(&db, &repo, source, &cli.format),
+        Commands::Import { source } => cmd_import(&db, &repo, source, &data_dir, &cli.format),
         Commands::Lookup { query, limit } => cmd_lookup(&query, limit, &cli.format),
         Commands::Reading { action } => cmd_reading(&repo, action, &cli.format),
         Commands::Tag { action } => cmd_tag(&repo, action, &cli.format),
@@ -1974,6 +1994,7 @@ fn cmd_import(
     db: &Database,
     _repo: &BookRepository,
     source: ImportSource,
+    data_dir: &Path,
     output_format: &OutputFormat,
 ) -> Result<()> {
     match source {
@@ -2027,7 +2048,158 @@ fn cmd_import(
 
             Ok(())
         }
+        ImportSource::Backup {
+            path,
+            replace,
+            dry_run,
+        } => cmd_import_backup(db, &path, replace, dry_run, data_dir, output_format),
     }
+}
+
+fn cmd_import_backup(
+    db: &Database,
+    path: &Path,
+    replace: bool,
+    dry_run: bool,
+    data_dir: &Path,
+    output_format: &OutputFormat,
+) -> Result<()> {
+    if !path.exists() {
+        anyhow::bail!("backup not found: {}", path.display());
+    }
+
+    let manifest =
+        toku_export::read_backup_manifest(path).context("could not read backup manifest")?;
+
+    if dry_run {
+        let c = &manifest.counts;
+        match output_format {
+            OutputFormat::Json => {
+                println!("{}", serde_json::to_string_pretty(&manifest)?);
+            }
+            _ => {
+                eprintln!("Dry run — no changes will be made.");
+                eprintln!(
+                    "Backup format v{} ({}), created {}",
+                    manifest.format_version,
+                    if manifest.encrypted {
+                        "encrypted"
+                    } else {
+                        "plaintext"
+                    },
+                    manifest.created_at
+                );
+                eprintln!(
+                    "Would restore: {} books, {} reading sessions, {} progress, {} notes, \
+                     {} reviews, {} tags, {} shelves, {} works, {} series, {} files",
+                    c.books,
+                    c.reading_sessions,
+                    c.reading_progress,
+                    c.notes,
+                    c.reviews,
+                    c.tags,
+                    c.shelves,
+                    c.works,
+                    c.series,
+                    c.files,
+                );
+                eprintln!("Mode: {}", if replace { "replace" } else { "merge" });
+            }
+        }
+        return Ok(());
+    }
+
+    // Decrypt only when the artifact is sealed; plaintext restores stay fully
+    // offline with no key required.
+    let key = if manifest.encrypted {
+        Some(load_library_key(data_dir).context(
+            "backup is encrypted but no library data key is configured; enroll this device \
+             with `toku sync` to restore an encrypted backup",
+        )?)
+    } else {
+        None
+    };
+
+    let mode = if replace {
+        toku_db::RestoreMode::Replace
+    } else {
+        toku_db::RestoreMode::Merge
+    };
+
+    let result = toku_export::import_backup(path, db, data_dir, mode, key.as_ref())
+        .context("backup restore failed")?;
+
+    match output_format {
+        OutputFormat::Json => {
+            let out = serde_json::json!({
+                "mode": if replace { "replace" } else { "merge" },
+                "books_inserted": result.books_inserted,
+                "books_updated": result.books_updated,
+                "reading_sessions": result.reading_sessions,
+                "reading_progress": result.reading_progress,
+                "notes": result.notes,
+                "reviews": result.reviews,
+                "tags": result.tags,
+                "shelves": result.shelves,
+                "works": result.works,
+                "series": result.series,
+                "isbns": result.isbns,
+                "files": result.files,
+            });
+            println!("{}", serde_json::to_string_pretty(&out)?);
+        }
+        OutputFormat::Csv => {
+            println!("metric,count");
+            println!("books_inserted,{}", result.books_inserted);
+            println!("books_updated,{}", result.books_updated);
+            println!("reading_sessions,{}", result.reading_sessions);
+            println!("reading_progress,{}", result.reading_progress);
+            println!("notes,{}", result.notes);
+            println!("reviews,{}", result.reviews);
+            println!("tags,{}", result.tags);
+            println!("shelves,{}", result.shelves);
+            println!("works,{}", result.works);
+            println!("series,{}", result.series);
+            println!("isbns,{}", result.isbns);
+            println!("files,{}", result.files);
+        }
+        OutputFormat::Table => {
+            eprintln!(
+                "✓ Restored backup ({} mode)",
+                if replace { "replace" } else { "merge" }
+            );
+            eprintln!(
+                "  {} books added, {} updated · {} sessions · {} progress · {} notes · \
+                 {} reviews · {} files",
+                result.books_inserted,
+                result.books_updated,
+                result.reading_sessions,
+                result.reading_progress,
+                result.notes,
+                result.reviews,
+                result.files,
+            );
+        }
+    }
+
+    Ok(())
+}
+
+/// Load the library data key from the configured sync server's local key store,
+/// if one is enrolled. Fully local — no network access.
+fn load_library_key(data_dir: &Path) -> Result<toku_core::SyncKey> {
+    let config = toku_core::TokuConfig::load(data_dir).unwrap_or_default();
+    let server = config
+        .sync
+        .as_ref()
+        .map(|s| s.server.clone())
+        .ok_or_else(|| anyhow::anyhow!("no sync server configured"))?;
+    let token_store = sync::token_store::TokenStore::new(data_dir);
+    let key_bytes = token_store
+        .load_sync_key(&server)?
+        .ok_or_else(|| anyhow::anyhow!("no library data key stored for {server}"))?;
+    toku_core::SyncKey::from_exported_bytes(&key_bytes)
+        .map_err(|e| anyhow::anyhow!("stored library data key is invalid: {e}"))
 }
 
 fn cmd_export(db: &Database, data_dir: &Path, target: ExportTarget) -> Result<()> {
@@ -2066,9 +2238,22 @@ fn cmd_export(db: &Database, data_dir: &Path, target: ExportTarget) -> Result<()
             }
             Ok(())
         }
-        ExportTarget::Backup { output } => {
-            toku_export::export_backup(db, data_dir, &output).context("backup export failed")?;
-            eprintln!("✓ Backup saved to {}", output.display());
+        ExportTarget::Backup { output, encrypt } => {
+            let key = if encrypt {
+                Some(load_library_key(data_dir).context(
+                    "cannot encrypt backup: no library data key is configured; enroll this \
+                     device with `toku sync` first, or omit --encrypt for a plaintext backup",
+                )?)
+            } else {
+                None
+            };
+            toku_export::export_backup(db, data_dir, &output, key.as_ref())
+                .context("backup export failed")?;
+            eprintln!(
+                "✓ Backup saved to {}{}",
+                output.display(),
+                if encrypt { " (encrypted)" } else { "" }
+            );
             Ok(())
         }
     }

--- a/crates/toku-core/src/backup_schema.rs
+++ b/crates/toku-core/src/backup_schema.rs
@@ -1,0 +1,410 @@
+//! Canonical, versioned, lossless backup schema (ADR-012).
+//!
+//! A single set of `serde` types describes the **whole** persisted domain model.
+//! [`LibraryData`] is the payload of a canonical backup (`library.json`) and is
+//! also the shared shape that the sync snapshot projects its non-binary subset
+//! from (ADR-012 D2).
+//!
+//! Every field maps to a database column. `TEXT` columns are represented as
+//! `String` / `Option<String>` so a round trip preserves the stored bytes
+//! exactly (ids, timestamps, HLCs, positions), and integer columns keep their
+//! integer type. New optional fields and whole new entity vectors are additive
+//! and default-constructed on restore (`#[serde(default)]`), so an older Toku
+//! can restore a newer backup's shared subset and vice versa (ADR-012 D5).
+
+use serde::{Deserialize, Serialize};
+
+/// The current canonical backup / snapshot schema version.
+///
+/// Starts at `2`: the superseded flat `LibraryExport` was version `"1"`, and the
+/// lossless format is the next generation (ADR-012 D5).
+pub const BACKUP_FORMAT_VERSION: u32 = 2;
+
+/// Metadata envelope written to `manifest.json` inside the backup ZIP.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BackupManifest {
+    /// Integer schema version (see [`BACKUP_FORMAT_VERSION`]).
+    pub format_version: u32,
+    /// RFC 3339 timestamp of when the backup was created.
+    pub created_at: String,
+    /// Per-entity row counts, for a quick human/inspection summary.
+    pub counts: BackupCounts,
+    /// Whether `library.json` inside the ZIP is sealed (ADR-012 D4).
+    #[serde(default)]
+    pub encrypted: bool,
+    /// The AEAD envelope when `encrypted` is true; absent for plaintext backups.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub envelope: Option<crate::crypto::EncryptedEnvelope>,
+}
+
+/// Row counts for each entity vector, surfaced in the manifest.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct BackupCounts {
+    #[serde(default)]
+    pub books: usize,
+    #[serde(default)]
+    pub authors: usize,
+    #[serde(default)]
+    pub reading_sessions: usize,
+    #[serde(default)]
+    pub reading_progress: usize,
+    #[serde(default)]
+    pub notes: usize,
+    #[serde(default)]
+    pub reviews: usize,
+    #[serde(default)]
+    pub tags: usize,
+    #[serde(default)]
+    pub shelves: usize,
+    #[serde(default)]
+    pub works: usize,
+    #[serde(default)]
+    pub series: usize,
+    #[serde(default)]
+    pub isbns: usize,
+    #[serde(default)]
+    pub files: usize,
+    #[serde(default)]
+    pub covers: usize,
+}
+
+/// The complete library payload (`library.json`).
+///
+/// Every persisted, user-owned table is represented. Ordering within each
+/// vector is by primary key so serialization is deterministic.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct LibraryData {
+    #[serde(default)]
+    pub books: Vec<BookRow>,
+    #[serde(default)]
+    pub authors: Vec<AuthorRow>,
+    #[serde(default)]
+    pub book_authors: Vec<BookAuthorRow>,
+    #[serde(default)]
+    pub isbns: Vec<IsbnRow>,
+    #[serde(default)]
+    pub works: Vec<WorkRow>,
+    #[serde(default)]
+    pub series: Vec<SeriesRow>,
+    #[serde(default)]
+    pub book_series: Vec<BookSeriesRow>,
+    #[serde(default)]
+    pub shelves: Vec<ShelfRow>,
+    #[serde(default)]
+    pub book_shelves: Vec<BookShelfRow>,
+    #[serde(default)]
+    pub tags: Vec<TagRow>,
+    #[serde(default)]
+    pub book_tags: Vec<BookTagRow>,
+    #[serde(default)]
+    pub reading_sessions: Vec<ReadingSessionRow>,
+    #[serde(default)]
+    pub reading_progress: Vec<ReadingProgressRow>,
+    #[serde(default)]
+    pub notes: Vec<NoteRow>,
+    #[serde(default)]
+    pub reviews: Vec<ReviewRow>,
+    #[serde(default)]
+    pub user_settings: Vec<UserSettingRow>,
+    #[serde(default)]
+    pub metadata_provenance: Vec<ProvenanceRow>,
+    #[serde(default)]
+    pub entity_hlc: Vec<EntityHlcRow>,
+    #[serde(default)]
+    pub files: Vec<FileRow>,
+    #[serde(default)]
+    pub import_logs: Vec<ImportLogRow>,
+    #[serde(default)]
+    pub import_books: Vec<ImportBookRow>,
+}
+
+impl LibraryData {
+    /// Compute per-entity counts (covers is filled in by the exporter, which
+    /// knows how many cover binaries were actually written).
+    pub fn counts(&self) -> BackupCounts {
+        BackupCounts {
+            books: self.books.len(),
+            authors: self.authors.len(),
+            reading_sessions: self.reading_sessions.len(),
+            reading_progress: self.reading_progress.len(),
+            notes: self.notes.len(),
+            reviews: self.reviews.len(),
+            tags: self.tags.len(),
+            shelves: self.shelves.len(),
+            works: self.works.len(),
+            series: self.series.len(),
+            isbns: self.isbns.len(),
+            files: self.files.len(),
+            covers: 0,
+        }
+    }
+}
+
+/// A row of `books` (Book = Edition), including source IDs and tombstones.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct BookRow {
+    pub id: String,
+    pub title: String,
+    #[serde(default)]
+    pub subtitle: Option<String>,
+    #[serde(default)]
+    pub description: Option<String>,
+    #[serde(default)]
+    pub page_count: Option<i64>,
+    #[serde(default)]
+    pub pub_date: Option<String>,
+    #[serde(default)]
+    pub language: Option<String>,
+    pub format: String,
+    #[serde(default)]
+    pub duration_minutes: Option<i64>,
+    #[serde(default)]
+    pub cover_hash: Option<String>,
+    #[serde(default)]
+    pub work_id: Option<String>,
+    pub status: String,
+    #[serde(default)]
+    pub rating: Option<i64>,
+    #[serde(default)]
+    pub goodreads_id: Option<String>,
+    #[serde(default)]
+    pub calibre_id: Option<i64>,
+    pub created_at: String,
+    pub updated_at: String,
+    #[serde(default)]
+    pub deleted_at: Option<String>,
+    #[serde(default)]
+    pub deleted_by_device: Option<String>,
+}
+
+/// A row of `authors`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AuthorRow {
+    pub id: String,
+    pub name: String,
+    #[serde(default)]
+    pub sort_name: Option<String>,
+}
+
+/// A row of `book_authors` (role + ordering preserved).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct BookAuthorRow {
+    pub book_id: String,
+    pub author_id: String,
+    pub role: String,
+    pub position: i64,
+}
+
+/// A row of `isbns` (all ISBN-10 / ISBN-13 per book).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct IsbnRow {
+    pub isbn: String,
+    pub book_id: String,
+}
+
+/// A row of `works`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct WorkRow {
+    pub id: String,
+    pub title: String,
+    #[serde(default)]
+    pub original_language: Option<String>,
+    #[serde(default)]
+    pub first_published: Option<String>,
+    pub created_at: String,
+}
+
+/// A row of `series`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SeriesRow {
+    pub id: String,
+    pub name: String,
+    #[serde(default)]
+    pub total_books: Option<i64>,
+}
+
+/// A row of `book_series` (position preserved as TEXT: "1.5", "2a", ...).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct BookSeriesRow {
+    pub book_id: String,
+    pub series_id: String,
+    #[serde(default)]
+    pub position: Option<String>,
+}
+
+/// A row of `shelves` (smart-shelf definition preserved).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ShelfRow {
+    pub id: String,
+    pub name: String,
+    #[serde(default)]
+    pub is_smart: bool,
+    #[serde(default)]
+    pub smart_filter: Option<String>,
+    pub created_at: String,
+}
+
+/// A row of `book_shelves`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct BookShelfRow {
+    pub book_id: String,
+    pub shelf_id: String,
+}
+
+/// A row of `tags` (tag_type preserved — "dark" mood != "dark" genre).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TagRow {
+    pub id: String,
+    pub name: String,
+    pub tag_type: String,
+    pub created_at: String,
+}
+
+/// A row of `book_tags`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct BookTagRow {
+    pub book_id: String,
+    pub tag_id: String,
+}
+
+/// A row of `reading_sessions`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ReadingSessionRow {
+    pub id: String,
+    pub book_id: String,
+    pub started_at: String,
+    #[serde(default)]
+    pub finished_at: Option<String>,
+    #[serde(default)]
+    pub start_page: Option<i64>,
+    #[serde(default)]
+    pub end_page: Option<i64>,
+    #[serde(default)]
+    pub rating: Option<i64>,
+    #[serde(default)]
+    pub notes: Option<String>,
+    pub created_at: String,
+}
+
+/// A row of `reading_progress`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ReadingProgressRow {
+    pub id: String,
+    pub book_id: String,
+    #[serde(default)]
+    pub session_id: Option<String>,
+    pub progress_type: String,
+    pub value: i64,
+    #[serde(default)]
+    pub note: Option<String>,
+    pub logged_at: String,
+    pub created_at: String,
+}
+
+/// A row of `notes` (tombstone preserved).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct NoteRow {
+    pub id: String,
+    pub book_id: String,
+    pub content: String,
+    #[serde(default)]
+    pub deleted_at: Option<String>,
+    #[serde(default)]
+    pub deleted_by_device: Option<String>,
+    pub created_at: String,
+    pub updated_at: String,
+}
+
+/// A row of `reviews` (tombstone preserved).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ReviewRow {
+    pub id: String,
+    pub book_id: String,
+    #[serde(default)]
+    pub content: Option<String>,
+    #[serde(default)]
+    pub rating: Option<i64>,
+    #[serde(default)]
+    pub deleted_at: Option<String>,
+    #[serde(default)]
+    pub deleted_by_device: Option<String>,
+    pub created_at: String,
+    pub updated_at: String,
+}
+
+/// A row of `user_settings`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct UserSettingRow {
+    pub id: String,
+    pub key: String,
+    pub value: String,
+    #[serde(default)]
+    pub sync_hlc: Option<String>,
+    pub updated_at: String,
+}
+
+/// A row of `metadata_provenance` (per-field source + user-override + HLC).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ProvenanceRow {
+    pub book_id: String,
+    pub field_name: String,
+    pub source: String,
+    pub source_date: String,
+    #[serde(default)]
+    pub is_user_override: bool,
+    #[serde(default)]
+    pub sync_hlc: Option<String>,
+}
+
+/// A row of `sync_entity_hlc` — per-field HLC for notes/reviews/etc. LWW.
+///
+/// Carried so that notes/reviews merge and tombstone precedence round-trip
+/// exactly (ADR-012 D3).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct EntityHlcRow {
+    pub entity_type: String,
+    pub entity_id: String,
+    pub field_name: String,
+    pub sync_hlc: String,
+    #[serde(default)]
+    pub device_id: Option<String>,
+}
+
+/// A row of `files` — ebook file association (binary stored separately).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct FileRow {
+    pub id: String,
+    pub book_id: String,
+    pub path: String,
+    pub format: String,
+    pub size_bytes: i64,
+    /// SHA-256 checksum, hex-encoded — also the content address in the ZIP.
+    pub checksum: String,
+    pub source: String,
+    #[serde(default)]
+    pub source_ref: Option<String>,
+    pub created_at: String,
+    pub updated_at: String,
+}
+
+/// A row of `import_logs`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ImportLogRow {
+    pub id: String,
+    pub source: String,
+    pub file_path: String,
+    pub started_at: String,
+    #[serde(default)]
+    pub finished_at: Option<String>,
+    pub total_rows: i64,
+    pub imported: i64,
+    pub skipped: i64,
+    pub errors: i64,
+}
+
+/// A row of `import_books` (which books came from which import).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ImportBookRow {
+    pub import_id: String,
+    pub book_id: String,
+}

--- a/crates/toku-core/src/lib.rs
+++ b/crates/toku-core/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod backup_schema;
 mod book;
 mod config;
 pub mod crypto;
@@ -9,6 +10,7 @@ pub mod merge;
 pub mod stats;
 pub mod sync;
 
+pub use backup_schema::*;
 pub use book::*;
 pub use config::*;
 pub use crypto::*;

--- a/crates/toku-db/src/lib.rs
+++ b/crates/toku-db/src/lib.rs
@@ -1,6 +1,7 @@
 mod backfill;
 mod database;
 mod error;
+mod library_io;
 mod merge;
 mod repo;
 mod snapshot;
@@ -9,6 +10,7 @@ mod sync_repo;
 pub use backfill::{BackfillCounts, backfill_sync_ops};
 pub use database::Database;
 pub use error::DbError;
+pub use library_io::{LibraryIo, RestoreMode, RestoreResult};
 pub use merge::MergeEngine;
 pub use repo::{
     BookRepository, book_op_fields, progress_op_fields, session_op_fields, tag_op_fields,

--- a/crates/toku-db/src/library_io.rs
+++ b/crates/toku-db/src/library_io.rs
@@ -1,0 +1,1334 @@
+//! Full-domain library export and restore (ADR-012).
+//!
+//! [`LibraryIo::export_library`] reads every persisted, user-owned table into
+//! the shared [`LibraryData`] schema. [`LibraryIo::restore_library`] writes it
+//! back with either merge (default, idempotent, precedence-respecting) or
+//! replace (verbatim into a cleared library) semantics.
+//!
+//! Binaries (cover images and ebook files) live outside this module: the
+//! backup container in `toku-export` reads/writes them content-addressed, using
+//! the `cover_hash` and `files.checksum` values carried here.
+
+use rusqlite::{Row, params};
+use toku_core::backup_schema::*;
+
+use crate::{Database, DbError};
+
+/// Restore strategy for [`LibraryIo::restore_library`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RestoreMode {
+    /// Additive, precedence-respecting merge into a possibly non-empty library.
+    Merge,
+    /// Verbatim restore into a cleared library (disaster recovery / fresh DB).
+    Replace,
+}
+
+/// Per-entity counts produced by a restore.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct RestoreResult {
+    pub books_inserted: usize,
+    pub books_updated: usize,
+    pub authors: usize,
+    pub reading_sessions: usize,
+    pub reading_progress: usize,
+    pub notes: usize,
+    pub reviews: usize,
+    pub tags: usize,
+    pub shelves: usize,
+    pub works: usize,
+    pub series: usize,
+    pub isbns: usize,
+    pub files: usize,
+    pub import_logs: usize,
+}
+
+/// Full-domain (de)serialization over a [`Database`].
+pub struct LibraryIo<'a> {
+    db: &'a Database,
+}
+
+impl<'a> LibraryIo<'a> {
+    pub fn new(db: &'a Database) -> Self {
+        Self { db }
+    }
+
+    // -----------------------------------------------------------------------
+    // Export
+    // -----------------------------------------------------------------------
+
+    /// Read the entire library into the shared [`LibraryData`] schema.
+    pub fn export_library(&self) -> Result<LibraryData, DbError> {
+        let conn = &self.db.conn;
+        Ok(LibraryData {
+            books: query_vec(
+                conn,
+                "SELECT id, title, subtitle, description, page_count, pub_date, language,
+                        format, duration_minutes, cover_hash, work_id, status, rating,
+                        goodreads_id, calibre_id, created_at, updated_at,
+                        deleted_at, deleted_by_device
+                 FROM books ORDER BY id",
+                row_to_book,
+            )?,
+            authors: query_vec(
+                conn,
+                "SELECT id, name, sort_name FROM authors ORDER BY id",
+                |r| {
+                    Ok(AuthorRow {
+                        id: r.get(0)?,
+                        name: r.get(1)?,
+                        sort_name: r.get(2)?,
+                    })
+                },
+            )?,
+            book_authors: query_vec(
+                conn,
+                "SELECT book_id, author_id, role, position FROM book_authors
+                 ORDER BY book_id, position, author_id",
+                |r| {
+                    Ok(BookAuthorRow {
+                        book_id: r.get(0)?,
+                        author_id: r.get(1)?,
+                        role: r.get(2)?,
+                        position: r.get(3)?,
+                    })
+                },
+            )?,
+            isbns: query_vec(conn, "SELECT isbn, book_id FROM isbns ORDER BY isbn", |r| {
+                Ok(IsbnRow {
+                    isbn: r.get(0)?,
+                    book_id: r.get(1)?,
+                })
+            })?,
+            works: query_vec(
+                conn,
+                "SELECT id, title, original_language, first_published, created_at
+                 FROM works ORDER BY id",
+                |r| {
+                    Ok(WorkRow {
+                        id: r.get(0)?,
+                        title: r.get(1)?,
+                        original_language: r.get(2)?,
+                        first_published: r.get(3)?,
+                        created_at: r.get(4)?,
+                    })
+                },
+            )?,
+            series: query_vec(
+                conn,
+                "SELECT id, name, total_books FROM series ORDER BY id",
+                |r| {
+                    Ok(SeriesRow {
+                        id: r.get(0)?,
+                        name: r.get(1)?,
+                        total_books: r.get(2)?,
+                    })
+                },
+            )?,
+            book_series: query_vec(
+                conn,
+                "SELECT book_id, series_id, position FROM book_series
+                 ORDER BY book_id, series_id",
+                |r| {
+                    Ok(BookSeriesRow {
+                        book_id: r.get(0)?,
+                        series_id: r.get(1)?,
+                        position: r.get(2)?,
+                    })
+                },
+            )?,
+            shelves: query_vec(
+                conn,
+                "SELECT id, name, is_smart, smart_filter, created_at FROM shelves ORDER BY id",
+                |r| {
+                    Ok(ShelfRow {
+                        id: r.get(0)?,
+                        name: r.get(1)?,
+                        is_smart: r.get::<_, i64>(2)? != 0,
+                        smart_filter: r.get(3)?,
+                        created_at: r.get(4)?,
+                    })
+                },
+            )?,
+            book_shelves: query_vec(
+                conn,
+                "SELECT book_id, shelf_id FROM book_shelves ORDER BY book_id, shelf_id",
+                |r| {
+                    Ok(BookShelfRow {
+                        book_id: r.get(0)?,
+                        shelf_id: r.get(1)?,
+                    })
+                },
+            )?,
+            tags: query_vec(
+                conn,
+                "SELECT id, name, tag_type, created_at FROM tags ORDER BY id",
+                |r| {
+                    Ok(TagRow {
+                        id: r.get(0)?,
+                        name: r.get(1)?,
+                        tag_type: r.get(2)?,
+                        created_at: r.get(3)?,
+                    })
+                },
+            )?,
+            book_tags: query_vec(
+                conn,
+                "SELECT book_id, tag_id FROM book_tags ORDER BY book_id, tag_id",
+                |r| {
+                    Ok(BookTagRow {
+                        book_id: r.get(0)?,
+                        tag_id: r.get(1)?,
+                    })
+                },
+            )?,
+            reading_sessions: query_vec(
+                conn,
+                "SELECT id, book_id, started_at, finished_at, start_page, end_page,
+                        rating, notes, created_at
+                 FROM reading_sessions ORDER BY id",
+                |r| {
+                    Ok(ReadingSessionRow {
+                        id: r.get(0)?,
+                        book_id: r.get(1)?,
+                        started_at: r.get(2)?,
+                        finished_at: r.get(3)?,
+                        start_page: r.get(4)?,
+                        end_page: r.get(5)?,
+                        rating: r.get(6)?,
+                        notes: r.get(7)?,
+                        created_at: r.get(8)?,
+                    })
+                },
+            )?,
+            reading_progress: query_vec(
+                conn,
+                "SELECT id, book_id, session_id, progress_type, value, note,
+                        logged_at, created_at
+                 FROM reading_progress ORDER BY id",
+                |r| {
+                    Ok(ReadingProgressRow {
+                        id: r.get(0)?,
+                        book_id: r.get(1)?,
+                        session_id: r.get(2)?,
+                        progress_type: r.get(3)?,
+                        value: r.get(4)?,
+                        note: r.get(5)?,
+                        logged_at: r.get(6)?,
+                        created_at: r.get(7)?,
+                    })
+                },
+            )?,
+            notes: query_vec(
+                conn,
+                "SELECT id, book_id, content, deleted_at, deleted_by_device,
+                        created_at, updated_at
+                 FROM notes ORDER BY id",
+                |r| {
+                    Ok(NoteRow {
+                        id: r.get(0)?,
+                        book_id: r.get(1)?,
+                        content: r.get(2)?,
+                        deleted_at: r.get(3)?,
+                        deleted_by_device: r.get(4)?,
+                        created_at: r.get(5)?,
+                        updated_at: r.get(6)?,
+                    })
+                },
+            )?,
+            reviews: query_vec(
+                conn,
+                "SELECT id, book_id, content, rating, deleted_at, deleted_by_device,
+                        created_at, updated_at
+                 FROM reviews ORDER BY id",
+                |r| {
+                    Ok(ReviewRow {
+                        id: r.get(0)?,
+                        book_id: r.get(1)?,
+                        content: r.get(2)?,
+                        rating: r.get(3)?,
+                        deleted_at: r.get(4)?,
+                        deleted_by_device: r.get(5)?,
+                        created_at: r.get(6)?,
+                        updated_at: r.get(7)?,
+                    })
+                },
+            )?,
+            user_settings: query_vec(
+                conn,
+                "SELECT id, key, value, sync_hlc, updated_at FROM user_settings ORDER BY id",
+                |r| {
+                    Ok(UserSettingRow {
+                        id: r.get(0)?,
+                        key: r.get(1)?,
+                        value: r.get(2)?,
+                        sync_hlc: r.get(3)?,
+                        updated_at: r.get(4)?,
+                    })
+                },
+            )?,
+            metadata_provenance: query_vec(
+                conn,
+                "SELECT book_id, field_name, source, source_date, is_user_override, sync_hlc
+                 FROM metadata_provenance ORDER BY book_id, field_name",
+                |r| {
+                    Ok(ProvenanceRow {
+                        book_id: r.get(0)?,
+                        field_name: r.get(1)?,
+                        source: r.get(2)?,
+                        source_date: r.get(3)?,
+                        is_user_override: r.get::<_, i64>(4)? != 0,
+                        sync_hlc: r.get(5)?,
+                    })
+                },
+            )?,
+            entity_hlc: query_vec(
+                conn,
+                "SELECT entity_type, entity_id, field_name, sync_hlc, device_id
+                 FROM sync_entity_hlc ORDER BY entity_type, entity_id, field_name",
+                |r| {
+                    Ok(EntityHlcRow {
+                        entity_type: r.get(0)?,
+                        entity_id: r.get(1)?,
+                        field_name: r.get(2)?,
+                        sync_hlc: r.get(3)?,
+                        device_id: r.get(4)?,
+                    })
+                },
+            )?,
+            files: query_vec(
+                conn,
+                "SELECT id, book_id, path, format, size_bytes, checksum, source,
+                        source_ref, created_at, updated_at
+                 FROM files ORDER BY id",
+                |r| {
+                    Ok(FileRow {
+                        id: r.get(0)?,
+                        book_id: r.get(1)?,
+                        path: r.get(2)?,
+                        format: r.get(3)?,
+                        size_bytes: r.get(4)?,
+                        checksum: r.get(5)?,
+                        source: r.get(6)?,
+                        source_ref: r.get(7)?,
+                        created_at: r.get(8)?,
+                        updated_at: r.get(9)?,
+                    })
+                },
+            )?,
+            import_logs: query_vec(
+                conn,
+                "SELECT id, source, file_path, started_at, finished_at,
+                        total_rows, imported, skipped, errors
+                 FROM import_logs ORDER BY id",
+                |r| {
+                    Ok(ImportLogRow {
+                        id: r.get(0)?,
+                        source: r.get(1)?,
+                        file_path: r.get(2)?,
+                        started_at: r.get(3)?,
+                        finished_at: r.get(4)?,
+                        total_rows: r.get(5)?,
+                        imported: r.get(6)?,
+                        skipped: r.get(7)?,
+                        errors: r.get(8)?,
+                    })
+                },
+            )?,
+            import_books: query_vec(
+                conn,
+                "SELECT import_id, book_id FROM import_books ORDER BY import_id, book_id",
+                |r| {
+                    Ok(ImportBookRow {
+                        import_id: r.get(0)?,
+                        book_id: r.get(1)?,
+                    })
+                },
+            )?,
+        })
+    }
+
+    // -----------------------------------------------------------------------
+    // Restore
+    // -----------------------------------------------------------------------
+
+    /// Write [`LibraryData`] into the database with the given [`RestoreMode`].
+    ///
+    /// Runs in a single transaction: either the whole restore commits or the
+    /// database is left untouched.
+    pub fn restore_library(
+        &self,
+        data: &LibraryData,
+        mode: RestoreMode,
+    ) -> Result<RestoreResult, DbError> {
+        let tx = self.db.conn.unchecked_transaction()?;
+        let mut result = RestoreResult::default();
+
+        if mode == RestoreMode::Replace {
+            clear_library(&tx)?;
+        }
+
+        // Independent parent entities first (dedup by natural key where the
+        // schema has a UNIQUE constraint, so join rows can be remapped).
+        let mut book_map = IdMap::new();
+        let mut tag_map = IdMap::new();
+        let mut shelf_map = IdMap::new();
+
+        // Books (and their metadata provenance, applied together for LWW).
+        restore_books(&tx, data, mode, &mut book_map, &mut result)?;
+
+        // Authors, works, series: insert-if-absent by id (identity remap).
+        for a in &data.authors {
+            let n = tx.execute(
+                "INSERT OR IGNORE INTO authors (id, name, sort_name) VALUES (?1, ?2, ?3)",
+                params![a.id, a.name, a.sort_name],
+            )?;
+            result.authors += n;
+        }
+        for w in &data.works {
+            let n = tx.execute(
+                "INSERT OR IGNORE INTO works
+                    (id, title, original_language, first_published, created_at)
+                 VALUES (?1, ?2, ?3, ?4, ?5)",
+                params![
+                    w.id,
+                    w.title,
+                    w.original_language,
+                    w.first_published,
+                    w.created_at
+                ],
+            )?;
+            result.works += n;
+        }
+        for s in &data.series {
+            let n = tx.execute(
+                "INSERT OR IGNORE INTO series (id, name, total_books) VALUES (?1, ?2, ?3)",
+                params![s.id, s.name, s.total_books],
+            )?;
+            result.series += n;
+        }
+
+        // Tags: dedup by (name, tag_type) UNIQUE.
+        for t in &data.tags {
+            let local_id: Option<String> = tx
+                .query_row(
+                    "SELECT id FROM tags WHERE name = ?1 AND tag_type = ?2",
+                    params![t.name, t.tag_type],
+                    |r| r.get(0),
+                )
+                .optional_dberr()?;
+            match local_id {
+                Some(id) => tag_map.set(&t.id, &id),
+                None => {
+                    tx.execute(
+                        "INSERT INTO tags (id, name, tag_type, created_at)
+                         VALUES (?1, ?2, ?3, ?4)",
+                        params![t.id, t.name, t.tag_type, t.created_at],
+                    )?;
+                    tag_map.set(&t.id, &t.id);
+                    result.tags += 1;
+                }
+            }
+        }
+
+        // Shelves: dedup by name UNIQUE.
+        for s in &data.shelves {
+            let local_id: Option<String> = tx
+                .query_row(
+                    "SELECT id FROM shelves WHERE name = ?1",
+                    params![s.name],
+                    |r| r.get(0),
+                )
+                .optional_dberr()?;
+            match local_id {
+                Some(id) => shelf_map.set(&s.id, &id),
+                None => {
+                    tx.execute(
+                        "INSERT INTO shelves (id, name, is_smart, smart_filter, created_at)
+                         VALUES (?1, ?2, ?3, ?4, ?5)",
+                        params![
+                            s.id,
+                            s.name,
+                            i64::from(s.is_smart),
+                            s.smart_filter,
+                            s.created_at
+                        ],
+                    )?;
+                    shelf_map.set(&s.id, &s.id);
+                    result.shelves += 1;
+                }
+            }
+        }
+
+        // Join rows: insert-if-absent, remapping ids that may have deduped.
+        for ba in &data.book_authors {
+            let book_id = book_map.get(&ba.book_id);
+            tx.execute(
+                "INSERT OR IGNORE INTO book_authors (book_id, author_id, role, position)
+                 VALUES (?1, ?2, ?3, ?4)",
+                params![book_id, ba.author_id, ba.role, ba.position],
+            )?;
+        }
+        for i in &data.isbns {
+            let book_id = book_map.get(&i.book_id);
+            let n = tx.execute(
+                "INSERT OR IGNORE INTO isbns (isbn, book_id) VALUES (?1, ?2)",
+                params![i.isbn, book_id],
+            )?;
+            result.isbns += n;
+        }
+        for bs in &data.book_series {
+            let book_id = book_map.get(&bs.book_id);
+            tx.execute(
+                "INSERT OR IGNORE INTO book_series (book_id, series_id, position)
+                 VALUES (?1, ?2, ?3)",
+                params![book_id, bs.series_id, bs.position],
+            )?;
+        }
+        for bsh in &data.book_shelves {
+            let book_id = book_map.get(&bsh.book_id);
+            let shelf_id = shelf_map.get(&bsh.shelf_id);
+            tx.execute(
+                "INSERT OR IGNORE INTO book_shelves (book_id, shelf_id) VALUES (?1, ?2)",
+                params![book_id, shelf_id],
+            )?;
+        }
+        for bt in &data.book_tags {
+            let book_id = book_map.get(&bt.book_id);
+            let tag_id = tag_map.get(&bt.tag_id);
+            tx.execute(
+                "INSERT OR IGNORE INTO book_tags (book_id, tag_id) VALUES (?1, ?2)",
+                params![book_id, tag_id],
+            )?;
+        }
+
+        // Append-only facts: sessions then progress (progress may reference a
+        // session). Insert-if-absent by id.
+        for s in &data.reading_sessions {
+            let book_id = book_map.get(&s.book_id);
+            let n = tx.execute(
+                "INSERT OR IGNORE INTO reading_sessions
+                    (id, book_id, started_at, finished_at, start_page, end_page,
+                     rating, notes, created_at)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)",
+                params![
+                    s.id,
+                    book_id,
+                    s.started_at,
+                    s.finished_at,
+                    s.start_page,
+                    s.end_page,
+                    s.rating,
+                    s.notes,
+                    s.created_at
+                ],
+            )?;
+            result.reading_sessions += n;
+        }
+        for p in &data.reading_progress {
+            let book_id = book_map.get(&p.book_id);
+            let n = tx.execute(
+                "INSERT OR IGNORE INTO reading_progress
+                    (id, book_id, session_id, progress_type, value, note,
+                     logged_at, created_at)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
+                params![
+                    p.id,
+                    book_id,
+                    p.session_id,
+                    p.progress_type,
+                    p.value,
+                    p.note,
+                    p.logged_at,
+                    p.created_at
+                ],
+            )?;
+            result.reading_progress += n;
+        }
+
+        // Entity HLC rows underpin notes/reviews LWW; write them before so the
+        // per-field comparisons below see incoming clocks.
+        restore_entity_hlc(&tx, data, &book_map)?;
+
+        // Notes / reviews: LWW by HLC honouring tombstones.
+        result.notes = restore_notes(&tx, data, mode, &book_map)?;
+        result.reviews = restore_reviews(&tx, data, mode, &book_map)?;
+
+        // Settings: LWW by key.
+        restore_settings(&tx, data, mode)?;
+
+        // Files: insert-if-absent by id (binary dedup handled by the container).
+        for f in &data.files {
+            let book_id = book_map.get(&f.book_id);
+            let n = tx.execute(
+                "INSERT OR IGNORE INTO files
+                    (id, book_id, path, format, size_bytes, checksum, source,
+                     source_ref, created_at, updated_at)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)",
+                params![
+                    f.id,
+                    book_id,
+                    f.path,
+                    f.format,
+                    f.size_bytes,
+                    f.checksum,
+                    f.source,
+                    f.source_ref,
+                    f.created_at,
+                    f.updated_at
+                ],
+            )?;
+            result.files += n;
+        }
+
+        // Import logs and their book links (insert-if-absent).
+        for l in &data.import_logs {
+            let n = tx.execute(
+                "INSERT OR IGNORE INTO import_logs
+                    (id, source, file_path, started_at, finished_at,
+                     total_rows, imported, skipped, errors)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)",
+                params![
+                    l.id,
+                    l.source,
+                    l.file_path,
+                    l.started_at,
+                    l.finished_at,
+                    l.total_rows,
+                    l.imported,
+                    l.skipped,
+                    l.errors
+                ],
+            )?;
+            result.import_logs += n;
+        }
+        for ib in &data.import_books {
+            let book_id = book_map.get(&ib.book_id);
+            tx.execute(
+                "INSERT OR IGNORE INTO import_books (import_id, book_id) VALUES (?1, ?2)",
+                params![ib.import_id, book_id],
+            )?;
+        }
+
+        // Recompute FTS search_text (including author names) for restored books.
+        tx.execute(
+            "UPDATE books SET search_text = TRIM(
+                COALESCE(title, '') || ' ' || COALESCE(subtitle, '') || ' ' ||
+                COALESCE(description, '') || ' ' ||
+                COALESCE((SELECT GROUP_CONCAT(a.name, ' ')
+                          FROM book_authors ba JOIN authors a ON a.id = ba.author_id
+                          WHERE ba.book_id = books.id), ''))",
+            [],
+        )?;
+
+        tx.commit()?;
+        Ok(result)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Books + provenance
+// ---------------------------------------------------------------------------
+
+fn restore_books(
+    tx: &rusqlite::Transaction<'_>,
+    data: &LibraryData,
+    mode: RestoreMode,
+    book_map: &mut IdMap,
+    result: &mut RestoreResult,
+) -> Result<(), DbError> {
+    // Index provenance rows by incoming book id for quick per-book lookup.
+    for book in &data.books {
+        let existing = if mode == RestoreMode::Replace {
+            None
+        } else {
+            find_existing_book(tx, book, data)?
+        };
+
+        match existing {
+            None => {
+                insert_book(tx, book)?;
+                book_map.set(&book.id, &book.id);
+                result.books_inserted += 1;
+                // Copy provenance verbatim for a freshly inserted book.
+                for pr in provenance_for(data, &book.id) {
+                    upsert_provenance(tx, &book.id, pr)?;
+                }
+            }
+            Some(local_id) => {
+                book_map.set(&book.id, &local_id);
+                let changed = merge_book_fields(tx, &local_id, book, data)?;
+                if changed {
+                    result.books_updated += 1;
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+fn insert_book(tx: &rusqlite::Transaction<'_>, b: &BookRow) -> Result<(), DbError> {
+    tx.execute(
+        "INSERT INTO books
+            (id, title, subtitle, description, page_count, pub_date, language,
+             format, duration_minutes, cover_hash, work_id, status, rating,
+             goodreads_id, calibre_id, created_at, updated_at,
+             deleted_at, deleted_by_device, search_text)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13,
+                 ?14, ?15, ?16, ?17, ?18, ?19, ?20)",
+        params![
+            b.id,
+            b.title,
+            b.subtitle,
+            b.description,
+            b.page_count,
+            b.pub_date,
+            b.language,
+            b.format,
+            b.duration_minutes,
+            b.cover_hash,
+            b.work_id,
+            b.status,
+            b.rating,
+            b.goodreads_id,
+            b.calibre_id,
+            b.created_at,
+            b.updated_at,
+            b.deleted_at,
+            b.deleted_by_device,
+            b.title
+        ],
+    )?;
+    Ok(())
+}
+
+/// Match an incoming book to an existing local row: id, then source IDs, then
+/// any shared ISBN (ADR-012 D3).
+fn find_existing_book(
+    tx: &rusqlite::Transaction<'_>,
+    book: &BookRow,
+    data: &LibraryData,
+) -> Result<Option<String>, DbError> {
+    if let Some(id) = tx
+        .query_row(
+            "SELECT id FROM books WHERE id = ?1",
+            params![book.id],
+            |r| r.get::<_, String>(0),
+        )
+        .optional_dberr()?
+    {
+        return Ok(Some(id));
+    }
+    if let Some(gr) = &book.goodreads_id
+        && let Some(id) = tx
+            .query_row(
+                "SELECT id FROM books WHERE goodreads_id = ?1",
+                params![gr],
+                |r| r.get::<_, String>(0),
+            )
+            .optional_dberr()?
+    {
+        return Ok(Some(id));
+    }
+    if let Some(cal) = book.calibre_id
+        && let Some(id) = tx
+            .query_row(
+                "SELECT id FROM books WHERE calibre_id = ?1",
+                params![cal],
+                |r| r.get::<_, String>(0),
+            )
+            .optional_dberr()?
+    {
+        return Ok(Some(id));
+    }
+    for isbn in data.isbns.iter().filter(|i| i.book_id == book.id) {
+        if let Some(id) = tx
+            .query_row(
+                "SELECT book_id FROM isbns WHERE isbn = ?1",
+                params![isbn.isbn],
+                |r| r.get::<_, String>(0),
+            )
+            .optional_dberr()?
+        {
+            return Ok(Some(id));
+        }
+    }
+    Ok(None)
+}
+
+/// Apply incoming book fields to an existing row using per-field provenance
+/// LWW: a field is applied only when its incoming HLC is strictly newer than
+/// the local HLC, which inherently protects a newer local user edit.
+fn merge_book_fields(
+    tx: &rusqlite::Transaction<'_>,
+    local_id: &str,
+    incoming: &BookRow,
+    data: &LibraryData,
+) -> Result<bool, DbError> {
+    let mut changed = false;
+    for pr in provenance_for(data, &incoming.id) {
+        let incoming_hlc = pr
+            .sync_hlc
+            .clone()
+            .unwrap_or_else(|| pr.source_date.clone());
+        let local_hlc: Option<String> = tx
+            .query_row(
+                "SELECT COALESCE(sync_hlc, source_date) FROM metadata_provenance
+                 WHERE book_id = ?1 AND field_name = ?2",
+                params![local_id, pr.field_name],
+                |r| r.get(0),
+            )
+            .optional_dberr()?;
+        let apply = match &local_hlc {
+            None => true,
+            Some(lh) => incoming_hlc > *lh,
+        };
+        if !apply {
+            continue;
+        }
+        if apply_book_field(tx, local_id, &pr.field_name, incoming)? {
+            changed = true;
+        }
+        upsert_provenance_at(tx, local_id, pr, &incoming_hlc)?;
+    }
+    Ok(changed)
+}
+
+/// Update a single book column identified by a provenance `field_name`.
+fn apply_book_field(
+    tx: &rusqlite::Transaction<'_>,
+    local_id: &str,
+    field: &str,
+    b: &BookRow,
+) -> Result<bool, DbError> {
+    let n = match field {
+        "title" => tx.execute(
+            "UPDATE books SET title = ?1 WHERE id = ?2",
+            params![b.title, local_id],
+        )?,
+        "subtitle" => tx.execute(
+            "UPDATE books SET subtitle = ?1 WHERE id = ?2",
+            params![b.subtitle, local_id],
+        )?,
+        "description" => tx.execute(
+            "UPDATE books SET description = ?1 WHERE id = ?2",
+            params![b.description, local_id],
+        )?,
+        "page_count" => tx.execute(
+            "UPDATE books SET page_count = ?1 WHERE id = ?2",
+            params![b.page_count, local_id],
+        )?,
+        "pub_date" => tx.execute(
+            "UPDATE books SET pub_date = ?1 WHERE id = ?2",
+            params![b.pub_date, local_id],
+        )?,
+        "language" => tx.execute(
+            "UPDATE books SET language = ?1 WHERE id = ?2",
+            params![b.language, local_id],
+        )?,
+        "format" => tx.execute(
+            "UPDATE books SET format = ?1 WHERE id = ?2",
+            params![b.format, local_id],
+        )?,
+        "duration_minutes" => tx.execute(
+            "UPDATE books SET duration_minutes = ?1 WHERE id = ?2",
+            params![b.duration_minutes, local_id],
+        )?,
+        "cover_hash" => tx.execute(
+            "UPDATE books SET cover_hash = ?1 WHERE id = ?2",
+            params![b.cover_hash, local_id],
+        )?,
+        "status" => tx.execute(
+            "UPDATE books SET status = ?1 WHERE id = ?2",
+            params![b.status, local_id],
+        )?,
+        "rating" => tx.execute(
+            "UPDATE books SET rating = ?1 WHERE id = ?2",
+            params![b.rating, local_id],
+        )?,
+        // Unknown/unmapped provenance field: nothing to update on the row.
+        _ => 0,
+    };
+    // Keep updated_at monotonic with the applied change.
+    if n > 0 {
+        tx.execute(
+            "UPDATE books SET updated_at = ?1 WHERE id = ?2",
+            params![b.updated_at, local_id],
+        )?;
+    }
+    Ok(n > 0)
+}
+
+fn provenance_for<'d>(
+    data: &'d LibraryData,
+    book_id: &str,
+) -> impl Iterator<Item = &'d ProvenanceRow> {
+    data.metadata_provenance
+        .iter()
+        .filter(move |p| p.book_id == book_id)
+}
+
+fn upsert_provenance(
+    tx: &rusqlite::Transaction<'_>,
+    book_id: &str,
+    pr: &ProvenanceRow,
+) -> Result<(), DbError> {
+    tx.execute(
+        "INSERT INTO metadata_provenance
+            (book_id, field_name, source, source_date, is_user_override, sync_hlc)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6)
+         ON CONFLICT(book_id, field_name) DO UPDATE SET
+            source = excluded.source, source_date = excluded.source_date,
+            is_user_override = excluded.is_user_override, sync_hlc = excluded.sync_hlc",
+        params![
+            book_id,
+            pr.field_name,
+            pr.source,
+            pr.source_date,
+            i64::from(pr.is_user_override),
+            pr.sync_hlc
+        ],
+    )?;
+    Ok(())
+}
+
+fn upsert_provenance_at(
+    tx: &rusqlite::Transaction<'_>,
+    book_id: &str,
+    pr: &ProvenanceRow,
+    hlc: &str,
+) -> Result<(), DbError> {
+    tx.execute(
+        "INSERT INTO metadata_provenance
+            (book_id, field_name, source, source_date, is_user_override, sync_hlc)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6)
+         ON CONFLICT(book_id, field_name) DO UPDATE SET
+            source = excluded.source, source_date = excluded.source_date,
+            is_user_override = excluded.is_user_override, sync_hlc = excluded.sync_hlc",
+        params![
+            book_id,
+            pr.field_name,
+            pr.source,
+            pr.source_date,
+            i64::from(pr.is_user_override),
+            hlc
+        ],
+    )?;
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Notes / reviews / settings / entity HLC
+// ---------------------------------------------------------------------------
+
+fn restore_entity_hlc(
+    tx: &rusqlite::Transaction<'_>,
+    data: &LibraryData,
+    book_map: &IdMap,
+) -> Result<(), DbError> {
+    for h in &data.entity_hlc {
+        // Remap book-scoped entity ids (notes/reviews carry their own ids, so
+        // only book entities need remapping).
+        let entity_id = if h.entity_type == "book" {
+            book_map.get(&h.entity_id)
+        } else {
+            h.entity_id.clone()
+        };
+        tx.execute(
+            "INSERT INTO sync_entity_hlc
+                (entity_type, entity_id, field_name, sync_hlc, device_id)
+             VALUES (?1, ?2, ?3, ?4, ?5)
+             ON CONFLICT(entity_type, entity_id, field_name) DO UPDATE SET
+                sync_hlc = excluded.sync_hlc, device_id = excluded.device_id
+             WHERE excluded.sync_hlc > sync_entity_hlc.sync_hlc",
+            params![
+                h.entity_type,
+                entity_id,
+                h.field_name,
+                h.sync_hlc,
+                h.device_id
+            ],
+        )?;
+    }
+    Ok(())
+}
+
+fn entity_hlc(
+    data: &LibraryData,
+    entity_type: &str,
+    entity_id: &str,
+    field: &str,
+) -> Option<String> {
+    data.entity_hlc
+        .iter()
+        .find(|h| h.entity_type == entity_type && h.entity_id == entity_id && h.field_name == field)
+        .map(|h| h.sync_hlc.clone())
+}
+
+fn local_entity_hlc(
+    tx: &rusqlite::Transaction<'_>,
+    entity_type: &str,
+    entity_id: &str,
+    field: &str,
+) -> Result<Option<String>, DbError> {
+    tx.query_row(
+        "SELECT sync_hlc FROM sync_entity_hlc
+         WHERE entity_type = ?1 AND entity_id = ?2 AND field_name = ?3",
+        params![entity_type, entity_id, field],
+        |r| r.get(0),
+    )
+    .optional_dberr()
+}
+
+fn restore_notes(
+    tx: &rusqlite::Transaction<'_>,
+    data: &LibraryData,
+    mode: RestoreMode,
+    book_map: &IdMap,
+) -> Result<usize, DbError> {
+    let mut count = 0;
+    for note in &data.notes {
+        let book_id = book_map.get(&note.book_id);
+        let exists: bool = tx
+            .query_row(
+                "SELECT 1 FROM notes WHERE id = ?1",
+                params![note.id],
+                |_| Ok(()),
+            )
+            .optional_dberr()?
+            .is_some();
+
+        if !exists {
+            tx.execute(
+                "INSERT INTO notes
+                    (id, book_id, content, deleted_at, deleted_by_device,
+                     created_at, updated_at)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
+                params![
+                    note.id,
+                    book_id,
+                    note.content,
+                    note.deleted_at,
+                    note.deleted_by_device,
+                    note.created_at,
+                    note.updated_at
+                ],
+            )?;
+            count += 1;
+        } else if mode == RestoreMode::Merge {
+            let incoming = entity_hlc(data, "note", &note.id, "content");
+            let local = local_entity_hlc(tx, "note", &note.id, "content")?;
+            let apply = match (&incoming, &local) {
+                (Some(i), Some(l)) => i > l,
+                (Some(_), None) => true,
+                // No incoming clock: fall back to updated_at LWW.
+                (None, _) => is_newer_updated_at(tx, "notes", &note.id, &note.updated_at)?,
+            };
+            if apply {
+                tx.execute(
+                    "UPDATE notes SET content = ?1, deleted_at = ?2,
+                        deleted_by_device = ?3, updated_at = ?4 WHERE id = ?5",
+                    params![
+                        note.content,
+                        note.deleted_at,
+                        note.deleted_by_device,
+                        note.updated_at,
+                        note.id
+                    ],
+                )?;
+            }
+        }
+    }
+    Ok(count)
+}
+
+fn restore_reviews(
+    tx: &rusqlite::Transaction<'_>,
+    data: &LibraryData,
+    mode: RestoreMode,
+    book_map: &IdMap,
+) -> Result<usize, DbError> {
+    let mut count = 0;
+    for review in &data.reviews {
+        let book_id = book_map.get(&review.book_id);
+        let exists: bool = tx
+            .query_row(
+                "SELECT 1 FROM reviews WHERE id = ?1",
+                params![review.id],
+                |_| Ok(()),
+            )
+            .optional_dberr()?
+            .is_some();
+
+        if !exists {
+            tx.execute(
+                "INSERT INTO reviews
+                    (id, book_id, content, rating, deleted_at, deleted_by_device,
+                     created_at, updated_at)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
+                params![
+                    review.id,
+                    book_id,
+                    review.content,
+                    review.rating,
+                    review.deleted_at,
+                    review.deleted_by_device,
+                    review.created_at,
+                    review.updated_at
+                ],
+            )?;
+            count += 1;
+        } else if mode == RestoreMode::Merge {
+            let incoming = entity_hlc(data, "review", &review.id, "content");
+            let local = local_entity_hlc(tx, "review", &review.id, "content")?;
+            let apply = match (&incoming, &local) {
+                (Some(i), Some(l)) => i > l,
+                (Some(_), None) => true,
+                (None, _) => is_newer_updated_at(tx, "reviews", &review.id, &review.updated_at)?,
+            };
+            if apply {
+                tx.execute(
+                    "UPDATE reviews SET content = ?1, rating = ?2, deleted_at = ?3,
+                        deleted_by_device = ?4, updated_at = ?5 WHERE id = ?6",
+                    params![
+                        review.content,
+                        review.rating,
+                        review.deleted_at,
+                        review.deleted_by_device,
+                        review.updated_at,
+                        review.id
+                    ],
+                )?;
+            }
+        }
+    }
+    Ok(count)
+}
+
+fn restore_settings(
+    tx: &rusqlite::Transaction<'_>,
+    data: &LibraryData,
+    mode: RestoreMode,
+) -> Result<(), DbError> {
+    for s in &data.user_settings {
+        let local: Option<(String, Option<String>)> = tx
+            .query_row(
+                "SELECT id, sync_hlc FROM user_settings WHERE key = ?1",
+                params![s.key],
+                |r| Ok((r.get(0)?, r.get(1)?)),
+            )
+            .optional_dberr()?;
+        match local {
+            None => {
+                tx.execute(
+                    "INSERT OR IGNORE INTO user_settings (id, key, value, sync_hlc, updated_at)
+                     VALUES (?1, ?2, ?3, ?4, ?5)",
+                    params![s.id, s.key, s.value, s.sync_hlc, s.updated_at],
+                )?;
+            }
+            Some((local_id, local_hlc)) if mode == RestoreMode::Merge => {
+                let apply = match (&s.sync_hlc, &local_hlc) {
+                    (Some(i), Some(l)) => i > l,
+                    (Some(_), None) => true,
+                    (None, _) => false,
+                };
+                if apply {
+                    tx.execute(
+                        "UPDATE user_settings SET value = ?1, sync_hlc = ?2, updated_at = ?3
+                         WHERE id = ?4",
+                        params![s.value, s.sync_hlc, s.updated_at, local_id],
+                    )?;
+                }
+            }
+            Some(_) => {}
+        }
+    }
+    Ok(())
+}
+
+fn is_newer_updated_at(
+    tx: &rusqlite::Transaction<'_>,
+    table: &str,
+    id: &str,
+    incoming_updated_at: &str,
+) -> Result<bool, DbError> {
+    let sql = format!("SELECT updated_at FROM {table} WHERE id = ?1");
+    let local: Option<String> = tx
+        .query_row(&sql, params![id], |r| r.get(0))
+        .optional_dberr()?;
+    Ok(match local {
+        Some(l) => incoming_updated_at > l.as_str(),
+        None => true,
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Replace: clear all user-owned tables (children first for FK safety).
+// ---------------------------------------------------------------------------
+
+fn clear_library(tx: &rusqlite::Transaction<'_>) -> Result<(), DbError> {
+    for table in [
+        "book_authors",
+        "isbns",
+        "book_series",
+        "book_shelves",
+        "book_tags",
+        "metadata_provenance",
+        "reading_progress",
+        "reading_sessions",
+        "notes",
+        "reviews",
+        "files",
+        "import_books",
+        "import_logs",
+        "sync_entity_hlc",
+        "user_settings",
+        "books",
+        "authors",
+        "series",
+        "shelves",
+        "tags",
+        "works",
+    ] {
+        tx.execute(&format!("DELETE FROM {table}"), [])?;
+    }
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// A remap from incoming entity ids to the local ids they resolved to.
+struct IdMap {
+    map: std::collections::HashMap<String, String>,
+}
+
+impl IdMap {
+    fn new() -> Self {
+        Self {
+            map: std::collections::HashMap::new(),
+        }
+    }
+    fn set(&mut self, from: &str, to: &str) {
+        self.map.insert(from.to_string(), to.to_string());
+    }
+    /// Resolve an incoming id to its local id, defaulting to identity for ids
+    /// that were never remapped (the common same-instance case).
+    fn get(&self, from: &str) -> String {
+        self.map
+            .get(from)
+            .cloned()
+            .unwrap_or_else(|| from.to_string())
+    }
+}
+
+fn query_vec<T, F>(conn: &rusqlite::Connection, sql: &str, f: F) -> Result<Vec<T>, DbError>
+where
+    F: Fn(&Row<'_>) -> rusqlite::Result<T>,
+{
+    let mut stmt = conn.prepare(sql)?;
+    let rows = stmt
+        .query_map([], |r| f(r))?
+        .collect::<rusqlite::Result<Vec<T>>>()?;
+    Ok(rows)
+}
+
+fn row_to_book(r: &Row<'_>) -> rusqlite::Result<BookRow> {
+    Ok(BookRow {
+        id: r.get(0)?,
+        title: r.get(1)?,
+        subtitle: r.get(2)?,
+        description: r.get(3)?,
+        page_count: r.get(4)?,
+        pub_date: r.get(5)?,
+        language: r.get(6)?,
+        format: r.get(7)?,
+        duration_minutes: r.get(8)?,
+        cover_hash: r.get(9)?,
+        work_id: r.get(10)?,
+        status: r.get(11)?,
+        rating: r.get(12)?,
+        goodreads_id: r.get(13)?,
+        calibre_id: r.get(14)?,
+        created_at: r.get(15)?,
+        updated_at: r.get(16)?,
+        deleted_at: r.get(17)?,
+        deleted_by_device: r.get(18)?,
+    })
+}
+
+/// Convenience: map a rusqlite "no rows" into `Ok(None)` and other errors into
+/// [`DbError`], so restore lookups stay terse.
+trait OptionalDbErr<T> {
+    fn optional_dberr(self) -> Result<Option<T>, DbError>;
+}
+
+impl<T> OptionalDbErr<T> for rusqlite::Result<T> {
+    fn optional_dberr(self) -> Result<Option<T>, DbError> {
+        match self {
+            Ok(v) => Ok(Some(v)),
+            Err(rusqlite::Error::QueryReturnedNoRows) => Ok(None),
+            Err(e) => Err(DbError::Sqlite(e)),
+        }
+    }
+}
+
+#[cfg(test)]
+mod smoke_tests {
+    use super::*;
+    use toku_core::{Author, Book, BookFormat, ContributorRole, ReadingStatus};
+
+    #[test]
+    fn export_then_replace_restore_roundtrips_a_book() {
+        let src = Database::open_in_memory().unwrap();
+        let repo = crate::BookRepository::new(&src);
+        let mut book = Book::new("Dune");
+        book.status = ReadingStatus::Read;
+        book.format = BookFormat::Physical;
+        book.rating = Some(9);
+        repo.create_book(&book).unwrap();
+        repo.add_book_author(
+            &Author::new("Frank Herbert"),
+            &book.id,
+            ContributorRole::Author,
+            0,
+        )
+        .unwrap();
+        repo.add_isbn("9780441172719", &book.id).unwrap();
+
+        let data = LibraryIo::new(&src).export_library().unwrap();
+        assert_eq!(data.books.len(), 1);
+        assert_eq!(data.isbns.len(), 1);
+
+        let dst = Database::open_in_memory().unwrap();
+        let res = LibraryIo::new(&dst)
+            .restore_library(&data, RestoreMode::Replace)
+            .unwrap();
+        assert_eq!(res.books_inserted, 1);
+
+        let data2 = LibraryIo::new(&dst).export_library().unwrap();
+        assert_eq!(data.books, data2.books);
+        assert_eq!(data.isbns, data2.isbns);
+        assert_eq!(data.book_authors, data2.book_authors);
+    }
+
+    #[test]
+    fn merge_is_idempotent() {
+        let src = Database::open_in_memory().unwrap();
+        let repo = crate::BookRepository::new(&src);
+        let book = Book::new("Neuromancer");
+        repo.create_book(&book).unwrap();
+        let data = LibraryIo::new(&src).export_library().unwrap();
+
+        let dst = Database::open_in_memory().unwrap();
+        let io = LibraryIo::new(&dst);
+        io.restore_library(&data, RestoreMode::Merge).unwrap();
+        io.restore_library(&data, RestoreMode::Merge).unwrap();
+
+        let n: i64 = dst
+            .conn
+            .query_row("SELECT COUNT(*) FROM books", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(n, 1);
+    }
+}

--- a/crates/toku-db/tests/library_roundtrip.rs
+++ b/crates/toku-db/tests/library_roundtrip.rs
@@ -1,0 +1,521 @@
+//! Full-domain lossless round-trip + merge-semantics tests for the canonical
+//! backup engine (ADR-012, issue #200).
+//!
+//! These run under `cargo test --workspace`, which is what the `Validate` CI
+//! gate executes — no CI job change required.
+
+use toku_db::{Database, LibraryIo, RestoreMode};
+
+/// Seed one fully-populated library covering every table the backup carries.
+/// Uses direct SQL so each column is set explicitly and losslessly.
+fn seed_full_library(db: &Database) {
+    let c = &db.conn;
+
+    // Work + series parents.
+    c.execute(
+        "INSERT INTO works (id, title, original_language, first_published, created_at)
+         VALUES ('w1', 'Dune (Work)', 'en', '1965', '2020-01-01T00:00:00Z')",
+        [],
+    )
+    .unwrap();
+    c.execute(
+        "INSERT INTO series (id, name, total_books) VALUES ('s1', 'Dune Saga', 6)",
+        [],
+    )
+    .unwrap();
+
+    // Book with every column populated, including tombstone provenance columns.
+    c.execute(
+        "INSERT INTO books
+            (id, title, subtitle, description, page_count, pub_date, language,
+             format, duration_minutes, cover_hash, work_id, status, rating,
+             goodreads_id, calibre_id, created_at, updated_at,
+             deleted_at, deleted_by_device, search_text)
+         VALUES
+            ('b1', 'Dune', 'Book One', 'Desert planet.', 412, '1965-08-01', 'en',
+             'audiobook', 1260, 'covdeadbeef', 'w1', 'read', 9,
+             'gr-555', 4242, '2021-01-01T00:00:00Z', '2021-02-01T00:00:00Z',
+             NULL, NULL, 'Dune')",
+        [],
+    )
+    .unwrap();
+    // A soft-deleted book (tombstone), to prove tombstones round-trip.
+    c.execute(
+        "INSERT INTO books
+            (id, title, format, status, created_at, updated_at,
+             deleted_at, deleted_by_device, search_text)
+         VALUES
+            ('b2', 'Ghost', 'physical', 'want_to_read', '2021-01-01T00:00:00Z',
+             '2021-03-01T00:00:00Z', '2021-03-02T00:00:00Z', 'device-A', 'Ghost')",
+        [],
+    )
+    .unwrap();
+
+    // Authors + roles.
+    c.execute(
+        "INSERT INTO authors (id, name, sort_name) VALUES
+            ('a1', 'Frank Herbert', 'Herbert, Frank'),
+            ('a2', 'Scott Brick', 'Brick, Scott')",
+        [],
+    )
+    .unwrap();
+    c.execute(
+        "INSERT INTO book_authors (book_id, author_id, role, position) VALUES
+            ('b1', 'a1', 'author', 0),
+            ('b1', 'a2', 'narrator', 1)",
+        [],
+    )
+    .unwrap();
+
+    // Multiple ISBNs (ISBN-10 and ISBN-13) — must all round-trip.
+    c.execute(
+        "INSERT INTO isbns (isbn, book_id) VALUES
+            ('9780441172719', 'b1'),
+            ('0441172717', 'b1')",
+        [],
+    )
+    .unwrap();
+
+    // book <-> series with position.
+    c.execute(
+        "INSERT INTO book_series (book_id, series_id, position) VALUES ('b1', 's1', '1')",
+        [],
+    )
+    .unwrap();
+
+    // Shelves: one normal, one smart with a filter definition.
+    c.execute(
+        "INSERT INTO shelves (id, name, is_smart, smart_filter, created_at) VALUES
+            ('sh1', 'Favorites', 0, NULL, '2021-01-01T00:00:00Z'),
+            ('sh2', 'Recent Sci-Fi', 1, '{\"genre\":\"sci-fi\"}', '2021-01-02T00:00:00Z')",
+        [],
+    )
+    .unwrap();
+    c.execute(
+        "INSERT INTO book_shelves (book_id, shelf_id) VALUES ('b1', 'sh1')",
+        [],
+    )
+    .unwrap();
+
+    // Typed tags.
+    c.execute(
+        "INSERT INTO tags (id, name, tag_type, created_at) VALUES
+            ('t1', 'epic', 'genre', '2021-01-01T00:00:00Z'),
+            ('t2', 'tense', 'mood', '2021-01-01T00:00:00Z')",
+        [],
+    )
+    .unwrap();
+    c.execute(
+        "INSERT INTO book_tags (book_id, tag_id) VALUES ('b1', 't1'), ('b1', 't2')",
+        [],
+    )
+    .unwrap();
+
+    // Reading session + progress (append-only facts).
+    c.execute(
+        "INSERT INTO reading_sessions
+            (id, book_id, started_at, finished_at, start_page, end_page, rating, notes, created_at)
+         VALUES
+            ('rs1', 'b1', '2021-01-05T00:00:00Z', '2021-01-20T00:00:00Z', 1, 412, 9,
+             'loved it', '2021-01-05T00:00:00Z')",
+        [],
+    )
+    .unwrap();
+    c.execute(
+        "INSERT INTO reading_progress
+            (id, book_id, session_id, progress_type, value, note, logged_at, created_at)
+         VALUES
+            ('rp1', 'b1', 'rs1', 'page', 200, 'halfway', '2021-01-10T00:00:00Z',
+             '2021-01-10T00:00:00Z')",
+        [],
+    )
+    .unwrap();
+
+    // Notes: one live, one tombstoned.
+    c.execute(
+        "INSERT INTO notes (id, book_id, content, deleted_at, deleted_by_device, created_at, updated_at)
+         VALUES
+            ('n1', 'b1', 'The spice must flow.', NULL, NULL, '2021-01-06T00:00:00Z', '2021-01-06T00:00:00Z'),
+            ('n2', 'b1', 'obsolete', '2021-01-07T00:00:00Z', 'device-A', '2021-01-06T00:00:00Z', '2021-01-07T00:00:00Z')",
+        [],
+    )
+    .unwrap();
+
+    // Review.
+    c.execute(
+        "INSERT INTO reviews (id, book_id, content, rating, deleted_at, deleted_by_device, created_at, updated_at)
+         VALUES ('rv1', 'b1', 'A masterpiece.', 9, NULL, NULL, '2021-01-21T00:00:00Z', '2021-01-21T00:00:00Z')",
+        [],
+    )
+    .unwrap();
+
+    // User settings.
+    c.execute(
+        "INSERT INTO user_settings (id, key, value, sync_hlc, updated_at) VALUES
+            ('us1', 'theme', 'dark', '2021-01-01T00:00:00Z-0001-devA', '2021-01-01T00:00:00Z')",
+        [],
+    )
+    .unwrap();
+
+    // Provenance with sync_hlc + user override flag.
+    c.execute(
+        "INSERT INTO metadata_provenance (book_id, field_name, source, source_date, is_user_override, sync_hlc)
+         VALUES
+            ('b1', 'title', 'user', '2021-02-01T00:00:00Z', 1, '2021-02-01T00:00:00Z-0001-devA'),
+            ('b1', 'rating', 'goodreads', '2021-01-01T00:00:00Z', 0, '2021-01-01T00:00:00Z-0001-devA')",
+        [],
+    )
+    .unwrap();
+
+    // Entity HLC underpinning notes/reviews LWW.
+    c.execute(
+        "INSERT INTO sync_entity_hlc (entity_type, entity_id, field_name, sync_hlc, device_id)
+         VALUES
+            ('note', 'n1', 'content', '2021-01-06T00:00:00Z-0001-devA', 'devA'),
+            ('review', 'rv1', 'content', '2021-01-21T00:00:00Z-0001-devA', 'devA')",
+        [],
+    )
+    .unwrap();
+
+    // File association (binary lives elsewhere; row must round-trip).
+    c.execute(
+        "INSERT INTO files (id, book_id, path, format, size_bytes, checksum, source, source_ref, created_at, updated_at)
+         VALUES ('f1', 'b1', '/lib/dune.epub', 'epub', 1024, 'sha-abc123', 'calibre', 'orig/path', '2021-01-01T00:00:00Z', '2021-01-01T00:00:00Z')",
+        [],
+    )
+    .unwrap();
+
+    // Import log + link.
+    c.execute(
+        "INSERT INTO import_logs (id, source, file_path, started_at, finished_at, total_rows, imported, skipped, errors)
+         VALUES ('imp1', 'goodreads', '/tmp/gr.csv', '2021-01-01T00:00:00Z', '2021-01-01T00:01:00Z', 10, 9, 1, 0)",
+        [],
+    )
+    .unwrap();
+    c.execute(
+        "INSERT INTO import_books (import_id, book_id) VALUES ('imp1', 'b1')",
+        [],
+    )
+    .unwrap();
+}
+
+#[test]
+fn full_model_replace_roundtrip_is_structurally_equal() {
+    let src = Database::open_in_memory().unwrap();
+    seed_full_library(&src);
+    let exported = LibraryIo::new(&src).export_library().unwrap();
+
+    // Restore verbatim into a fresh database.
+    let dst = Database::open_in_memory().unwrap();
+    LibraryIo::new(&dst)
+        .restore_library(&exported, RestoreMode::Replace)
+        .unwrap();
+    let reexported = LibraryIo::new(&dst).export_library().unwrap();
+
+    // Structural equality across every entity — this is the lossless guarantee.
+    assert_eq!(exported.books, reexported.books, "books");
+    assert_eq!(exported.authors, reexported.authors, "authors");
+    assert_eq!(
+        exported.book_authors, reexported.book_authors,
+        "book_authors"
+    );
+    assert_eq!(exported.isbns, reexported.isbns, "isbns");
+    assert_eq!(exported.works, reexported.works, "works");
+    assert_eq!(exported.series, reexported.series, "series");
+    assert_eq!(exported.book_series, reexported.book_series, "book_series");
+    assert_eq!(exported.shelves, reexported.shelves, "shelves");
+    assert_eq!(
+        exported.book_shelves, reexported.book_shelves,
+        "book_shelves"
+    );
+    assert_eq!(exported.tags, reexported.tags, "tags");
+    assert_eq!(exported.book_tags, reexported.book_tags, "book_tags");
+    assert_eq!(
+        exported.reading_sessions, reexported.reading_sessions,
+        "reading_sessions"
+    );
+    assert_eq!(
+        exported.reading_progress, reexported.reading_progress,
+        "reading_progress"
+    );
+    assert_eq!(exported.notes, reexported.notes, "notes");
+    assert_eq!(exported.reviews, reexported.reviews, "reviews");
+    assert_eq!(
+        exported.user_settings, reexported.user_settings,
+        "user_settings"
+    );
+    assert_eq!(
+        exported.metadata_provenance, reexported.metadata_provenance,
+        "metadata_provenance"
+    );
+    assert_eq!(exported.entity_hlc, reexported.entity_hlc, "entity_hlc");
+    assert_eq!(exported.files, reexported.files, "files");
+    assert_eq!(exported.import_logs, reexported.import_logs, "import_logs");
+    assert_eq!(
+        exported.import_books, reexported.import_books,
+        "import_books"
+    );
+
+    // The whole struct is equal (guards against a field being missed above).
+    assert_eq!(exported, reexported);
+}
+
+#[test]
+fn merge_into_fresh_db_then_reexport_is_equal() {
+    let src = Database::open_in_memory().unwrap();
+    seed_full_library(&src);
+    let exported = LibraryIo::new(&src).export_library().unwrap();
+
+    let dst = Database::open_in_memory().unwrap();
+    LibraryIo::new(&dst)
+        .restore_library(&exported, RestoreMode::Merge)
+        .unwrap();
+    let reexported = LibraryIo::new(&dst).export_library().unwrap();
+
+    assert_eq!(exported, reexported);
+}
+
+#[test]
+fn merge_is_idempotent() {
+    let src = Database::open_in_memory().unwrap();
+    seed_full_library(&src);
+    let exported = LibraryIo::new(&src).export_library().unwrap();
+
+    let dst = Database::open_in_memory().unwrap();
+    let io = LibraryIo::new(&dst);
+    io.restore_library(&exported, RestoreMode::Merge).unwrap();
+    let after_first = LibraryIo::new(&dst).export_library().unwrap();
+    // Re-applying the same backup must be a no-op.
+    io.restore_library(&exported, RestoreMode::Merge).unwrap();
+    let after_second = LibraryIo::new(&dst).export_library().unwrap();
+
+    assert_eq!(after_first, after_second);
+    assert_eq!(exported, after_second);
+}
+
+#[test]
+fn merge_never_clobbers_a_newer_local_user_edit() {
+    // Local DB has a book whose title was edited by the user at a NEWER HLC.
+    let local = Database::open_in_memory().unwrap();
+    local
+        .conn
+        .execute(
+            "INSERT INTO books (id, title, format, status, created_at, updated_at, search_text)
+             VALUES ('b1', 'User Title', 'physical', 'read', '2021-01-01T00:00:00Z', '2021-05-01T00:00:00Z', 'User Title')",
+            [],
+        )
+        .unwrap();
+    local
+        .conn
+        .execute(
+            "INSERT INTO metadata_provenance (book_id, field_name, source, source_date, is_user_override, sync_hlc)
+             VALUES ('b1', 'title', 'user', '2021-05-01T00:00:00Z', 1, '2021-05-01T00:00:00Z-0001-devLocal')",
+            [],
+        )
+        .unwrap();
+
+    // Incoming backup carries an OLDER title change for the same book.
+    let src = Database::open_in_memory().unwrap();
+    src.conn
+        .execute(
+            "INSERT INTO books (id, title, format, status, created_at, updated_at, search_text)
+             VALUES ('b1', 'Old Title', 'physical', 'read', '2021-01-01T00:00:00Z', '2021-02-01T00:00:00Z', 'Old Title')",
+            [],
+        )
+        .unwrap();
+    src.conn
+        .execute(
+            "INSERT INTO metadata_provenance (book_id, field_name, source, source_date, is_user_override, sync_hlc)
+             VALUES ('b1', 'title', 'goodreads', '2021-02-01T00:00:00Z', 0, '2021-02-01T00:00:00Z-0001-devA')",
+            [],
+        )
+        .unwrap();
+    let exported = LibraryIo::new(&src).export_library().unwrap();
+
+    LibraryIo::new(&local)
+        .restore_library(&exported, RestoreMode::Merge)
+        .unwrap();
+
+    let title: String = local
+        .conn
+        .query_row("SELECT title FROM books WHERE id = 'b1'", [], |r| r.get(0))
+        .unwrap();
+    assert_eq!(
+        title, "User Title",
+        "newer local user edit must survive merge"
+    );
+}
+
+#[test]
+fn merge_applies_a_newer_incoming_field() {
+    // Local has an OLD field; incoming backup has a NEWER change → applied.
+    let local = Database::open_in_memory().unwrap();
+    local
+        .conn
+        .execute(
+            "INSERT INTO books (id, title, format, status, created_at, updated_at, search_text)
+             VALUES ('b1', 'Old', 'physical', 'read', '2021-01-01T00:00:00Z', '2021-01-01T00:00:00Z', 'Old')",
+            [],
+        )
+        .unwrap();
+    local
+        .conn
+        .execute(
+            "INSERT INTO metadata_provenance (book_id, field_name, source, source_date, is_user_override, sync_hlc)
+             VALUES ('b1', 'title', 'goodreads', '2021-01-01T00:00:00Z', 0, '2021-01-01T00:00:00Z-0001-devA')",
+            [],
+        )
+        .unwrap();
+
+    let src = Database::open_in_memory().unwrap();
+    src.conn
+        .execute(
+            "INSERT INTO books (id, title, format, status, created_at, updated_at, search_text)
+             VALUES ('b1', 'New', 'physical', 'read', '2021-01-01T00:00:00Z', '2021-06-01T00:00:00Z', 'New')",
+            [],
+        )
+        .unwrap();
+    src.conn
+        .execute(
+            "INSERT INTO metadata_provenance (book_id, field_name, source, source_date, is_user_override, sync_hlc)
+             VALUES ('b1', 'title', 'user', '2021-06-01T00:00:00Z', 1, '2021-06-01T00:00:00Z-0001-devB')",
+            [],
+        )
+        .unwrap();
+    let exported = LibraryIo::new(&src).export_library().unwrap();
+
+    LibraryIo::new(&local)
+        .restore_library(&exported, RestoreMode::Merge)
+        .unwrap();
+
+    let title: String = local
+        .conn
+        .query_row("SELECT title FROM books WHERE id = 'b1'", [], |r| r.get(0))
+        .unwrap();
+    assert_eq!(title, "New", "newer incoming field must be applied");
+}
+
+#[test]
+fn merge_sessions_are_append_only_insert_if_absent() {
+    let src = Database::open_in_memory().unwrap();
+    seed_full_library(&src);
+    let exported = LibraryIo::new(&src).export_library().unwrap();
+
+    // Destination already has the same book and session id.
+    let dst = Database::open_in_memory().unwrap();
+    let io = LibraryIo::new(&dst);
+    io.restore_library(&exported, RestoreMode::Merge).unwrap();
+
+    // Applying again must not duplicate the append-only session.
+    let res = io.restore_library(&exported, RestoreMode::Merge).unwrap();
+    assert_eq!(
+        res.reading_sessions, 0,
+        "existing session must not re-insert"
+    );
+
+    let n: i64 = dst
+        .conn
+        .query_row("SELECT COUNT(*) FROM reading_sessions", [], |r| r.get(0))
+        .unwrap();
+    assert_eq!(n, 1);
+}
+
+#[test]
+fn replace_clears_existing_rows_before_restoring() {
+    // Destination starts with an unrelated book that must be gone after replace.
+    let dst = Database::open_in_memory().unwrap();
+    dst.conn
+        .execute(
+            "INSERT INTO books (id, title, format, status, created_at, updated_at, search_text)
+             VALUES ('zzz', 'Should Vanish', 'physical', 'read', '2020-01-01T00:00:00Z', '2020-01-01T00:00:00Z', 'Should Vanish')",
+            [],
+        )
+        .unwrap();
+
+    let src = Database::open_in_memory().unwrap();
+    seed_full_library(&src);
+    let exported = LibraryIo::new(&src).export_library().unwrap();
+
+    LibraryIo::new(&dst)
+        .restore_library(&exported, RestoreMode::Replace)
+        .unwrap();
+
+    let gone: i64 = dst
+        .conn
+        .query_row("SELECT COUNT(*) FROM books WHERE id = 'zzz'", [], |r| {
+            r.get(0)
+        })
+        .unwrap();
+    assert_eq!(gone, 0, "replace must clear pre-existing rows");
+
+    let reexported = LibraryIo::new(&dst).export_library().unwrap();
+    assert_eq!(exported, reexported);
+}
+
+#[test]
+fn merge_dedups_book_by_isbn_and_remaps_joins() {
+    // Local book has a different id but a shared ISBN → incoming must merge into
+    // it rather than create a duplicate, and join rows must remap to local id.
+    let local = Database::open_in_memory().unwrap();
+    local
+        .conn
+        .execute(
+            "INSERT INTO books (id, title, format, status, created_at, updated_at, search_text)
+             VALUES ('local-id', 'Dune', 'physical', 'read', '2021-01-01T00:00:00Z', '2021-01-01T00:00:00Z', 'Dune')",
+            [],
+        )
+        .unwrap();
+    local
+        .conn
+        .execute(
+            "INSERT INTO isbns (isbn, book_id) VALUES ('9780441172719', 'local-id')",
+            [],
+        )
+        .unwrap();
+
+    let src = Database::open_in_memory().unwrap();
+    src.conn
+        .execute(
+            "INSERT INTO books (id, title, format, status, created_at, updated_at, search_text)
+             VALUES ('incoming-id', 'Dune', 'physical', 'read', '2021-01-01T00:00:00Z', '2021-01-01T00:00:00Z', 'Dune')",
+            [],
+        )
+        .unwrap();
+    src.conn
+        .execute(
+            "INSERT INTO isbns (isbn, book_id) VALUES ('9780441172719', 'incoming-id')",
+            [],
+        )
+        .unwrap();
+    src.conn
+        .execute("INSERT INTO tags (id, name, tag_type, created_at) VALUES ('t9', 'epic', 'genre', '2021-01-01T00:00:00Z')", [])
+        .unwrap();
+    src.conn
+        .execute(
+            "INSERT INTO book_tags (book_id, tag_id) VALUES ('incoming-id', 't9')",
+            [],
+        )
+        .unwrap();
+    let exported = LibraryIo::new(&src).export_library().unwrap();
+
+    LibraryIo::new(&local)
+        .restore_library(&exported, RestoreMode::Merge)
+        .unwrap();
+
+    let books: i64 = local
+        .conn
+        .query_row("SELECT COUNT(*) FROM books", [], |r| r.get(0))
+        .unwrap();
+    assert_eq!(books, 1, "ISBN match must not duplicate the book");
+
+    // The incoming tag link must have been remapped onto the local book id.
+    let linked: i64 = local
+        .conn
+        .query_row(
+            "SELECT COUNT(*) FROM book_tags WHERE book_id = 'local-id'",
+            [],
+            |r| r.get(0),
+        )
+        .unwrap();
+    assert_eq!(linked, 1, "join row must remap to the local book id");
+}

--- a/crates/toku-export/Cargo.toml
+++ b/crates/toku-export/Cargo.toml
@@ -20,3 +20,4 @@ zip = "8"
 
 [dev-dependencies]
 tempfile = "3"
+rusqlite.workspace = true

--- a/crates/toku-export/src/backup.rs
+++ b/crates/toku-export/src/backup.rs
@@ -1,142 +1,283 @@
+//! Canonical, versioned, lossless backup container (ADR-012).
+//!
+//! A backup is a ZIP holding:
+//! - `manifest.json` — [`BackupManifest`] (`format_version`, `created_at`,
+//!   entity counts, `encrypted` flag + AEAD envelope when sealed).
+//! - `library.json` — the full [`LibraryData`] domain schema (omitted when the
+//!   backup is encrypted; the sealed payload then lives in the manifest
+//!   envelope).
+//! - `covers/<sha256>.jpg` — cover images, content-addressed by `cover_hash`.
+//! - `files/<checksum>.<ext>` — ebook files, content-addressed by
+//!   `files.checksum`.
+//!
+//! Export and restore both work fully offline. Encryption is an optional outer
+//! wrapper over `library.json` using the snapshot AEAD path; the unencrypted
+//! plaintext backup is the default artifact (ADR-012 D4).
+
+use std::collections::HashSet;
 use std::fs;
-use std::io::Write;
+use std::io::{Read, Write};
 use std::path::Path;
 
 use zip::write::SimpleFileOptions;
 
-use toku_db::Database;
+use toku_core::backup_schema::{BACKUP_FORMAT_VERSION, BackupManifest, LibraryData};
+use toku_core::crypto::{EncryptedEnvelope, SyncKey, decrypt_snapshot, encrypt_snapshot};
+use toku_db::{Database, LibraryIo, RestoreMode, RestoreResult};
 
-use crate::{ExportError, build_library_export};
+use crate::ExportError;
 
-/// Create a canonical backup ZIP containing manifest.json, library.json, and cover images.
+/// Create a canonical lossless backup ZIP.
+///
+/// When `key` is `Some`, `library.json` is sealed with the library data key and
+/// the manifest records the AEAD envelope; binaries remain plaintext in the
+/// archive (at-rest binary sealing is deferred to a later phase). With `None`,
+/// a fully plaintext backup is written — the default offline artifact.
 pub fn export_backup(
     db: &Database,
     data_dir: &Path,
     output_path: &Path,
+    key: Option<&SyncKey>,
 ) -> Result<(), ExportError> {
-    let export = build_library_export(db)?;
+    let data = LibraryIo::new(db).export_library()?;
+    let library_json = serde_json::to_string_pretty(&data)?;
+
+    let (encrypted, envelope): (bool, Option<EncryptedEnvelope>) = match key {
+        Some(k) => {
+            let env = encrypt_snapshot(k, &library_json)
+                .map_err(|e| ExportError::Crypto(e.to_string()))?;
+            (true, Some(env))
+        }
+        None => (false, None),
+    };
 
     let file = fs::File::create(output_path)?;
     let mut zip = zip::ZipWriter::new(file);
     let options = SimpleFileOptions::default().compression_method(zip::CompressionMethod::Deflated);
 
-    // Write manifest.json
-    let manifest = serde_json::json!({
-        "version": export.version,
-        "exported_at": export.exported_at,
-        "book_count": export.book_count,
-    });
-    zip.start_file("manifest.json", options)?;
-    zip.write_all(serde_json::to_string_pretty(&manifest)?.as_bytes())?;
+    // Payload: plaintext library.json, or nothing (sealed payload rides in the
+    // manifest envelope).
+    if !encrypted {
+        zip.start_file("library.json", options)?;
+        zip.write_all(library_json.as_bytes())?;
+    }
 
-    // Write library.json
-    zip.start_file("library.json", options)?;
-    zip.write_all(serde_json::to_string_pretty(&export)?.as_bytes())?;
-
-    // Copy cover images
+    // Cover binaries, content-addressed and de-duplicated by hash.
     let covers_dir = data_dir.join("covers");
-    if covers_dir.is_dir() {
-        for book in &export.books {
-            if let Some(hash) = &book.cover_hash {
-                let cover_path = covers_dir.join(format!("{hash}.jpg"));
-                if cover_path.exists() {
-                    let cover_data = fs::read(&cover_path)?;
-                    zip.start_file(format!("covers/{hash}.jpg"), options)?;
-                    zip.write_all(&cover_data)?;
-                }
+    let mut written_covers: HashSet<String> = HashSet::new();
+    for book in &data.books {
+        if let Some(hash) = &book.cover_hash
+            && written_covers.insert(hash.clone())
+        {
+            let cover_path = covers_dir.join(format!("{hash}.jpg"));
+            if cover_path.exists() {
+                let bytes = fs::read(&cover_path)?;
+                zip.start_file(format!("covers/{hash}.jpg"), options)?;
+                zip.write_all(&bytes)?;
             }
         }
     }
+
+    // Ebook binaries, content-addressed by checksum and de-duplicated.
+    let mut written_files: HashSet<String> = HashSet::new();
+    for f in &data.files {
+        let entry = format!("files/{}.{}", f.checksum, f.format);
+        if !written_files.insert(entry.clone()) {
+            continue;
+        }
+        let src = Path::new(&f.path);
+        if src.exists() {
+            let bytes = fs::read(src)?;
+            zip.start_file(entry, options)?;
+            zip.write_all(&bytes)?;
+        }
+    }
+
+    let mut counts = data.counts();
+    counts.covers = written_covers.len();
+    let manifest = BackupManifest {
+        format_version: BACKUP_FORMAT_VERSION,
+        created_at: chrono::Utc::now().to_rfc3339(),
+        counts,
+        encrypted,
+        envelope,
+    };
+    zip.start_file("manifest.json", options)?;
+    zip.write_all(serde_json::to_string_pretty(&manifest)?.as_bytes())?;
 
     zip.finish()?;
     Ok(())
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use std::io::Read;
-    use toku_core::{Book, BookFormat, ReadingStatus};
-    use toku_db::BookRepository;
+/// Read and validate the manifest of a backup ZIP without restoring anything.
+///
+/// Used for `--dry-run` and to surface encryption/version state before a write.
+pub fn read_backup_manifest(zip_path: &Path) -> Result<BackupManifest, ExportError> {
+    let file = fs::File::open(zip_path)?;
+    let mut archive = zip::ZipArchive::new(file)?;
+    parse_manifest(&mut archive)
+}
 
-    #[test]
-    fn backup_contains_manifest_and_library() {
-        let db = Database::open_in_memory().unwrap();
-        let repo = BookRepository::new(&db);
+/// Restore a canonical backup into the database (ADR-012 D3).
+///
+/// `mode` selects merge (default, additive, precedence-respecting) or replace
+/// (verbatim into a cleared library). `key` decrypts a sealed `library.json`.
+/// Binaries are extracted content-addressed after the database transaction
+/// commits; extraction is idempotent (existing content is left in place).
+pub fn import_backup(
+    zip_path: &Path,
+    db: &Database,
+    data_dir: &Path,
+    mode: RestoreMode,
+    key: Option<&SyncKey>,
+) -> Result<RestoreResult, ExportError> {
+    let file = fs::File::open(zip_path)?;
+    let mut archive = zip::ZipArchive::new(file)?;
 
-        let mut book = Book::new("Dune");
-        book.status = ReadingStatus::Read;
-        book.format = BookFormat::Physical;
-        repo.create_book(&book).unwrap();
+    let manifest = parse_manifest(&mut archive)?;
 
-        let tmp = tempfile::TempDir::new().unwrap();
-        let data_dir = tmp.path().join("data");
-        fs::create_dir_all(&data_dir).unwrap();
-        let output = tmp.path().join("backup.zip");
+    let library_json = if manifest.encrypted {
+        let envelope = manifest
+            .envelope
+            .as_ref()
+            .ok_or_else(|| ExportError::Malformed("encrypted backup has no envelope".into()))?;
+        let key = key.ok_or_else(|| {
+            ExportError::Crypto(
+                "backup is encrypted but no library data key is available to decrypt it".into(),
+            )
+        })?;
+        decrypt_snapshot(key, envelope).map_err(|e| ExportError::Crypto(e.to_string()))?
+    } else {
+        read_zip_entry_string(&mut archive, "library.json")?
+    };
 
-        export_backup(&db, &data_dir, &output).unwrap();
+    let data: LibraryData = serde_json::from_str(&library_json)
+        .map_err(|e| ExportError::Malformed(format!("library.json: {e}")))?;
 
-        let file = fs::File::open(&output).unwrap();
-        let mut archive = zip::ZipArchive::new(file).unwrap();
+    let result = LibraryIo::new(db).restore_library(&data, mode)?;
 
-        let mut names: Vec<String> = (0..archive.len())
-            .map(|i| archive.by_index(i).unwrap().name().to_string())
-            .collect();
-        names.sort();
+    extract_binaries(&mut archive, data_dir, &data)?;
 
-        assert!(names.contains(&"manifest.json".to_string()));
-        assert!(names.contains(&"library.json".to_string()));
+    Ok(result)
+}
 
-        // Verify manifest parses
-        {
-            let mut manifest_file = archive.by_name("manifest.json").unwrap();
-            let mut manifest_str = String::new();
-            manifest_file.read_to_string(&mut manifest_str).unwrap();
-            let manifest: serde_json::Value = serde_json::from_str(&manifest_str).unwrap();
-            assert_eq!(manifest["version"], "1");
-            assert_eq!(manifest["book_count"], 1);
+// ---------------------------------------------------------------------------
+// Internals
+// ---------------------------------------------------------------------------
+
+/// Parse and version-check `manifest.json`, distinguishing a superseded v1 flat
+/// archive from a current v2 lossless one.
+fn parse_manifest<R: Read + std::io::Seek>(
+    archive: &mut zip::ZipArchive<R>,
+) -> Result<BackupManifest, ExportError> {
+    let raw = read_zip_entry_string(archive, "manifest.json")?;
+    let value: serde_json::Value = serde_json::from_str(&raw)
+        .map_err(|e| ExportError::Malformed(format!("manifest.json: {e}")))?;
+
+    // A v1 flat backup carries a string `version` and no `format_version`.
+    if value.get("format_version").is_none() {
+        if value.get("version").is_some() {
+            return Err(ExportError::UnsupportedVersion(1, BACKUP_FORMAT_VERSION));
         }
+        return Err(ExportError::Malformed(
+            "manifest.json is missing format_version".into(),
+        ));
+    }
 
-        // Verify library.json round-trips
+    let manifest: BackupManifest = serde_json::from_value(value)
+        .map_err(|e| ExportError::Malformed(format!("manifest.json: {e}")))?;
+
+    if manifest.format_version < BACKUP_FORMAT_VERSION {
+        // Only v1 exists below the current version; treat any sub-current value
+        // as the superseded flat format.
+        return Err(ExportError::UnsupportedVersion(
+            manifest.format_version,
+            BACKUP_FORMAT_VERSION,
+        ));
+    }
+    if manifest.format_version > BACKUP_FORMAT_VERSION {
+        return Err(ExportError::FutureVersion(
+            manifest.format_version,
+            BACKUP_FORMAT_VERSION,
+        ));
+    }
+
+    Ok(manifest)
+}
+
+fn read_zip_entry_string<R: Read + std::io::Seek>(
+    archive: &mut zip::ZipArchive<R>,
+    name: &str,
+) -> Result<String, ExportError> {
+    let mut entry = archive
+        .by_name(name)
+        .map_err(|_| ExportError::Malformed(format!("backup is missing {name}")))?;
+    let mut s = String::new();
+    entry.read_to_string(&mut s)?;
+    Ok(s)
+}
+
+/// Extract cover and ebook binaries to their content-addressed locations,
+/// skipping any content already present (dedup by hash/checksum, ADR-011).
+fn extract_binaries<R: Read + std::io::Seek>(
+    archive: &mut zip::ZipArchive<R>,
+    data_dir: &Path,
+    data: &LibraryData,
+) -> Result<(), ExportError> {
+    // Covers → data_dir/covers/<hash>.jpg
+    let covers_dir = data_dir.join("covers");
+    let mut done: HashSet<String> = HashSet::new();
+    for book in &data.books {
+        if let Some(hash) = &book.cover_hash
+            && done.insert(hash.clone())
         {
-            let mut lib_file = archive.by_name("library.json").unwrap();
-            let mut lib_str = String::new();
-            lib_file.read_to_string(&mut lib_str).unwrap();
-            let parsed: crate::LibraryExport = serde_json::from_str(&lib_str).unwrap();
-            assert_eq!(parsed.books.len(), 1);
-            assert_eq!(parsed.books[0].title, "Dune");
+            let entry_name = format!("covers/{hash}.jpg");
+            let dest = covers_dir.join(format!("{hash}.jpg"));
+            if dest.exists() {
+                continue;
+            }
+            if let Some(bytes) = read_zip_entry_bytes(archive, &entry_name)? {
+                if let Some(parent) = dest.parent() {
+                    fs::create_dir_all(parent)?;
+                }
+                fs::write(&dest, bytes)?;
+            }
         }
     }
 
-    #[test]
-    fn backup_includes_cover_files() {
-        let db = Database::open_in_memory().unwrap();
-        let repo = BookRepository::new(&db);
+    // Ebook files → their recorded path (reconstructs the on-disk library).
+    let mut file_done: HashSet<String> = HashSet::new();
+    for f in &data.files {
+        let entry_name = format!("files/{}.{}", f.checksum, f.format);
+        if !file_done.insert(entry_name.clone()) {
+            continue;
+        }
+        let dest = Path::new(&f.path);
+        if dest.exists() {
+            continue;
+        }
+        if let Some(bytes) = read_zip_entry_bytes(archive, &entry_name)? {
+            if let Some(parent) = dest.parent() {
+                fs::create_dir_all(parent)?;
+            }
+            fs::write(dest, bytes)?;
+        }
+    }
 
-        let mut book = Book::new("Dune");
-        book.status = ReadingStatus::Read;
-        book.format = BookFormat::Physical;
-        book.cover_hash = Some("abc123def456".to_string());
-        repo.create_book(&book).unwrap();
+    Ok(())
+}
 
-        let tmp = tempfile::TempDir::new().unwrap();
-        let data_dir = tmp.path().join("data");
-        let covers_dir = data_dir.join("covers");
-        fs::create_dir_all(&covers_dir).unwrap();
-
-        // Write a fake cover image
-        let cover_content = b"fake-jpeg-data";
-        fs::write(covers_dir.join("abc123def456.jpg"), cover_content).unwrap();
-
-        let output = tmp.path().join("backup.zip");
-        export_backup(&db, &data_dir, &output).unwrap();
-
-        let file = fs::File::open(&output).unwrap();
-        let mut archive = zip::ZipArchive::new(file).unwrap();
-
-        let mut cover_file = archive.by_name("covers/abc123def456.jpg").unwrap();
-        let mut cover_data = Vec::new();
-        cover_file.read_to_end(&mut cover_data).unwrap();
-        assert_eq!(cover_data, cover_content);
+fn read_zip_entry_bytes<R: Read + std::io::Seek>(
+    archive: &mut zip::ZipArchive<R>,
+    name: &str,
+) -> Result<Option<Vec<u8>>, ExportError> {
+    match archive.by_name(name) {
+        Ok(mut entry) => {
+            let mut buf = Vec::new();
+            entry.read_to_end(&mut buf)?;
+            Ok(Some(buf))
+        }
+        Err(zip::result::ZipError::FileNotFound) => Ok(None),
+        Err(e) => Err(ExportError::Zip(e)),
     }
 }

--- a/crates/toku-export/src/error.rs
+++ b/crates/toku-export/src/error.rs
@@ -15,6 +15,25 @@ pub enum ExportError {
     #[error("ZIP error: {0}")]
     Zip(#[from] zip::result::ZipError),
 
+    #[error(
+        "unsupported backup format version {0}. The flat v1 backup was export-only and \
+         is superseded by ADR-012; re-run `toku export backup` from your live library to \
+         produce a restorable v{1} archive."
+    )]
+    UnsupportedVersion(u32, u32),
+
+    #[error(
+        "backup format version {0} is newer than this build supports (max v{1}); \
+         upgrade Toku to restore it"
+    )]
+    FutureVersion(u32, u32),
+
+    #[error("encryption error: {0}")]
+    Crypto(String),
+
+    #[error("malformed backup: {0}")]
+    Malformed(String),
+
     #[error("export error: {0}")]
     Other(String),
 }

--- a/crates/toku-export/src/lib.rs
+++ b/crates/toku-export/src/lib.rs
@@ -4,7 +4,7 @@ mod error;
 mod json_export;
 mod markdown_export;
 
-pub use backup::export_backup;
+pub use backup::{export_backup, import_backup, read_backup_manifest};
 pub use csv_export::export_csv;
 pub use error::ExportError;
 pub use json_export::export_json;

--- a/crates/toku-export/tests/backup_container.rs
+++ b/crates/toku-export/tests/backup_container.rs
@@ -1,0 +1,228 @@
+//! Backup container round-trip tests: versioned JSON-in-ZIP with
+//! content-addressed binaries, optional encryption, and v1 rejection
+//! (ADR-012, issue #200). Runs under `cargo test --workspace`.
+
+use std::fs;
+use std::io::Write;
+use std::path::Path;
+
+use toku_core::SyncKey;
+use toku_db::{Database, LibraryIo, RestoreMode};
+use toku_export::{export_backup, import_backup, read_backup_manifest};
+
+const COVER_HASH: &str = "covhash123";
+const COVER_BYTES: &[u8] = b"\xFF\xD8\xFFfake-jpeg-cover-bytes";
+const EBOOK_BYTES: &[u8] = b"PK\x03\x04fake-epub-payload-bytes";
+const EBOOK_CHECKSUM: &str = "sha-ebook-999";
+
+/// Seed a book plus a cover binary and an ebook binary on disk under `data_dir`.
+/// Returns the absolute ebook path recorded in the `files` table.
+fn seed_with_binaries(db: &Database, data_dir: &Path) -> std::path::PathBuf {
+    let covers_dir = data_dir.join("covers");
+    fs::create_dir_all(&covers_dir).unwrap();
+    fs::write(covers_dir.join(format!("{COVER_HASH}.jpg")), COVER_BYTES).unwrap();
+
+    let files_dir = data_dir.join("files");
+    fs::create_dir_all(&files_dir).unwrap();
+    let ebook_path = files_dir.join("dune.epub");
+    fs::write(&ebook_path, EBOOK_BYTES).unwrap();
+
+    let c = &db.conn;
+    c.execute(
+        "INSERT INTO books
+            (id, title, subtitle, description, page_count, format, status, rating,
+             cover_hash, created_at, updated_at, search_text)
+         VALUES
+            ('b1', 'Dune', 'Book One', 'Desert.', 412, 'ebook', 'read', 9,
+             ?1, '2021-01-01T00:00:00Z', '2021-01-01T00:00:00Z', 'Dune')",
+        rusqlite::params![COVER_HASH],
+    )
+    .unwrap();
+    c.execute(
+        "INSERT INTO authors (id, name, sort_name) VALUES ('a1', 'Frank Herbert', 'Herbert, Frank')",
+        [],
+    )
+    .unwrap();
+    c.execute(
+        "INSERT INTO book_authors (book_id, author_id, role, position) VALUES ('b1', 'a1', 'author', 0)",
+        [],
+    )
+    .unwrap();
+    c.execute(
+        "INSERT INTO isbns (isbn, book_id) VALUES ('9780441172719', 'b1')",
+        [],
+    )
+    .unwrap();
+    c.execute(
+        "INSERT INTO files (id, book_id, path, format, size_bytes, checksum, source, source_ref, created_at, updated_at)
+         VALUES ('f1', 'b1', ?1, 'epub', ?2, ?3, 'user', NULL, '2021-01-01T00:00:00Z', '2021-01-01T00:00:00Z')",
+        rusqlite::params![ebook_path.to_string_lossy(), EBOOK_BYTES.len() as i64, EBOOK_CHECKSUM],
+    )
+    .unwrap();
+
+    ebook_path
+}
+
+#[test]
+fn zip_roundtrip_restores_data_and_binaries() {
+    let tmp = tempfile::tempdir().unwrap();
+    let src_dir = tmp.path().join("src");
+    fs::create_dir_all(&src_dir).unwrap();
+
+    let src = Database::open_in_memory().unwrap();
+    let ebook_path = seed_with_binaries(&src, &src_dir);
+    let exported = LibraryIo::new(&src).export_library().unwrap();
+
+    let zip_path = tmp.path().join("backup.zip");
+    export_backup(&src, &src_dir, &zip_path, None).unwrap();
+    assert!(zip_path.exists());
+
+    // Manifest reports plaintext v2 with the expected counts.
+    let manifest = read_backup_manifest(&zip_path).unwrap();
+    assert_eq!(manifest.format_version, 2);
+    assert!(!manifest.encrypted);
+    assert_eq!(manifest.counts.books, 1);
+    assert_eq!(manifest.counts.covers, 1);
+    assert_eq!(manifest.counts.files, 1);
+
+    // Remove the on-disk binary so extraction has to recreate it.
+    fs::remove_file(&ebook_path).unwrap();
+
+    // Restore into a fresh DB + fresh data_dir.
+    let dst_dir = tmp.path().join("dst");
+    fs::create_dir_all(&dst_dir).unwrap();
+    let dst = Database::open_in_memory().unwrap();
+    let result = import_backup(&zip_path, &dst, &dst_dir, RestoreMode::Replace, None).unwrap();
+    assert_eq!(result.books_inserted, 1);
+
+    // Structural equality of the whole library.
+    let reexported = LibraryIo::new(&dst).export_library().unwrap();
+    assert_eq!(exported, reexported);
+
+    // Cover extracted content-addressed under the destination data dir.
+    let cover_dest = dst_dir.join("covers").join(format!("{COVER_HASH}.jpg"));
+    assert!(cover_dest.exists(), "cover must be extracted");
+    assert_eq!(fs::read(&cover_dest).unwrap(), COVER_BYTES);
+
+    // Ebook reconstructed byte-for-byte at its recorded path.
+    assert!(ebook_path.exists(), "ebook must be re-extracted");
+    assert_eq!(fs::read(&ebook_path).unwrap(), EBOOK_BYTES);
+}
+
+#[test]
+fn encrypted_roundtrip_seals_library_json() {
+    let tmp = tempfile::tempdir().unwrap();
+    let src_dir = tmp.path().join("src");
+    fs::create_dir_all(&src_dir).unwrap();
+
+    let src = Database::open_in_memory().unwrap();
+    seed_with_binaries(&src, &src_dir);
+    let exported = LibraryIo::new(&src).export_library().unwrap();
+
+    let salt = SyncKey::generate_salt().unwrap();
+    let key = SyncKey::derive("correct horse battery staple", &salt).unwrap();
+
+    let zip_path = tmp.path().join("secret.zip");
+    export_backup(&src, &src_dir, &zip_path, Some(&key)).unwrap();
+
+    let manifest = read_backup_manifest(&zip_path).unwrap();
+    assert!(manifest.encrypted, "manifest must flag encryption");
+    assert!(
+        manifest.envelope.is_some(),
+        "sealed payload must ride in the manifest"
+    );
+
+    // library.json must NOT be present in cleartext inside the archive.
+    let raw = fs::File::open(&zip_path).unwrap();
+    let mut archive = zip::ZipArchive::new(raw).unwrap();
+    assert!(
+        archive.by_name("library.json").is_err(),
+        "encrypted archive must not contain a plaintext library.json"
+    );
+    drop(archive);
+
+    // Decrypt with the key → identical data.
+    let dst_dir = tmp.path().join("dst");
+    fs::create_dir_all(&dst_dir).unwrap();
+    let dst = Database::open_in_memory().unwrap();
+    import_backup(&zip_path, &dst, &dst_dir, RestoreMode::Replace, Some(&key)).unwrap();
+    let reexported = LibraryIo::new(&dst).export_library().unwrap();
+    assert_eq!(exported, reexported);
+}
+
+#[test]
+fn encrypted_backup_without_key_is_refused() {
+    let tmp = tempfile::tempdir().unwrap();
+    let src_dir = tmp.path().join("src");
+    fs::create_dir_all(&src_dir).unwrap();
+
+    let src = Database::open_in_memory().unwrap();
+    seed_with_binaries(&src, &src_dir);
+
+    let salt = SyncKey::generate_salt().unwrap();
+    let key = SyncKey::derive("passphrase", &salt).unwrap();
+    let zip_path = tmp.path().join("secret.zip");
+    export_backup(&src, &src_dir, &zip_path, Some(&key)).unwrap();
+
+    let dst = Database::open_in_memory().unwrap();
+    let err = import_backup(&zip_path, &dst, tmp.path(), RestoreMode::Replace, None)
+        .expect_err("must refuse to restore an encrypted backup without a key");
+    let msg = err.to_string().to_lowercase();
+    assert!(
+        msg.contains("encrypt") || msg.contains("key"),
+        "actionable error: {msg}"
+    );
+}
+
+#[test]
+fn v1_flat_manifest_is_rejected_with_actionable_error() {
+    let tmp = tempfile::tempdir().unwrap();
+    let zip_path = tmp.path().join("old.zip");
+
+    // Hand-build a superseded v1 archive: a manifest with "version" (not
+    // "format_version").
+    let file = fs::File::create(&zip_path).unwrap();
+    let mut zip = zip::ZipWriter::new(file);
+    let opts: zip::write::SimpleFileOptions = Default::default();
+    zip.start_file("manifest.json", opts).unwrap();
+    zip.write_all(br#"{"version": 1, "created_at": "2020-01-01T00:00:00Z"}"#)
+        .unwrap();
+    zip.start_file("library.json", opts).unwrap();
+    zip.write_all(b"{}").unwrap();
+    zip.finish().unwrap();
+
+    let dst = Database::open_in_memory().unwrap();
+    let err = import_backup(&zip_path, &dst, tmp.path(), RestoreMode::Replace, None)
+        .expect_err("v1 flat archive must be rejected");
+    let msg = err.to_string();
+    // The error must be actionable (mention re-exporting / superseded format).
+    assert!(
+        msg.to_lowercase().contains("supersed")
+            || msg.to_lowercase().contains("export backup")
+            || msg.to_lowercase().contains("version"),
+        "error should guide the user: {msg}"
+    );
+}
+
+#[test]
+fn merge_import_is_idempotent_over_the_container() {
+    let tmp = tempfile::tempdir().unwrap();
+    let src_dir = tmp.path().join("src");
+    fs::create_dir_all(&src_dir).unwrap();
+
+    let src = Database::open_in_memory().unwrap();
+    seed_with_binaries(&src, &src_dir);
+
+    let zip_path = tmp.path().join("backup.zip");
+    export_backup(&src, &src_dir, &zip_path, None).unwrap();
+
+    let dst_dir = tmp.path().join("dst");
+    fs::create_dir_all(&dst_dir).unwrap();
+    let dst = Database::open_in_memory().unwrap();
+    import_backup(&zip_path, &dst, &dst_dir, RestoreMode::Merge, None).unwrap();
+    let after_first = LibraryIo::new(&dst).export_library().unwrap();
+    import_backup(&zip_path, &dst, &dst_dir, RestoreMode::Merge, None).unwrap();
+    let after_second = LibraryIo::new(&dst).export_library().unwrap();
+
+    assert_eq!(after_first, after_second);
+}


### PR DESCRIPTION
## Description

Makes `toku export backup` a **canonical, lossless** backup and adds a matching `toku import backup` restore command, so a user's entire library round-trips with full fidelity and stays fully portable.

The previous backup was a flat, lossy snapshot with no way to restore it. This replaces it with a versioned, self-describing archive that captures the whole domain model plus binaries, and a real merge/replace restore engine — verified by an export → fresh-DB restore → structural-equality test.

### What's included

- **Shared versioned backup schema** (`toku-core/src/backup_schema.rs`): a single `LibraryData` type (format version 2) covering every persisted, user-owned table — books (audiobook durations, works, soft-delete tombstones), contributors and roles, every ISBN, tags with their types, shelves including smart-shelf definitions, series with positions, reading sessions and progress, notes, reviews, ratings, per-field metadata provenance, user settings, files, and import history.
- **Full-domain export + restore engine** (`toku-db/src/library_io.rs`): `export_library()` reads the whole library into the shared schema; `restore_library()` writes it back with two modes. **Merge** (default) is additive and precedence-respecting — books match by id, then Goodreads/Calibre id, then ISBN; per-field last-writer-wins that never clobbers a newer user edit; reading sessions and progress are append-only; notes/reviews resolve by clock while honoring deletions; joins insert-if-absent; and re-running a restore is a no-op. **Replace** restores verbatim into a cleared library for disaster recovery.
- **Versioned container** (`toku-export/src/backup.rs`): a JSON-in-ZIP archive — `manifest.json` + `library.json` + content-addressed `covers/<hash>.jpg` and `files/<checksum>.<ext>` binaries. `import_backup` restores data and re-materializes cover and ebook binaries on disk. Superseded flat (version 1) archives are refused with an actionable message telling the user to re-export.
- **Optional encryption**: `--encrypt` seals `library.json` with the library data key (AES-256-GCM); import transparently decrypts. Unencrypted plaintext remains the default, fully-offline artifact.
- **CLI**: `toku import backup <archive.zip> [--replace] [--dry-run] [--format table|json|csv]` and `toku export backup [--encrypt]`.
- **Tests** (run under `cargo test --workspace`): fresh-DB round-trip structural equality across all entities, merge idempotency, merge precedence in both directions, replace, ISBN-dedup with join remap, ZIP binary byte-equal round-trip, encrypted round-trip, encrypted-without-key refusal, and version-1 rejection.

Export and restore work with zero network access; nothing leaves the device unless sync is separately opted into.

## Related Issues

Closes #200
Relates to #207

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI / infrastructure
- [ ] Other (describe below)

## Crate

- [x] `toku-core` — Domain models, traits, state machine
- [x] `toku-db` — SQLite persistence, migrations, FTS5
- [ ] `toku-import` — Importers (Goodreads, Calibre, StoryGraph)
- [ ] `toku-meta` — Metadata fetching (Open Library, Google Books)
- [x] `toku-cli` — CLI binary
- [x] `toku-export` — Exporters (CSV, JSON, Markdown, BibTeX)
- [ ] `docs/` — Documentation

## Data Integrity Checklist

- [x] No user data is sent to any server without explicit opt-in
- [x] Import operations are idempotent (re-importing the same file creates no duplicates)
- [x] User edits to metadata are never overwritten by auto-enrichment
- [x] New fields track provenance (source + timestamp)
- [x] Export round-trip is preserved (if applicable)

## Checklist

- [x] I have read [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] `cargo fmt --check` passes
- [x] `cargo clippy --workspace -- -D warnings` passes
- [x] `cargo test --workspace` passes (559 passed, 0 failed)
- [x] I have updated documentation (if applicable) — CHANGELOG `## [Unreleased]`

### Notes for reviewers

- No database migration and no CI job changes were needed — the backup serializes already-persisted tables, and the new tests ride the existing `cargo test --workspace` suite.
- The non-backup export targets (CSV / JSON / Markdown) are intentionally left unchanged; only the backup format is superseded.
- Encryption is gated on an explicit `--encrypt` flag (plus auto-decrypt on import) rather than encrypting implicitly whenever a key is present — happy to switch to implicit if preferred.
- Unifying the sync snapshot onto the shared schema was left out of this change to avoid altering the sync wire format; suggest a follow-up under #207.