### PR TITLE
feat(export): offline passphrase-encrypted backups (no sync required)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the archive with your library data key (AES-256-GCM); `toku import backup`
   transparently decrypts it. Unencrypted plaintext remains the default offline
   artifact (#200)
+- Encrypted backups now work **without sync**. If you have never enrolled in
+  sync, `toku export backup --encrypt` prompts for a passphrase (or reads
+  `TOKU_BACKUP_PASSPHRASE`), derives a key with Argon2id, and seals the archive
+  with AES-256-GCM. The archive is **self-describing** — the key-derivation salt
+  and parameters travel inside it — so `toku import backup` restores it on any
+  machine with just the passphrase, no config or sync account required. Sync
+  users are unaffected: with a server configured, `--encrypt` still uses your
+  enrolled library key. **Losing the passphrase makes the backup
+  unrecoverable — there is no backdoor** (#204)
 
 - Opting into sync now uploads the library you already have. On `toku sync signup` (and on a
   `toku sync enroll` that creates a fresh library), Toku backfills your existing books,

--- a/crates/toku-cli/src/main.rs
+++ b/crates/toku-cli/src/main.rs
@@ -731,8 +731,10 @@ enum ExportTarget {
         #[arg(long, short)]
         output: PathBuf,
 
-        /// Seal the backup with the configured library data key (AES-256-GCM).
-        /// Requires an enrolled sync key; the default is an unencrypted archive.
+        /// Encrypt the backup (AES-256-GCM). A sync-enrolled device seals it with
+        /// the library data key; an offline-only device prompts for a passphrase
+        /// (or reads TOKU_BACKUP_PASSPHRASE) and embeds the KDF salt so the
+        /// archive restores anywhere with the passphrase. Default: unencrypted.
         #[arg(long)]
         encrypt: bool,
     },
@@ -2110,12 +2112,22 @@ fn cmd_import_backup(
     }
 
     // Decrypt only when the artifact is sealed; plaintext restores stay fully
-    // offline with no key required.
+    // offline with no key required. A passphrase-sealed backup (manifest carries
+    // a `kdf` descriptor) re-derives its key from the embedded salt + passphrase;
+    // a sync-key backup uses the enrolled library key as before.
     let key = if manifest.encrypted {
-        Some(load_library_key(data_dir).context(
-            "backup is encrypted but no library data key is configured; enroll this device \
-             with `toku sync` to restore an encrypted backup",
-        )?)
+        if let Some(kdf) = manifest.kdf.as_ref() {
+            let passphrase = read_backup_passphrase_open()?;
+            Some(
+                kdf.derive_key(&passphrase)
+                    .map_err(|e| anyhow::anyhow!("failed to derive backup key: {e}"))?,
+            )
+        } else {
+            Some(load_library_key(data_dir).context(
+                "backup is encrypted but no library data key is configured; enroll this device \
+                 with `toku sync` to restore an encrypted backup",
+            )?)
+        }
     } else {
         None
     };
@@ -2126,8 +2138,14 @@ fn cmd_import_backup(
         toku_db::RestoreMode::Merge
     };
 
-    let result = toku_export::import_backup(path, db, data_dir, mode, key.as_ref())
-        .context("backup restore failed")?;
+    let result =
+        toku_export::import_backup(path, db, data_dir, mode, key.as_ref()).map_err(|e| {
+            if manifest.kdf.is_some() && matches!(e, toku_export::ExportError::Crypto(_)) {
+                anyhow::anyhow!("could not decrypt backup — wrong passphrase or corrupted archive")
+            } else {
+                anyhow::anyhow!("backup restore failed: {e}")
+            }
+        })?;
 
     match output_format {
         OutputFormat::Json => {
@@ -2239,21 +2257,42 @@ fn cmd_export(db: &Database, data_dir: &Path, target: ExportTarget) -> Result<()
             Ok(())
         }
         ExportTarget::Backup { output, encrypt } => {
-            let key = if encrypt {
-                Some(load_library_key(data_dir).context(
-                    "cannot encrypt backup: no library data key is configured; enroll this \
-                     device with `toku sync` first, or omit --encrypt for a plaintext backup",
-                )?)
+            if !encrypt {
+                toku_export::export_backup(db, data_dir, &output, None)
+                    .context("backup export failed")?;
+                eprintln!("✓ Backup saved to {}", output.display());
+                return Ok(());
+            }
+
+            // Encrypted path. A sync user keeps today's behavior (seal with the
+            // enrolled library key). An offline-only user (no sync configured)
+            // falls back to a passphrase-derived local key; the KDF salt travels
+            // in the archive so the backup restores anywhere with the passphrase.
+            if sync_is_configured(data_dir) {
+                let key = load_library_key(data_dir).context(
+                    "cannot encrypt backup: enroll this device with `toku sync` first, \
+                     or omit --encrypt for a plaintext backup",
+                )?;
+                toku_export::export_backup(db, data_dir, &output, Some(&key))
+                    .context("backup export failed")?;
+                eprintln!(
+                    "✓ Backup saved to {} (encrypted with sync library key)",
+                    output.display()
+                );
             } else {
-                None
-            };
-            toku_export::export_backup(db, data_dir, &output, key.as_ref())
-                .context("backup export failed")?;
-            eprintln!(
-                "✓ Backup saved to {}{}",
-                output.display(),
-                if encrypt { " (encrypted)" } else { "" }
-            );
+                let passphrase = read_backup_passphrase_new()?;
+                let kdf = toku_core::backup_schema::BackupKdf::generate()
+                    .map_err(|e| anyhow::anyhow!("failed to prepare backup key: {e}"))?;
+                let key = kdf
+                    .derive_key(&passphrase)
+                    .map_err(|e| anyhow::anyhow!("failed to derive backup key: {e}"))?;
+                toku_export::export_backup_with_kdf(db, data_dir, &output, &key, kdf)
+                    .context("backup export failed")?;
+                eprintln!(
+                    "✓ Backup saved to {} (encrypted with passphrase)",
+                    output.display()
+                );
+            }
             Ok(())
         }
     }
@@ -4406,6 +4445,55 @@ fn prompt_line(prompt: &str) -> Result<String> {
 fn read_password_prompt(prompt: &str) -> Result<String> {
     eprint!("{prompt}");
     rpassword::read_password().context("failed to read password")
+}
+
+/// Environment variable that supplies a backup passphrase non-interactively
+/// (automation escape hatch for `toku export/import backup --encrypt`).
+const BACKUP_PASSPHRASE_ENV: &str = "TOKU_BACKUP_PASSPHRASE";
+
+/// True when a sync server is configured, i.e. the user is a sync user and
+/// `--encrypt` should seal with the enrolled library key rather than a
+/// passphrase (preserves pre-existing behavior for sync users).
+fn sync_is_configured(data_dir: &Path) -> bool {
+    TokuConfig::load(data_dir)
+        .ok()
+        .and_then(|c| c.sync)
+        .is_some()
+}
+
+/// Read a passphrase for sealing a NEW backup: env override, else prompt twice
+/// with confirmation. Rejects empty/mismatched input.
+fn read_backup_passphrase_new() -> Result<String> {
+    if let Ok(p) = std::env::var(BACKUP_PASSPHRASE_ENV) {
+        if p.is_empty() {
+            anyhow::bail!("{BACKUP_PASSPHRASE_ENV} is set but empty");
+        }
+        return Ok(p);
+    }
+    let passphrase = read_password_prompt("Backup passphrase: ")?;
+    if passphrase.is_empty() {
+        anyhow::bail!("backup passphrase cannot be empty");
+    }
+    let confirm = read_password_prompt("Confirm backup passphrase: ")?;
+    if passphrase != confirm {
+        anyhow::bail!("passphrases do not match");
+    }
+    Ok(passphrase)
+}
+
+/// Read a passphrase to OPEN an existing encrypted backup: env override, else a
+/// single prompt (no confirmation).
+fn read_backup_passphrase_open() -> Result<String> {
+    if let Ok(p) = std::env::var(BACKUP_PASSPHRASE_ENV)
+        && !p.is_empty()
+    {
+        return Ok(p);
+    }
+    let passphrase = read_password_prompt("Backup passphrase: ")?;
+    if passphrase.is_empty() {
+        anyhow::bail!("backup passphrase cannot be empty");
+    }
+    Ok(passphrase)
 }
 
 /// Read a new password twice (with confirmation), rejecting empties/mismatches.

--- a/crates/toku-cli/tests/backup_encrypt_cli.rs
+++ b/crates/toku-cli/tests/backup_encrypt_cli.rs
@@ -1,0 +1,151 @@
+//! End-to-end CLI tests for offline, passphrase-encrypted backups (#204).
+//!
+//! Drives the real `toku` binary against throwaway data directories with **no
+//! sync configured**, exercising the offline-first path: `export backup
+//! --encrypt` seals with a passphrase-derived local key (KDF salt embedded in
+//! the archive), and `import backup` restores it on a *fresh profile* using only
+//! the passphrase. The passphrase is supplied non-interactively via
+//! `TOKU_BACKUP_PASSPHRASE` so the tests need no TTY.
+
+use std::path::Path;
+use std::process::{Command, ExitStatus};
+
+use toku_db::{BookRepository, Database};
+
+const PASSPHRASE: &str = "correct horse battery staple";
+
+/// Run `toku` against `data_dir`, optionally supplying a backup passphrase via
+/// the environment. Returns the exit status (stdout/stderr inherited).
+fn toku_with_passphrase(data_dir: &Path, args: &[&str], passphrase: Option<&str>) -> ExitStatus {
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_toku"));
+    cmd.arg("--data-dir").arg(data_dir).args(args);
+    match passphrase {
+        Some(p) => {
+            cmd.env("TOKU_BACKUP_PASSPHRASE", p);
+        }
+        None => {
+            cmd.env_remove("TOKU_BACKUP_PASSPHRASE");
+        }
+    }
+    cmd.status().expect("run toku")
+}
+
+fn book_count(data_dir: &Path) -> usize {
+    let db = Database::open(&data_dir.join("toku.db")).expect("open db");
+    BookRepository::new(&db)
+        .list_books()
+        .expect("list books")
+        .len()
+}
+
+#[test]
+fn offline_passphrase_backup_roundtrips_on_a_fresh_profile() {
+    let src = tempfile::tempdir().unwrap();
+    assert!(
+        toku_with_passphrase(
+            src.path(),
+            &["add", "--title", "Dune", "--author", "Frank Herbert"],
+            None
+        )
+        .success()
+    );
+
+    let zip = src.path().join("backup.zip");
+    let zip_str = zip.to_str().unwrap();
+
+    // Seal with the passphrase (offline: no sync configured).
+    assert!(
+        toku_with_passphrase(
+            src.path(),
+            &["export", "backup", "--output", zip_str, "--encrypt"],
+            Some(PASSPHRASE),
+        )
+        .success(),
+        "offline --encrypt export must succeed with a passphrase"
+    );
+    assert!(zip.exists(), "backup archive must be written");
+
+    // Restore on a brand-new profile using only the passphrase.
+    let dst = tempfile::tempdir().unwrap();
+    assert!(
+        toku_with_passphrase(
+            dst.path(),
+            &["import", "backup", zip_str, "--replace"],
+            Some(PASSPHRASE),
+        )
+        .success(),
+        "restore on a fresh profile must succeed with the same passphrase"
+    );
+    assert_eq!(
+        book_count(dst.path()),
+        1,
+        "the restored library must contain the book"
+    );
+}
+
+#[test]
+fn wrong_passphrase_restore_fails_cleanly() {
+    let src = tempfile::tempdir().unwrap();
+    assert!(
+        toku_with_passphrase(
+            src.path(),
+            &["add", "--title", "Dune", "--author", "Frank Herbert"],
+            None
+        )
+        .success()
+    );
+
+    let zip = src.path().join("backup.zip");
+    let zip_str = zip.to_str().unwrap();
+    assert!(
+        toku_with_passphrase(
+            src.path(),
+            &["export", "backup", "--output", zip_str, "--encrypt"],
+            Some(PASSPHRASE),
+        )
+        .success()
+    );
+
+    let dst = tempfile::tempdir().unwrap();
+    let status = toku_with_passphrase(
+        dst.path(),
+        &["import", "backup", zip_str, "--replace"],
+        Some("the wrong passphrase"),
+    );
+    assert!(
+        !status.success(),
+        "a wrong passphrase must fail the restore, not silently succeed"
+    );
+}
+
+#[test]
+fn plaintext_backup_still_works_without_a_passphrase() {
+    let src = tempfile::tempdir().unwrap();
+    assert!(
+        toku_with_passphrase(
+            src.path(),
+            &["add", "--title", "Dune", "--author", "Frank Herbert"],
+            None
+        )
+        .success()
+    );
+
+    let zip = src.path().join("plain.zip");
+    let zip_str = zip.to_str().unwrap();
+    // No --encrypt, no passphrase: the default plaintext artifact is unchanged.
+    assert!(
+        toku_with_passphrase(src.path(), &["export", "backup", "--output", zip_str], None)
+            .success()
+    );
+
+    let dst = tempfile::tempdir().unwrap();
+    assert!(
+        toku_with_passphrase(
+            dst.path(),
+            &["import", "backup", zip_str, "--replace"],
+            None
+        )
+        .success()
+    );
+    assert_eq!(book_count(dst.path()), 1);
+}

--- a/crates/toku-core/src/backup_schema.rs
+++ b/crates/toku-core/src/backup_schema.rs
@@ -12,6 +12,7 @@
 //! and default-constructed on restore (`#[serde(default)]`), so an older Toku
 //! can restore a newer backup's shared subset and vice versa (ADR-012 D5).
 
+use base64::prelude::*;
 use serde::{Deserialize, Serialize};
 
 /// The current canonical backup / snapshot schema version.
@@ -35,6 +36,91 @@ pub struct BackupManifest {
     /// The AEAD envelope when `encrypted` is true; absent for plaintext backups.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub envelope: Option<crate::crypto::EncryptedEnvelope>,
+    /// Key-derivation parameters when the backup was sealed with a
+    /// **passphrase-derived local key** (offline-first path). Present only for
+    /// passphrase backups; absent when the archive was sealed with an enrolled
+    /// sync library key (whose key material lives on the device, not in the
+    /// archive). Carrying the salt + KDF params here makes a passphrase backup
+    /// **self-describing and portable**: it can be restored on any machine with
+    /// only the passphrase, without relying on local configuration.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub kdf: Option<BackupKdf>,
+}
+
+/// Argon2id key-derivation parameters embedded in a passphrase-sealed backup.
+///
+/// The salt and cost parameters travel inside `manifest.json` so the archive is
+/// self-describing — restore re-derives the same AES key from the passphrase and
+/// this salt on any machine, with no dependency on local `config.toml`. The
+/// passphrase itself is **never** stored.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct BackupKdf {
+    /// Descriptor schema version.
+    pub version: u16,
+    /// KDF algorithm identifier (currently only `argon2id`).
+    pub algorithm: String,
+    /// Base64-encoded 16-byte per-backup salt.
+    pub salt: String,
+    /// Argon2 memory cost in KiB.
+    pub memory_kib: u32,
+    /// Argon2 iterations (time cost).
+    pub iterations: u32,
+    /// Argon2 parallelism.
+    pub parallelism: u32,
+}
+
+/// Current [`BackupKdf`] descriptor schema version.
+pub const BACKUP_KDF_VERSION: u16 = 1;
+
+/// Argon2id algorithm identifier stored in [`BackupKdf::algorithm`].
+pub const BACKUP_KDF_ALGORITHM: &str = "argon2id";
+
+impl BackupKdf {
+    /// Build a fresh descriptor with a random 16-byte salt and the default
+    /// Argon2id parameters used by [`crate::crypto::SyncKey::derive`].
+    pub fn generate() -> Result<Self, crate::TokuError> {
+        let salt = crate::crypto::SyncKey::generate_salt()?;
+        Ok(Self {
+            version: BACKUP_KDF_VERSION,
+            algorithm: BACKUP_KDF_ALGORITHM.to_string(),
+            salt: base64::prelude::BASE64_STANDARD.encode(salt),
+            memory_kib: crate::crypto::ARGON2_M_COST,
+            iterations: crate::crypto::ARGON2_T_COST,
+            parallelism: crate::crypto::ARGON2_P_COST,
+        })
+    }
+
+    /// Re-derive the AES key from `passphrase` using the embedded salt and
+    /// parameters. Rejects descriptors this build cannot honor so a wrong key is
+    /// never silently produced.
+    pub fn derive_key(&self, passphrase: &str) -> Result<crate::crypto::SyncKey, crate::TokuError> {
+        if self.algorithm != BACKUP_KDF_ALGORITHM {
+            return Err(crate::TokuError::Crypto(format!(
+                "unsupported backup KDF algorithm: {}",
+                self.algorithm
+            )));
+        }
+        if (self.memory_kib, self.iterations, self.parallelism)
+            != (
+                crate::crypto::ARGON2_M_COST,
+                crate::crypto::ARGON2_T_COST,
+                crate::crypto::ARGON2_P_COST,
+            )
+        {
+            return Err(crate::TokuError::Crypto(
+                "unsupported backup KDF parameters for this Toku version".to_string(),
+            ));
+        }
+
+        let salt_bytes = BASE64_STANDARD
+            .decode(&self.salt)
+            .map_err(|e| crate::TokuError::Crypto(format!("invalid backup KDF salt: {e}")))?;
+        let salt: [u8; 16] = salt_bytes.try_into().map_err(|_| {
+            crate::TokuError::Crypto("backup KDF salt must be 16 bytes".to_string())
+        })?;
+
+        crate::crypto::SyncKey::derive(passphrase, &salt)
+    }
 }
 
 /// Row counts for each entity vector, surfaced in the manifest.
@@ -407,4 +493,59 @@ pub struct ImportLogRow {
 pub struct ImportBookRow {
     pub import_id: String,
     pub book_id: String,
+}
+
+#[cfg(test)]
+mod kdf_tests {
+    use super::*;
+
+    #[test]
+    fn generate_uses_default_argon2id_params() {
+        let kdf = BackupKdf::generate().unwrap();
+        assert_eq!(kdf.version, BACKUP_KDF_VERSION);
+        assert_eq!(kdf.algorithm, BACKUP_KDF_ALGORITHM);
+        assert_eq!(kdf.memory_kib, crate::crypto::ARGON2_M_COST);
+        assert_eq!(kdf.iterations, crate::crypto::ARGON2_T_COST);
+        assert_eq!(kdf.parallelism, crate::crypto::ARGON2_P_COST);
+        // 16-byte salt, base64-encoded.
+        let salt = BASE64_STANDARD.decode(&kdf.salt).unwrap();
+        assert_eq!(salt.len(), 16);
+    }
+
+    #[test]
+    fn same_passphrase_and_salt_derive_the_same_key() {
+        let kdf = BackupKdf::generate().unwrap();
+        let a = kdf.derive_key("hunter2").unwrap();
+        let b = kdf.derive_key("hunter2").unwrap();
+        assert_eq!(a.as_exported_bytes(), b.as_exported_bytes());
+    }
+
+    #[test]
+    fn different_passphrases_derive_different_keys() {
+        let kdf = BackupKdf::generate().unwrap();
+        let a = kdf.derive_key("hunter2").unwrap();
+        let b = kdf.derive_key("hunter3").unwrap();
+        assert_ne!(a.as_exported_bytes(), b.as_exported_bytes());
+    }
+
+    #[test]
+    fn rejects_unsupported_algorithm() {
+        let mut kdf = BackupKdf::generate().unwrap();
+        kdf.algorithm = "scrypt".to_string();
+        assert!(kdf.derive_key("pw").is_err());
+    }
+
+    #[test]
+    fn rejects_unsupported_params() {
+        let mut kdf = BackupKdf::generate().unwrap();
+        kdf.iterations = 99;
+        assert!(kdf.derive_key("pw").is_err());
+    }
+
+    #[test]
+    fn rejects_malformed_salt() {
+        let mut kdf = BackupKdf::generate().unwrap();
+        kdf.salt = "not-base64!!".to_string();
+        assert!(kdf.derive_key("pw").is_err());
+    }
 }

--- a/crates/toku-core/src/crypto.rs
+++ b/crates/toku-core/src/crypto.rs
@@ -41,11 +41,11 @@ pub use srp::*;
 // ---------------------------------------------------------------------------
 
 /// Argon2id memory cost in KiB (64 MB).
-const ARGON2_M_COST: u32 = 65536;
+pub const ARGON2_M_COST: u32 = 65536;
 /// Argon2id time cost (iterations).
-const ARGON2_T_COST: u32 = 3;
+pub const ARGON2_T_COST: u32 = 3;
 /// Argon2id parallelism.
-const ARGON2_P_COST: u32 = 1;
+pub const ARGON2_P_COST: u32 = 1;
 
 /// Current encryption envelope version.
 const ENCRYPTION_ENVELOPE_VERSION: u16 = 1;

--- a/crates/toku-export/src/backup.rs
+++ b/crates/toku-export/src/backup.rs
@@ -21,7 +21,7 @@ use std::path::Path;
 
 use zip::write::SimpleFileOptions;
 
-use toku_core::backup_schema::{BACKUP_FORMAT_VERSION, BackupManifest, LibraryData};
+use toku_core::backup_schema::{BACKUP_FORMAT_VERSION, BackupKdf, BackupManifest, LibraryData};
 use toku_core::crypto::{EncryptedEnvelope, SyncKey, decrypt_snapshot, encrypt_snapshot};
 use toku_db::{Database, LibraryIo, RestoreMode, RestoreResult};
 
@@ -38,6 +38,33 @@ pub fn export_backup(
     data_dir: &Path,
     output_path: &Path,
     key: Option<&SyncKey>,
+) -> Result<(), ExportError> {
+    write_backup(db, data_dir, output_path, key, None)
+}
+
+/// Create an encrypted backup sealed with a **passphrase-derived local key**,
+/// embedding the `kdf` descriptor (salt + Argon2id params) in the manifest so
+/// the archive is self-describing and restorable on any machine with only the
+/// passphrase. Used by the offline-first path where no sync key is enrolled;
+/// the sealing itself reuses the same AEAD snapshot envelope as [`export_backup`].
+pub fn export_backup_with_kdf(
+    db: &Database,
+    data_dir: &Path,
+    output_path: &Path,
+    key: &SyncKey,
+    kdf: BackupKdf,
+) -> Result<(), ExportError> {
+    write_backup(db, data_dir, output_path, Some(key), Some(kdf))
+}
+
+/// Shared backup writer. `kdf` is recorded in the manifest for passphrase-sealed
+/// archives (portability), and is `None` for plaintext or sync-key backups.
+fn write_backup(
+    db: &Database,
+    data_dir: &Path,
+    output_path: &Path,
+    key: Option<&SyncKey>,
+    kdf: Option<BackupKdf>,
 ) -> Result<(), ExportError> {
     let data = LibraryIo::new(db).export_library()?;
     let library_json = serde_json::to_string_pretty(&data)?;
@@ -101,6 +128,7 @@ pub fn export_backup(
         counts,
         encrypted,
         envelope,
+        kdf,
     };
     zip.start_file("manifest.json", options)?;
     zip.write_all(serde_json::to_string_pretty(&manifest)?.as_bytes())?;

--- a/crates/toku-export/src/lib.rs
+++ b/crates/toku-export/src/lib.rs
@@ -4,7 +4,7 @@ mod error;
 mod json_export;
 mod markdown_export;
 
-pub use backup::{export_backup, import_backup, read_backup_manifest};
+pub use backup::{export_backup, export_backup_with_kdf, import_backup, read_backup_manifest};
 pub use csv_export::export_csv;
 pub use error::ExportError;
 pub use json_export::export_json;

--- a/crates/toku-export/tests/backup_container.rs
+++ b/crates/toku-export/tests/backup_container.rs
@@ -8,7 +8,7 @@ use std::path::Path;
 
 use toku_core::SyncKey;
 use toku_db::{Database, LibraryIo, RestoreMode};
-use toku_export::{export_backup, import_backup, read_backup_manifest};
+use toku_export::{export_backup, export_backup_with_kdf, import_backup, read_backup_manifest};
 
 const COVER_HASH: &str = "covhash123";
 const COVER_BYTES: &[u8] = b"\xFF\xD8\xFFfake-jpeg-cover-bytes";
@@ -171,6 +171,102 @@ fn encrypted_backup_without_key_is_refused() {
     assert!(
         msg.contains("encrypt") || msg.contains("key"),
         "actionable error: {msg}"
+    );
+}
+
+#[test]
+fn passphrase_backup_restores_on_a_fresh_profile() {
+    use toku_core::backup_schema::BackupKdf;
+
+    let tmp = tempfile::tempdir().unwrap();
+    let src_dir = tmp.path().join("src");
+    fs::create_dir_all(&src_dir).unwrap();
+
+    let src = Database::open_in_memory().unwrap();
+    seed_with_binaries(&src, &src_dir);
+    let exported = LibraryIo::new(&src).export_library().unwrap();
+
+    // Seal with a passphrase-derived local key; the KDF descriptor is embedded
+    // in the manifest so the archive is self-describing.
+    let passphrase = "correct horse battery staple";
+    let kdf = BackupKdf::generate().unwrap();
+    let key = kdf.derive_key(passphrase).unwrap();
+    let zip_path = tmp.path().join("passphrase.zip");
+    export_backup_with_kdf(&src, &src_dir, &zip_path, &key, kdf).unwrap();
+
+    // Manifest is self-describing: encrypted, envelope present, kdf present, and
+    // no plaintext library.json inside the archive.
+    let manifest = read_backup_manifest(&zip_path).unwrap();
+    assert!(manifest.encrypted, "manifest must flag encryption");
+    assert!(
+        manifest.envelope.is_some(),
+        "sealed payload rides in manifest"
+    );
+    let embedded = manifest
+        .kdf
+        .as_ref()
+        .expect("kdf descriptor must travel in the manifest for portability");
+    assert_eq!(embedded.algorithm, "argon2id");
+    let raw = fs::File::open(&zip_path).unwrap();
+    let mut archive = zip::ZipArchive::new(raw).unwrap();
+    assert!(
+        archive.by_name("library.json").is_err(),
+        "encrypted archive must not contain a plaintext library.json"
+    );
+    drop(archive);
+
+    // Restore on a FRESH profile using only the passphrase + embedded salt — no
+    // local config, no sync enrollment.
+    let dst_dir = tmp.path().join("dst");
+    fs::create_dir_all(&dst_dir).unwrap();
+    let dst = Database::open_in_memory().unwrap();
+    let rederived = embedded.derive_key(passphrase).unwrap();
+    import_backup(
+        &zip_path,
+        &dst,
+        &dst_dir,
+        RestoreMode::Replace,
+        Some(&rederived),
+    )
+    .unwrap();
+    let reexported = LibraryIo::new(&dst).export_library().unwrap();
+    assert_eq!(exported, reexported);
+}
+
+#[test]
+fn passphrase_backup_wrong_passphrase_fails_cleanly() {
+    use toku_core::backup_schema::BackupKdf;
+
+    let tmp = tempfile::tempdir().unwrap();
+    let src_dir = tmp.path().join("src");
+    fs::create_dir_all(&src_dir).unwrap();
+
+    let src = Database::open_in_memory().unwrap();
+    seed_with_binaries(&src, &src_dir);
+
+    let kdf = BackupKdf::generate().unwrap();
+    let key = kdf.derive_key("right passphrase").unwrap();
+    let zip_path = tmp.path().join("passphrase.zip");
+    export_backup_with_kdf(&src, &src_dir, &zip_path, &key, kdf).unwrap();
+
+    // A wrong passphrase derives a different key; decryption must fail cleanly
+    // (AEAD tag mismatch) rather than panic or return garbage.
+    let manifest = read_backup_manifest(&zip_path).unwrap();
+    let embedded = manifest.kdf.expect("kdf descriptor present");
+    let wrong = embedded.derive_key("wrong passphrase").unwrap();
+
+    let dst = Database::open_in_memory().unwrap();
+    let err = import_backup(
+        &zip_path,
+        &dst,
+        tmp.path(),
+        RestoreMode::Replace,
+        Some(&wrong),
+    )
+    .expect_err("wrong passphrase must not decrypt");
+    assert!(
+        matches!(err, toku_export::ExportError::Crypto(_)),
+        "expected a crypto error, got: {err:?}"
     );
 }
 

--- a/docs/adr/016-at-rest-encryption.md
+++ b/docs/adr/016-at-rest-encryption.md
@@ -1,0 +1,236 @@
+# ADR-016: Optional At-Rest Database Encryption + Portable Encrypted Backups
+
+**Status**: Proposed
+**Date**: 2026-07-27
+**Extends**: ADR-010 (zero-knowledge sync), ADR-012 (canonical lossless backup); does not supersede either
+**Issue**: #204 (seq 10 of epic #207)
+
+> **Numbering note.** ADR-014 is reserved for the managed multi-tenant SaaS design (#203) and
+> ADR-015 for web/sync auth coherence (#205); both are tracked separately. This ADR takes **016**
+> per its position in the sequence. Earlier planning notes that guessed "ADR-015" for this work
+> are superseded by this note.
+>
+> **Scope split.** This ADR is the **design gate**. It documents the full at-rest-encryption
+> design so a focused implementation PR can follow. Only one piece ships alongside this ADR:
+> **portable, passphrase-encrypted backups for offline-only users** (Decision C), which needs no
+> new dependency. The heavyweight SQLCipher work (Decisions A/B) is **deferred to a follow-up
+> implementation issue** that references this ADR. The follow-up is flagged to the coordinator to
+> file; this ADR does not create it.
+
+## Context
+
+Toku is local-first and CLI-first: the entire library — books, reading sessions, notes, ratings,
+provenance — lives in a local SQLite database (`toku.db`) that works with no account, no server,
+and no network. ADR-010 established that the **optional** hosted-sync layer is zero-knowledge: the
+relay stores only client-encrypted ciphertext. ADR-012 established a canonical, lossless,
+self-describing backup container (JSON-in-ZIP) with an optional AEAD wrapper over `library.json`.
+
+Two local-confidentiality gaps remain, both called out in #204 and in ADR-010 §A3:
+
+1. **The local `toku.db` is plaintext at rest.** Every open path in
+   `crates/toku-db/src/database.rs` (`Database::open`, `open_no_migrate`, `open_in_memory`) sets
+   only `journal_mode=WAL` and `foreign_keys=ON`. `rusqlite` links **bundled standard SQLite**
+   (root `Cargo.toml`: `rusqlite = { version = "0.39", features = ["bundled", "column_decltype"] }`),
+   not SQLCipher. Confidentiality at rest therefore depends entirely on **OS full-disk
+   encryption**. Device theft on a machine without FDE exposes the whole library.
+
+2. **Offline-only users cannot encrypt a backup.** `toku export backup --encrypt` exists (#200,
+   ADR-012), but the CLI gated it behind an **enrolled sync key** (`load_library_key` requires a
+   configured sync server). A user who never opts into sync could not produce a ciphertext backup.
+
+### Constraints that frame every decision
+
+- **Local-first / offline.** Every core feature must work with no network. At-rest encryption must
+  not add a network dependency, and the **disabled path must be byte-for-byte identical to today**
+  (an unencrypted DB opens exactly as it does now).
+- **Opt-in, off by default.** Encryption is a choice, never imposed. A brand-new install is
+  unencrypted unless the user asks otherwise.
+- **User data ownership / no lock-in.** The user can always migrate an encrypted DB back to
+  plaintext and export their data. Keys and formats are documented and open.
+- **CLI-first, but shared core.** The same `toku.db` is opened by the CLI, the `toku serve` web
+  dashboard, the FFI consumed by the native apps, and the sync client. Any key mechanism must work
+  at every entry point.
+- **Do not break the build gate.** CI's `apple` job cross-compiles `toku-ffi` for
+  `aarch64-apple-ios-sim` and `aarch64-apple-watchos-sim`. SQLCipher + vendored OpenSSL is
+  notoriously hard to cross-compile there; the design must keep that build green.
+
+## Decision
+
+### D1 — SQLCipher, feature-gated on `toku-db`, off by default
+
+Add at-rest encryption via **SQLCipher** (`PRAGMA key`), enabled through an **off-by-default cargo
+feature** on `toku-db` (working name `sqlcipher`). The feature swaps `libsqlite3-sys`'s bundled
+SQLite for a bundled SQLCipher build — the intended selector is
+**`bundled-sqlcipher-vendored-openssl`** (vendored OpenSSL avoids a system-library dependency;
+exact feature name to be confirmed against `rusqlite 0.39` / `libsqlite3-sys` at implementation
+time).
+
+Scoping the feature to `toku-db` — rather than flipping the workspace-level `rusqlite` dependency —
+is deliberate:
+
+- The **`toku-sync` relay** has its own `SyncDatabase` and stores only zero-knowledge ciphertext;
+  it must **not** be re-keyed with a user's local key. A workspace-wide swap would drag it in.
+- The default workspace build, and the CI `test` / `msrv` / `audit` / **`apple`** jobs, stay on
+  standard SQLite, so the merge gate is unaffected until the implementation PR deliberately adds a
+  dedicated leg that compiles the feature.
+
+When the feature is **off** (the default), `database.rs` is unchanged and there is no SQLCipher
+code path at all.
+
+### D2 — Apply the key immediately after open, on all three paths
+
+When the feature is on **and** a key is supplied, each open path must issue `PRAGMA key` (and any
+`PRAGMA cipher_*` compatibility pragmas) **as the very first statement after `Connection::open`,
+before** `journal_mode=WAL`, `foreign_keys=ON`, and before any migration or query. SQLCipher
+requires the key before the database header is read. Concretely, the three constructors gain keyed
+variants (e.g. `Database::open_encrypted(path, &key)`, `open_no_migrate_encrypted`,
+`open_in_memory` stays plaintext for tests). The existing unkeyed functions remain and behave
+exactly as today, preserving the disabled path.
+
+A wrong key is detected on the **first** statement after `PRAGMA key` (SQLCipher returns
+`SQLITE_NOTADB` / "file is not a database"). That must surface as a clear
+"incorrect passphrase or not an encrypted Toku database" error — never a panic and never a partial
+open.
+
+### D3 — Key source: dedicated passphrase → Argon2id → key (B1)
+
+The key is derived from a **dedicated DB passphrase**, independent of sync:
+
+```text
+DB passphrase --Argon2id (m=64MB, t=3, p=1, 16-byte salt)--> 256-bit key --PRAGMA key--> toku.db
+```
+
+This reuses the existing, audited derivation in
+`crates/toku-core/src/crypto.rs::SyncKey::derive` (same Argon2id parameters as sync). Only the
+**salt + KDF parameters + a verifier** are persisted (in `config.toml` under a new `[encryption]`
+section); the passphrase and the derived key are **never** written to disk. Rationale: an
+offline-first, no-account tool must let a user with no sync enrollment encrypt their DB.
+
+**Rejected / secondary alternatives** (see Alternatives Considered): reusing the sync identity
+(couples local at-rest to sync enrollment — bad for offline-only users); an OS-keychain-managed
+random key as the *sole* mechanism (awkward on headless Linux, ties confidentiality to the login
+keychain). A keychain-stored passphrase and a `TOKU_DB_PASSPHRASE` env var are acceptable
+**convenience layers on top of** the passphrase, not replacements for it.
+
+### D4 — Key availability across short-lived CLI processes (open question, flagged)
+
+The CLI runs many short-lived processes, so prompting for a passphrase on **every** invocation is
+hostile. The implementation PR must choose among (each with a distinct threat trade-off — this is a
+**maintainer security decision**, documented here, not resolved now):
+
+- **Interactive prompt** (via `rpassword`) on each unlock — simplest, but painful for scripting and
+  repeated commands.
+- **OS keychain** (the repo already uses `apple-native-keyring-store`) — best UX, but ties
+  confidentiality to the login session and is awkward headless.
+- **`TOKU_DB_PASSPHRASE` env var** — automation escape hatch; exposes the passphrase to the process
+  environment.
+- **Ephemeral unlocked-session token** (a short-lived agent) — good UX, more moving parts.
+
+Recommendation: passphrase prompt as the baseline, with keychain and env var as opt-in
+conveniences.
+
+### D5 — Per-entry-point open wiring
+
+Every site that opens `toku.db` must obtain the key and call the keyed constructor when encryption
+is enabled:
+
+- **CLI** — the primary dispatch (`crates/toku-cli/src/main.rs`, ~L1044) and the two other opens
+  (~L5173, ~L5351). This is where the passphrase is prompted/resolved.
+- **Web (`toku serve`)** — the migrating open (`crates/toku-web/src/lib.rs`, ~L227) plus every
+  request-time `Database::open_no_migrate` in the handlers (`handlers.rs`, `library_handlers.rs`,
+  `opds.rs`, `sync_status.rs`, `auth.rs`, `import_handlers.rs`, `conflicts_handlers.rs`). The
+  server is a trusted local process that holds the key for its lifetime.
+- **FFI** — `toku_open` (`crates/toku-ffi/src/lib.rs`, ~L204) needs a **key-carrying variant**
+  (e.g. `toku_open_encrypted(path, key)`); this is a signature/ABI addition the Swift/iOS/macOS/
+  watchOS apps adopt, and the regenerated `toku.h` must ship with it.
+- **Sync client** — `crates/toku-sync-client/src/orchestrator.rs` (~L187) opens the same local DB.
+
+### D6 — Migration: plaintext ↔ encrypted, both directions
+
+For data ownership and no-lock-in, the implementation provides an explicit, idempotent migration
+(e.g. `toku db encrypt` / `toku db decrypt`) using SQLCipher's `sqlcipher_export()` (attach a new
+keyed/plaintext database and copy). The command keeps a backup copy of the original file until the
+new one is verified, and refuses to run destructively without confirmation. Re-running when already
+in the target state is a no-op.
+
+### D7 — Encrypted backups for offline-only users (ships now)
+
+Acceptance criterion (b) of #204 — an encrypted, restorable backup — is **already met for sync
+users** via the enrolled library key (#200). The remaining gap is offline-only users. This ADR
+ships that piece because it needs **no new dependency**:
+
+- `toku export backup --encrypt`, when **no sync server is configured**, prompts for a passphrase
+  (or reads `TOKU_BACKUP_PASSPHRASE`), derives a key via `SyncKey::derive`, and seals the archive
+  with the existing AEAD snapshot envelope.
+- **Portability requirement:** the KDF **salt + parameters travel inside `manifest.json`** (a new
+  optional `kdf` descriptor on `BackupManifest`). The AEAD envelope carries only the nonce, so
+  without the embedded salt a passphrase backup could not be restored on another machine. Embedding
+  it makes the archive **self-describing**: restore re-derives the key from the passphrase alone,
+  with no dependency on local `config.toml`.
+- **Precedence:** if a sync server is configured, `--encrypt` uses the enrolled library key exactly
+  as before (no `kdf` in the manifest). Only non-sync users take the passphrase path. On restore,
+  the artifact is self-selecting: `manifest.kdf` present ⇒ passphrase backup; absent ⇒ sync-key
+  backup.
+
+This keeps the sync path unchanged and gives offline users first-class encrypted backups. It is
+independent of the SQLCipher work and does not touch `database.rs`.
+
+### D8 — Threat model
+
+At-rest DB encryption defends against **offline device/disk theft** on a machine without OS
+full-disk encryption. It does **not** defend against a compromised running process, a keylogger, or
+a weak passphrase, and — like all four of Toku's encryption guarantees — it is distinct from
+in-transit (operator TLS), relay zero-knowledge (E2E ciphertext), and the trusted local web
+dashboard. `docs/security/self-host-threat-model.md` is updated to retire the "local DB is
+plaintext" gap (conditional on opt-in) and to describe portable passphrase backups.
+
+## Consequences
+
+- **Positive:** opt-in defense-in-depth against device theft; offline users get portable encrypted
+  backups today; no change to the default experience; sync and relay postures untouched.
+- **Cost / risk:** SQLCipher enlarges the encrypted build and adds an OpenSSL cross-compile burden
+  — highest for the `apple` (iOS/watchOS) target (**flagged**). Mitigated by feature-gating and
+  keeping the feature **off** in default/`apple` CI; the implementation PR adds a dedicated CI leg
+  that compiles the feature to prove it builds.
+- **Lost passphrase = unrecoverable.** Both an encrypted DB and a passphrase backup are
+  unrecoverable if the passphrase is lost — there is no backdoor by design. Documented prominently
+  in `docs/recovery.md`.
+- **CI / Terraform:** no CI job is renamed under any option, so **no change to
+  `kafkade/github-infra`'s `repo_toku.tf` `required_status_checks`** is required. The apple/build
+  risk is the item to watch.
+
+## Implementation notes (for the deferred follow-up)
+
+- **Files:** root `Cargo.toml` + `crates/toku-db/Cargo.toml` (feature/dep);
+  `crates/toku-db/src/database.rs` (keyed constructors on all three open paths);
+  `crates/toku-core/src/config.rs` (`[encryption]` salt/params/verifier);
+  CLI opt-in + unlock (`toku-cli`); web open sites; `toku-ffi` (`toku_open_encrypted` +
+  regenerated `toku.h`); migration command; docs.
+- **Tests:** open-with-key roundtrip; wrong-key clean failure; disabled-path-unchanged;
+  plaintext↔encrypted migration idempotency; plus a CI leg that compiles the `sqlcipher` feature.
+
+## Alternatives Considered
+
+| Option | Rejected because |
+|--------|-----------------|
+| **Full workspace SQLCipher swap now** (flip `rusqlite` for every crate) | Highest risk: likely breaks the `apple` iOS/watchOS OpenSSL cross-compile — the merge gate — and re-keys the `toku-sync` relay DB, which must stay zero-knowledge ciphertext. Enlarges every build for a feature most of them never use. |
+| **Reuse the sync identity for the DB key (B2)** | Couples local at-rest encryption to sync enrollment, so an offline-only user could not encrypt their DB — contradicts local-first. The sync Secret Key + password derive a *data* key for the relay, a different purpose. |
+| **OS-keychain-managed random key as the sole mechanism (B3)** | Ties confidentiality to the login keychain, is awkward/absent on headless Linux, and offers no user-memorable recovery path. Retained only as an optional convenience layer over the passphrase. |
+| **Application-layer field encryption instead of SQLCipher** | Would leave indexes, FTS5 content, and the schema in plaintext, breaking search and defeating the goal; reinvents a well-solved primitive. |
+| **Encrypt backups by storing the salt in local `config.toml`** | A backup restored on another machine would not have that config, so it would be unrestorable — violates portability. The salt must travel **in** the archive (D7). |
+| **Bump `BACKUP_FORMAT_VERSION` for the new `kdf` field** | Unnecessary: `kdf` is an additive, `#[serde(default)]` optional field, backward/forward compatible per ADR-012 D5. Older Toku ignores it; newer Toku defaults it to absent. |
+
+## References
+
+- ADR-010 — Self-hosted server, zero-knowledge encryption, two-secret SRP auth (§A3 documents the
+  current plaintext-local-DB state and names #204 as the follow-up)
+- ADR-011 — File management (ebook binaries; cover/file content addressing)
+- ADR-012 / #200 — Canonical lossless backup & restore format (the AEAD envelope and manifest this
+  ADR extends with a portable `kdf` descriptor)
+- ADR-013 — Local identity & key bootstrap (offline Secret Key generation)
+- Issues: #204 (this ADR / seq 10), #203 (ADR-014, SaaS), #205 (ADR-015, auth coherence),
+  #200 (backup format); epic #207
+- Code: `crates/toku-db/src/database.rs`, `crates/toku-core/src/crypto.rs` (`SyncKey::derive`),
+  `crates/toku-core/src/backup_schema.rs` (`BackupManifest`, `BackupKdf`),
+  `crates/toku-export/src/backup.rs`, `crates/toku-cli/src/main.rs`
+- Docs: `docs/security/self-host-threat-model.md`, `docs/recovery.md`, `docs/self-hosting.md`

--- a/docs/recovery.md
+++ b/docs/recovery.md
@@ -154,3 +154,36 @@ toku export backup   # canonical, portable ZIP archive of your library
 
 Keep at least one offline backup. Combined with your Emergency Kit, that is everything you
 need to recover from any single loss.
+
+## Encrypted backups without sync (backup passphrase)
+
+You do **not** need a sync account to encrypt a backup. On a device that has never enrolled
+in sync, add `--encrypt`:
+
+```sh
+toku export backup --encrypt --output library.enc.zip
+```
+
+Toku prompts for a **backup passphrase** (entered twice to confirm), derives a key from it
+with Argon2id, and seals the archive with AES-256-GCM. For automation you can supply the
+passphrase via the `TOKU_BACKUP_PASSPHRASE` environment variable instead of the prompt.
+
+The archive is **self-describing**: the key-derivation salt and parameters are stored inside
+it, so it restores on **any** machine with only the passphrase — no `config.toml`, no sync
+account, nothing else to carry:
+
+```sh
+toku import backup library.enc.zip           # prompts for the same passphrase
+TOKU_BACKUP_PASSPHRASE=… toku import backup library.enc.zip   # non-interactive
+```
+
+If a sync server **is** configured, `--encrypt` keeps using your enrolled library key exactly
+as before; the passphrase path is only the fallback for offline-only users. On restore Toku
+detects which kind of encrypted backup it is from the archive itself.
+
+> **⚠️ Lose the passphrase and the backup is gone.** A passphrase-encrypted backup has **no
+> backdoor and no reset** — the same zero-knowledge stance as the Secret Key. If you forget
+> the passphrase, that archive is permanently unrecoverable. Write the passphrase down and
+> store it offline (a password manager, a safe), separate from the backup itself. A wrong
+> passphrase on restore fails cleanly ("could not decrypt backup") and never corrupts your
+> current library.

--- a/docs/security/self-host-threat-model.md
+++ b/docs/security/self-host-threat-model.md
@@ -47,6 +47,26 @@ The sync server (`toku-sync`) is the shared, internet-facing component.
 Trust boundaries: client device ↔ network ↔ server process ↔ server disk; plus, in
 multi-user mode, user ↔ admin and user ↔ user.
 
+### Local device at rest (single-device / offline)
+
+The network model above concerns hosted sync. For the **default single-device, offline** use,
+the relevant adversary is **offline theft of the device or disk**. Today the local `toku.db`
+is **plaintext at rest** — `toku-db` links standard SQLite, so confidentiality depends entirely
+on **OS full-disk encryption**. This is a known gap tracked in #204.
+
+[ADR-016](../adr/016-at-rest-encryption.md) designs the mitigation: **optional, off-by-default**
+at-rest DB encryption (SQLCipher, feature-gated on `toku-db`), keyed by a dedicated passphrase
+through Argon2id — independent of sync. When enabled, an offline attacker who takes the disk sees
+only ciphertext; the disabled default path is byte-for-byte unchanged. The heavyweight SQLCipher
+dependency is **deferred to a follow-up implementation**; ADR-016 is the design gate.
+
+Shipping now (from ADR-016 Decision C): **offline-only users can encrypt backups.**
+`toku export backup --encrypt` without a sync account derives a key from a passphrase (Argon2id)
+and seals the archive with AES-256-GCM; the KDF salt/params travel **inside** the archive so it
+restores on any machine with only the passphrase (see [`recovery.md`](../recovery.md)). This does
+not protect the live `toku.db` — only the exported artifact — and a lost passphrase makes that
+artifact unrecoverable by design.
+
 ## 2. Assets
 
 | Asset | Where it lives | Must never reach server |
@@ -192,6 +212,10 @@ for release are listed in [§9](#9-residual-risks-accepted).
   by at-rest disk encryption on headless hosts.
 - Deployment must still provide TLS, 0600 DB perms, at-rest encryption, and NTP (F11); these are
   operator responsibilities documented in `sync-server.md`.
+- The local `toku.db` is plaintext at rest by default; single-device confidentiality relies on OS
+  full-disk encryption. Optional at-rest DB encryption is designed in
+  [ADR-016](../adr/016-at-rest-encryption.md) (opt-in, off by default) with the SQLCipher
+  implementation deferred; offline passphrase-encrypted backups ship now (#204).
 
 ## 10. Sign-off
 


### PR DESCRIPTION
## Description

Lets offline-only users encrypt their backups, and lands the design for optional
at-rest database encryption.

Today `toku export backup --encrypt` requires an enrolled sync account, so a user
who never opts into sync cannot produce a ciphertext backup. This PR closes that
gap without touching the sync path.

**What's included**

- **Offline passphrase-encrypted backups.** When no sync server is configured,
  `toku export backup --encrypt` prompts for a passphrase (or reads
  `TOKU_BACKUP_PASSPHRASE` for automation), derives a 256-bit key with Argon2id,
  and seals the archive with AES-256-GCM.
- **Portable, self-describing archives.** The key-derivation salt and parameters
  travel inside `manifest.json` (a new optional `kdf` descriptor), so
  `toku import backup` re-derives the key from the passphrase alone and restores
  on any machine — no local config or sync account required.
- **Sync path unchanged.** With a server configured, `--encrypt` still uses your
  enrolled library key exactly as before. Restore auto-detects which kind of
  encrypted backup it is from the archive itself. Plaintext backups remain the
  default. A wrong passphrase fails cleanly and never corrupts the target library.
- **At-rest encryption design.** Adds a design document for optional,
  off-by-default SQLCipher database encryption (dedicated passphrase → Argon2id →
  `PRAGMA key`), keeping the default and cross-platform builds untouched. The
  SQLCipher implementation is deferred to a follow-up issue; this PR ships only
  the backup capability.
- **Docs.** Recovery guide gains an offline-backup passphrase section with a
  "lose the passphrase = unrecoverable" warning; the self-host threat model gains
  a local at-rest section.

The manifest `kdf` field is additive and optional, so existing backups keep
restoring unchanged with no format-version bump.

## Related Issues

<!-- SQLCipher at-rest DB implementation is tracked separately -->

Relates to #204 · Relates to #207 · follow-up implementation tracked in #225

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI / infrastructure
- [ ] Other (describe below)

## Crate

- [x] `toku-core` — Domain models, traits, state machine
- [ ] `toku-db` — SQLite persistence, migrations, FTS5
- [ ] `toku-import` — Importers (Goodreads, Calibre, StoryGraph)
- [ ] `toku-meta` — Metadata fetching (Open Library, Google Books)
- [x] `toku-cli` — CLI binary
- [x] `toku-export` — Exporters (CSV, JSON, Markdown, BibTeX)
- [x] `docs/` — Documentation

## Data Integrity Checklist

- [x] No user data is sent to any server without explicit opt-in
- [x] Import operations are idempotent (re-importing the same file creates no duplicates)
- [x] User edits to metadata are never overwritten by auto-enrichment
- [x] New fields track provenance (source + timestamp) — N/A: no user metadata fields added (the `kdf` descriptor is backup-container metadata)
- [x] Export round-trip is preserved (plaintext unchanged; encrypted seal→restore round-trips)

## Checklist

- [x] I have read [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] `cargo fmt --check` passes
- [x] `cargo clippy --workspace -- -D warnings` passes
- [x] `cargo test --workspace` passes
- [x] I have updated documentation (if applicable)