### PR TITLE
fix(sync): point stale `toku sync init` guidance at signup/login/enroll

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -72,7 +72,7 @@ Cargo workspace with 12 crates:
 
 ## CI / Infrastructure Dependency
 
-**Branch protection for this repo is managed via Terraform in `kafkade/github-infra` (`repo_toku.tf`).** The `required_status_checks` list must match the job names in `.github/workflows/ci.yml`. If you rename, add, or remove CI jobs that are used as merge gates (currently `Validate`), the corresponding IaC config must be updated or PRs will be permanently blocked. Always flag this when proposing workflow changes.
+**Branch protection for this repo is managed via Terraform in `kafkade/github-infra` (`repo_toku.tf`).** The `required_status_checks` list must match the job names in `.github/workflows/validate.yml`. If you rename, add, or remove CI jobs that are used as merge gates (currently `Validate`), the corresponding IaC config must be updated or PRs will be permanently blocked. Always flag this when proposing workflow changes.
 
 ## Releasing
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Sync error messages now point at the right command. When sync isn't set up, when your
+  device has no auth token, after `toku sync disable`, or when a library key hasn't been
+  unlocked, Toku now tells you to run `toku sync signup`, `toku sync login`, or
+  `toku sync enroll` — whichever actually fits your situation — instead of the deprecated
+  `toku sync init`. The web dashboard's sync page says the same thing. `toku sync init`
+  still works and still prints its deprecation notice; only the guidance text changed (#221)
+
 - Sync now propagates ordinary edits incrementally. Every create/update/delete on a
   syncable entity (books, reading sessions, progress, and tags) now stages a sync op
   atomically with the write, in a single choke-point in the persistence layer, so all

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -453,7 +453,7 @@ Rejected alternatives:
 | JSON (full) | Backup, programmatic access | **MVP** | 🟢 |
 | CSV | Spreadsheet users | **MVP** | 🟢 |
 | Markdown | Blog posts, reading lists | Phase 2 | 🟢 |
-| ZIP backup (canonical) | Full backup/migration | ✅ Shipped (#200) | 🟡 |
+| ZIP backup (canonical) | Full backup/migration | Phase 2 ✅ (#200) | 🟡 |
 | BibTeX | Academic citations | Phase 3 | 🟡 |
 | OPDS | E-reader catalog | Phase 6 | 🟢 |
 | HTML | Static reading list site | Phase 3 | 🟡 |
@@ -767,13 +767,18 @@ File management lives in a new `toku-files` crate that depends on `toku-core` an
 - Apple Books: annotations in `~/Library/Containers/com.apple.iBooksX/` `[Validation Required]`.
 - Phase: Post-1.0 research. High value but each reader is a separate integration effort.
 
-### 7.5 — Self-Hosted Sync Server 🔴
+### 7.5 — Self-Hosted Sync Server 🟡
 
-- Deferred to Phase 7. See ADR-010 for the current architecture decision.
-- Immich-style self-hostable Docker image with first-run admin onboarding, real user
-  accounts, and 1Password-style two-secret SRP authentication.
-- Mandatory zero-knowledge E2E encryption — no plaintext mode for hosted sync.
-- Axum server with REST API (op-log wire protocol from ADR-008 retained).
+- **Shipped (Phase 7)**: the `toku-sync` Axum server with a REST API (op-log wire protocol from
+  ADR-008 retained), mandatory zero-knowledge E2E encryption — no plaintext mode for hosted sync —
+  and 1Password-style two-secret SRP authentication (ADR-010). Immich-style self-hostable Docker
+  image (`ghcr.io/kafkade/toku-sync`) with first-run admin onboarding and real user accounts,
+  op-log emission on every mutation (#194), and new-device bootstrap (#199).
+- Optional managed-tier controls for operators running a shared instance — per-user quotas,
+  per-user rate limiting, admin-scoped encrypted backup, and signup email verification — are off
+  by default and preserve the zero-knowledge guarantee (#206).
+- **Remaining (why still 🟡)**: genuine multi-device client integration — the iOS, macOS, web, and
+  Windows apps actually syncing between each other end-to-end (the CLI already does).
 - cr-sqlite kept as a research alternative if it matures for iOS/WASM.
 
 ---

--- a/crates/toku-cli/src/main.rs
+++ b/crates/toku-cli/src/main.rs
@@ -4579,16 +4579,18 @@ fn cmd_sync(data_dir: &Path, action: SyncAction, output_format: &OutputFormat) -
 
     /// Helper: get sync config or error with a helpful message.
     fn require_sync(config: &toku_core::TokuConfig) -> Result<&toku_core::SyncConfig> {
-        config
-            .sync
-            .as_ref()
-            .ok_or_else(|| anyhow::anyhow!("sync is not configured. Run `toku sync init` first."))
+        config.sync.as_ref().ok_or_else(|| {
+            anyhow::anyhow!(
+                "sync is not configured. Run `toku sync signup` (new account) or \
+                 `toku sync enroll` (existing account) first."
+            )
+        })
     }
 
     /// Helper: get auth token for the configured server.
     fn require_token(token_store: &sync::token_store::TokenStore, server: &str) -> Result<String> {
         token_store.load(server)?.ok_or_else(|| {
-            anyhow::anyhow!("no auth token found for {server}. Run `toku sync init` first.")
+            anyhow::anyhow!("no auth token found for {server}. Run `toku sync login` first.")
         })
     }
 
@@ -5250,7 +5252,9 @@ fn cmd_sync(data_dir: &Path, action: SyncAction, output_format: &OutputFormat) -
                 }
                 _ => {
                     eprintln!("Sync disabled. Local data preserved.");
-                    eprintln!("  Run `toku sync init` to re-enable.");
+                    eprintln!(
+                        "  Run `toku sync enroll` to re-enable (or `toku sync signup` for a new account)."
+                    );
                 }
             }
             Ok(())
@@ -5442,7 +5446,9 @@ fn cmd_sync(data_dir: &Path, action: SyncAction, output_format: &OutputFormat) -
             let client = sync::client::SyncClient::new(server)?;
 
             let device = sync_repo.get_device()?.ok_or_else(|| {
-                anyhow::anyhow!("no device identity found. Run `toku sync init` first.")
+                anyhow::anyhow!(
+                    "no device identity found. Run `toku sync signup` or `toku sync enroll` first."
+                )
             })?;
             let mut clock = toku_core::HybridClock::new(&device.device_id);
             let hlc_str = clock.now().to_canonical();
@@ -5452,7 +5458,8 @@ fn cmd_sync(data_dir: &Path, action: SyncAction, output_format: &OutputFormat) -
             let key_bytes = token_store.load_sync_key(server)?.ok_or_else(|| {
                 anyhow::anyhow!(
                     "hosted sync requires client-side encryption but no key is configured.\n\
-                     Run `toku sync init --passphrase` to enroll this device with encryption."
+                     Run `toku sync login` to unlock your library key with your password and \
+                     Secret Key, or `toku sync enroll` to enroll this device into your account."
                 )
             })?;
             let key = toku_core::SyncKey::from_exported_bytes(&key_bytes)

--- a/crates/toku-sync-client/src/orchestrator.rs
+++ b/crates/toku-sync-client/src/orchestrator.rs
@@ -188,16 +188,18 @@ fn open_db(data_dir: &Path) -> anyhow::Result<Database> {
 }
 
 fn require_sync(config: &toku_core::TokuConfig) -> anyhow::Result<&toku_core::SyncConfig> {
-    config
-        .sync
-        .as_ref()
-        .ok_or_else(|| anyhow::anyhow!("sync is not configured. Run sync init first."))
+    config.sync.as_ref().ok_or_else(|| {
+        anyhow::anyhow!(
+            "sync is not configured. Run `toku sync signup` (new account) or \
+             `toku sync enroll` (existing account) first."
+        )
+    })
 }
 
 fn require_token(token_store: &TokenStore, server: &str) -> anyhow::Result<String> {
-    token_store
-        .load(server)?
-        .ok_or_else(|| anyhow::anyhow!("no auth token found for {server}. Run sync init first."))
+    token_store.load(server)?.ok_or_else(|| {
+        anyhow::anyhow!("no auth token found for {server}. Run `toku sync login` first.")
+    })
 }
 
 /// Load the client-side encryption key when encryption is enabled for this
@@ -407,7 +409,8 @@ pub fn init(
             // actionable error instead of registering an unusable device.
             Err(anyhow::anyhow!(
                 "hosted sync requires client-side encryption: a passphrase is mandatory.\n\
-                 Re-run with `toku sync init --passphrase` (you will be prompted securely).\n\
+                 Run `toku sync signup` (new account) or `toku sync enroll` (existing account) \
+                 to set up encryption.\n\
                  Local-only, single-device usage needs no sync and no passphrase."
             ))
         }
@@ -444,7 +447,8 @@ pub fn push(data_dir: &Path) -> anyhow::Result<PushOutcome> {
     let key = load_encryption_key(&token_store, server, sync_config)?.ok_or_else(|| {
         anyhow::anyhow!(
             "hosted sync requires client-side encryption but no key is configured.\n\
-             Re-run `toku sync init --passphrase` to enroll this device with encryption."
+             Run `toku sync login` to unlock your library key with your password and Secret Key, \
+             or `toku sync enroll` to enroll this device into your account."
         )
     })?;
     let wire_ops: Vec<WireOp> = unpushed
@@ -593,7 +597,8 @@ pub fn bootstrap(data_dir: &Path, reset_cursor: bool) -> anyhow::Result<Bootstra
         let key = load_encryption_key(&token_store, server, sync_config)?.ok_or_else(|| {
             anyhow::anyhow!(
                 "downloaded an encrypted snapshot but no key is configured.\n\
-                 Re-run `toku sync init --passphrase` to enroll this device with encryption."
+                 Run `toku sync login` to unlock your library key with your password and \
+                 Secret Key, or `toku sync enroll` to enroll this device into your account."
             )
         })?;
         let envelope: toku_core::EncryptedEnvelope = serde_json::from_str(&snap.snapshot_json)

--- a/crates/toku-web/src/views.rs
+++ b/crates/toku-web/src/views.rs
@@ -59,7 +59,7 @@ pub fn sync_page(o: &SyncOverview) -> Markup {
         @if !o.configured {
             div.conflict-empty {
                 p { "Sync is not configured on this device." }
-                p.muted { "Set up sync from the command line (" code { "toku sync init" } ") or a native app. The web dashboard is a read-only companion." }
+                p.muted { "Set up sync from the command line (" code { "toku sync signup" } " or " code { "toku sync enroll" } ") or a native app. The web dashboard is a read-only companion." }
             }
         } @else {
             div.sync-card {


### PR DESCRIPTION
## Description

Three small follow-ups from epic #207: the CLI still told users to run the deprecated `toku sync init`, and two docs files described a reality the tree has moved past.

**What's included**

- **Stale sync guidance (#221)** — every error/hint that pointed at the deprecated `toku sync init` now names the command that actually fits its situation:
  - no sync config → `toku sync signup` (new account) / `toku sync enroll` (existing account)
  - no auth token for the server → `toku sync login`
  - after `toku sync disable` → `toku sync enroll` to re-enable. (Checked the code rather than guessing: `orchestrator::login()` only mints a *device* session when `config.sync` still carries a `device_id`, and `disable` clears it — so `login` alone cannot restore sync.)
  - `toku sync compact` with no device identity → `signup` / `enroll`
  - missing library key (compact, push, snapshot download) → `login` to unlock with password + Secret Key, or `enroll` to enroll the device

  Fixed in `crates/toku-cli/src/main.rs` and in `crates/toku-sync-client/src/orchestrator.rs`. The latter is not named in the issue, but its errors are printed verbatim by `toku sync push/pull/bootstrap`, so they are CLI error strings and fall under the same acceptance criterion.

  The deprecated `toku sync init` command, its `[Deprecated]` help text, and its runtime deprecation notice are unchanged — only guidance text moved. No behavior change, and no test asserted on any of these strings.

- **ROADMAP §7.5 (#224)** — "Self-Hosted Sync Server" was 🔴 "Deferred to Phase 7" while the server has actually shipped. Now 🟡 with a shipped/remaining split matching the existing Phase 7 style: shipped = the Axum `toku-sync` server (ADR-008 wire protocol), mandatory zero-knowledge E2E, two-secret SRP (ADR-010), the self-hostable Docker image with first-run admin onboarding, op-log emission (#194) and new-device bootstrap (#199); remaining = genuine multi-device client integration across iOS/macOS/web/Windows. A short bullet notes the managed-tier controls from #206 (per-user quotas, per-user rate limiting, admin-scoped encrypted backup, signup email verification), which are **off by default** and preserve the zero-knowledge guarantee. Each claim was verified against the tree, not copied from the issue text. The export table's backup row was also aligned to `Phase 2 ✅ (#200)` so it keeps planned-phase info like its neighbors.

- **Agent instructions (#228)** — the CI/infrastructure note pointed at `.github/workflows/ci.yml`, which does not exist. Corrected to `.github/workflows/validate.yml` (workflow `name: CI`, gating job `Validate`). No stale reference remains repo-wide.

### Note on scope

One hunk is a **deliberate extra, outside the issue's stated scope**: `crates/toku-web/src/views.rs:62`, the read-only sync page copy, which had the same stale `toku sync init` instruction. #221 is scoped to CLI messages, so this is a different surface (web copy). It's one line and leaving it wrong seemed worse than fixing it — but it is cleanly separable and can be dropped without affecting anything else in this PR.

No CI job was renamed, added, or removed, so no `kafkade/github-infra` Terraform change is needed.

## Related Issues

Closes #221
Closes #224
Closes #228

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI / infrastructure
- [ ] Other (describe below)

## Crate

- [ ] `toku-core` — Domain models, traits, state machine
- [ ] `toku-db` — SQLite persistence, migrations, FTS5
- [ ] `toku-import` — Importers (Goodreads, Calibre, StoryGraph)
- [ ] `toku-meta` — Metadata fetching (Open Library, Google Books)
- [x] `toku-cli` — CLI binary
- [ ] `toku-export` — Exporters (CSV, JSON, Markdown, BibTeX)
- [x] `docs/` — Documentation (`ROADMAP.md`, `.github/copilot-instructions.md`)

Also touched: `toku-sync-client` (CLI-visible sync errors) and `toku-web` (sync page copy — the out-of-scope extra noted above).

## Data Integrity Checklist

- [x] No user data is sent to any server without explicit opt-in — message text only; no network or storage behavior changed
- [x] Import operations are idempotent (re-importing the same file creates no duplicates) — N/A, importers untouched
- [x] User edits to metadata are never overwritten by auto-enrichment — N/A, no metadata paths touched
- [x] New fields track provenance (source + timestamp) — N/A, no new fields
- [x] Export round-trip is preserved (if applicable) — N/A, exporters untouched

## Checklist

- [x] I have read [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] `cargo fmt --check` passes
- [x] `cargo clippy --workspace -- -D warnings` passes
- [x] `cargo test --workspace` passes
- [x] I have updated documentation (if applicable)