### PR TITLE
docs: correct local-at-rest data-boundary claim in copilot-instructions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -35,11 +35,18 @@ Cargo workspace with 12 crates:
 
 | Data Type | Storage | Network? |
 |---|---|---|
-| User's book library, reading sessions, notes, ratings | Local SQLite (encrypted at rest if sync enabled) | Never sent unless sync opted in |
+| User's book library, reading sessions, notes, ratings | Local SQLite — plaintext at rest (OS full-disk encryption only; app-level DB encryption is future #204) | Never sent unless sync opted in |
 | Book metadata from APIs | Cached locally after fetch | Open Library / Google Books (optional) |
 | Cover images | Local filesystem, content-addressed (SHA-256) | Fetched once, stored locally forever |
 | Import source data (Goodreads CSV, Calibre DB) | Parsed on-device, stored in local DB | Never leaves device |
 | Statistics and analytics | Computed locally from user data | Never sent anywhere |
+
+**Where encryption actually applies** — keep these four guarantees distinct; do not conflate them:
+
+- **Local, at rest** — the working `toku.db` is **plaintext**. `Database::open` sets only `journal_mode=WAL` + `foreign_keys=ON`, and `rusqlite` uses bundled SQLite (not SQLCipher), so protection depends entirely on **OS full-disk encryption**. Optional app-level at-rest encryption is future work (#204).
+- **In transit (self-host / sync)** — network confidentiality relies on **operator-provided TLS**; Toku does not ship its own transport layer.
+- **Relay (zero-knowledge E2E)** — the sync relay stores **only client-encrypted ciphertext** and never sees plaintext or keys.
+- **Web dashboard** — `toku serve` is a **trusted local server** that holds plaintext while running; treat it as inside your trust boundary.
 
 ### Key Data Model Decisions
 


### PR DESCRIPTION
## Description

Corrects a false security claim in the repository's agent-guidance file. The **Data Boundary Rule** table stated that the local library database is "encrypted at rest if sync enabled" — it is not.

Verified against the code:

- `Database::open` (`crates/toku-db/src/database.rs`) sets only `journal_mode=WAL` and `foreign_keys=ON` — there is no SQLCipher or other at-rest encryption.
- `rusqlite` uses the **bundled** standard SQLite build (`Cargo.toml`), not SQLCipher.

So the local `toku.db` is **plaintext at rest**; a stolen device exposes the whole library unless the OS provides full-disk encryption.

### What's included

- **Table cell fix**: the library row's Storage cell now reads `Local SQLite — plaintext at rest (OS full-disk encryption only; app-level DB encryption is future #204)`.
- **New clarifying note** beneath the table, separating four previously-conflated guarantees:
  - **Local, at rest** — plaintext; protected only by OS full-disk encryption (app-level encryption is future #204).
  - **In transit (self-host / sync)** — operator-provided TLS.
  - **Relay (zero-knowledge E2E)** — stores only client-encrypted ciphertext.
  - **Web dashboard** — a trusted local server that holds plaintext while running.

Wording matches the existing `docs/adr/010-self-host-auth.md` A3 amendment, which already flags this correction. Rows 2–5 of the table are unchanged.

## Related Issues

Closes #196

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI / infrastructure
- [ ] Other (describe below)

## Crate

- [ ] `toku-core` — Domain models, traits, state machine
- [ ] `toku-db` — SQLite persistence, migrations, FTS5
- [ ] `toku-import` — Importers (Goodreads, Calibre, StoryGraph)
- [ ] `toku-meta` — Metadata fetching (Open Library, Google Books)
- [ ] `toku-cli` — CLI binary
- [ ] `toku-export` — Exporters (CSV, JSON, Markdown, BibTeX)
- [x] `docs/` — Documentation

Touches only `.github/copilot-instructions.md` (agent-guidance docs). No crate source changed.

## Data Integrity Checklist

- [x] No user data is sent to any server without explicit opt-in
- [x] Import operations are idempotent (re-importing the same file creates no duplicates)
- [x] User edits to metadata are never overwritten by auto-enrichment
- [x] New fields track provenance (source + timestamp)
- [x] Export round-trip is preserved (if applicable)

Docs-only change — no behavior touched; all data-integrity guarantees are unaffected.

## Checklist

- [x] I have read [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] `cargo fmt --check` passes
- [ ] `cargo clippy --workspace -- -D warnings` passes — N/A (docs-only; no Rust changed)
- [ ] `cargo test --workspace` passes — N/A (docs-only; no Rust changed)
- [x] I have updated documentation (if applicable)

Markdown lint (`markdownlint-cli --config .github/.markdownlint.json`) passes on the changed file.