### PR TITLE
docs: reconcile ADR-010 with shipped auth/crypto implementation (#197)

### DIFF
--- a/docs/adr/010-self-host-auth.md
+++ b/docs/adr/010-self-host-auth.md
@@ -5,6 +5,112 @@
 **Supersedes**: ADR-006, ADR-008
 **Issue**: #114 (Epic), #115 (this ADR)
 
+## Amendment — 2026-07-27: Implementation Reconciliation (#197)
+
+> This dated amendment reconciles ADR-010 with the shipped implementation as part
+> of the on-device-first architecture assessment (epic #207, seq 6). The original
+> **Decision** below is preserved as written; where the shipped construction
+> differs, this amendment is authoritative and the affected passages carry an
+> inline `Amended (#197)` pointer. **No code changed** — the shipped security
+> properties are correct for a personal, no-sharing, local-first tool; only this
+> ADR's depiction was stale. This amendment extends, and stays consistent with,
+> ADR-013.
+
+### A1 — Master unlock key: shipped KDF is a two-step construction
+
+The "Key Hierarchy" diagram and bullets below depict the Secret Key and account
+password entering **Argon2id together** to yield the unlock key. The shipped
+derivation (`crates/toku-core/src/crypto/key_hierarchy.rs`,
+`MasterUnlockKey::derive`) is instead **two steps**, and only the password is run
+through the memory-hard KDF:
+
+```text
+password_derived = Argon2id(password, salt=per-account, m=64 MB, t=3, p=1) -> 32 bytes
+unlock_key       = SHA-256( "toku/master-unlock-key/v1" || Secret Key || password_derived )
+```
+
+- The Secret Key is folded in via a **domain-separated SHA-256 combine**, not by
+  being fed into Argon2id. Running only the (low-entropy) password through the
+  memory-hard KDF while combining the (128-bit, high-entropy) Secret Key with a
+  fast hash is the intended design — the Secret Key needs no key-stretching.
+- The shipped algorithm identifier is `argon2id+sha256-2skd`
+  (`MASTER_KDF_ALGORITHM`).
+- Naming: the code type is `MasterUnlockKey`; this ADR calls it the "Account
+  Unlock Key". They are the same key.
+
+The security intent is unchanged from the original decision — both secrets are
+required to derive the unlock key. Only the construction differs, so this is a
+documentation reconciliation, not a code change.
+
+### A2 — Data-key cardinality: one wrapped data key per account (not per library)
+
+**Decision (maintainer-confirmed): the data key is per-account.** The original
+"one key per library, generated at library creation" wording is superseded.
+
+Shipped reality:
+
+- `crates/toku-sync/migrations/V7__wrapped_data_key.sql` stores a single
+  `wrapped_data_key` column on the **`users`** table — one wrapped data key per
+  **account**. `AccountKeys::create` generates exactly one leaf `SyncKey` per
+  account; `signup`/`enroll` recover that one account data key and reuse it for
+  whichever library the enrolling device lands on.
+- The server does support **multiple libraries per user**: `enroll_device`
+  (`crates/toku-sync/src/handlers.rs`) mints a fresh library (UUID v7) whenever a
+  device enrolls without naming a `library_id`, and `libraries.user_id`
+  (migration V5) links many libraries to one account.
+
+**Consequence (stated plainly):** a single account's multiple libraries are **not
+cryptographically isolated from each other** — they are all encrypted under the
+same per-account data key, so compromise of that data key exposes every library
+the account owns. This is an accepted posture for a **personal, single-user tool
+with no sharing feature**: there is no second party from whom one library must be
+kept secret, so inter-library key separation buys nothing today.
+
+**Rationale:** consistent with this ADR already rejecting per-item keys as
+"unnecessary complexity for a personal tool" (see Alternatives Considered); and it
+gives the simplest recovery — one key to wrap at signup and unwrap per device
+enroll.
+
+**Migration path (if ever needed):** should per-library isolation become a real
+requirement (for example a future selective-sharing feature), move to per-library
+`wrapped_data_key` rows keyed by `(user_id, library_id)` and generate a distinct
+`SyncKey` per library at library creation — matching the original diagram below.
+No such work is planned or tracked; this note only records the exit path.
+
+**Naming debt:** the code and this ADR still call the leaf key the "library data
+key" (`WrappedDataKey`, `DATA_KEY_WRAP_INFO = "toku/library-data-key-wrap/v1"`,
+and the diagram below) even though its scope is per-account. Left as-is to avoid a
+churny rename; flagged here so the term is not read as implying per-library scope.
+
+### A3 — "Encrypted at rest" is scoped to the server and in transit, not the local DB
+
+This ADR's zero-knowledge guarantees — "the server stores only encrypted blobs",
+mandatory `encrypted` envelopes, and wrapped keys — apply to **data at the server
+and in transit**, plus the **zero-knowledge-wrapped data key**. They do **not**
+imply that the local working database is encrypted at rest.
+
+- The local `toku.db` is **not encrypted at rest today**: `toku-db`'s database
+  open path (`crates/toku-db/src/database.rs`) sets only `journal_mode=WAL` and
+  `foreign_keys=ON` — there is no SQLCipher or other at-rest encryption.
+- Optional at-rest DB encryption (SQLCipher) plus encrypted backups are separate,
+  future work tracked in **#204** (epic #207, seq 10).
+- The same overclaim in `.github/copilot-instructions.md`'s data-boundary table
+  ("Local SQLite (encrypted at rest if sync enabled)") is corrected under **#196**
+  (seq 7); this amendment and #196 must stay consistent.
+
+Local-first, offline-first, user-data-ownership, and CLI-first are unchanged; this
+is a scoping clarification that avoids overstating the local-disk guarantee.
+
+### Note — F1 / #161 (Secret Key in the SRP verifier) shipped
+
+The two-secret SRP verifier described in "Two-Secret Authentication Model" is
+implemented as written: `toku_core::srp_verifier_input(secret_key, password)`
+(`crates/toku-core/src/crypto/srp.rs`, domain `toku/srp/verifier-input/v1`) folds
+the Secret Key into every verifier create/verify site. Issue **#161** (the F1
+finding that the Secret Key was initially not folded into the verifier) is
+**closed/shipped**, so the threat-model claim that a stolen verifier is not
+brute-forceable against the password alone is now true as implemented.
+
 ## Context
 
 ADR-006 chose **optional** symmetric encryption (single passphrase → Argon2id → AES-256-GCM)
@@ -87,6 +193,11 @@ Key, or any encryption key from it.
 
 ### Key Hierarchy
 
+> **Amended (#197):** The shipped master-unlock-key derivation is a two-step
+> construction — Argon2id over the password, then a domain-separated SHA-256
+> combine with the Secret Key — not both secrets entering Argon2id together. See
+> the 2026-07-27 Amendment (A1) above.
+
 ```text
 Secret Key + Account Password
           │
@@ -116,6 +227,11 @@ Concretely:
 - **Library Key**: per-library AES-256-GCM key, generated at library creation. Wrapped
   with the account's public key and stored on the server. The client unwraps it using the
   private key after authentication.
+
+> **Amended (#197):** The wrapped data key is stored **per account**
+> (`users.wrapped_data_key`), not per library; a single account's libraries all
+> share one data key and are not cryptographically isolated from each other. See
+> the 2026-07-27 Amendment (A2) above.
 
 The server stores: SRP verifier, wrapped private key ciphertext, wrapped library key
 ciphertext. It **cannot** derive any plaintext data from these.
@@ -197,6 +313,11 @@ binding and op-type indexing while leaking only aggregate counts, never content.
 exposure is documented in `docs/sync-server.md`.
 
 ### Revised Threat Model
+
+> **Amended (#197):** "Zero-knowledge / encrypted" here scopes to server-side +
+> in-transit + the ZK-wrapped data key. The local `toku.db` is **not** encrypted
+> at rest today (WAL + FK pragmas only); SQLCipher at-rest is future work (#204).
+> See the 2026-07-27 Amendment (A3) above.
 
 | Threat | Old model (ADR-006/008) | New model (ADR-010) |
 |--------|-------------------------|---------------------|


### PR DESCRIPTION
## Description

Reconciles ADR-010 (self-hosted server, zero-knowledge encryption, two-secret SRP auth) with what the code actually ships. The ADR was written ahead of implementation and three descriptions drifted from the shipped construction. Since ADR-010 is **Accepted**, this does not rewrite the original decision: it adds a single dated amendment and small inline pointers, leaving the original text intact beneath them.

Docs-only — no Rust, migration, CI, or infrastructure changes. The shipped security properties were verified to be correct for a personal, no-sharing, local-first tool; only the ADR's depiction was stale.

### What's included

A new `## Amendment — 2026-07-27: Implementation Reconciliation (#197)` section in `docs/adr/010-self-host-auth.md`, plus three inline `> Amended (#197)` pointers at the affected passages:

- **A1 — Master unlock key KDF.** Documents the shipped two-step construction: Argon2id runs over the password only, then a domain-separated `SHA-256("toku/master-unlock-key/v1" || Secret Key || password_derived)` folds in the Secret Key (algorithm id `argon2id+sha256-2skd`). Replaces the earlier depiction of both secrets entering Argon2id together, and notes the `MasterUnlockKey` (code) vs “Account Unlock Key” (doc) naming.
- **A2 — Data-key cardinality.** Records the explicit decision that the wrapped data key is **per account** (stored on the `users` table), not per library. States plainly that a single account's multiple libraries are **not** cryptographically isolated from one another (they share one account data key), with the rationale (personal single-user tool, no sharing, simplest recovery), an inline migration path if per-library isolation is ever needed, and a note on the residual “library data key” naming.
- **A3 — At-rest scope.** Scopes the zero-knowledge / “encrypted” guarantees to server-side + in-transit + the wrapped data key, and clarifies that the local working `toku.db` is **not** encrypted at rest today (WAL + foreign-key pragmas only). Cross-references future SQLCipher work (#204) and the matching docs fix (#196).
- **F1 note.** Confirms the Secret Key is already folded into the SRP verifier input (shipped/closed via #161), so the threat-model brute-force claim is now true as implemented.

## Related Issues

- Closes #197
- Relates to #207 (on-device-first assessment epic), #196, #204, #161
- Consistent with ADR-013 (local identity & key bootstrap)

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI / infrastructure
- [ ] Other (describe below)

## Crate

- [ ] `toku-core` — Domain models, traits, state machine
- [ ] `toku-db` — SQLite persistence, migrations, FTS5
- [ ] `toku-import` — Importers (Goodreads, Calibre, StoryGraph)
- [ ] `toku-meta` — Metadata fetching (Open Library, Google Books)
- [ ] `toku-cli` — CLI binary
- [ ] `toku-export` — Exporters (CSV, JSON, Markdown, BibTeX)
- [x] `docs/` — Documentation

## Data Integrity Checklist

<!-- Documentation-only change: no code paths, data flows, imports, or exports are modified. Items below are unaffected. -->

- [x] No user data is sent to any server without explicit opt-in
- [x] Import operations are idempotent (re-importing the same file creates no duplicates)
- [x] User edits to metadata are never overwritten by auto-enrichment
- [x] New fields track provenance (source + timestamp)
- [x] Export round-trip is preserved (if applicable)

## Checklist

- [x] I have read [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] `cargo fmt --check` passes
- [ ] `cargo clippy --workspace -- -D warnings` passes — not run locally; unaffected (docs-only, no Rust modified). CI `Validate` will confirm.
- [ ] `cargo test --workspace` passes — not run locally; unaffected (docs-only, no Rust modified). CI `Validate` will confirm.
- [x] I have updated documentation (this PR is the documentation update)

<!-- markdownlint-cli2 (.github/.markdownlint.json): 0 issues. No CHANGELOG entry — non-user-facing docs reconciliation. Per repo Git Policy, changes are left uncommitted for the maintainer to review and commit. -->