### PR TITLE
feat(sync): per-user quotas, rate limiting, encrypted backup, and signup email verification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `toku sync login` after approval. A new `toku sync bootstrap [--reset-cursor]` command
   exposes the same restore path for manual re-provisioning and recovery. Your local SQLite
   database remains the primary recovery (#199)
+- Managed-tier controls for operators running a shared or public `toku-sync` relay. Every
+  control is **off by default**, so a self-hosted or offline relay is completely unchanged
+  until you opt in, and the **zero-knowledge** guarantee is preserved throughout — the server
+  still only ever stores client-encrypted ciphertext. New capabilities (all #206, ADR-014):
+  - **Per-account storage quotas.** Cap how much stored ciphertext (bytes) and how many ops
+    each account may accumulate, via `--default-max-user-bytes` / `--default-max-user-ops`
+    (instance-wide) with an optional per-account override in the `user_quota` table. A push or
+    snapshot that would exceed the ceiling is rejected with HTTP `413`; quotas are measured
+    from ciphertext sizes and counts only, never content. Unowned libraries (the classic
+    self-host case) are always exempt.
+  - **Per-account rate limiting.** An authenticated-user request ceiling
+    (`--per-user-rate-max` within `--per-user-rate-window-secs`) layered above the existing
+    per-IP and global limiters, returning HTTP `429` when tripped. Disabled by default
+    (`--per-user-rate-max 0`).
+  - **Per-account encrypted backup & restore.** Admin-scoped
+    `GET /api/v1/admin/users/{id}/backup` exports a JSON bundle of one account's ciphertext
+    ops and snapshots plus opaque library metadata, and
+    `POST /api/v1/admin/users/{id}/backup/restore` re-ingests it idempotently. The bundle
+    contains **no** plaintext and **no** key material — the backup is ciphertext-only, so
+    zero-knowledge holds end-to-end.
+  - **Self-serve signup email verification.** Optionally require new (non-admin) signups to
+    confirm their email before they can obtain a session
+    (`--require-email-verification`, with `--smtp-url` / `--smtp-from` / `--public-base-url`
+    for delivery). New endpoints `POST /api/v1/account/verify-email` and
+    `POST /api/v1/account/resend-verification` (velocity-capped) complete the flow. The first
+    admin account is always auto-verified, and with verification off the signup flow is
+    identical to before.
 
 ### Changed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -450,6 +450,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "base64"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b25655df2c3cdd83c5e5b293b88acd880332b2ddadd7c30ac43144fdc0033da9"
+
+[[package]]
 name = "base64ct"
 version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1500,6 +1506,22 @@ name = "either"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
+
+[[package]]
+name = "email-encoding"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "420b9da095f052ea597503e39073b5b3c522f7db933fbac202d91d24492693fd"
+dependencies = [
+ "base64 0.23.0",
+ "memchr",
+]
+
+[[package]]
+name = "email_address"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e079f19b08ca6239f47f8ba8509c11cf3ea30095831f7fed61441475edd8c449"
 
 [[package]]
 name = "embed-resource"
@@ -2773,6 +2795,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
+name = "lettre"
+version = "0.11.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0da65617f6cb926332d039cb578aad56178da86e128db6a1b09f4c94fa5b3349"
+dependencies = [
+ "base64 0.22.1",
+ "email-encoding",
+ "email_address",
+ "fastrand",
+ "futures-util",
+ "httpdate",
+ "idna",
+ "mime",
+ "nom 8.0.0",
+ "percent-encoding",
+ "quoted_printable",
+ "rustls",
+ "socket2",
+ "tokio",
+ "url",
+ "webpki-roots",
+]
+
+[[package]]
 name = "libappindicator"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3135,6 +3181,15 @@ checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
 dependencies = [
  "memchr",
  "minimal-lexical",
+]
+
+[[package]]
+name = "nom"
+version = "8.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -4097,6 +4152,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "quoted_printable"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "478e0585659a122aa407eb7e3c0e1fa51b1d8a870038bd29f0cf4a8551eea972"
+
+[[package]]
 name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4556,6 +4617,7 @@ version = "0.23.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
 dependencies = [
+ "log",
  "once_cell",
  "ring",
  "rustls-pki-types",
@@ -5646,7 +5708,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4ea810f0692f9f51b382fff5893887bb4580f5fa246fde546e0b13e7fcee662"
 dependencies = [
  "fnv",
- "nom",
+ "nom 7.1.3",
  "phf 0.11.3",
  "phf_codegen 0.11.3",
 ]
@@ -6051,6 +6113,7 @@ dependencies = [
  "chrono",
  "clap",
  "hex",
+ "lettre",
  "rand 0.10.2",
  "refinery",
  "reqwest 0.12.28",

--- a/crates/toku-sync/Cargo.toml
+++ b/crates/toku-sync/Cargo.toml
@@ -17,6 +17,10 @@ axum = "0.8"
 base64 = "0.22"
 clap = { version = "4", features = ["derive", "env"] }
 chrono.workspace = true
+# SMTP delivery for account email verification (#206). Optional at runtime: the
+# server logs the verification link when no SMTP relay is configured. rustls TLS
+# avoids a system OpenSSL build dependency in CI.
+lettre = { version = "0.11", default-features = false, features = ["builder", "smtp-transport", "rustls-tls", "pool"] }
 hex = "0.4"
 rand = "0.10"
 rusqlite.workspace = true
@@ -42,6 +46,7 @@ base64 = "0.22"
 hex = "0.4"
 rand = "0.10"
 reqwest = { workspace = true, features = ["json", "blocking"] }
+rusqlite.workspace = true
 sha2.workspace = true
 srp = { version = "=0.7.0-rc.3", features = ["getrandom"] }
 tower = "0.5"

--- a/crates/toku-sync/migrations/V10__managed_hardening.sql
+++ b/crates/toku-sync/migrations/V10__managed_hardening.sql
@@ -1,0 +1,56 @@
+-- Managed-tier server hardening (issue #206, ADR-014 D2/D3/D4/D6).
+--
+-- Additive, idempotent, and backward-compatible: every column and table added
+-- here defaults to the pre-existing self-hosted behaviour (no quota, no
+-- per-user rate limit, no email verification). A self-hosted or offline relay
+-- is byte-for-byte unchanged until an operator opts in via config or the
+-- per-user entitlement seam below. None of these columns hold user content —
+-- the zero-knowledge guarantee is untouched.
+
+-- ── D4: signup email verification ────────────────────────────────────────────
+
+-- Whether the account has proven control of its email. Defaults to 1 (verified)
+-- so every pre-existing account, the first-run admin bootstrap, and any
+-- self-hosted signup keep working without a verification round-trip. Only a
+-- managed instance that turns on `require_email_verification` mints new
+-- non-admin accounts as unverified (0).
+ALTER TABLE users ADD COLUMN email_verified INTEGER NOT NULL DEFAULT 1;
+
+-- Instance-wide toggle. 0 = self-hosted default (no verification). When 1, new
+-- non-admin signups must confirm their email before they can obtain a session.
+ALTER TABLE instance_config ADD COLUMN require_email_verification INTEGER NOT NULL DEFAULT 0;
+
+-- Single-use, expiring email-verification tokens. Only the SHA-256 hash of the
+-- token is stored (like session tokens); the raw token travels to the user by
+-- email and is never persisted in the clear. This is account metadata, not
+-- library data.
+CREATE TABLE email_verification_tokens (
+    token_hash  TEXT PRIMARY KEY,                         -- sha256(raw token), hex
+    user_id     TEXT NOT NULL REFERENCES users(id),
+    expires_at  TEXT NOT NULL,                            -- ISO-8601 UTC datetime
+    created_at  TEXT NOT NULL
+);
+CREATE INDEX idx_email_verif_tokens_user ON email_verification_tokens(user_id);
+CREATE INDEX idx_email_verif_tokens_expires ON email_verification_tokens(expires_at);
+
+-- ── D2: per-user quotas ──────────────────────────────────────────────────────
+
+-- Instance-wide default ceilings applied to every owned account. NULL =
+-- unlimited (self-hosted default). A managed operator sets these to a positive
+-- byte / op count to enforce a baseline ceiling.
+ALTER TABLE instance_config ADD COLUMN default_max_user_bytes INTEGER;  -- NULL = unlimited
+ALTER TABLE instance_config ADD COLUMN default_max_user_ops   INTEGER;  -- NULL = unlimited
+
+-- Per-user entitlement override (ADR-014 D5 plan-lookup seam, cached
+-- server-side). This is the structural input the D2 quota check reads to
+-- resolve a ceiling for a given account; it carries only capability ceilings
+-- (bytes / ops), never any price, tier, or billing state. A NULL column falls
+-- back to the instance default (and NULL there means unlimited). An external
+-- billing/plan system, if one ever exists, would write rows here — this repo
+-- ships only the seam.
+CREATE TABLE user_quota (
+    user_id     TEXT PRIMARY KEY REFERENCES users(id),
+    max_bytes   INTEGER,                                  -- NULL = fall back to instance default
+    max_ops     INTEGER,                                  -- NULL = fall back to instance default
+    updated_at  TEXT NOT NULL
+);

--- a/crates/toku-sync/src/auth.rs
+++ b/crates/toku-sync/src/auth.rs
@@ -26,7 +26,7 @@ use std::fmt::Write;
 use std::path::PathBuf;
 
 use axum::Json;
-use axum::extract::{FromRequestParts, Request, State};
+use axum::extract::{Extension, FromRequestParts, Request, State};
 use axum::http::header::AUTHORIZATION;
 use axum::http::request::Parts;
 use axum::middleware::Next;
@@ -34,12 +34,16 @@ use axum::response::Response;
 use sha2::{Digest, Sha256};
 use srp::ServerG2048;
 
+use rusqlite::OptionalExtension;
+
 use crate::db::SyncDatabase;
 use crate::error::SyncError;
+use crate::managed::ManagedRuntime;
 use crate::models::{
     AccountChallengeRequest, AccountChallengeResponse, AccountVerifyRequest, AccountVerifyResponse,
-    EnrollRequest, EnrollResponse, SignupRequest, SignupResponse, SrpChallengeRequest,
-    SrpChallengeResponse, SrpVerifyRequest, SrpVerifyResponse,
+    EnrollRequest, EnrollResponse, ResendVerificationRequest, SignupRequest, SignupResponse,
+    SrpChallengeRequest, SrpChallengeResponse, SrpVerifyRequest, SrpVerifyResponse,
+    VerifyEmailRequest, VerifyEmailResponse,
 };
 
 /// Maximum failed login attempts before account lockout.
@@ -56,6 +60,10 @@ const SESSION_TTL_HOURS: i64 = 24;
 pub struct AuthDevice {
     pub device_id: String,
     pub library_id: String,
+    /// The account that owns this device's library, when the library has been
+    /// claimed by a user account. `None` for legacy unowned relay libraries
+    /// (self-hosted open-relay model), which are exempt from per-user controls.
+    pub user_id: Option<String>,
 }
 
 impl<S: Send + Sync> FromRequestParts<S> for AuthDevice {
@@ -150,9 +158,10 @@ pub async fn require_auth(
             //    active devices may authenticate — a rejected/pending device
             //    (issue #120) is denied even if a stale session row lingers.
             let session = db.conn.query_row(
-                "SELECT s.device_id, s.library_id
+                "SELECT s.device_id, s.library_id, l.user_id
                  FROM sessions s
                  JOIN devices d ON d.device_id = s.device_id
+                 LEFT JOIN libraries l ON l.id = s.library_id
                  WHERE s.session_token_hash = ?1
                    AND s.expires_at > datetime('now')
                    AND d.status = 'active'",
@@ -161,6 +170,7 @@ pub async fn require_auth(
                     Ok(AuthDevice {
                         device_id: row.get(0)?,
                         library_id: row.get(1)?,
+                        user_id: row.get(2)?,
                     })
                 },
             );
@@ -176,13 +186,16 @@ pub async fn require_auth(
             let device = db
                 .conn
                 .query_row(
-                    "SELECT device_id, library_id
-                     FROM devices WHERE auth_token_hash = ?1 AND status = 'active'",
+                    "SELECT d.device_id, d.library_id, l.user_id
+                     FROM devices d
+                     LEFT JOIN libraries l ON l.id = d.library_id
+                     WHERE d.auth_token_hash = ?1 AND d.status = 'active'",
                     [&token_hash],
                     |row| {
                         Ok(AuthDevice {
                             device_id: row.get(0)?,
                             library_id: row.get(1)?,
+                            user_id: row.get(2)?,
                         })
                     },
                 )
@@ -812,6 +825,7 @@ fn validate_email(email: &str) -> Result<(), SyncError> {
 /// server never sees the password or Secret Key.
 pub async fn account_signup(
     State(db_path): State<PathBuf>,
+    Extension(managed): Extension<ManagedRuntime>,
     Json(req): Json<SignupRequest>,
 ) -> Result<Json<SignupResponse>, SyncError> {
     validate_email(&req.email)?;
@@ -821,6 +835,10 @@ pub async fn account_signup(
         .map_err(|_| SyncError::BadRequest("srp_verifier must be hex-encoded".into()))?;
 
     let user_id = uuid::Uuid::now_v7().to_string();
+    // Verification token is minted up front (cheap, CSPRNG) and only persisted +
+    // emailed when the instance requires verification for this account.
+    let verification_token = generate_token();
+    let verification_token_hash = sha256_hex(&verification_token);
 
     let resp = tokio::task::spawn_blocking({
         let db_path = db_path.clone();
@@ -832,6 +850,7 @@ pub async fn account_signup(
         let account_public_key = req.account_public_key.clone();
         let kdf_params = req.kdf_params.clone();
         let wrapped_data_key = req.wrapped_data_key.clone();
+        let verification_token_hash = verification_token_hash.clone();
         move || -> Result<SignupResponse, SyncError> {
             let db = SyncDatabase::open_no_migrate(&db_path)?;
 
@@ -862,6 +881,19 @@ pub async fn account_signup(
                 "user"
             };
 
+            // Email verification (ADR-014 D4): gate only non-admin signups, and
+            // only when the instance opts in. The admin bootstrap is always
+            // verified so an operator can never lock themselves out.
+            let require_verification: i64 = tx_guard
+                .query_row(
+                    "SELECT require_email_verification FROM instance_config WHERE id = 1",
+                    [],
+                    |row| row.get(0),
+                )
+                .unwrap_or(0);
+            let needs_verification = require_verification == 1 && role == "user";
+            let email_verified: i64 = if needs_verification { 0 } else { 1 };
+
             // Reject duplicate emails with a clear 409.
             let email_taken: i64 = tx_guard.query_row(
                 "SELECT COUNT(*) FROM users WHERE email = ?1",
@@ -875,8 +907,9 @@ pub async fn account_signup(
             tx_guard.execute(
                 "INSERT INTO users
                  (id, email, srp_salt, srp_verifier, wrapped_private_key,
-                  account_public_key, kdf_params, wrapped_data_key, role, status, created_at)
-                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, 'active', datetime('now'))",
+                  account_public_key, kdf_params, wrapped_data_key, role, status,
+                  email_verified, created_at)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, 'active', ?10, datetime('now'))",
                 rusqlite::params![
                     user_id,
                     email,
@@ -887,8 +920,18 @@ pub async fn account_signup(
                     kdf_params,
                     wrapped_data_key,
                     role,
+                    email_verified,
                 ],
             )?;
+
+            if needs_verification {
+                tx_guard.execute(
+                    "INSERT INTO email_verification_tokens
+                     (token_hash, user_id, expires_at, created_at)
+                     VALUES (?1, ?2, datetime('now', '+24 hours'), datetime('now'))",
+                    rusqlite::params![verification_token_hash, user_id],
+                )?;
+            }
 
             // First admin bootstrap: adopt any orphan relay libraries/devices
             // (registered under the old unauthenticated model, user_id IS NULL)
@@ -926,13 +969,205 @@ pub async fn account_signup(
                 role: role.to_string(),
                 adopted_libraries,
                 adopted_devices,
+                email_verification_required: needs_verification,
             })
         }
     })
     .await
     .map_err(|e| SyncError::Internal(format!("task join error: {e}")))??;
 
+    // Deliver the verification link outside the DB transaction. Mail failures
+    // must not roll back a committed account; the user can re-request via
+    // `resend-verification`. The link carries only an opaque token — no library
+    // data — so the zero-knowledge boundary is untouched.
+    if resp.email_verification_required {
+        let verify_url = build_verify_url(managed.public_base_url.as_deref(), &verification_token);
+        let mailer = managed.mailer.clone();
+        let to = resp.email.clone();
+        let _ = tokio::task::spawn_blocking(move || mailer.send_verification(&to, &verify_url))
+            .await
+            .map_err(|e| SyncError::Internal(format!("task join error: {e}")))?
+            .map_err(|e| {
+                tracing::warn!(target: "toku_sync::mailer", error = %e, "verification email send failed");
+                e
+            });
+    }
+
     Ok(Json(resp))
+}
+
+/// Build the email-verification URL from the configured public base URL and an
+/// opaque token. When no base URL is configured (self-hosted / tests) the path
+/// is returned relative so the token is still recoverable from logs/captures.
+fn build_verify_url(public_base_url: Option<&str>, token: &str) -> String {
+    let base = public_base_url.unwrap_or("").trim_end_matches('/');
+    format!("{base}/api/v1/account/verify-email?token={token}")
+}
+
+/// `POST /api/v1/account/verify-email`
+///
+/// Confirm control of a signup email by presenting the one-time token delivered
+/// by [`account_signup`]. Marks the account verified and consumes the token.
+/// The token is account metadata only — this path never touches library data.
+pub async fn verify_email(
+    State(db_path): State<PathBuf>,
+    Json(req): Json<VerifyEmailRequest>,
+) -> Result<Json<VerifyEmailResponse>, SyncError> {
+    if req.token.trim().is_empty() {
+        return Err(SyncError::BadRequest("token is required".into()));
+    }
+    let token_hash = sha256_hex(&req.token);
+
+    let resp = tokio::task::spawn_blocking({
+        let db_path = db_path.clone();
+        move || -> Result<VerifyEmailResponse, SyncError> {
+            let db = SyncDatabase::open_no_migrate(&db_path)?;
+            let tx = db.conn.unchecked_transaction()?;
+
+            let row: Option<(String, bool)> = tx
+                .query_row(
+                    "SELECT user_id, expires_at < datetime('now')
+                     FROM email_verification_tokens WHERE token_hash = ?1",
+                    [&token_hash],
+                    |r| Ok((r.get(0)?, r.get(1)?)),
+                )
+                .optional()?;
+
+            let (user_id, expired) =
+                row.ok_or_else(|| SyncError::BadRequest("invalid or expired token".into()))?;
+            if expired {
+                // Consume the stale token so it can't be probed further.
+                tx.execute(
+                    "DELETE FROM email_verification_tokens WHERE token_hash = ?1",
+                    [&token_hash],
+                )?;
+                tx.commit()?;
+                return Err(SyncError::BadRequest("invalid or expired token".into()));
+            }
+
+            tx.execute(
+                "UPDATE users SET email_verified = 1 WHERE id = ?1",
+                [&user_id],
+            )?;
+            // One account, one verification: drop every outstanding token.
+            tx.execute(
+                "DELETE FROM email_verification_tokens WHERE user_id = ?1",
+                [&user_id],
+            )?;
+
+            crate::security::audit(
+                &db,
+                "email.verify",
+                Some(&user_id),
+                Some(&user_id),
+                "success",
+                None,
+                None,
+            );
+            tx.commit()?;
+            Ok(VerifyEmailResponse { verified: true })
+        }
+    })
+    .await
+    .map_err(|e| SyncError::Internal(format!("task join error: {e}")))??;
+
+    Ok(Json(resp))
+}
+
+/// Maximum verification emails per address inside [`RESEND_WINDOW_SECS`].
+const RESEND_MAX_PER_WINDOW: i64 = 3;
+/// Velocity window for `resend-verification`, in seconds (15 minutes).
+const RESEND_WINDOW_SECS: i64 = 900;
+
+/// `POST /api/v1/account/resend-verification`
+///
+/// Re-issue a verification email for an unverified account. Responds `202` for
+/// any well-formed email regardless of whether it maps to an account, so the
+/// endpoint never reveals which addresses are registered. Per-email velocity
+/// capped to blunt mail-flooding abuse.
+pub async fn resend_verification(
+    State(db_path): State<PathBuf>,
+    Extension(managed): Extension<ManagedRuntime>,
+    Json(req): Json<ResendVerificationRequest>,
+) -> Result<Json<VerifyEmailResponse>, SyncError> {
+    validate_email(&req.email)?;
+
+    let outcome = tokio::task::spawn_blocking({
+        let db_path = db_path.clone();
+        let email = req.email.clone();
+        move || -> Result<Option<(String, String)>, SyncError> {
+            let db = SyncDatabase::open_no_migrate(&db_path)?;
+
+            // Per-email velocity cap (anti-abuse, ADR-014 D4/D7). Counted from the
+            // audit log so it survives process restarts.
+            let recent: i64 = db
+                .conn
+                .query_row(
+                    "SELECT COUNT(*) FROM audit_log
+                     WHERE event_type = 'email.resend' AND target = ?1
+                       AND ts > datetime('now', ?2)",
+                    rusqlite::params![email, format!("-{RESEND_WINDOW_SECS} seconds")],
+                    |r| r.get(0),
+                )
+                .unwrap_or(0);
+            if recent >= RESEND_MAX_PER_WINDOW {
+                return Err(SyncError::RateLimited {
+                    retry_after: format!("{RESEND_WINDOW_SECS}s"),
+                });
+            }
+
+            // Resolve the account without leaking existence to the caller.
+            let user: Option<(String, i64)> = db
+                .conn
+                .query_row(
+                    "SELECT id, email_verified FROM users WHERE email = ?1",
+                    [&email],
+                    |r| Ok((r.get(0)?, r.get(1)?)),
+                )
+                .optional()?;
+
+            // Always record the attempt for the velocity cap.
+            crate::security::audit(
+                &db,
+                "email.resend",
+                None,
+                Some(&email),
+                "success",
+                None,
+                None,
+            );
+
+            match user {
+                // Unknown address or already-verified account: nothing to send,
+                // but we still return 202 to the caller.
+                None => Ok(None),
+                Some((_, verified)) if verified != 0 => Ok(None),
+                Some((user_id, _)) => {
+                    let token = generate_token();
+                    let token_hash = sha256_hex(&token);
+                    db.conn.execute(
+                        "INSERT INTO email_verification_tokens
+                         (token_hash, user_id, expires_at, created_at)
+                         VALUES (?1, ?2, datetime('now', '+24 hours'), datetime('now'))",
+                        rusqlite::params![token_hash, user_id],
+                    )?;
+                    Ok(Some((email, token)))
+                }
+            }
+        }
+    })
+    .await
+    .map_err(|e| SyncError::Internal(format!("task join error: {e}")))??;
+
+    if let Some((to, token)) = outcome {
+        let verify_url = build_verify_url(managed.public_base_url.as_deref(), &token);
+        let mailer = managed.mailer.clone();
+        let _ = tokio::task::spawn_blocking(move || mailer.send_verification(&to, &verify_url))
+            .await
+            .map_err(|e| SyncError::Internal(format!("task join error: {e}")))?;
+    }
+
+    Ok(Json(VerifyEmailResponse { verified: false }))
 }
 
 /// `POST /api/v1/account/challenge`
@@ -1122,7 +1357,7 @@ pub async fn account_verify(
                 return Err(SyncError::Unauthorized);
             }
 
-            let (email, srp_salt_hex, srp_verifier_hex, role, status, failed_attempts, locked_until): (
+            let (email, srp_salt_hex, srp_verifier_hex, role, status, failed_attempts, locked_until, email_verified): (
                 String,
                 String,
                 String,
@@ -1130,10 +1365,11 @@ pub async fn account_verify(
                 String,
                 i64,
                 Option<String>,
+                i64,
             ) = db
                 .conn
                 .query_row(
-                    "SELECT email, srp_salt, srp_verifier, role, status, failed_attempts, locked_until
+                    "SELECT email, srp_salt, srp_verifier, role, status, failed_attempts, locked_until, email_verified
                      FROM users WHERE id = ?1",
                     [&user_id],
                     |row| {
@@ -1145,6 +1381,7 @@ pub async fn account_verify(
                             row.get(4)?,
                             row.get(5)?,
                             row.get(6)?,
+                            row.get(7)?,
                         ))
                     },
                 )
@@ -1230,6 +1467,26 @@ pub async fn account_verify(
             }
 
             let m2_hex = hex::encode(server_verifier.proof());
+
+            // Email-verification gate (ADR-014 D4): only issue a session once the
+            // account has confirmed its address. Checked *after* the SRP proof so
+            // verification status never leaks to an unauthenticated caller.
+            // `email_verified` defaults to 1, so self-hosted and admin accounts
+            // pass unconditionally.
+            if email_verified == 0 {
+                crate::security::audit(
+                    &db,
+                    "login.failure",
+                    Some(&email),
+                    Some(&user_id),
+                    "failure",
+                    Some("email not verified"),
+                    None,
+                );
+                return Err(SyncError::Forbidden(
+                    "email address not verified; check your inbox or request a new link".into(),
+                ));
+            }
 
             let _ = db.conn.execute(
                 "UPDATE users SET failed_attempts = 0, locked_until = NULL WHERE id = ?1",

--- a/crates/toku-sync/src/config.rs
+++ b/crates/toku-sync/src/config.rs
@@ -19,6 +19,60 @@ pub struct Config {
     /// Log verbosity (error, warn, info, debug, trace). Overridden by `RUST_LOG` if set.
     #[arg(long, default_value = "info", env = "TOKU_SYNC_LOG_LEVEL")]
     pub log_level: String,
+
+    // ── Managed-tier controls (issue #206, ADR-014) ──────────────────────────
+    //
+    // Every knob below defaults to the self-hosted behaviour: no quota, no
+    // per-user rate limit, no email verification. A self-hosted or offline relay
+    // is unchanged until an operator opts in. None of these affect the
+    // zero-knowledge guarantee — the server still only ever holds ciphertext.
+    /// Per-account stored-ciphertext ceiling in bytes. Unset = unlimited
+    /// (self-hosted default). Applies to every owned account unless overridden
+    /// per user via the `user_quota` entitlement table.
+    #[arg(long, env = "TOKU_SYNC_DEFAULT_MAX_USER_BYTES")]
+    pub default_max_user_bytes: Option<i64>,
+
+    /// Per-account stored-op ceiling. Unset = unlimited (self-hosted default).
+    #[arg(long, env = "TOKU_SYNC_DEFAULT_MAX_USER_OPS")]
+    pub default_max_user_ops: Option<i64>,
+
+    /// Per-authenticated-user request ceiling within the rate window. 0 =
+    /// disabled (self-hosted default); the per-IP + global limiter still applies.
+    #[arg(long, default_value = "0", env = "TOKU_SYNC_PER_USER_RATE_MAX")]
+    pub per_user_rate_max: u32,
+
+    /// Fixed-window length (seconds) for the per-user rate limiter.
+    #[arg(
+        long,
+        default_value = "60",
+        env = "TOKU_SYNC_PER_USER_RATE_WINDOW_SECS"
+    )]
+    pub per_user_rate_window_secs: u64,
+
+    /// Require new (non-admin) signups to confirm their email before they can
+    /// obtain a session. Off by default (self-hosted). When on, `--smtp-url`,
+    /// `--smtp-from`, and `--public-base-url` must also be set.
+    #[arg(
+        long,
+        default_value = "false",
+        env = "TOKU_SYNC_REQUIRE_EMAIL_VERIFICATION"
+    )]
+    pub require_email_verification: bool,
+
+    /// SMTP relay URL for verification email delivery, e.g.
+    /// `smtps://user:pass@smtp.example.com:465`. Unset = log the link instead of
+    /// sending (dev / self-host).
+    #[arg(long, env = "TOKU_SYNC_SMTP_URL")]
+    pub smtp_url: Option<String>,
+
+    /// `From:` address for verification emails, e.g. `Toku <no-reply@example.com>`.
+    #[arg(long, env = "TOKU_SYNC_SMTP_FROM")]
+    pub smtp_from: Option<String>,
+
+    /// Public base URL the server is reachable at, used to build verification
+    /// links, e.g. `https://sync.example.com`.
+    #[arg(long, env = "TOKU_SYNC_PUBLIC_BASE_URL")]
+    pub public_base_url: Option<String>,
 }
 
 impl Config {

--- a/crates/toku-sync/src/error.rs
+++ b/crates/toku-sync/src/error.rs
@@ -32,6 +32,9 @@ pub enum SyncError {
     #[error("too many failed authentication attempts; retry after {retry_after}")]
     RateLimited { retry_after: String },
 
+    #[error("quota exceeded: {0}")]
+    QuotaExceeded(String),
+
     #[error("account locked until {until}")]
     AccountLocked { until: String },
 
@@ -54,6 +57,7 @@ impl IntoResponse for SyncError {
             SyncError::PlaintextRejected(_) => StatusCode::UNPROCESSABLE_ENTITY,
             SyncError::Conflict(_) => StatusCode::CONFLICT,
             SyncError::RateLimited { .. } => StatusCode::TOO_MANY_REQUESTS,
+            SyncError::QuotaExceeded(_) => StatusCode::PAYLOAD_TOO_LARGE,
             SyncError::AccountLocked { .. } => StatusCode::from_u16(423).unwrap(),
             SyncError::UpgradeRequired { .. } => StatusCode::UPGRADE_REQUIRED,
             SyncError::Internal(_) => StatusCode::INTERNAL_SERVER_ERROR,

--- a/crates/toku-sync/src/handlers.rs
+++ b/crates/toku-sync/src/handlers.rs
@@ -2,18 +2,19 @@ use std::path::PathBuf;
 
 use axum::Json;
 use axum::extract::{Path, Query, State};
+use rusqlite::OptionalExtension;
 
 use crate::auth::{AuthDevice, AuthUser, generate_token, sha256_hex};
 use crate::db::SyncDatabase;
 use crate::error::SyncError;
 use crate::models::{
-    AccountDeviceListResponse, AccountDeviceSummary, AccountKeysResponse, DeviceApprovalRequest,
-    DeviceApprovalsConfigResponse, DeviceResponse, DeviceSessionResponse, DownloadSnapshotResponse,
-    EnrollDeviceRequest, EnrollDeviceResponse, HealthResponse, OpPayload, PullQuery, PullResponse,
-    PushRequest, PushResponse, RegisterRequest, RegisterResponse, RegistrationConfigResponse,
-    RekeyRequest, RekeyResponse, SetDeviceApprovalsRequest, SetRegistrationRequest,
-    SetUserStatusRequest, UploadSnapshotRequest, UploadSnapshotResponse, UserListResponse,
-    UserSummary,
+    AccountDeviceListResponse, AccountDeviceSummary, AccountKeysResponse, BackupLibrary, BackupOp,
+    BackupSnapshot, DeviceApprovalRequest, DeviceApprovalsConfigResponse, DeviceResponse,
+    DeviceSessionResponse, DownloadSnapshotResponse, EnrollDeviceRequest, EnrollDeviceResponse,
+    HealthResponse, OpPayload, PullQuery, PullResponse, PushRequest, PushResponse, RegisterRequest,
+    RegisterResponse, RegistrationConfigResponse, RekeyRequest, RekeyResponse,
+    RestoreBackupResponse, SetDeviceApprovalsRequest, SetRegistrationRequest, SetUserStatusRequest,
+    UploadSnapshotRequest, UploadSnapshotResponse, UserBackupBundle, UserListResponse, UserSummary,
 };
 
 const MAX_BATCH_SIZE: usize = 1000;
@@ -96,8 +97,108 @@ fn require_ciphertext_snapshot(snapshot_json: &str) -> Result<(), SyncError> {
     }
 }
 
-// ── Health ──────────────────────────────────────────────────────────────────
+// ── Per-user quotas (issue #206, ADR-014 D2) ─────────────────────────────────
 
+/// Resolve the effective storage/op ceilings for an account: a per-user
+/// `user_quota` override wins, else the instance-wide default, else unlimited
+/// (`None`). This is the ADR-014 D5 plan-lookup seam — it reads capability
+/// ceilings only, never any price or billing state.
+fn resolve_quota_ceilings(
+    conn: &rusqlite::Connection,
+    user_id: &str,
+) -> Result<(Option<i64>, Option<i64>), SyncError> {
+    let over: Option<(Option<i64>, Option<i64>)> = conn
+        .query_row(
+            "SELECT max_bytes, max_ops FROM user_quota WHERE user_id = ?1",
+            [user_id],
+            |r| Ok((r.get(0)?, r.get(1)?)),
+        )
+        .optional()?;
+    let (inst_bytes, inst_ops): (Option<i64>, Option<i64>) = conn
+        .query_row(
+            "SELECT default_max_user_bytes, default_max_user_ops FROM instance_config WHERE id = 1",
+            [],
+            |r| Ok((r.get(0)?, r.get(1)?)),
+        )
+        .optional()?
+        .unwrap_or((None, None));
+    let (ov_bytes, ov_ops) = over.unwrap_or((None, None));
+    Ok((ov_bytes.or(inst_bytes), ov_ops.or(inst_ops)))
+}
+
+/// Enforce per-account storage/op quotas before persisting new writes.
+///
+/// Zero-knowledge preserved: this reads only ciphertext **sizes** and **counts**
+/// keyed by ownership — never plaintext. Libraries with no owning account
+/// (legacy self-hosted open relay, `libraries.user_id IS NULL`) are exempt, so
+/// the default self-hosted relay is unaffected. `incoming_bytes` / `incoming_ops`
+/// are the size and count this request would add.
+fn enforce_user_quota(
+    conn: &rusqlite::Connection,
+    library_id: &str,
+    incoming_bytes: i64,
+    incoming_ops: i64,
+) -> Result<(), SyncError> {
+    // Resolve the owning account; unowned libraries are exempt.
+    let user_id: Option<String> = conn
+        .query_row(
+            "SELECT user_id FROM libraries WHERE id = ?1",
+            [library_id],
+            |row| row.get(0),
+        )
+        .optional()?
+        .flatten();
+    let Some(user_id) = user_id else {
+        return Ok(());
+    };
+
+    let (max_bytes, max_ops) = resolve_quota_ceilings(conn, &user_id)?;
+    if max_bytes.is_none() && max_ops.is_none() {
+        return Ok(());
+    }
+
+    if let Some(limit) = max_bytes {
+        let ops_bytes: i64 = conn.query_row(
+            "SELECT COALESCE(SUM(LENGTH(o.payload)), 0)
+             FROM ops o JOIN libraries l ON l.id = o.library_id
+             WHERE l.user_id = ?1",
+            [&user_id],
+            |row| row.get(0),
+        )?;
+        let snap_bytes: i64 = conn.query_row(
+            "SELECT COALESCE(SUM(LENGTH(s.snapshot_json)), 0)
+             FROM snapshots s JOIN libraries l ON l.id = s.library_id
+             WHERE l.user_id = ?1",
+            [&user_id],
+            |row| row.get(0),
+        )?;
+        let used = ops_bytes + snap_bytes;
+        if used + incoming_bytes > limit {
+            return Err(SyncError::QuotaExceeded(format!(
+                "storage quota exceeded: {used} stored + {incoming_bytes} new bytes exceeds the {limit}-byte ceiling"
+            )));
+        }
+    }
+
+    if incoming_ops > 0
+        && let Some(limit) = max_ops
+    {
+        let used: i64 = conn.query_row(
+            "SELECT COUNT(*) FROM ops o JOIN libraries l ON l.id = o.library_id WHERE l.user_id = ?1",
+            [&user_id],
+            |row| row.get(0),
+        )?;
+        if used + incoming_ops > limit {
+            return Err(SyncError::QuotaExceeded(format!(
+                "op-count quota exceeded: {used} stored + {incoming_ops} new ops exceeds the {limit}-op ceiling"
+            )));
+        }
+    }
+
+    Ok(())
+}
+
+// ── Health ──────────────────────────────────────────────────────────────────
 pub async fn health(State(db_path): State<PathBuf>) -> Json<HealthResponse> {
     let min = SyncDatabase::open_no_migrate(&db_path)
         .map(|db| crate::protocol::min_protocol(&db))
@@ -868,6 +969,18 @@ pub async fn push_ops(
                 ));
             }
 
+            // Per-user storage/op quota (ADR-014 D2). Reads ciphertext sizes and
+            // counts only — ZK-safe. Unowned libraries are exempt.
+            let incoming_bytes: i64 = ops
+                .iter()
+                .map(|op| {
+                    serde_json::to_string(&op.payload)
+                        .map(|s| s.len() as i64)
+                        .unwrap_or(0)
+                })
+                .sum();
+            enforce_user_quota(&db.conn, &library_id, incoming_bytes, ops.len() as i64)?;
+
             let tx = db.conn.unchecked_transaction()?;
 
             let mut accepted = 0usize;
@@ -1093,6 +1206,11 @@ pub async fn upload_snapshot(
         let hlc = req.hlc_at_snapshot;
         move || -> Result<UploadSnapshotResponse, SyncError> {
             let db = SyncDatabase::open_no_migrate(&db_path)?;
+
+            // Per-user storage quota (ADR-014 D2): count the snapshot ciphertext
+            // size. ZK-safe (size only); unowned libraries are exempt.
+            enforce_user_quota(&db.conn, &library_id, snapshot_json.len() as i64, 0)?;
+
             let tx = db.conn.unchecked_transaction()?;
 
             // Store the snapshot
@@ -1463,6 +1581,251 @@ pub async fn set_user_status(
     .map_err(|e| SyncError::Internal(format!("task join error: {e}")))??;
 
     Ok(Json(summary))
+}
+
+/// `GET /api/v1/admin/users/{id}/backup` — export a per-user encrypted backup
+/// (admin only, ADR-014 D6).
+///
+/// Zero-knowledge preserved: the bundle carries only ciphertext (`ops.payload`,
+/// `snapshots.snapshot_json`) plus the opaque metadata the relay already stores
+/// in the clear (op ids, HLCs, device ids, library salts). No plaintext user
+/// content and no key material ever leave the relay.
+pub async fn admin_backup_user(
+    State(db_path): State<PathBuf>,
+    user: AuthUser,
+    Path(target_id): Path<String>,
+) -> Result<Json<UserBackupBundle>, SyncError> {
+    require_admin(&user)?;
+
+    let bundle = tokio::task::spawn_blocking({
+        let db_path = db_path.clone();
+        let target_id = target_id.clone();
+        move || -> Result<UserBackupBundle, SyncError> {
+            let db = SyncDatabase::open_no_migrate(&db_path)?;
+
+            // Load the target account (404 if absent).
+            let email: String = db
+                .conn
+                .query_row("SELECT email FROM users WHERE id = ?1", [&target_id], |r| {
+                    r.get(0)
+                })
+                .optional()?
+                .ok_or_else(|| SyncError::NotFound(format!("user {target_id} not found")))?;
+
+            let mut lib_stmt = db.conn.prepare(
+                "SELECT id, salt, created_at FROM libraries WHERE user_id = ?1 ORDER BY created_at",
+            )?;
+            let libraries = lib_stmt
+                .query_map([&target_id], |row| {
+                    Ok(BackupLibrary {
+                        id: row.get(0)?,
+                        salt: row.get(1)?,
+                        created_at: row.get(2)?,
+                    })
+                })?
+                .collect::<Result<Vec<_>, _>>()?;
+
+            let mut op_stmt = db.conn.prepare(
+                "SELECT o.op_id, o.library_id, o.device_id, o.hlc, o.entity_type,
+                        o.entity_id, o.op_type, o.payload, o.received_at
+                 FROM ops o JOIN libraries l ON l.id = o.library_id
+                 WHERE l.user_id = ?1
+                 ORDER BY o.library_id, o.hlc",
+            )?;
+            let ops = op_stmt
+                .query_map([&target_id], |row| {
+                    Ok(BackupOp {
+                        op_id: row.get(0)?,
+                        library_id: row.get(1)?,
+                        device_id: row.get(2)?,
+                        hlc: row.get(3)?,
+                        entity_type: row.get(4)?,
+                        entity_id: row.get(5)?,
+                        op_type: row.get(6)?,
+                        payload: row.get(7)?,
+                        received_at: row.get(8)?,
+                    })
+                })?
+                .collect::<Result<Vec<_>, _>>()?;
+
+            let mut snap_stmt = db.conn.prepare(
+                "SELECT s.library_id, s.snapshot_json, s.hlc_at_snapshot,
+                        s.created_by_device, s.created_at
+                 FROM snapshots s JOIN libraries l ON l.id = s.library_id
+                 WHERE l.user_id = ?1
+                 ORDER BY s.library_id, s.created_at",
+            )?;
+            let snapshots = snap_stmt
+                .query_map([&target_id], |row| {
+                    Ok(BackupSnapshot {
+                        library_id: row.get(0)?,
+                        snapshot_json: row.get(1)?,
+                        hlc_at_snapshot: row.get(2)?,
+                        created_by_device: row.get(3)?,
+                        created_at: row.get(4)?,
+                    })
+                })?
+                .collect::<Result<Vec<_>, _>>()?;
+
+            crate::security::audit(
+                &db,
+                "user.backup",
+                Some(&user.user_id),
+                Some(&target_id),
+                "success",
+                Some(&format!(
+                    "{} libraries, {} ops, {} snapshots",
+                    libraries.len(),
+                    ops.len(),
+                    snapshots.len()
+                )),
+                None,
+            );
+
+            let exported_at: String = db
+                .conn
+                .query_row("SELECT datetime('now')", [], |r| r.get(0))?;
+
+            Ok(UserBackupBundle {
+                version: 1,
+                user_id: target_id,
+                email,
+                exported_at,
+                libraries,
+                ops,
+                snapshots,
+            })
+        }
+    })
+    .await
+    .map_err(|e| SyncError::Internal(format!("task join error: {e}")))??;
+
+    Ok(Json(bundle))
+}
+
+/// `POST /api/v1/admin/users/{id}/backup/restore` — restore a per-user encrypted
+/// backup (admin only, ADR-014 D6).
+///
+/// Idempotent: ops are re-inserted by `op_id` and snapshots by natural key, so
+/// re-running is a no-op. The bundle's `user_id` must match the path id, and
+/// libraries are (re)attached under that account. Ciphertext is written back
+/// verbatim — zero-knowledge preserved.
+pub async fn admin_restore_user(
+    State(db_path): State<PathBuf>,
+    user: AuthUser,
+    Path(target_id): Path<String>,
+    Json(bundle): Json<UserBackupBundle>,
+) -> Result<Json<RestoreBackupResponse>, SyncError> {
+    require_admin(&user)?;
+
+    if bundle.user_id != target_id {
+        return Err(SyncError::BadRequest(
+            "backup bundle user_id does not match the target account".into(),
+        ));
+    }
+
+    let resp = tokio::task::spawn_blocking({
+        let db_path = db_path.clone();
+        let target_id = target_id.clone();
+        let actor_id = user.user_id.clone();
+        move || -> Result<RestoreBackupResponse, SyncError> {
+            let db = SyncDatabase::open_no_migrate(&db_path)?;
+
+            // The target account must exist before we can attach libraries to it
+            // (FK libraries.user_id → users.id).
+            let exists: bool = db
+                .conn
+                .query_row("SELECT 1 FROM users WHERE id = ?1", [&target_id], |_| Ok(()))
+                .optional()?
+                .is_some();
+            if !exists {
+                return Err(SyncError::NotFound(format!("user {target_id} not found")));
+            }
+
+            let tx = db.conn.unchecked_transaction()?;
+
+            let mut libraries_restored = 0usize;
+            for lib in &bundle.libraries {
+                let changed = tx.execute(
+                    "INSERT INTO libraries (id, created_at, salt, user_id)
+                     VALUES (?1, ?2, ?3, ?4)
+                     ON CONFLICT(id) DO UPDATE SET user_id = excluded.user_id",
+                    rusqlite::params![lib.id, lib.created_at, lib.salt, target_id],
+                )?;
+                libraries_restored += changed;
+            }
+
+            let mut ops_restored = 0usize;
+            for op in &bundle.ops {
+                let changed = tx.execute(
+                    "INSERT OR IGNORE INTO ops
+                       (op_id, library_id, device_id, hlc, entity_type,
+                        entity_id, op_type, payload, received_at)
+                     VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)",
+                    rusqlite::params![
+                        op.op_id,
+                        op.library_id,
+                        op.device_id,
+                        op.hlc,
+                        op.entity_type,
+                        op.entity_id,
+                        op.op_type,
+                        op.payload,
+                        op.received_at,
+                    ],
+                )?;
+                ops_restored += changed;
+            }
+
+            let mut snapshots_restored = 0usize;
+            for snap in &bundle.snapshots {
+                // Natural-key dedupe (snapshots.id is a synthetic autoincrement).
+                let changed = tx.execute(
+                    "INSERT INTO snapshots
+                       (library_id, snapshot_json, hlc_at_snapshot,
+                        created_by_device, created_at)
+                     SELECT ?1, ?2, ?3, ?4, ?5
+                     WHERE NOT EXISTS (
+                        SELECT 1 FROM snapshots
+                        WHERE library_id = ?1 AND hlc_at_snapshot = ?3
+                          AND created_by_device = ?4
+                     )",
+                    rusqlite::params![
+                        snap.library_id,
+                        snap.snapshot_json,
+                        snap.hlc_at_snapshot,
+                        snap.created_by_device,
+                        snap.created_at,
+                    ],
+                )?;
+                snapshots_restored += changed;
+            }
+
+            crate::security::audit(
+                &db,
+                "user.restore",
+                Some(&actor_id),
+                Some(&target_id),
+                "success",
+                Some(&format!(
+                    "{libraries_restored} libraries, {ops_restored} ops, {snapshots_restored} snapshots"
+                )),
+                None,
+            );
+
+            tx.commit()?;
+
+            Ok(RestoreBackupResponse {
+                libraries_restored,
+                ops_restored,
+                snapshots_restored,
+            })
+        }
+    })
+    .await
+    .map_err(|e| SyncError::Internal(format!("task join error: {e}")))??;
+
+    Ok(Json(resp))
 }
 
 /// `GET /api/v1/admin/registration` — read the open-registration flag (admin only).

--- a/crates/toku-sync/src/lib.rs
+++ b/crates/toku-sync/src/lib.rs
@@ -10,6 +10,8 @@ pub mod config;
 pub mod db;
 pub mod error;
 pub mod handlers;
+pub mod mailer;
+pub mod managed;
 pub mod models;
 pub mod protocol;
 pub mod security;
@@ -22,10 +24,34 @@ use axum::middleware;
 use axum::routing::{delete, get, post};
 use tower_http::trace::TraceLayer;
 
-/// Build the sync server's Axum router, backed by the SQLite database at
-/// `db_path`. The database must already exist with migrations applied (see
-/// [`db::SyncDatabase::open`]).
+pub use managed::ManagedRuntime;
+
+/// Build the sync server's Axum router with the **self-hosted** default managed
+/// runtime (no per-user rate limit, logging-only mailer). Storage/op quotas and
+/// email verification remain governed by `instance_config`, which defaults to
+/// unlimited / disabled. Every existing caller and test keeps today's behaviour.
 pub fn build_router(db_path: PathBuf) -> Router {
+    build_router_with(db_path, ManagedRuntime::default())
+}
+
+/// Build the sync server's Axum router, backed by the SQLite database at
+/// `db_path`, with an explicit [`ManagedRuntime`] carrying opt-in managed-tier
+/// capabilities (per-user rate limiting, SMTP verification delivery). The
+/// database must already exist with migrations applied (see
+/// [`db::SyncDatabase::open`]).
+pub fn build_router_with(db_path: PathBuf, managed: ManagedRuntime) -> Router {
+    // Per-authenticated-user rate limiter (ADR-014 D3), disabled by default.
+    // Applied as an *inner* layer to the auth middleware so it runs after the
+    // owning identity is resolved into the request extensions.
+    let user_limiter = managed.user_rate_limiter.clone();
+    let per_user_rate = {
+        let user_limiter = user_limiter.clone();
+        move |req, next| {
+            let limiter = user_limiter.clone();
+            async move { security::user_rate_limit(limiter, req, next).await }
+        }
+    };
+
     // Routes that require authentication
     let authenticated = Router::new()
         .route("/api/v1/devices", get(handlers::list_devices))
@@ -38,6 +64,7 @@ pub fn build_router(db_path: PathBuf) -> Router {
         .route("/api/v1/snapshot", post(handlers::upload_snapshot))
         .route("/api/v1/rekey", post(handlers::rekey))
         .route("/api/v1/auth/logout", post(handlers::device_logout))
+        .layer(middleware::from_fn(per_user_rate.clone()))
         .layer(middleware::from_fn_with_state(
             db_path.clone(),
             auth::require_auth,
@@ -49,6 +76,16 @@ pub fn build_router(db_path: PathBuf) -> Router {
         .route(
             "/api/v1/admin/users/{id}/status",
             post(handlers::set_user_status),
+        )
+        // Per-user encrypted backup / restore (issue #206, ADR-014 D6). Operator
+        // (admin) scoped; ciphertext + opaque metadata only, ZK preserved.
+        .route(
+            "/api/v1/admin/users/{id}/backup",
+            get(handlers::admin_backup_user),
+        )
+        .route(
+            "/api/v1/admin/users/{id}/backup/restore",
+            post(handlers::admin_restore_user),
         )
         .route(
             "/api/v1/admin/registration",
@@ -79,6 +116,7 @@ pub fn build_router(db_path: PathBuf) -> Router {
         // Zero-knowledge account key bundle for multi-device recovery (#143).
         .route("/api/v1/account/keys", get(handlers::account_keys))
         .route("/api/v1/account/logout", post(handlers::account_logout))
+        .layer(middleware::from_fn(per_user_rate.clone()))
         .layer(middleware::from_fn_with_state(
             db_path.clone(),
             auth::require_user_auth,
@@ -99,6 +137,12 @@ pub fn build_router(db_path: PathBuf) -> Router {
         .route("/api/v1/account/signup", post(auth::account_signup))
         .route("/api/v1/account/challenge", post(auth::account_challenge))
         .route("/api/v1/account/verify", post(auth::account_verify))
+        // Self-serve signup email verification (issue #206, ADR-014 D4).
+        .route("/api/v1/account/verify-email", post(auth::verify_email))
+        .route(
+            "/api/v1/account/resend-verification",
+            post(auth::resend_verification),
+        )
         .layer(middleware::from_fn(move |req, next| {
             let limiter = limiter.clone();
             async move { security::rate_limit(limiter, req, next).await }
@@ -118,6 +162,8 @@ pub fn build_router(db_path: PathBuf) -> Router {
         .route("/health", get(handlers::health))
         .merge(gated)
         .layer(DefaultBodyLimit::max(50 * 1024 * 1024)) // 50 MB (rekey may be large)
+        // Managed-tier capabilities available to every handler (issue #206).
+        .layer(axum::Extension(managed))
         .layer(TraceLayer::new_for_http())
         .with_state(db_path)
 }

--- a/crates/toku-sync/src/mailer.rs
+++ b/crates/toku-sync/src/mailer.rs
@@ -1,0 +1,124 @@
+//! Pluggable outbound email for self-serve signup verification (issue #206,
+//! ADR-014 D4).
+//!
+//! Email is **account metadata**, not library content — the verification link
+//! carries only an opaque one-time token, so this path never touches the
+//! zero-knowledge data boundary. Delivery is intentionally pluggable:
+//!
+//! - [`LoggingMailer`] (default) logs the verification link. This keeps the
+//!   self-hosted and offline relay working with no SMTP dependency, and lets
+//!   tests capture the link without a real mail server.
+//! - [`SmtpMailer`] delivers over SMTP (via `lettre`) and is wired only when the
+//!   operator configures `--smtp-url` / `--smtp-from`.
+
+use std::sync::{Arc, Mutex};
+
+use crate::error::SyncError;
+
+/// Deliver account-lifecycle emails. Implementations must be cheap to clone via
+/// `Arc` and safe to share across request handlers.
+pub trait Mailer: Send + Sync {
+    /// Deliver an email-verification message to `to` containing `verify_url`.
+    fn send_verification(&self, to: &str, verify_url: &str) -> Result<(), SyncError>;
+}
+
+/// Default mailer: logs the verification link instead of sending it. Used when
+/// no SMTP relay is configured (self-hosted / dev) and by the test harness.
+#[derive(Debug, Default, Clone)]
+pub struct LoggingMailer;
+
+impl Mailer for LoggingMailer {
+    fn send_verification(&self, to: &str, verify_url: &str) -> Result<(), SyncError> {
+        tracing::info!(
+            target: "toku_sync::mailer",
+            to,
+            verify_url,
+            "email verification link generated (no SMTP configured — logging only)"
+        );
+        Ok(())
+    }
+}
+
+/// In-memory mailer that records every message. Test-only helper so integration
+/// tests can read back the verification link a real mailer would have sent.
+#[derive(Debug, Default, Clone)]
+pub struct CapturingMailer {
+    sent: Arc<Mutex<Vec<(String, String)>>>,
+}
+
+impl CapturingMailer {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// All `(to, verify_url)` pairs captured so far.
+    pub fn sent(&self) -> Vec<(String, String)> {
+        self.sent.lock().map(|v| v.clone()).unwrap_or_default()
+    }
+
+    /// The most recently captured verification URL, if any.
+    pub fn last_url(&self) -> Option<String> {
+        self.sent
+            .lock()
+            .ok()
+            .and_then(|v| v.last().map(|(_, url)| url.clone()))
+    }
+}
+
+impl Mailer for CapturingMailer {
+    fn send_verification(&self, to: &str, verify_url: &str) -> Result<(), SyncError> {
+        if let Ok(mut sent) = self.sent.lock() {
+            sent.push((to.to_string(), verify_url.to_string()));
+        }
+        Ok(())
+    }
+}
+
+/// SMTP-backed mailer (via `lettre`), used when the operator configures an SMTP
+/// relay. Built from a connection URL such as
+/// `smtps://user:pass@smtp.example.com:465`.
+pub struct SmtpMailer {
+    transport: lettre::SmtpTransport,
+    from: lettre::message::Mailbox,
+}
+
+impl SmtpMailer {
+    /// Construct an SMTP mailer from a relay URL and a `From:` mailbox. Returns
+    /// an error if either is malformed; delivery failures surface later, per
+    /// send.
+    pub fn from_config(url: &str, from: &str) -> Result<Self, SyncError> {
+        let transport = lettre::SmtpTransport::from_url(url)
+            .map_err(|e| SyncError::Internal(format!("invalid SMTP url: {e}")))?
+            .build();
+        let from = from
+            .parse::<lettre::message::Mailbox>()
+            .map_err(|e| SyncError::Internal(format!("invalid SMTP from address: {e}")))?;
+        Ok(Self { transport, from })
+    }
+}
+
+impl Mailer for SmtpMailer {
+    fn send_verification(&self, to: &str, verify_url: &str) -> Result<(), SyncError> {
+        use lettre::Transport;
+        use lettre::message::header::ContentType;
+
+        let to_mbox = to
+            .parse::<lettre::message::Mailbox>()
+            .map_err(|e| SyncError::BadRequest(format!("invalid recipient address: {e}")))?;
+
+        let email = lettre::Message::builder()
+            .from(self.from.clone())
+            .to(to_mbox)
+            .subject("Verify your Toku sync account")
+            .header(ContentType::TEXT_PLAIN)
+            .body(format!(
+                "Confirm your email address to activate your Toku sync account:\n\n{verify_url}\n\nIf you did not request this, you can ignore this message.\n"
+            ))
+            .map_err(|e| SyncError::Internal(format!("failed to build email: {e}")))?;
+
+        self.transport
+            .send(&email)
+            .map_err(|e| SyncError::Internal(format!("failed to send verification email: {e}")))?;
+        Ok(())
+    }
+}

--- a/crates/toku-sync/src/main.rs
+++ b/crates/toku-sync/src/main.rs
@@ -1,8 +1,12 @@
+use std::sync::Arc;
+use std::time::Duration;
+
 use clap::Parser;
 
-use toku_sync::build_router;
 use toku_sync::config::Config;
 use toku_sync::db::SyncDatabase;
+use toku_sync::mailer::{LoggingMailer, Mailer, SmtpMailer};
+use toku_sync::{ManagedRuntime, build_router_with};
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
@@ -17,11 +21,17 @@ async fn main() -> anyhow::Result<()> {
     init_tracing(&config.log_level);
     let db_path = config.db_path();
 
-    // Run migrations once at startup
-    SyncDatabase::open(&db_path)
+    // Run migrations once at startup, then project the managed-tier operator
+    // knobs into `instance_config` so the DB-driven enforcement paths (quotas,
+    // email verification) observe this process's configuration.
+    let db = SyncDatabase::open(&db_path)
         .map_err(|e| anyhow::anyhow!("failed to initialize database: {e}"))?;
+    seed_instance_config(&db, &config)
+        .map_err(|e| anyhow::anyhow!("failed to apply managed config: {e}"))?;
+    drop(db);
 
-    let app = build_router(db_path);
+    let managed = build_managed_runtime(&config)?;
+    let app = build_router_with(db_path, managed);
     let addr = config.bind_addr();
 
     let listener = tokio::net::TcpListener::bind(&addr).await?;
@@ -38,6 +48,59 @@ async fn main() -> anyhow::Result<()> {
     .await?;
 
     Ok(())
+}
+
+/// Project the managed-tier operator knobs from [`Config`] into the singleton
+/// `instance_config` row. These are deployment-level settings, so config is the
+/// source of truth on every boot. Admin-managed flags (e.g. `registration_open`)
+/// are intentionally left untouched.
+fn seed_instance_config(db: &SyncDatabase, config: &Config) -> anyhow::Result<()> {
+    db.conn.execute(
+        "UPDATE instance_config
+         SET require_email_verification = ?1,
+             default_max_user_bytes = ?2,
+             default_max_user_ops = ?3,
+             updated_at = datetime('now')
+         WHERE id = 1",
+        rusqlite::params![
+            i64::from(config.require_email_verification),
+            config.default_max_user_bytes,
+            config.default_max_user_ops,
+        ],
+    )?;
+    Ok(())
+}
+
+/// Assemble the [`ManagedRuntime`] from config. Defaults reproduce the
+/// self-hosted relay (logging mailer, disabled per-user limiter). Fails fast if
+/// email verification is required without a way to deliver the link.
+fn build_managed_runtime(config: &Config) -> anyhow::Result<ManagedRuntime> {
+    let mailer: Arc<dyn Mailer> = match (&config.smtp_url, &config.smtp_from) {
+        (Some(url), Some(from)) => Arc::new(
+            SmtpMailer::from_config(url, from)
+                .map_err(|e| anyhow::anyhow!("failed to configure SMTP mailer: {e}"))?,
+        ),
+        (None, None) => Arc::new(LoggingMailer),
+        _ => {
+            anyhow::bail!("--smtp-url and --smtp-from must be set together");
+        }
+    };
+
+    if config.require_email_verification
+        && (config.smtp_url.is_none() || config.public_base_url.is_none())
+    {
+        anyhow::bail!(
+            "--require-email-verification needs --smtp-url, --smtp-from, and --public-base-url so \
+             verification links can be delivered"
+        );
+    }
+
+    Ok(ManagedRuntime::new(
+        mailer,
+        config.public_base_url.clone(),
+        config.per_user_rate_max,
+        Duration::from_secs(config.per_user_rate_window_secs),
+    ))
 }
 
 /// Initialise the tracing subscriber. `RUST_LOG` takes precedence; otherwise the
@@ -102,6 +165,7 @@ mod tests {
 
     use axum::body::Body;
     use axum::http::{Request, StatusCode};
+    use toku_sync::build_router;
     use tower::ServiceExt;
 
     fn test_db_path() -> PathBuf {

--- a/crates/toku-sync/src/managed.rs
+++ b/crates/toku-sync/src/managed.rs
@@ -1,0 +1,65 @@
+//! Managed-tier runtime wiring (issue #206, ADR-014).
+//!
+//! [`ManagedRuntime`] carries the process-level, opt-in managed-tier
+//! capabilities that cannot live in the database: the outbound [`Mailer`] used
+//! for signup verification and the in-memory per-user [`UserRateLimiter`]. It is
+//! attached to the router as an axum `Extension` so handlers and middleware can
+//! read it.
+//!
+//! The [`Default`] impl is the **self-hosted** configuration — a logging-only
+//! mailer and a disabled per-user limiter — so `build_router` (and therefore the
+//! test harness and every existing caller) behaves exactly as before. A managed
+//! operator constructs a configured runtime via [`ManagedRuntime::new`].
+//!
+//! Storage- and op-count quotas and the `require_email_verification` toggle are
+//! deliberately **not** here: they live in `instance_config` / `user_quota` and
+//! are read from the database per request, so they need no process wiring.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use crate::mailer::{LoggingMailer, Mailer};
+use crate::security::UserRateLimiter;
+
+/// Process-level managed-tier capabilities, shared across handlers via an axum
+/// `Extension`. Cheap to clone (everything is `Arc`-backed).
+#[derive(Clone)]
+pub struct ManagedRuntime {
+    /// Outbound mail transport for signup verification links.
+    pub mailer: Arc<dyn Mailer>,
+    /// Public base URL used to build verification links (e.g.
+    /// `https://sync.example.com`). `None` when unconfigured.
+    pub public_base_url: Option<String>,
+    /// Per-authenticated-user rate limiter (disabled by default).
+    pub user_rate_limiter: Arc<UserRateLimiter>,
+}
+
+impl Default for ManagedRuntime {
+    fn default() -> Self {
+        Self {
+            mailer: Arc::new(LoggingMailer),
+            public_base_url: None,
+            user_rate_limiter: Arc::new(UserRateLimiter::new(0, Duration::from_secs(60))),
+        }
+    }
+}
+
+impl ManagedRuntime {
+    /// Build a configured managed runtime. A `per_user_rate_max` of `0` leaves
+    /// the per-user limiter disabled.
+    pub fn new(
+        mailer: Arc<dyn Mailer>,
+        public_base_url: Option<String>,
+        per_user_rate_max: u32,
+        per_user_rate_window: Duration,
+    ) -> Self {
+        Self {
+            mailer,
+            public_base_url,
+            user_rate_limiter: Arc::new(UserRateLimiter::new(
+                per_user_rate_max,
+                per_user_rate_window,
+            )),
+        }
+    }
+}

--- a/crates/toku-sync/src/models.rs
+++ b/crates/toku-sync/src/models.rs
@@ -220,6 +220,11 @@ pub struct SignupResponse {
     /// Relay devices adopted under this account during first-admin bootstrap.
     #[serde(default)]
     pub adopted_devices: i64,
+    /// `true` when the instance requires email verification (ADR-014 D4) and this
+    /// account must confirm its address before it can log in. `false` for the
+    /// default self-hosted relay, which never gates on verification.
+    #[serde(default)]
+    pub email_verification_required: bool,
 }
 
 /// `POST /api/v1/account/challenge` — start a user SRP login.
@@ -391,4 +396,85 @@ pub struct AccountKeysResponse {
     pub wrapped_private_key: String,
     /// JSON-serialized `toku_core::WrappedDataKey`.
     pub wrapped_data_key: String,
+}
+
+// ── Signup email verification (issue #206, ADR-014 D4) ───────────────────────
+
+/// `POST /api/v1/account/verify-email` — confirm control of a signup email.
+#[derive(Debug, Deserialize)]
+pub struct VerifyEmailRequest {
+    /// The opaque one-time token delivered by email.
+    pub token: String,
+}
+
+#[derive(Debug, Serialize)]
+pub struct VerifyEmailResponse {
+    pub verified: bool,
+}
+
+/// `POST /api/v1/account/resend-verification` — re-issue a verification email.
+#[derive(Debug, Deserialize)]
+pub struct ResendVerificationRequest {
+    pub email: String,
+}
+
+// ── Per-user encrypted backup (issue #206, ADR-014 D6) ───────────────────────
+
+/// Opaque library metadata carried in a per-user backup. No plaintext content.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct BackupLibrary {
+    pub id: String,
+    pub salt: Option<String>,
+    pub created_at: String,
+}
+
+/// A single stored op in a per-user backup. `payload` is the verbatim stored
+/// ciphertext envelope string (or `"null"`); every other field is opaque
+/// metadata the relay already holds in the clear.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct BackupOp {
+    pub op_id: String,
+    pub library_id: String,
+    pub device_id: String,
+    pub hlc: String,
+    pub entity_type: String,
+    pub entity_id: String,
+    pub op_type: String,
+    pub payload: String,
+    pub received_at: String,
+}
+
+/// A single stored snapshot in a per-user backup. `snapshot_json` is verbatim
+/// ciphertext.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct BackupSnapshot {
+    pub library_id: String,
+    pub snapshot_json: String,
+    pub hlc_at_snapshot: String,
+    pub created_by_device: String,
+    pub created_at: String,
+}
+
+/// A per-account encrypted backup bundle (ADR-014 D6): ciphertext ops +
+/// snapshots plus opaque library metadata, scoped by ownership. Contains **no**
+/// plaintext user content and **no** key material — the zero-knowledge boundary
+/// is preserved end-to-end, including in the backup.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct UserBackupBundle {
+    /// Bundle format version.
+    pub version: u32,
+    pub user_id: String,
+    pub email: String,
+    pub exported_at: String,
+    pub libraries: Vec<BackupLibrary>,
+    pub ops: Vec<BackupOp>,
+    pub snapshots: Vec<BackupSnapshot>,
+}
+
+/// Response to `POST /api/v1/admin/users/{id}/backup/restore`.
+#[derive(Debug, Serialize)]
+pub struct RestoreBackupResponse {
+    pub libraries_restored: usize,
+    pub ops_restored: usize,
+    pub snapshots_restored: usize,
 }

--- a/crates/toku-sync/src/security.rs
+++ b/crates/toku-sync/src/security.rs
@@ -226,3 +226,97 @@ pub async fn rate_limit(
     }
     Ok(next.run(req).await)
 }
+
+// ── Per-authenticated-user rate limiting (issue #206, ADR-014 D3) ─────────────
+
+/// A fixed-window limiter keyed by an arbitrary string identity (the resolved
+/// `user_id`), layered *above* the per-IP [`RateLimiter`]. Per-IP limiting is
+/// insufficient at scale — many users share an IP (NAT, mobile carriers) and one
+/// abusive account behind rotating IPs evades an IP bucket entirely — so the
+/// managed tier keys a second window on the authenticated user.
+///
+/// A `max` of `0` disables the limiter entirely, which is the self-hosted
+/// default: the per-IP + global limiter remains as defense-in-depth.
+pub struct UserRateLimiter {
+    inner: Mutex<KeyedWindow>,
+    per_key_max: u32,
+    window: Duration,
+}
+
+struct KeyedWindow {
+    started: Instant,
+    per_key: HashMap<String, u32>,
+}
+
+impl UserRateLimiter {
+    /// Create a per-user limiter. `per_key_max == 0` means "disabled".
+    pub fn new(per_key_max: u32, window: Duration) -> Self {
+        Self {
+            inner: Mutex::new(KeyedWindow {
+                started: Instant::now(),
+                per_key: HashMap::new(),
+            }),
+            per_key_max,
+            window,
+        }
+    }
+
+    /// True when this limiter enforces anything at all.
+    pub fn enabled(&self) -> bool {
+        self.per_key_max > 0
+    }
+
+    /// Record a request from identity `key`. Returns `Some(retry_after_secs)`
+    /// when the request should be rejected, or `None` when it is allowed. A
+    /// disabled limiter always allows.
+    pub fn check(&self, key: &str) -> Option<u64> {
+        if self.per_key_max == 0 {
+            return None;
+        }
+        let mut w = self.inner.lock().unwrap_or_else(|e| e.into_inner());
+        if w.started.elapsed() >= self.window {
+            w.started = Instant::now();
+            w.per_key.clear();
+        }
+        let retry_after = self.window.saturating_sub(w.started.elapsed()).as_secs() + 1;
+
+        let entry = w.per_key.entry(key.to_string()).or_insert(0);
+        if *entry >= self.per_key_max {
+            return Some(retry_after);
+        }
+        *entry += 1;
+        None
+    }
+}
+
+/// Axum middleware enforcing [`UserRateLimiter`]. Runs *after* the auth
+/// middleware (so [`crate::auth::AuthDevice`] / [`crate::auth::AuthUser`] are in
+/// the request extensions) and keys its window on the resolved `user_id`.
+/// Requests without a resolved owning user (legacy unowned relay devices) are
+/// not per-user limited — they still pass through the per-IP limiter.
+pub async fn user_rate_limit(
+    limiter: Arc<UserRateLimiter>,
+    req: Request,
+    next: Next,
+) -> Result<Response, SyncError> {
+    if limiter.enabled()
+        && let Some(user_id) = resolved_user_id(&req)
+        && let Some(retry_after) = limiter.check(&user_id)
+    {
+        return Err(SyncError::RateLimited {
+            retry_after: format!("{retry_after}s"),
+        });
+    }
+    Ok(next.run(req).await)
+}
+
+/// Extract the resolved owning `user_id` from request extensions, from either an
+/// authenticated user session or an authenticated device that belongs to a user.
+fn resolved_user_id(req: &Request) -> Option<String> {
+    if let Some(user) = req.extensions().get::<crate::auth::AuthUser>() {
+        return Some(user.user_id.clone());
+    }
+    req.extensions()
+        .get::<crate::auth::AuthDevice>()
+        .and_then(|d| d.user_id.clone())
+}

--- a/crates/toku-sync/tests/harness/mod.rs
+++ b/crates/toku-sync/tests/harness/mod.rs
@@ -31,8 +31,8 @@ use toku_core::{
     ReadingStatus, SyncOp, TagType,
 };
 use toku_db::{BookRepository, Database, MergeEngine, SyncRepository};
-use toku_sync::build_router;
 use toku_sync::db::SyncDatabase;
+use toku_sync::{ManagedRuntime, build_router_with};
 use uuid::Uuid;
 
 /// Ensure the token store never touches the OS keychain during tests.
@@ -66,6 +66,12 @@ pub struct TestServer {
 impl TestServer {
     /// Start a fresh server with an empty, migrated database.
     pub fn start() -> Self {
+        Self::start_managed(ManagedRuntime::default())
+    }
+
+    /// Start a fresh server with an explicit [`ManagedRuntime`] (managed-tier
+    /// capabilities such as a capturing mailer or per-user rate limiter).
+    pub fn start_managed(managed: ManagedRuntime) -> Self {
         let tempdir = tempfile::tempdir().expect("create server temp dir");
         let db_path = tempdir.path().join("server.db");
 
@@ -84,7 +90,7 @@ impl TestServer {
             .expect("bind loopback listener");
         let addr = listener.local_addr().expect("read local addr");
 
-        let router = build_router(db_path);
+        let router = build_router_with(db_path, managed);
         runtime.spawn(async move {
             axum::serve(listener, router).await.expect("serve");
         });

--- a/crates/toku-sync/tests/quotas.rs
+++ b/crates/toku-sync/tests/quotas.rs
@@ -1,0 +1,238 @@
+//! Per-user storage / op-count quota tests (issue #206, ADR-014 D2).
+//!
+//! The quota check enforces per-account ceilings on the push and snapshot
+//! ingest paths while preserving zero-knowledge — it reads only ciphertext
+//! *sizes* and *counts*, never plaintext. These tests assert:
+//!   * an over-byte push is rejected with 413 and nothing is persisted;
+//!   * an over-op-count push is rejected with 413;
+//!   * the instance-wide default ceiling applies to owned accounts;
+//!   * a library with no owning account (self-hosted open relay) is exempt.
+
+mod harness;
+
+use harness::{SimulatedDevice, TestServer};
+use serde_json::json;
+use tokio::runtime::Runtime;
+use toku_core::{EntityType, HybridClock, OpType};
+use toku_sync::db::SyncDatabase;
+use uuid::Uuid;
+
+fn rt() -> Runtime {
+    Runtime::new().expect("tokio runtime")
+}
+
+async fn post(
+    base_url: &str,
+    path: &str,
+    token: &str,
+    body: serde_json::Value,
+) -> (reqwest::StatusCode, String) {
+    let resp = reqwest::Client::new()
+        .post(format!("{base_url}{path}"))
+        .bearer_auth(token)
+        .json(&body)
+        .send()
+        .await
+        .expect("request sent");
+    let status = resp.status();
+    let text = resp.text().await.unwrap_or_default();
+    (status, text)
+}
+
+fn hlc_for(device_id: Uuid) -> String {
+    HybridClock::new(&device_id).now().to_canonical()
+}
+
+/// An encrypted `Create` op for `device`, targeting a fresh entity.
+fn encrypted_op(device: &SimulatedDevice, server: &TestServer) -> serde_json::Value {
+    let key = device.sync_key(server);
+    let entity_id = Uuid::now_v7();
+    let envelope = toku_core::encrypt_fields(
+        &key,
+        &json!({ "title": "quota probe payload that is comfortably over ten bytes" }),
+        &EntityType::Book,
+        &entity_id,
+        &OpType::Create,
+    )
+    .expect("encrypt fields");
+    json!({
+        "op_id": Uuid::now_v7().to_string(),
+        "device_id": device.device_id().to_string(),
+        "hlc": hlc_for(device.device_id()),
+        "entity_type": EntityType::Book.as_str(),
+        "entity_id": entity_id.to_string(),
+        "op_type": OpType::Create.as_str(),
+        "payload": serde_json::to_value(&envelope).unwrap(),
+    })
+}
+
+/// Attach `library_id` to a freshly-created owning account and return that
+/// account's id. Mirrors what admin adoption / account enrollment does, but
+/// keeps the test focused on quota logic.
+fn own_library(server: &TestServer, library_id: &str) -> String {
+    let user_id = Uuid::now_v7().to_string();
+    let db = SyncDatabase::open_no_migrate(&server.db_path()).expect("open server db");
+    db.conn
+        .execute(
+            "INSERT INTO users (id, email, srp_salt, srp_verifier, created_at)
+             VALUES (?1, ?2, 'aa', 'bb', datetime('now'))",
+            rusqlite::params![user_id, format!("{user_id}@example.com")],
+        )
+        .expect("insert owning user");
+    db.conn
+        .execute(
+            "UPDATE libraries SET user_id = ?1 WHERE id = ?2",
+            rusqlite::params![user_id, library_id],
+        )
+        .expect("attach library to user");
+    user_id
+}
+
+fn set_user_quota(
+    server: &TestServer,
+    user_id: &str,
+    max_bytes: Option<i64>,
+    max_ops: Option<i64>,
+) {
+    let db = SyncDatabase::open_no_migrate(&server.db_path()).expect("open server db");
+    db.conn
+        .execute(
+            "INSERT INTO user_quota (user_id, max_bytes, max_ops, updated_at)
+             VALUES (?1, ?2, ?3, datetime('now'))",
+            rusqlite::params![user_id, max_bytes, max_ops],
+        )
+        .expect("set user quota");
+}
+
+fn stored_op_count(server: &TestServer, library_id: &str) -> i64 {
+    let db = SyncDatabase::open_no_migrate(&server.db_path()).expect("open server db");
+    db.conn
+        .query_row(
+            "SELECT COUNT(*) FROM ops WHERE library_id = ?1",
+            [library_id],
+            |r| r.get(0),
+        )
+        .expect("count ops")
+}
+
+#[test]
+fn over_byte_quota_rejected_with_413() {
+    let server = TestServer::start();
+    let device = SimulatedDevice::register(&server, "quota-bytes", "device-a", None);
+    let token = device.auth_token(&server);
+    let user_id = own_library(&server, "quota-bytes");
+    // A 10-byte ceiling is smaller than any real encrypted envelope.
+    set_user_quota(&server, &user_id, Some(10), None);
+
+    let op = encrypted_op(&device, &server);
+    let (status, body) = rt().block_on(post(
+        server.base_url(),
+        "/api/v1/push",
+        &token,
+        json!({ "ops": [op] }),
+    ));
+
+    assert_eq!(
+        status,
+        reqwest::StatusCode::PAYLOAD_TOO_LARGE,
+        "over-byte push must be rejected with 413; body: {body}"
+    );
+    assert_eq!(
+        stored_op_count(&server, "quota-bytes"),
+        0,
+        "a quota-rejected op must not be persisted"
+    );
+}
+
+#[test]
+fn over_op_count_quota_rejected_with_413() {
+    let server = TestServer::start();
+    let device = SimulatedDevice::register(&server, "quota-ops", "device-a", None);
+    let token = device.auth_token(&server);
+    let user_id = own_library(&server, "quota-ops");
+    // Generous byte ceiling, zero op-count headroom.
+    set_user_quota(&server, &user_id, Some(1_000_000), Some(0));
+
+    let op = encrypted_op(&device, &server);
+    let (status, body) = rt().block_on(post(
+        server.base_url(),
+        "/api/v1/push",
+        &token,
+        json!({ "ops": [op] }),
+    ));
+
+    assert_eq!(
+        status,
+        reqwest::StatusCode::PAYLOAD_TOO_LARGE,
+        "over-op-count push must be rejected with 413; body: {body}"
+    );
+    assert_eq!(stored_op_count(&server, "quota-ops"), 0);
+}
+
+#[test]
+fn instance_default_ceiling_applies_to_owned_accounts() {
+    let server = TestServer::start();
+    let device = SimulatedDevice::register(&server, "quota-default", "device-a", None);
+    let token = device.auth_token(&server);
+    own_library(&server, "quota-default");
+    // No per-user override: the instance-wide default must be the fallback.
+    {
+        let db = SyncDatabase::open_no_migrate(&server.db_path()).expect("open server db");
+        db.conn
+            .execute(
+                "UPDATE instance_config SET default_max_user_bytes = 10 WHERE id = 1",
+                [],
+            )
+            .expect("set instance default");
+    }
+
+    let op = encrypted_op(&device, &server);
+    let (status, body) = rt().block_on(post(
+        server.base_url(),
+        "/api/v1/push",
+        &token,
+        json!({ "ops": [op] }),
+    ));
+
+    assert_eq!(
+        status,
+        reqwest::StatusCode::PAYLOAD_TOO_LARGE,
+        "instance default ceiling must apply to owned accounts; body: {body}"
+    );
+}
+
+#[test]
+fn unowned_library_is_exempt_from_quota() {
+    let server = TestServer::start();
+    let device = SimulatedDevice::register(&server, "quota-exempt", "device-a", None);
+    let token = device.auth_token(&server);
+    // Library is left unowned (self-hosted open-relay model). Even a tiny
+    // instance-wide ceiling must not apply.
+    {
+        let db = SyncDatabase::open_no_migrate(&server.db_path()).expect("open server db");
+        db.conn
+            .execute(
+                "UPDATE instance_config SET default_max_user_bytes = 1 WHERE id = 1",
+                [],
+            )
+            .expect("set instance default");
+    }
+
+    let op = encrypted_op(&device, &server);
+    let (status, body) = rt().block_on(post(
+        server.base_url(),
+        "/api/v1/push",
+        &token,
+        json!({ "ops": [op] }),
+    ));
+
+    assert!(
+        status.is_success(),
+        "unowned (self-hosted) library must be exempt from quotas; status {status}, body: {body}"
+    );
+    assert_eq!(
+        stored_op_count(&server, "quota-exempt"),
+        1,
+        "the accepted op should be persisted"
+    );
+}

--- a/crates/toku-sync/tests/rate_limit_user.rs
+++ b/crates/toku-sync/tests/rate_limit_user.rs
@@ -1,0 +1,109 @@
+//! Per-authenticated-user rate limiting tests (issue #206, ADR-014 D3).
+//!
+//! The managed tier layers a per-user request window *above* the per-IP + global
+//! limiter. These tests assert that one user hitting the ceiling is throttled
+//! (429) while a second user is unaffected, and that the limiter is disabled by
+//! default (self-hosted relay unchanged).
+
+mod harness;
+
+use harness::{SimulatedDevice, TestServer};
+use std::sync::Arc;
+use std::time::Duration;
+use tokio::runtime::Runtime;
+use toku_sync::ManagedRuntime;
+use toku_sync::db::SyncDatabase;
+use toku_sync::mailer::LoggingMailer;
+
+fn rt() -> Runtime {
+    Runtime::new().expect("tokio runtime")
+}
+
+/// GET `path` with a bearer token; return the HTTP status.
+fn get_status(base_url: &str, path: &str, token: &str) -> reqwest::StatusCode {
+    rt().block_on(async {
+        reqwest::Client::new()
+            .get(format!("{base_url}{path}"))
+            .bearer_auth(token)
+            .send()
+            .await
+            .expect("request sent")
+            .status()
+    })
+}
+
+/// Attach `library_id` to a fresh owning account so per-user limiting engages
+/// (unowned libraries are intentionally exempt).
+fn own_library(server: &TestServer, library_id: &str) -> String {
+    let user_id = uuid::Uuid::now_v7().to_string();
+    let db = SyncDatabase::open_no_migrate(&server.db_path()).expect("open server db");
+    db.conn
+        .execute(
+            "INSERT INTO users (id, email, srp_salt, srp_verifier, created_at)
+             VALUES (?1, ?2, 'aa', 'bb', datetime('now'))",
+            rusqlite::params![user_id, format!("{user_id}@example.com")],
+        )
+        .expect("insert user");
+    db.conn
+        .execute(
+            "UPDATE libraries SET user_id = ?1 WHERE id = ?2",
+            rusqlite::params![user_id, library_id],
+        )
+        .expect("attach library");
+    user_id
+}
+
+fn managed_with_user_rate(max: u32) -> ManagedRuntime {
+    ManagedRuntime::new(Arc::new(LoggingMailer), None, max, Duration::from_secs(60))
+}
+
+#[test]
+fn per_user_limit_throttles_one_user_not_another() {
+    // Allow 3 requests per user per window.
+    let server = TestServer::start_managed(managed_with_user_rate(3));
+
+    let device_a = SimulatedDevice::register(&server, "rl-user-a", "device-a", None);
+    let device_b = SimulatedDevice::register(&server, "rl-user-b", "device-b", None);
+    own_library(&server, "rl-user-a");
+    own_library(&server, "rl-user-b");
+
+    let token_a = device_a.auth_token(&server);
+    let token_b = device_b.auth_token(&server);
+
+    // User A: the 4th request within the window must be throttled.
+    let mut throttled = false;
+    for _ in 0..4 {
+        let status = get_status(server.base_url(), "/api/v1/salt", &token_a);
+        if status == reqwest::StatusCode::TOO_MANY_REQUESTS {
+            throttled = true;
+        }
+    }
+    assert!(throttled, "user A should hit the per-user ceiling");
+
+    // User B shares the server but has its own bucket — unaffected.
+    let status_b = get_status(server.base_url(), "/api/v1/salt", &token_b);
+    assert_ne!(
+        status_b,
+        reqwest::StatusCode::TOO_MANY_REQUESTS,
+        "a second user must not be throttled by user A's traffic"
+    );
+}
+
+#[test]
+fn per_user_limit_disabled_by_default() {
+    // Default runtime: per-user limiter off. Many authed requests from one user
+    // must all pass (the per-IP limiter's default ceiling is far higher).
+    let server = TestServer::start();
+    let device = SimulatedDevice::register(&server, "rl-off", "device-a", None);
+    own_library(&server, "rl-off");
+    let token = device.auth_token(&server);
+
+    for _ in 0..10 {
+        let status = get_status(server.base_url(), "/api/v1/salt", &token);
+        assert_ne!(
+            status,
+            reqwest::StatusCode::TOO_MANY_REQUESTS,
+            "per-user limiting must be off by default"
+        );
+    }
+}

--- a/crates/toku-sync/tests/signup_verification.rs
+++ b/crates/toku-sync/tests/signup_verification.rs
@@ -1,0 +1,301 @@
+//! Self-serve signup email-verification tests (issue #206, ADR-014 D4).
+//!
+//! When an instance turns on `require_email_verification`, a new non-admin
+//! signup starts unverified and cannot obtain a session until it confirms its
+//! address via the emailed token. The admin bootstrap is always auto-verified,
+//! and with the flag off the flow is byte-for-byte the pre-existing behaviour.
+
+mod harness;
+
+use harness::TestServer;
+use serde_json::json;
+use sha2::{Digest, Sha256};
+use srp::ClientG2048;
+use std::sync::Arc;
+use std::time::Duration;
+use tokio::runtime::Runtime;
+use toku_sync::ManagedRuntime;
+use toku_sync::db::SyncDatabase;
+use toku_sync::mailer::CapturingMailer;
+
+fn rt() -> Runtime {
+    Runtime::new().expect("tokio runtime")
+}
+
+async fn post(
+    base_url: &str,
+    path: &str,
+    body: serde_json::Value,
+) -> (reqwest::StatusCode, String) {
+    let resp = reqwest::Client::new()
+        .post(format!("{base_url}{path}"))
+        .json(&body)
+        .send()
+        .await
+        .expect("request sent");
+    let status = resp.status();
+    let text = resp.text().await.unwrap_or_default();
+    (status, text)
+}
+
+// ── SRP helpers ───────────────────────────────────────────────────────────────
+
+fn salt_for(email: &str) -> Vec<u8> {
+    Sha256::digest(format!("salt:{email}").as_bytes())[..16].to_vec()
+}
+
+fn verifier_hex(email: &str, password: &str, salt: &[u8]) -> String {
+    let client = ClientG2048::<Sha256>::new();
+    hex::encode(client.compute_verifier(email.as_bytes(), password.as_bytes(), salt))
+}
+
+fn signup(server: &TestServer, email: &str, password: &str) -> (u16, serde_json::Value) {
+    let salt = salt_for(email);
+    let body = json!({
+        "email": email,
+        "srp_salt": hex::encode(&salt),
+        "srp_verifier": verifier_hex(email, password, &salt),
+    });
+    let (status, text) = rt().block_on(post(server.base_url(), "/api/v1/account/signup", body));
+    (
+        status.as_u16(),
+        serde_json::from_str(&text).unwrap_or(serde_json::Value::Null),
+    )
+}
+
+/// Attempt an SRP login; returns the HTTP status (200 = session issued).
+fn login_status(server: &TestServer, email: &str, password: &str) -> u16 {
+    use rand::RngExt;
+    let client = ClientG2048::<Sha256>::new();
+    let mut a = [0u8; 48];
+    rand::rng().fill(&mut a);
+    let a_pub = client.compute_public_ephemeral(&a);
+
+    let (status, challenge) = rt().block_on(post(
+        server.base_url(),
+        "/api/v1/account/challenge",
+        json!({ "email": email, "client_public_a": hex::encode(&a_pub) }),
+    ));
+    if status != reqwest::StatusCode::OK {
+        return status.as_u16();
+    }
+    let challenge: serde_json::Value = serde_json::from_str(&challenge).unwrap();
+    let challenge_id = challenge["challenge_id"].as_str().unwrap();
+    let server_b = hex::decode(challenge["server_public_b"].as_str().unwrap()).unwrap();
+    let salt = hex::decode(challenge["srp_salt"].as_str().unwrap()).unwrap();
+    let verifier = client
+        .process_reply(&a, email.as_bytes(), password.as_bytes(), &salt, &server_b)
+        .expect("process_reply");
+    let m1 = hex::encode(verifier.proof());
+
+    let (status, _) = rt().block_on(post(
+        server.base_url(),
+        "/api/v1/account/verify",
+        json!({ "challenge_id": challenge_id, "client_proof_m1": m1 }),
+    ));
+    status.as_u16()
+}
+
+/// Turn on `require_email_verification` on a running server's database and open
+/// registration so a second (non-admin) account can sign up.
+fn enable_verification_and_registration(server: &TestServer) {
+    let db = SyncDatabase::open_no_migrate(&server.db_path()).expect("open server db");
+    db.conn
+        .execute(
+            "UPDATE instance_config
+             SET require_email_verification = 1, registration_open = 1 WHERE id = 1",
+            [],
+        )
+        .expect("enable verification");
+}
+
+/// Extract the `token` query parameter from a captured verification URL.
+fn token_from_url(url: &str) -> String {
+    url.split("token=")
+        .nth(1)
+        .expect("verify url carries a token")
+        .to_string()
+}
+
+fn managed_with(mailer: CapturingMailer) -> ManagedRuntime {
+    ManagedRuntime::new(
+        Arc::new(mailer),
+        Some("https://sync.test".to_string()),
+        0,
+        Duration::from_secs(60),
+    )
+}
+
+#[test]
+fn unverified_user_cannot_log_in_until_verified() {
+    let mailer = CapturingMailer::new();
+    let server = TestServer::start_managed(managed_with(mailer.clone()));
+
+    // Admin bootstrap: always auto-verified, and can log in immediately even
+    // with the flag on.
+    let (status, admin_body) = signup(&server, "admin@example.com", "correct horse");
+    assert_eq!(status, 200, "admin signup should succeed");
+    assert_eq!(
+        admin_body["email_verification_required"], false,
+        "admin bootstrap is never gated on verification"
+    );
+    assert_eq!(
+        login_status(&server, "admin@example.com", "correct horse"),
+        200,
+        "admin can log in without verifying"
+    );
+
+    // Now require verification for subsequent signups.
+    enable_verification_and_registration(&server);
+
+    let (status, body) = signup(&server, "user@example.com", "hunter2 hunter2");
+    assert_eq!(status, 200, "user signup should still succeed");
+    assert_eq!(
+        body["email_verification_required"], true,
+        "the new user must be told verification is required"
+    );
+
+    // Before verifying, login is blocked with 403 even with the right password.
+    assert_eq!(
+        login_status(&server, "user@example.com", "hunter2 hunter2"),
+        403,
+        "unverified user must be blocked from logging in"
+    );
+
+    // The mailer captured a verification link; redeem its token.
+    let url = mailer.last_url().expect("a verification email was sent");
+    let token = token_from_url(&url);
+    let (status, body) = rt().block_on(post(
+        server.base_url(),
+        "/api/v1/account/verify-email",
+        json!({ "token": token }),
+    ));
+    assert_eq!(
+        status,
+        reqwest::StatusCode::OK,
+        "verify-email failed: {body}"
+    );
+
+    // After verifying, login succeeds.
+    assert_eq!(
+        login_status(&server, "user@example.com", "hunter2 hunter2"),
+        200,
+        "verified user can log in"
+    );
+}
+
+#[test]
+fn verification_disabled_by_default() {
+    // Default runtime + default instance config = no verification gate.
+    let server = TestServer::start();
+    let (status, body) = signup(&server, "admin@example.com", "correct horse");
+    assert_eq!(status, 200);
+    assert_eq!(
+        body["email_verification_required"], false,
+        "verification must be off by default (self-hosted)"
+    );
+    assert_eq!(
+        login_status(&server, "admin@example.com", "correct horse"),
+        200,
+        "login works without any verification step by default"
+    );
+}
+
+#[test]
+fn invalid_verification_token_is_rejected() {
+    let mailer = CapturingMailer::new();
+    let server = TestServer::start_managed(managed_with(mailer));
+    let (status, body) = rt().block_on(post(
+        server.base_url(),
+        "/api/v1/account/verify-email",
+        json!({ "token": "not-a-real-token" }),
+    ));
+    assert_eq!(
+        status,
+        reqwest::StatusCode::BAD_REQUEST,
+        "an unknown token must be rejected; body: {body}"
+    );
+}
+
+#[test]
+fn resend_issues_a_working_verification_token() {
+    let mailer = CapturingMailer::new();
+    let server = TestServer::start_managed(managed_with(mailer.clone()));
+
+    // Admin bootstrap (auto-verified), then require verification for the next user.
+    let (status, _) = signup(&server, "admin@example.com", "correct horse");
+    assert_eq!(status, 200);
+    enable_verification_and_registration(&server);
+
+    let (status, _) = signup(&server, "user@example.com", "hunter2 hunter2");
+    assert_eq!(status, 200);
+    assert_eq!(
+        login_status(&server, "user@example.com", "hunter2 hunter2"),
+        403,
+        "unverified user starts blocked"
+    );
+
+    // Ask for a fresh verification email and redeem *that* token.
+    let (status, body) = rt().block_on(post(
+        server.base_url(),
+        "/api/v1/account/resend-verification",
+        json!({ "email": "user@example.com" }),
+    ));
+    assert_eq!(
+        status,
+        reqwest::StatusCode::OK,
+        "resend should be accepted: {body}"
+    );
+
+    let url = mailer.last_url().expect("resend sent a verification email");
+    let token = token_from_url(&url);
+    let (status, body) = rt().block_on(post(
+        server.base_url(),
+        "/api/v1/account/verify-email",
+        json!({ "token": token }),
+    ));
+    assert_eq!(
+        status,
+        reqwest::StatusCode::OK,
+        "a resent token must verify the account: {body}"
+    );
+    assert_eq!(
+        login_status(&server, "user@example.com", "hunter2 hunter2"),
+        200,
+        "the account can log in after redeeming a resent token"
+    );
+}
+
+#[test]
+fn resend_is_velocity_capped_per_email() {
+    let mailer = CapturingMailer::new();
+    let server = TestServer::start_managed(managed_with(mailer));
+
+    // The velocity cap applies per email regardless of whether the account
+    // exists (no existence leak), so an unknown address exercises it directly.
+    let email = "flooder@example.com";
+    for attempt in 0..3 {
+        let (status, body) = rt().block_on(post(
+            server.base_url(),
+            "/api/v1/account/resend-verification",
+            json!({ "email": email }),
+        ));
+        assert_eq!(
+            status,
+            reqwest::StatusCode::OK,
+            "attempt {attempt} within the window should be accepted: {body}"
+        );
+    }
+
+    // The next attempt inside the same window trips the per-email cap.
+    let (status, _) = rt().block_on(post(
+        server.base_url(),
+        "/api/v1/account/resend-verification",
+        json!({ "email": email }),
+    ));
+    assert_eq!(
+        status,
+        reqwest::StatusCode::TOO_MANY_REQUESTS,
+        "a 4th resend inside the window must be rate-limited"
+    );
+}

--- a/crates/toku-sync/tests/user_backup.rs
+++ b/crates/toku-sync/tests/user_backup.rs
@@ -1,0 +1,299 @@
+//! Per-user encrypted backup / restore tests (issue #206, ADR-014 D6).
+//!
+//! The admin-scoped backup exports only ciphertext (op payloads, snapshots) and
+//! the opaque metadata the relay already holds; restore re-ingests it
+//! idempotently under the same account. These tests assert the round-trip, the
+//! idempotency, the admin gate, and — critically — that the bundle carries no
+//! plaintext (zero-knowledge preserved end-to-end).
+
+mod harness;
+
+use harness::{SimulatedDevice, TestServer};
+use serde_json::json;
+use sha2::{Digest, Sha256};
+use srp::ClientG2048;
+use tokio::runtime::Runtime;
+use toku_core::{EntityType, HybridClock, OpType};
+use toku_sync::db::SyncDatabase;
+use uuid::Uuid;
+
+fn rt() -> Runtime {
+    Runtime::new().expect("tokio runtime")
+}
+
+async fn post(
+    base_url: &str,
+    path: &str,
+    token: Option<&str>,
+    body: serde_json::Value,
+) -> (reqwest::StatusCode, String) {
+    let mut req = reqwest::Client::new().post(format!("{base_url}{path}"));
+    if let Some(t) = token {
+        req = req.bearer_auth(t);
+    }
+    let resp = req.json(&body).send().await.expect("request sent");
+    let status = resp.status();
+    let text = resp.text().await.unwrap_or_default();
+    (status, text)
+}
+
+async fn get(base_url: &str, path: &str, token: Option<&str>) -> (reqwest::StatusCode, String) {
+    let mut req = reqwest::Client::new().get(format!("{base_url}{path}"));
+    if let Some(t) = token {
+        req = req.bearer_auth(t);
+    }
+    let resp = req.send().await.expect("request sent");
+    let status = resp.status();
+    let text = resp.text().await.unwrap_or_default();
+    (status, text)
+}
+
+fn hlc_for(device_id: Uuid) -> String {
+    HybridClock::new(&device_id).now().to_canonical()
+}
+
+// ── SRP account helpers (mirrors user_accounts.rs) ────────────────────────────
+
+fn salt_for(email: &str) -> Vec<u8> {
+    Sha256::digest(format!("salt:{email}").as_bytes())[..16].to_vec()
+}
+
+fn verifier_hex(email: &str, password: &str, salt: &[u8]) -> String {
+    let client = ClientG2048::<Sha256>::new();
+    hex::encode(client.compute_verifier(email.as_bytes(), password.as_bytes(), salt))
+}
+
+/// Sign up an account and return its `user_id`.
+fn signup(server: &TestServer, email: &str, password: &str) -> String {
+    let salt = salt_for(email);
+    let body = json!({
+        "email": email,
+        "srp_salt": hex::encode(&salt),
+        "srp_verifier": verifier_hex(email, password, &salt),
+    });
+    let (status, text) = rt().block_on(post(
+        server.base_url(),
+        "/api/v1/account/signup",
+        None,
+        body,
+    ));
+    assert_eq!(status, reqwest::StatusCode::OK, "signup failed: {text}");
+    let v: serde_json::Value = serde_json::from_str(&text).expect("signup json");
+    v["user_id"].as_str().expect("user_id").to_string()
+}
+
+/// Full SRP login; returns the user-session token.
+fn login(server: &TestServer, email: &str, password: &str) -> String {
+    use rand::RngExt;
+    let client = ClientG2048::<Sha256>::new();
+    let mut a = [0u8; 48];
+    rand::rng().fill(&mut a);
+    let a_pub = client.compute_public_ephemeral(&a);
+
+    let (_, challenge) = rt().block_on(post(
+        server.base_url(),
+        "/api/v1/account/challenge",
+        None,
+        json!({ "email": email, "client_public_a": hex::encode(&a_pub) }),
+    ));
+    let challenge: serde_json::Value = serde_json::from_str(&challenge).expect("challenge json");
+    let challenge_id = challenge["challenge_id"].as_str().expect("challenge_id");
+    let server_b = hex::decode(challenge["server_public_b"].as_str().unwrap()).unwrap();
+    let salt = hex::decode(challenge["srp_salt"].as_str().unwrap()).unwrap();
+    let verifier = client
+        .process_reply(&a, email.as_bytes(), password.as_bytes(), &salt, &server_b)
+        .expect("process_reply");
+    let m1 = hex::encode(verifier.proof());
+
+    let (status, body) = rt().block_on(post(
+        server.base_url(),
+        "/api/v1/account/verify",
+        None,
+        json!({ "challenge_id": challenge_id, "client_proof_m1": m1 }),
+    ));
+    assert_eq!(status, reqwest::StatusCode::OK, "login failed: {body}");
+    let v: serde_json::Value = serde_json::from_str(&body).expect("verify json");
+    v["session_token"]
+        .as_str()
+        .expect("session_token")
+        .to_string()
+}
+
+/// Attach `library_id` to `user_id` on the server (models admin adoption).
+fn attach_library(server: &TestServer, library_id: &str, user_id: &str) {
+    let db = SyncDatabase::open_no_migrate(&server.db_path()).expect("open server db");
+    db.conn
+        .execute(
+            "UPDATE libraries SET user_id = ?1 WHERE id = ?2",
+            rusqlite::params![user_id, library_id],
+        )
+        .expect("attach library");
+}
+
+/// Push one encrypted op into `library_id` via `device`, returning the secret
+/// title used (so a test can assert it never appears in the backup bundle).
+fn push_encrypted_op(server: &TestServer, device: &SimulatedDevice, secret_title: &str) {
+    let key = device.sync_key(server);
+    let entity_id = Uuid::now_v7();
+    let envelope = toku_core::encrypt_fields(
+        &key,
+        &json!({ "title": secret_title }),
+        &EntityType::Book,
+        &entity_id,
+        &OpType::Create,
+    )
+    .expect("encrypt fields");
+    let op = json!({
+        "op_id": Uuid::now_v7().to_string(),
+        "device_id": device.device_id().to_string(),
+        "hlc": hlc_for(device.device_id()),
+        "entity_type": EntityType::Book.as_str(),
+        "entity_id": entity_id.to_string(),
+        "op_type": OpType::Create.as_str(),
+        "payload": serde_json::to_value(&envelope).unwrap(),
+    });
+    let token = device.auth_token(server);
+    let (status, body) = rt().block_on(post(
+        server.base_url(),
+        "/api/v1/push",
+        Some(&token),
+        json!({ "ops": [op] }),
+    ));
+    assert!(status.is_success(), "seed push failed: {body}");
+}
+
+#[test]
+fn backup_restore_round_trips_and_is_idempotent() {
+    let server = TestServer::start();
+    // First signup bootstraps the admin.
+    let admin_id = signup(&server, "admin@example.com", "correct horse");
+    let admin_token = login(&server, "admin@example.com", "correct horse");
+
+    let device = SimulatedDevice::register(&server, "backup-lib", "device-a", None);
+    attach_library(&server, "backup-lib", &admin_id);
+    let secret = "A Very Secret Book Title";
+    push_encrypted_op(&server, &device, secret);
+
+    // Export the backup.
+    let (status, body) = rt().block_on(get(
+        server.base_url(),
+        &format!("/api/v1/admin/users/{admin_id}/backup"),
+        Some(&admin_token),
+    ));
+    assert_eq!(
+        status,
+        reqwest::StatusCode::OK,
+        "backup export failed: {body}"
+    );
+    let bundle: serde_json::Value = serde_json::from_str(&body).expect("bundle json");
+
+    assert_eq!(bundle["user_id"], admin_id);
+    assert_eq!(bundle["ops"].as_array().unwrap().len(), 1);
+    assert_eq!(bundle["libraries"].as_array().unwrap().len(), 1);
+
+    // Zero-knowledge: the plaintext title must appear nowhere in the bundle.
+    assert!(
+        !body.contains(secret),
+        "backup bundle must not contain plaintext content"
+    );
+
+    // Wipe the ops and restore from the bundle.
+    {
+        let db = SyncDatabase::open_no_migrate(&server.db_path()).expect("open server db");
+        db.conn.execute("DELETE FROM ops", []).expect("clear ops");
+    }
+    let (status, body) = rt().block_on(post(
+        server.base_url(),
+        &format!("/api/v1/admin/users/{admin_id}/backup/restore"),
+        Some(&admin_token),
+        bundle.clone(),
+    ));
+    assert_eq!(status, reqwest::StatusCode::OK, "restore failed: {body}");
+    let resp: serde_json::Value = serde_json::from_str(&body).unwrap();
+    assert_eq!(resp["ops_restored"], 1);
+
+    let op_count: i64 = {
+        let db = SyncDatabase::open_no_migrate(&server.db_path()).expect("open server db");
+        db.conn
+            .query_row("SELECT COUNT(*) FROM ops", [], |r| r.get(0))
+            .unwrap()
+    };
+    assert_eq!(op_count, 1, "restore must re-ingest the op");
+
+    // Idempotent: restoring again inserts nothing new.
+    let (status, body) = rt().block_on(post(
+        server.base_url(),
+        &format!("/api/v1/admin/users/{admin_id}/backup/restore"),
+        Some(&admin_token),
+        bundle,
+    ));
+    assert_eq!(
+        status,
+        reqwest::StatusCode::OK,
+        "second restore failed: {body}"
+    );
+    let resp: serde_json::Value = serde_json::from_str(&body).unwrap();
+    assert_eq!(resp["ops_restored"], 0, "re-restore must be a no-op");
+}
+
+#[test]
+fn backup_requires_admin() {
+    let server = TestServer::start();
+    // Admin bootstrap, then a plain user (registration opened by admin first).
+    let _admin_id = signup(&server, "admin@example.com", "correct horse");
+    let admin_token = login(&server, "admin@example.com", "correct horse");
+    let (status, _) = rt().block_on(async {
+        let resp = reqwest::Client::new()
+            .put(format!("{}/api/v1/admin/registration", server.base_url()))
+            .bearer_auth(&admin_token)
+            .json(&json!({ "open": true }))
+            .send()
+            .await
+            .expect("open registration");
+        (resp.status(), resp.text().await.unwrap_or_default())
+    });
+    assert_eq!(status, reqwest::StatusCode::OK);
+
+    let user_id = signup(&server, "user@example.com", "hunter2 hunter2");
+    let user_token = login(&server, "user@example.com", "hunter2 hunter2");
+
+    // A plain user cannot back up any account (admin-only capability).
+    let (status, _) = rt().block_on(get(
+        server.base_url(),
+        &format!("/api/v1/admin/users/{user_id}/backup"),
+        Some(&user_token),
+    ));
+    assert_eq!(
+        status,
+        reqwest::StatusCode::FORBIDDEN,
+        "non-admin backup must be forbidden"
+    );
+}
+
+#[test]
+fn restore_rejects_mismatched_user_id() {
+    let server = TestServer::start();
+    let admin_id = signup(&server, "admin@example.com", "correct horse");
+    let admin_token = login(&server, "admin@example.com", "correct horse");
+
+    let bundle = json!({
+        "version": 1,
+        "user_id": "some-other-user",
+        "email": "x@example.com",
+        "exported_at": "2024-01-01 00:00:00",
+        "libraries": [],
+        "ops": [],
+        "snapshots": [],
+    });
+    let (status, _) = rt().block_on(post(
+        server.base_url(),
+        &format!("/api/v1/admin/users/{admin_id}/backup/restore"),
+        Some(&admin_token),
+        bundle,
+    ));
+    assert_eq!(
+        status,
+        reqwest::StatusCode::BAD_REQUEST,
+        "restore must reject a bundle whose user_id != path id"
+    );
+}

--- a/docs/sync-server.md
+++ b/docs/sync-server.md
@@ -146,6 +146,8 @@ unauthenticated admin surface). The relevant endpoints are:
 | `GET/PUT /api/v1/admin/device-approvals` | Read / toggle the device-approval gate |
 | `GET /api/v1/admin/users` | List accounts |
 | `POST /api/v1/admin/users/{id}/status` | Enable / disable an account |
+| `GET /api/v1/admin/users/{id}/backup` | Export an account's ciphertext backup bundle (see [Managed-tier controls](#per-account-encrypted-backup--restore)) |
+| `POST /api/v1/admin/users/{id}/backup/restore` | Restore an account from a backup bundle |
 
 For example, to temporarily open self-registration so additional people can sign up
 (replace `$ADMIN_TOKEN` with your admin session token and close it again afterwards):
@@ -234,6 +236,90 @@ per-module filters (e.g. `RUST_LOG=toku_sync=debug,tower_http=debug`).
 
 > The container image defaults `TOKU_SYNC_DATA_DIR` to `/data`. When running the binary directly
 > (outside Docker) the default is `./toku-sync-data`.
+
+## Managed-tier controls
+
+For a shared, multi-tenant, or public instance you can enable a set of optional
+per-account controls (issue #206, [ADR-014](./adr/014-managed-multitenant-saas.md)).
+**Every control below is off by default**, so a single-user, self-hosted, or offline
+relay behaves exactly as it did before — you only opt in when you need them. None of
+these controls weaken the [zero-knowledge guarantee](#zero-knowledge-guarantee): the
+server still only ever stores and relays client-encrypted ciphertext.
+
+| Env variable | CLI flag | Default | Description |
+|--------------|----------|---------|-------------|
+| `TOKU_SYNC_DEFAULT_MAX_USER_BYTES` | `--default-max-user-bytes` | unset (unlimited) | Per-account stored-ciphertext ceiling, in bytes. |
+| `TOKU_SYNC_DEFAULT_MAX_USER_OPS` | `--default-max-user-ops` | unset (unlimited) | Per-account stored-op ceiling. |
+| `TOKU_SYNC_PER_USER_RATE_MAX` | `--per-user-rate-max` | `0` (disabled) | Max authenticated requests per account within the window. |
+| `TOKU_SYNC_PER_USER_RATE_WINDOW_SECS` | `--per-user-rate-window-secs` | `60` | Fixed-window length for the per-account rate limiter. |
+| `TOKU_SYNC_REQUIRE_EMAIL_VERIFICATION` | `--require-email-verification` | `false` | Require non-admin signups to confirm their email before login. |
+| `TOKU_SYNC_SMTP_URL` | `--smtp-url` | unset | SMTP relay URL for verification email, e.g. `smtps://smtp.example.com:465`. |
+| `TOKU_SYNC_SMTP_FROM` | `--smtp-from` | unset | `From:` address, e.g. `Toku <no-reply@example.com>`. |
+| `TOKU_SYNC_PUBLIC_BASE_URL` | `--public-base-url` | unset | Public base URL used to build verification links. |
+
+> **Fail-fast:** if `--require-email-verification` is set without `--smtp-url`,
+> `--smtp-from`, and `--public-base-url`, the server refuses to start. When SMTP is
+> unset but verification is off, no mail is sent.
+
+### Per-account storage quotas
+
+Cap how much stored ciphertext each account may accumulate. The instance-wide defaults
+(`--default-max-user-bytes` / `--default-max-user-ops`) apply to every **owned** account;
+a per-account override can be written to the `user_quota` entitlement table (the seam a
+future entitlement/plan lookup would populate — there is **no** pricing or billing logic
+here, only ceilings). A `push` or `snapshot` that would push an account over its ceiling
+is rejected with **HTTP 413 (Payload Too Large)** and nothing is persisted. Usage is
+computed from ciphertext **sizes and counts only** — the server never inspects content,
+so quotas do not touch the zero-knowledge boundary. Libraries with no owner (the classic
+self-hosted, account-less relay) are always exempt.
+
+### Per-account rate limiting
+
+`--per-user-rate-max` adds an authenticated request ceiling keyed on the account,
+layered **above** the always-on per-IP and global limiters that already guard the
+pre-auth endpoints. When an account exceeds the ceiling within
+`--per-user-rate-window-secs`, further requests get **HTTP 429 (Too Many Requests)**.
+Left at `0`, the per-account limiter is disabled and only the per-IP/global limiter
+applies (today's behavior).
+
+### Self-serve signup email verification
+
+With `--require-email-verification` on, a new non-admin `toku sync signup` account is
+created **unverified** and cannot obtain a session until it confirms its email. The
+server emails a one-time link (built from `--public-base-url`); the client — or the
+operator — completes it against:
+
+| Endpoint | Body | Purpose |
+|----------|------|---------|
+| `POST /api/v1/account/verify-email` | `{"token": "…"}` | Redeem the one-time token and mark the account verified. |
+| `POST /api/v1/account/resend-verification` | `{"email": "…"}` | Re-issue a verification email (velocity-capped per email). |
+
+The first admin account is **always** auto-verified so bootstrap never gets stuck, and
+tokens are opaque account metadata — no library data is involved. When SMTP is not
+configured (dev / self-host), the verification link is logged instead of mailed.
+
+### Per-account encrypted backup & restore
+
+Two admin-scoped endpoints let an operator back up and restore a single account's data
+**as ciphertext**:
+
+| Endpoint | Purpose |
+|----------|---------|
+| `GET /api/v1/admin/users/{id}/backup` | Export a JSON bundle of the account's ciphertext ops + snapshots and opaque library metadata. |
+| `POST /api/v1/admin/users/{id}/backup/restore` | Idempotently re-ingest a previously exported bundle under the same account. |
+
+Both require an **admin session** bearer token (there is no unauthenticated surface).
+The bundle contains **no plaintext and no key material** — only the same ciphertext and
+routing metadata the relay already holds — so it is safe to store off-box without
+widening the zero-knowledge boundary. Restore is idempotent: ops de-dupe by `op_id`,
+snapshots by their natural key, and libraries re-attach to the same owner, so re-running
+a restore is a no-op. This is a targeted per-account path and is distinct from the
+whole-database volume backup in [Data persistence](#data-persistence).
+
+> **Metadata exposure (ADR-014 D7).** Quotas and per-account backups operate on ciphertext
+> **sizes and counts** and the routing metadata already listed in
+> [Zero-knowledge guarantee](#zero-knowledge-guarantee) — never on content. No new plaintext
+> is read, stored, or exported by any managed-tier control.
 
 ## Data persistence
 


### PR DESCRIPTION
## Description

Adds the optional operator controls a shared or public `toku-sync` relay needs to run safely with more than one account. **Every control defaults to off/unlimited**, so a single-user, self-hosted, or offline relay behaves exactly as before, and the relay's zero-knowledge property is preserved throughout — it still only ever stores client-encrypted ciphertext.

### What's included

- **Per-account storage quotas.** Cap stored ciphertext bytes and op counts per account via `--default-max-user-bytes` / `--default-max-user-ops`, with an optional per-account override in a new `user_quota` table. Enforced on the push and snapshot paths; a request that would exceed the ceiling is rejected with HTTP `413` and nothing is persisted. Usage is computed purely from ciphertext sizes and counts. Libraries with no owner (the classic account-less self-hosted relay) are always exempt.
- **Per-account rate limiting.** A new authenticated-user request ceiling (`--per-user-rate-max` within `--per-user-rate-window-secs`) layered above the existing per-IP and global limiters, returning HTTP `429` when tripped. Disabled by default (`0`); the existing per-IP limiter is untouched.
- **Per-account encrypted backup & restore.** Admin-scoped `GET /api/v1/admin/users/{id}/backup` exports one account's ciphertext ops and snapshots plus opaque library metadata as a JSON bundle; `POST /api/v1/admin/users/{id}/backup/restore` re-ingests it idempotently (ops de-dupe by `op_id`, snapshots by natural key, libraries re-attach to the same owner). The bundle carries no plaintext and no key material, so it is safe to store off-box. This is a targeted per-account path, distinct from copying the whole `sync.db` volume.
- **Self-serve signup email verification.** Optionally require new non-admin signups to confirm their address before they can obtain a session (`--require-email-verification`, plus `--smtp-url` / `--smtp-from` / `--public-base-url`). Adds `POST /api/v1/account/verify-email` and `POST /api/v1/account/resend-verification` (velocity-capped per address). The first admin account is always auto-verified so bootstrap can never get stuck, and the server fails fast at startup if verification is enabled without delivery settings.

SMTP delivery goes through a small `Mailer` trait (`lettre` behind it); with no SMTP configured the verification link is logged instead of mailed, which keeps development and self-hosting frictionless.

Schema changes ship as a single additive, idempotent migration (`V10__managed_hardening.sql`): `users.email_verified` (defaults to verified), managed defaults on `instance_config`, the `user_quota` entitlement table, and `email_verification_tokens`.

These are capability/limit seams only — there is no pricing, plan-cost, or billing logic anywhere in the change.

### Testing

14 new integration tests across `quotas.rs`, `rate_limit_user.rs`, `user_backup.rs`, and `signup_verification.rs`, covering quota rejection on both bytes and op count, exemption for unowned libraries, per-user throttling isolation, backup/restore round-trip and idempotency, admin-only access, the verification gate and token redemption, and the resend velocity cap. Two white-box tests assert no plaintext ever appears in a backup bundle or in quota accounting. All pre-existing suites (`zero_knowledge.rs`, `user_accounts.rs`, `device_enrollment.rs`, `sync_multi_device.rs`) pass unchanged.

No new CI jobs and no rename of the `Validate` gate, so no branch-protection/IaC update is required.

## Related Issues

Closes #206
Relates to #207

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI / infrastructure
- [ ] Other (describe below)

## Crate

<!-- Which crate(s) does this touch? -->

- [ ] `toku-core` — Domain models, traits, state machine
- [ ] `toku-db` — SQLite persistence, migrations, FTS5
- [ ] `toku-import` — Importers (Goodreads, Calibre, StoryGraph)
- [ ] `toku-meta` — Metadata fetching (Open Library, Google Books)
- [ ] `toku-cli` — CLI binary
- [ ] `toku-export` — Exporters (CSV, JSON, Markdown, BibTeX)
- [x] `docs/` — Documentation
- [x] `toku-sync` — Sync relay server (not listed above; this is the primary crate touched)

## Data Integrity Checklist

<!-- Toku is a local-first tool — user data ownership is non-negotiable -->

- [x] No user data is sent to any server without explicit opt-in — server-side only; sync remains opt-in and the relay still stores nothing but client-encrypted ciphertext. Quotas read ciphertext sizes/counts and backups export ciphertext plus the routing metadata the relay already held in the clear, so no new plaintext is read, stored, or exported.
- [x] Import operations are idempotent (re-importing the same file creates no duplicates) — N/A for importers (untouched); the equivalent new path, backup restore, is idempotent and covered by a test.
- [x] User edits to metadata are never overwritten by auto-enrichment — N/A; no metadata or enrichment paths are touched.
- [x] New fields track provenance (source + timestamp) — N/A for library metadata; the new server-side rows (verification tokens, quota overrides, backup bundles) all carry creation/expiry timestamps.
- [x] Export round-trip is preserved (if applicable) — the new backup bundle round-trips byte-for-byte through restore, verified by test.

## Checklist

- [x] I have read [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] `cargo fmt --check` passes
- [x] `cargo clippy --workspace -- -D warnings` passes
- [x] `cargo test --workspace` passes
- [x] I have updated documentation (if applicable) — new "Managed-tier controls" section in `docs/sync-server.md` documenting every new knob and endpoint, plus the metadata-exposure note; CHANGELOG updated under `[Unreleased]`.