### PR TITLE
docs: fix sync onboarding, remove deprecated `toku sync init` lead

### DIFF
--- a/docs/sync-server.md
+++ b/docs/sync-server.md
@@ -67,17 +67,46 @@ docker compose up -d
 
 ## Connecting a client
 
-Once the server is reachable, point your Toku CLI at it:
+Once the server is reachable, point your Toku CLI at it. Which command you run depends on
+whether this is your **first** device on a new account, an **additional** device joining an
+existing account, or a device that is already enrolled:
 
 ```bash
-toku sync init --server https://sync.example.com
-toku sync push
-toku sync pull
+# First device / new account. The very first account on a fresh server also
+# becomes the instance admin (see below). Generates your Secret Key + Emergency
+# Kit and auto-uploads your existing library.
+toku sync signup --server https://sync.example.com --email you@example.com
+
+# Additional device for an existing account (password + Secret Key). Auto-restores
+# your prior library state (bootstrap) when joining an existing library.
+toku sync enroll --server https://sync.example.com --email you@example.com
+
+# A device that is already enrolled: just re-authenticate.
+toku sync login --server https://sync.example.com --email you@example.com
 ```
 
-`toku sync init` always prompts for an encryption passphrase — client-side end-to-end
-encryption is **mandatory** in hosted mode, so the server only ever stores opaque ciphertext.
-Use the same passphrase on every device. See `toku sync --help` for the full command set.
+Then sync changes in both directions as you work:
+
+```bash
+toku sync push   # upload local changes
+toku sync pull   # download remote changes
+```
+
+Client-side end-to-end encryption is **mandatory** in hosted mode, so the server only ever
+stores opaque ciphertext. It is keyed by your account **password + Secret Key** — there is no
+per-library passphrase to retype on each device. See the [First-run onboarding &
+admin](#first-run-onboarding--admin) section below for the first-account/admin details, and
+`toku sync --help` for the full command set.
+
+> **First opt-in uploads your existing library.** `toku sync signup` (and a `toku sync enroll`
+> that creates a **fresh** library) automatically backfills your existing books, reading
+> sessions, progress, and tags into the encrypted op log and pushes them — you do **not** need
+> to run `toku sync compact` to seed the server; opt-in reports how many items were uploaded.
+> A device joining an **existing** library is **bootstrapped** automatically (it applies the
+> latest server snapshot, then pulls remaining ops). You can also re-run that restore manually
+> with `toku sync bootstrap` (add `--reset-cursor` to re-sync from scratch). Sync does not
+> cover ebook file binaries. See [`recovery.md`](./recovery.md) for the full upload/restore
+> semantics.
 
 ## First-run onboarding & admin
 


### PR DESCRIPTION
## Description

The self-hosting guide's "Connecting a client" section led onboarding with the **deprecated** `toku sync init` command (and a paragraph describing the old per-library passphrase model). The CLI itself marks `init` deprecated, so new self-hosters were pointed at the wrong first command, and the first-opt-in upload and new-device bootstrap steps were never surfaced. The same file already had a correct `signup`/`enroll` onboarding section below it, so the two contradicted each other.

This rewrites the section so the file has one coherent onboarding narrative that leads with the supported commands.

### What's included

- **`docs/sync-server.md` — "Connecting a client" rewritten:**
  - Removed the deprecated `toku sync init --server …` lead and the "always prompts for an encryption passphrase" paragraph.
  - Now leads with the supported flow: first device / new account -> `toku sync signup` (the first account also becomes the instance admin; generates your Secret Key + Emergency Kit and auto-uploads your existing library); additional device -> `toku sync enroll` (password + Secret Key; auto-bootstrap); already-enrolled device -> `toku sync login`; then `toku sync push` / `toku sync pull` to sync.
  - Clarified that end-to-end encryption is keyed by your account password + Secret Key, with no per-library passphrase to retype per device.
  - Added a callout documenting the first-opt-in upload (automatic op-backfill of existing books, sessions, progress, and tags — no manual `toku sync compact`) and new-device bootstrap (automatic on active enroll, plus manual `toku sync bootstrap [--reset-cursor]`), and that ebook binaries are not synced. Cross-linked to the existing "First-run onboarding & admin" section.

### Audit

- `docs/self-hosting.md` needed no change (it is a pointer doc with no deprecated command lead).
- No `toku sync init` / `sync register` onboarding references remain in either onboarding doc.
- The legacy-relay migration section is intentionally left unchanged. ADRs, `CHANGELOG.md`, and `ROADMAP.md` are intentionally out of scope.

### Follow-up (not in this PR)

Several in-code, user-facing error strings still tell users to "Run `toku sync init` first" (`crates/toku-cli/src/main.rs`). These are code, not docs, and are tracked separately in #221.

## Related Issues

Closes #202

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI / infrastructure
- [ ] Other (describe below)

## Crate

- [ ] `toku-core` — Domain models, traits, state machine
- [ ] `toku-db` — SQLite persistence, migrations, FTS5
- [ ] `toku-import` — Importers (Goodreads, Calibre, StoryGraph)
- [ ] `toku-meta` — Metadata fetching (Open Library, Google Books)
- [ ] `toku-cli` — CLI binary
- [ ] `toku-export` — Exporters (CSV, JSON, Markdown, BibTeX)
- [x] `docs/` — Documentation

## Data Integrity Checklist

- [x] No user data is sent to any server without explicit opt-in
- [x] Import operations are idempotent (re-importing the same file creates no duplicates) — N/A (docs-only)
- [x] User edits to metadata are never overwritten by auto-enrichment — N/A (docs-only)
- [x] New fields track provenance (source + timestamp) — N/A (docs-only)
- [x] Export round-trip is preserved (if applicable) — N/A (docs-only)

## Checklist

- [x] I have read [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] `cargo fmt --check` passes — N/A (docs-only, no Rust changed)
- [x] `cargo clippy --workspace -- -D warnings` passes — N/A (docs-only, no Rust changed)
- [x] `cargo test --workspace` passes — N/A (docs-only, no Rust changed)
- [x] I have updated documentation (if applicable) — markdownlint-cli2 passes (0 issues) with `.github/.markdownlint.json`