### PR TITLE
feat(db): optional SQLCipher at-rest database encryption (opt-in, off by default)

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -176,6 +176,29 @@ jobs:
             -destination 'generic/platform=watchOS Simulator' \
             -configuration Debug build CODE_SIGNING_ALLOWED=NO EXCLUDED_ARCHS=x86_64
 
+  # ── At-rest encryption (SQLCipher) ────────────────────────────────────────────
+  # Proves the off-by-default `sqlcipher` feature (ADR-016) still compiles and its
+  # keyed-open / migration tests pass. Deliberately NON-gating: it is intentionally
+  # omitted from the `validate` job's `needs` list so the "Validate" required status
+  # check — and therefore kafkade/github-infra → repo_toku.tf — is unchanged. The
+  # feature bundles SQLCipher + vendored OpenSSL, which is the biggest cross-compile
+  # hazard in the tree; keeping this leg off the gate avoids blocking PRs on it.
+  sqlcipher:
+    name: SQLCipher feature (toku-db)
+    needs: changes
+    if: github.event_name == 'push' || needs.changes.outputs.rust == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: sqlcipher
+      - run: cargo clippy -p toku-db --features sqlcipher --all-targets -- -D warnings
+      - run: cargo test -p toku-db --features sqlcipher
+
   # ── Summary gate ──────────────────────────────────────────────────────────────
   # Single required status check for branch protection. Downstream jobs may be
   # skipped (path filters) — that is OK; only failures or cancellations block.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   users are unaffected: with a server configured, `--encrypt` still uses your
   enrolled library key. **Losing the passphrase makes the backup
   unrecoverable — there is no backdoor** (#204)
+- Optional at-rest database encryption (ADR-016). Builds compiled with the
+  `toku-db` `sqlcipher` feature can encrypt the live `toku.db` in place with
+  SQLCipher via a new `toku db` command group: `toku db encrypt` (prompts for a
+  new passphrase and keeps a verified plaintext backup until the swap is
+  confirmed), `toku db decrypt`, `toku db status`, and `toku db forget`. The
+  passphrase is stretched with Argon2id (m=64 MiB, t=3, p=1) into a 256-bit key;
+  Toku stores **only** the salt, KDF parameters, and a verifier in
+  `config.toml`'s `[encryption]` section — never the passphrase or derived key.
+  Short-lived CLI commands obtain the key from (in order) the opt-in
+  `TOKU_DB_PASSPHRASE` env var, an opt-in OS-keychain cache
+  (`toku db encrypt --remember`), or an interactive prompt. Encryption is
+  **opt-in and off by default**; the default plaintext path — and any build
+  without the `sqlcipher` feature — is byte-for-byte unchanged. A new
+  `toku_open_encrypted` C FFI entry point is added for the native apps
+  (`toku_open` is unchanged). **Losing the passphrase makes the database
+  unrecoverable — there is no backdoor** (#225)
 
 - Opting into sync now uploads the library you already have. On `toku sync signup` (and on a
   `toku sync enroll` that creates a fresh library), Toku backfills your existing books,

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2895,6 +2895,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1f111c8c41e7c61a49cd34e44c7619462967221a6443b0ec299e0ac30cfb9b1"
 dependencies = [
  "cc",
+ "openssl-sys",
  "pkg-config",
  "vcpkg",
 ]
@@ -3543,6 +3544,28 @@ name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "openssl-src"
+version = "300.6.1+3.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46eb8fb9fb3b61ce1c0f8a026c4c1a0714d3a9e138e7fbde78753ce2babc3846"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.117"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b47e7e6bb2c38cd930d25a23b40fa52e068c10e85f3e03a7f5ba5aaca5713695"
+dependencies = [
+ "cc",
+ "libc",
+ "openssl-src",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "option-ext"

--- a/crates/toku-cli/Cargo.toml
+++ b/crates/toku-cli/Cargo.toml
@@ -11,6 +11,12 @@ repository.workspace = true
 name = "toku"
 path = "src/main.rs"
 
+[features]
+# Opt-in at-rest DB encryption via SQLCipher (ADR-016). OFF by default; enables
+# the `toku db encrypt/decrypt/status` commands and keyed opens across the CLI,
+# the embedded web server, and the sync client.
+sqlcipher = ["toku-db/sqlcipher", "toku-web/sqlcipher", "toku-sync-client/sqlcipher"]
+
 [dependencies]
 toku-core.workspace = true
 toku-db.workspace = true

--- a/crates/toku-cli/src/main.rs
+++ b/crates/toku-cli/src/main.rs
@@ -284,6 +284,12 @@ enum Commands {
         action: OpdsAction,
     },
 
+    /// Manage at-rest database encryption (SQLCipher; opt-in, off by default)
+    Db {
+        #[command(subcommand)]
+        action: DbAction,
+    },
+
     /// Manage work grouping (link editions of the same creative work)
     Work {
         #[command(subcommand)]
@@ -741,6 +747,33 @@ enum ExportTarget {
 }
 
 #[derive(Clone, Subcommand)]
+enum DbAction {
+    /// Encrypt the local database in place (plaintext → SQLCipher). Prompts for
+    /// a new passphrase. A verified backup of the original is kept until the
+    /// encrypted database is confirmed. Idempotent.
+    Encrypt {
+        /// Proceed without the interactive confirmation prompt.
+        #[arg(long)]
+        yes: bool,
+        /// Also cache the passphrase in the OS keychain for future unlocks.
+        #[arg(long)]
+        remember: bool,
+    },
+    /// Decrypt the local database in place (SQLCipher → plaintext). Prompts for
+    /// the current passphrase. A verified backup is kept until confirmed.
+    /// Idempotent.
+    Decrypt {
+        /// Proceed without the interactive confirmation prompt.
+        #[arg(long)]
+        yes: bool,
+    },
+    /// Show whether the local database is encrypted and the KDF parameters.
+    Status,
+    /// Remove any DB passphrase cached in the OS keychain for this library.
+    Forget,
+}
+
+#[derive(Clone, Subcommand)]
 enum SyncAction {
     /// [Deprecated] Set up sync with a per-library passphrase. Prefer `signup`/`login`.
     Init {
@@ -996,6 +1029,25 @@ fn main() -> Result<()> {
     // Resolve command (default: Browse = TUI)
     let command = cli.command.unwrap_or(Commands::Browse);
 
+    #[cfg(feature = "sqlcipher")]
+    {
+        // Encrypted-DB unlock: for any command that touches the database, resolve
+        // the key once and install it process-wide so every open site (the CLI
+        // dispatch below, the web server, the sync client) opens keyed. Commands
+        // that need no DB — or that manage their own keying (`db`) — are skipped.
+        let needs_unlock = !matches!(
+            &command,
+            Commands::Config { .. }
+                | Commands::Completions { .. }
+                | Commands::Account { .. }
+                | Commands::Db { .. }
+        );
+        if needs_unlock {
+            let config = toku_core::TokuConfig::load(&data_dir).unwrap_or_default();
+            unlock_db_if_encrypted(&data_dir, &config)?;
+        }
+    }
+
     // Commands that don't need the database
     match &command {
         Commands::Config { path, edit } => return cmd_config(&data_dir, *path, *edit),
@@ -1033,6 +1085,9 @@ fn main() -> Result<()> {
         Commands::Opds { action } => {
             return cmd_opds(&data_dir, action);
         }
+        Commands::Db { action } => {
+            return cmd_db(&data_dir, action);
+        }
         Commands::Sync { action } => {
             return cmd_sync(&data_dir, action.clone(), &cli.format);
         }
@@ -1043,7 +1098,7 @@ fn main() -> Result<()> {
     }
 
     let db_path = data_dir.join("toku.db");
-    let db = Database::open(&db_path)
+    let db = Database::open_default(&db_path)
         .with_context(|| format!("failed to open database at {}", db_path.display()))?;
     let repo = BookRepository::new(&db);
 
@@ -1138,6 +1193,7 @@ fn main() -> Result<()> {
         | Commands::Completions { .. }
         | Commands::Serve { .. }
         | Commands::Opds { .. }
+        | Commands::Db { .. }
         | Commands::Sync { .. }
         | Commands::Account { .. } => {
             unreachable!()
@@ -1183,6 +1239,320 @@ fn cmd_config(data_dir: &Path, show_path: bool, open_edit: bool) -> Result<()> {
     let config = TokuConfig::load(data_dir).context("failed to load config")?;
     let toml_str = toml::to_string_pretty(&config).context("failed to serialize config")?;
     println!("{toml_str}");
+    Ok(())
+}
+
+/// Environment variable that supplies the DB unlock passphrase non-interactively
+/// (automation escape hatch for at-rest DB encryption). Opt-in by nature.
+#[cfg(feature = "sqlcipher")]
+#[cfg(feature = "sqlcipher")]
+const DB_PASSPHRASE_ENV: &str = "TOKU_DB_PASSPHRASE";
+
+/// Decode the stored base64 Argon2id salt into a fixed 16-byte array.
+#[cfg(feature = "sqlcipher")]
+fn decode_db_salt(salt_b64: &str) -> Result<[u8; 16]> {
+    use base64::Engine as _;
+    let bytes = base64::engine::general_purpose::STANDARD
+        .decode(salt_b64)
+        .context("invalid encryption salt in config")?;
+    bytes
+        .try_into()
+        .map_err(|_| anyhow::anyhow!("encryption salt must be 16 bytes"))
+}
+
+/// Resolve the DB unlock key for an already-encrypted database and install it
+/// process-wide. No-op when encryption is disabled or already unlocked.
+///
+/// Passphrase precedence (both caching layers are opt-in, never default):
+/// `TOKU_DB_PASSPHRASE` env → OS keychain (if the user cached it) →
+/// interactive prompt (the baseline).
+#[cfg(feature = "sqlcipher")]
+fn unlock_db_if_encrypted(data_dir: &Path, config: &TokuConfig) -> Result<()> {
+    let Some(enc) = config.encryption.as_ref().filter(|e| e.enabled) else {
+        return Ok(());
+    };
+    if toku_db::process_db_key().is_some() {
+        return Ok(());
+    }
+    let salt = decode_db_salt(&enc.salt)?;
+
+    let derive = |pass: &str| -> Result<toku_core::SyncKey> {
+        toku_core::SyncKey::derive(pass, &salt).map_err(|e| anyhow::anyhow!("{e}"))
+    };
+    let install = |key: toku_core::SyncKey| {
+        let _ = toku_db::set_process_db_key(key);
+    };
+
+    // 1. Env var (opt-in automation escape hatch).
+    if let Ok(pass) = std::env::var(DB_PASSPHRASE_ENV)
+        && !pass.is_empty()
+    {
+        let key = derive(&pass)?;
+        if toku_core::verify_db_key(&key, &enc.verifier) {
+            install(key);
+            return Ok(());
+        }
+        anyhow::bail!("incorrect passphrase from {DB_PASSPHRASE_ENV}");
+    }
+
+    // 2. OS keychain (opt-in — present only if the user cached it).
+    let token_store = sync::token_store::TokenStore::new(data_dir);
+    if let Some(pass) = token_store.load_db_passphrase() {
+        let key = derive(&pass)?;
+        if toku_core::verify_db_key(&key, &enc.verifier) {
+            install(key);
+            return Ok(());
+        }
+        eprintln!("warning: cached keychain passphrase is no longer valid; prompting instead");
+    }
+
+    // 3. Interactive prompt (baseline). Up to three attempts.
+    for attempt in 1..=3 {
+        let pass = read_password_prompt("Database passphrase: ")?;
+        if !pass.is_empty() {
+            let key = derive(&pass)?;
+            if toku_core::verify_db_key(&key, &enc.verifier) {
+                install(key);
+                return Ok(());
+            }
+        }
+        if attempt < 3 {
+            eprintln!("Incorrect passphrase, try again.");
+        }
+    }
+    anyhow::bail!("incorrect passphrase")
+}
+
+/// Handle `toku db` — manage at-rest database encryption.
+fn cmd_db(data_dir: &Path, action: &DbAction) -> Result<()> {
+    #[cfg(feature = "sqlcipher")]
+    {
+        match action {
+            DbAction::Encrypt { yes, remember } => cmd_db_encrypt(data_dir, *yes, *remember),
+            DbAction::Decrypt { yes } => cmd_db_decrypt(data_dir, *yes),
+            DbAction::Status => cmd_db_status(data_dir),
+            DbAction::Forget => {
+                let token_store = sync::token_store::TokenStore::new(data_dir);
+                token_store.forget_db_passphrase()?;
+                eprintln!("✓ Removed any cached DB passphrase from the OS keychain.");
+                Ok(())
+            }
+        }
+    }
+
+    #[cfg(not(feature = "sqlcipher"))]
+    {
+        let _ = (data_dir, action);
+        anyhow::bail!(
+            "this `toku` was built without at-rest encryption support.\n\
+             Rebuild with the `sqlcipher` feature: `cargo install toku-cli --features sqlcipher`."
+        )
+    }
+}
+
+#[cfg(feature = "sqlcipher")]
+fn cmd_db_status(data_dir: &Path) -> Result<()> {
+    let config = TokuConfig::load(data_dir).context("failed to load config")?;
+    match config.encryption.as_ref().filter(|e| e.enabled) {
+        Some(enc) => {
+            println!("At-rest encryption: ENABLED (SQLCipher)");
+            println!(
+                "KDF: Argon2id (m={} KiB, t={}, p={})",
+                enc.m_cost, enc.t_cost, enc.p_cost
+            );
+            println!("Lost passphrase = unrecoverable. There is no backdoor.");
+        }
+        None => {
+            println!("At-rest encryption: DISABLED (plaintext database)");
+            println!("Enable it with `toku db encrypt`.");
+        }
+    }
+    Ok(())
+}
+
+/// Read and confirm a NEW DB passphrase (env override, else prompt twice).
+#[cfg(feature = "sqlcipher")]
+fn read_new_db_passphrase() -> Result<String> {
+    if let Ok(pass) = std::env::var(DB_PASSPHRASE_ENV) {
+        if pass.is_empty() {
+            anyhow::bail!("{DB_PASSPHRASE_ENV} is set but empty");
+        }
+        return Ok(pass);
+    }
+    let pass = read_password_prompt("New database passphrase: ")?;
+    if pass.is_empty() {
+        anyhow::bail!("database passphrase cannot be empty");
+    }
+    let confirm = read_password_prompt("Confirm database passphrase: ")?;
+    if pass != confirm {
+        anyhow::bail!("passphrases do not match");
+    }
+    Ok(pass)
+}
+
+#[cfg(feature = "sqlcipher")]
+fn cmd_db_encrypt(data_dir: &Path, yes: bool, remember: bool) -> Result<()> {
+    let mut config = TokuConfig::load(data_dir).context("failed to load config")?;
+
+    // Idempotent: already encrypted.
+    if config.encryption.as_ref().is_some_and(|e| e.enabled) {
+        eprintln!("Database is already encrypted. Nothing to do.");
+        return Ok(());
+    }
+
+    let db_path = data_dir.join("toku.db");
+    if !db_path.exists() {
+        anyhow::bail!("no database found at {}", db_path.display());
+    }
+
+    if !yes {
+        eprintln!(
+            "This will encrypt {} in place.\n\
+             WARNING: if you lose the passphrase, the data is UNRECOVERABLE — there is no backdoor.",
+            db_path.display()
+        );
+        eprint!("Continue? [y/N]: ");
+        let mut input = String::new();
+        std::io::stdin()
+            .read_line(&mut input)
+            .context("failed to read confirmation")?;
+        if !matches!(input.trim(), "y" | "Y" | "yes" | "Yes") {
+            eprintln!("Aborted.");
+            return Ok(());
+        }
+    }
+
+    let passphrase = read_new_db_passphrase()?;
+    let salt = toku_core::SyncKey::generate_salt().map_err(|e| anyhow::anyhow!("{e}"))?;
+    let key = toku_core::SyncKey::derive(&passphrase, &salt).map_err(|e| anyhow::anyhow!("{e}"))?;
+
+    // Export plaintext → encrypted into a temp file, then swap.
+    let tmp_path = data_dir.join("toku.db.encrypting");
+    let _ = std::fs::remove_file(&tmp_path);
+    toku_db::crypt_migrate::encrypt_to(&db_path, &tmp_path, &key)
+        .context("failed to encrypt database")?;
+
+    // Verify the encrypted copy opens with the key before touching the original.
+    toku_db::Database::open_no_migrate_encrypted(&tmp_path, &key)
+        .context("verification of encrypted database failed")?;
+
+    // Keep a verified backup of the original until the swap is confirmed.
+    let backup_path = data_dir.join("toku.db.plaintext.bak");
+    std::fs::rename(&db_path, &backup_path).context("failed to back up the original database")?;
+    if let Err(e) = std::fs::rename(&tmp_path, &db_path) {
+        // Roll back: restore the original.
+        let _ = std::fs::rename(&backup_path, &db_path);
+        return Err(anyhow::anyhow!("failed to install encrypted database: {e}"));
+    }
+
+    // Persist the [encryption] descriptor (salt + params + verifier only).
+    use base64::Engine as _;
+    let verifier = toku_core::make_db_verifier(&key).map_err(|e| anyhow::anyhow!("{e}"))?;
+    config.encryption = Some(toku_core::EncryptionConfig {
+        enabled: true,
+        salt: base64::engine::general_purpose::STANDARD.encode(salt),
+        m_cost: toku_core::ARGON2_M_COST,
+        t_cost: toku_core::ARGON2_T_COST,
+        p_cost: toku_core::ARGON2_P_COST,
+        verifier,
+    });
+    config.save(data_dir).context("failed to save config")?;
+
+    if remember {
+        let token_store = sync::token_store::TokenStore::new(data_dir);
+        match token_store.store_db_passphrase(&passphrase) {
+            Ok(()) => eprintln!("✓ Cached passphrase in the OS keychain."),
+            Err(e) => eprintln!("warning: could not cache passphrase in keychain: {e}"),
+        }
+    }
+
+    eprintln!("✓ Database encrypted.");
+    eprintln!(
+        "  A plaintext backup remains at {}. Delete it once you've confirmed access:",
+        backup_path.display()
+    );
+    eprintln!("    rm {}", backup_path.display());
+    eprintln!("  Lost passphrase = unrecoverable. There is no backdoor.");
+    Ok(())
+}
+
+#[cfg(feature = "sqlcipher")]
+fn cmd_db_decrypt(data_dir: &Path, yes: bool) -> Result<()> {
+    let mut config = TokuConfig::load(data_dir).context("failed to load config")?;
+
+    // Idempotent: already plaintext.
+    let Some(enc) = config.encryption.clone().filter(|e| e.enabled) else {
+        eprintln!("Database is not encrypted. Nothing to do.");
+        return Ok(());
+    };
+
+    let db_path = data_dir.join("toku.db");
+    if !db_path.exists() {
+        anyhow::bail!("no database found at {}", db_path.display());
+    }
+
+    if !yes {
+        eprintln!(
+            "This will decrypt {} in place, leaving it as plaintext.",
+            db_path.display()
+        );
+        eprint!("Continue? [y/N]: ");
+        let mut input = String::new();
+        std::io::stdin()
+            .read_line(&mut input)
+            .context("failed to read confirmation")?;
+        if !matches!(input.trim(), "y" | "Y" | "yes" | "Yes") {
+            eprintln!("Aborted.");
+            return Ok(());
+        }
+    }
+
+    // Resolve the current passphrase and verify against the stored verifier.
+    // Precedence mirrors unlock: env var → OS keychain → interactive prompt.
+    let salt = decode_db_salt(&enc.salt)?;
+    let passphrase = if let Ok(pass) = std::env::var(DB_PASSPHRASE_ENV) {
+        if pass.is_empty() {
+            anyhow::bail!("{DB_PASSPHRASE_ENV} is set but empty");
+        }
+        pass
+    } else if let Some(pass) = sync::token_store::TokenStore::new(data_dir).load_db_passphrase() {
+        pass
+    } else {
+        read_password_prompt("Current database passphrase: ")?
+    };
+    let key = toku_core::SyncKey::derive(&passphrase, &salt).map_err(|e| anyhow::anyhow!("{e}"))?;
+    if !toku_core::verify_db_key(&key, &enc.verifier) {
+        anyhow::bail!("incorrect passphrase");
+    }
+
+    let tmp_path = data_dir.join("toku.db.decrypting");
+    let _ = std::fs::remove_file(&tmp_path);
+    toku_db::crypt_migrate::decrypt_to(&db_path, &tmp_path, &key)
+        .context("failed to decrypt database")?;
+
+    // Verify the plaintext copy opens before touching the original.
+    toku_db::Database::open_no_migrate(&tmp_path)
+        .context("verification of decrypted database failed")?;
+
+    let backup_path = data_dir.join("toku.db.encrypted.bak");
+    std::fs::rename(&db_path, &backup_path).context("failed to back up the encrypted database")?;
+    if let Err(e) = std::fs::rename(&tmp_path, &db_path) {
+        let _ = std::fs::rename(&backup_path, &db_path);
+        return Err(anyhow::anyhow!("failed to install plaintext database: {e}"));
+    }
+
+    // Clear the [encryption] descriptor and drop any cached passphrase.
+    config.encryption = None;
+    config.save(data_dir).context("failed to save config")?;
+    let token_store = sync::token_store::TokenStore::new(data_dir);
+    let _ = token_store.forget_db_passphrase();
+
+    eprintln!("✓ Database decrypted (now plaintext).");
+    eprintln!(
+        "  An encrypted backup remains at {}. Delete it once you've confirmed access:",
+        backup_path.display()
+    );
+    eprintln!("    rm {}", backup_path.display());
     Ok(())
 }
 
@@ -5258,7 +5628,7 @@ fn cmd_sync(data_dir: &Path, action: SyncAction, output_format: &OutputFormat) -
 
         SyncAction::Purge { days } => {
             let db_path = data_dir.join("toku.db");
-            let db = Database::open(&db_path).context("failed to open database")?;
+            let db = Database::open_default(&db_path).context("failed to open database")?;
             let repo = toku_db::BookRepository::new(&db);
             let purged = repo.purge_tombstones(days)?;
             match output_format {
@@ -5436,7 +5806,7 @@ fn cmd_sync(data_dir: &Path, action: SyncAction, output_format: &OutputFormat) -
             let token = require_token(&token_store, server)?;
 
             let db_path = data_dir.join("toku.db");
-            let db = Database::open(&db_path).context("failed to open database")?;
+            let db = Database::open_default(&db_path).context("failed to open database")?;
             let sync_repo = toku_db::SyncRepository::new(&db);
             let snapshot_repo = toku_db::SnapshotRepository::new(&db);
             let client = sync::client::SyncClient::new(server)?;

--- a/crates/toku-core/src/config.rs
+++ b/crates/toku-core/src/config.rs
@@ -20,6 +20,9 @@ pub struct TokuConfig {
     pub files: FilesConfig,
     /// OPDS server configuration (optional HTTP Basic auth).
     pub opds: OpdsConfig,
+    /// At-rest database encryption configuration (optional — absent until
+    /// `toku db encrypt`). Present only when the DB is SQLCipher-encrypted.
+    pub encryption: Option<EncryptionConfig>,
 }
 
 /// OPDS server configuration stored in `config.toml` under `[opds]`.
@@ -151,6 +154,30 @@ impl Default for FilesConfig {
     }
 }
 
+/// At-rest database encryption configuration stored in `config.toml` under
+/// `[encryption]`.
+///
+/// Present only when the local `toku.db` is SQLCipher-encrypted (`toku db
+/// encrypt`). It records **only** the KDF salt, Argon2id parameters, and a
+/// verifier token — never the passphrase or the derived key. The verifier lets
+/// the CLI reject a wrong passphrase before touching the database.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct EncryptionConfig {
+    /// Whether at-rest encryption is enabled for the local database.
+    pub enabled: bool,
+    /// Base64-encoded 128-bit Argon2id salt.
+    pub salt: String,
+    /// Argon2id memory cost in KiB.
+    pub m_cost: u32,
+    /// Argon2id time cost (iterations).
+    pub t_cost: u32,
+    /// Argon2id parallelism.
+    pub p_cost: u32,
+    /// Verifier token: `base64(nonce || AES-256-GCM(key, constant))`. Proves a
+    /// passphrase matches without persisting the key.
+    pub verifier: String,
+}
+
 /// Sync configuration stored in `config.toml` under `[sync]`.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct SyncConfig {
@@ -175,6 +202,7 @@ impl Default for TokuConfig {
             sync: None,
             files: FilesConfig::default(),
             opds: OpdsConfig::default(),
+            encryption: None,
         }
     }
 }
@@ -246,6 +274,7 @@ mod tests {
             sync: None,
             files: FilesConfig::default(),
             opds: OpdsConfig::default(),
+            encryption: None,
         };
         cfg.save(&dir).expect("save should succeed");
 
@@ -253,6 +282,31 @@ mod tests {
         assert_eq!(loaded, cfg);
 
         // Clean up
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn encryption_config_roundtrips_through_toml() {
+        let dir = std::env::temp_dir().join("toku-test-config-encryption");
+        let _ = std::fs::remove_dir_all(&dir);
+
+        let cfg = TokuConfig {
+            encryption: Some(EncryptionConfig {
+                enabled: true,
+                salt: "c2FsdHNhbHRzYWx0c2E=".to_string(),
+                m_cost: 65536,
+                t_cost: 3,
+                p_cost: 1,
+                verifier: "dmVyaWZpZXI=".to_string(),
+            }),
+            ..TokuConfig::default()
+        };
+        cfg.save(&dir).expect("save should succeed");
+
+        let loaded = TokuConfig::load(&dir).expect("load should succeed");
+        assert_eq!(loaded, cfg);
+        assert!(loaded.encryption.is_some());
+
         let _ = std::fs::remove_dir_all(&dir);
     }
 

--- a/crates/toku-core/src/crypto.rs
+++ b/crates/toku-core/src/crypto.rs
@@ -274,6 +274,73 @@ pub fn decrypt_fields(
 }
 
 // ---------------------------------------------------------------------------
+// At-rest DB key verifier
+// ---------------------------------------------------------------------------
+
+/// Constant plaintext sealed to build an at-rest DB key verifier.
+const DB_VERIFIER_PLAINTEXT: &[u8] = b"toku-db-key-verifier-v1";
+
+/// Fixed domain-separator AAD for the DB key verifier.
+const DB_VERIFIER_AAD: &str = "kind=db-verifier,v=1";
+
+/// Build a verifier token that proves knowledge of the derived at-rest DB key
+/// **without** persisting the key or the passphrase.
+///
+/// The token is `base64(nonce || AES-256-GCM(key, DB_VERIFIER_PLAINTEXT))`.
+/// It is stored in `config.toml` under `[encryption]` so a wrong passphrase is
+/// rejected *before* the encrypted database is ever opened, and so the config
+/// can confirm it matches the key that unlocks the DB.
+pub fn make_db_verifier(key: &SyncKey) -> Result<String, TokuError> {
+    let cipher = Aes256Gcm::new_from_slice(key.as_bytes())
+        .map_err(|e| TokuError::Crypto(format!("cipher init: {e}")))?;
+
+    let mut nonce_bytes = [0u8; 12];
+    getrandom::fill(&mut nonce_bytes)
+        .map_err(|e| TokuError::Crypto(format!("os rng failed for nonce: {e}")))?;
+    let nonce = Nonce::from(nonce_bytes);
+
+    let payload = Payload {
+        msg: DB_VERIFIER_PLAINTEXT,
+        aad: DB_VERIFIER_AAD.as_bytes(),
+    };
+    let ciphertext = cipher
+        .encrypt(&nonce, payload)
+        .map_err(|e| TokuError::Crypto(format!("verifier seal failed: {e}")))?;
+
+    let mut out = Vec::with_capacity(nonce_bytes.len() + ciphertext.len());
+    out.extend_from_slice(&nonce_bytes);
+    out.extend_from_slice(&ciphertext);
+    Ok(BASE64_STANDARD.encode(out))
+}
+
+/// True when `key` unseals the stored `verifier` token, i.e. the passphrase the
+/// key was derived from matches the one that created the verifier. Never panics;
+/// any malformed token or wrong key returns `false`.
+pub fn verify_db_key(key: &SyncKey, verifier: &str) -> bool {
+    let Ok(raw) = BASE64_STANDARD.decode(verifier) else {
+        return false;
+    };
+    if raw.len() < 12 {
+        return false;
+    }
+    let (nonce_bytes, ciphertext) = raw.split_at(12);
+    let Ok(nonce) = Nonce::try_from(nonce_bytes) else {
+        return false;
+    };
+    let Ok(cipher) = Aes256Gcm::new_from_slice(key.as_bytes()) else {
+        return false;
+    };
+    let payload = Payload {
+        msg: ciphertext,
+        aad: DB_VERIFIER_AAD.as_bytes(),
+    };
+    match cipher.decrypt(&nonce, payload) {
+        Ok(pt) => pt == DB_VERIFIER_PLAINTEXT,
+        Err(_) => false,
+    }
+}
+
+// ---------------------------------------------------------------------------
 // Snapshot encryption
 // ---------------------------------------------------------------------------
 
@@ -439,6 +506,42 @@ mod tests {
         let salt1 = SyncKey::generate_salt().unwrap();
         let salt2 = SyncKey::generate_salt().unwrap();
         assert_ne!(salt1, salt2, "two salts should not be equal");
+    }
+
+    // --- DB key verifier ---
+
+    #[test]
+    fn db_verifier_accepts_matching_key() {
+        let (key, _) = test_key_and_salt();
+        let verifier = make_db_verifier(&key).unwrap();
+        assert!(verify_db_key(&key, &verifier));
+    }
+
+    #[test]
+    fn db_verifier_rejects_wrong_key() {
+        let salt: [u8; 16] = [7; 16];
+        let key = SyncKey::derive("correct-passphrase", &salt).unwrap();
+        let wrong = SyncKey::derive("wrong-passphrase", &salt).unwrap();
+        let verifier = make_db_verifier(&key).unwrap();
+        assert!(!verify_db_key(&wrong, &verifier));
+    }
+
+    #[test]
+    fn db_verifier_rejects_malformed_token() {
+        let (key, _) = test_key_and_salt();
+        assert!(!verify_db_key(&key, ""));
+        assert!(!verify_db_key(&key, "not-base64!!!"));
+        assert!(!verify_db_key(&key, "c2hvcnQ=")); // "short" — < 12 bytes
+    }
+
+    #[test]
+    fn db_verifier_uses_random_nonce() {
+        let (key, _) = test_key_and_salt();
+        let a = make_db_verifier(&key).unwrap();
+        let b = make_db_verifier(&key).unwrap();
+        assert_ne!(a, b, "random nonce ⇒ distinct tokens");
+        assert!(verify_db_key(&key, &a));
+        assert!(verify_db_key(&key, &b));
     }
 
     #[test]

--- a/crates/toku-db/Cargo.toml
+++ b/crates/toku-db/Cargo.toml
@@ -19,5 +19,13 @@ refinery = { version = "0.9", features = ["rusqlite"] }
 directories = "6"
 base64 = "0.22"
 
+[features]
+# Optional at-rest database encryption via SQLCipher (ADR-016). OFF by default.
+# Selecting this swaps rusqlite's bundled standard SQLite for a bundled
+# SQLCipher build with vendored OpenSSL (no system OpenSSL dependency). Scoped
+# to this crate only: the default workspace build, the toku-sync relay, and the
+# CI `apple` cross-compile stay on standard SQLite.
+sqlcipher = ["rusqlite/bundled-sqlcipher-vendored-openssl"]
+
 [dev-dependencies]
 tempfile = "3"

--- a/crates/toku-db/src/crypt_migrate.rs
+++ b/crates/toku-db/src/crypt_migrate.rs
@@ -1,0 +1,171 @@
+//! Plaintext ↔ SQLCipher database migration via `sqlcipher_export()`.
+//!
+//! Only compiled when the `sqlcipher` feature is enabled (ADR-016 D6). These
+//! functions copy a whole database into a new file with a different key state,
+//! leaving the source untouched so the caller can verify the destination before
+//! swapping files.
+
+use std::path::Path;
+
+use rusqlite::Connection;
+
+use crate::DbError;
+use toku_core::SyncKey;
+
+/// Render a 256-bit key as SQLCipher's raw-key hex literal (`x'<64hex>'`).
+fn key_hex_literal(key: &SyncKey) -> String {
+    use std::fmt::Write as _;
+    let mut hex = String::with_capacity(64);
+    for byte in key.as_exported_bytes() {
+        write!(hex, "{byte:02x}").expect("writing to String cannot fail");
+    }
+    format!("x'{hex}'")
+}
+
+/// Copy a **plaintext** database at `src` into a new **encrypted** database at
+/// `dst`, keyed with `key`. `dst` must not already exist. `src` is left
+/// unchanged.
+pub fn encrypt_to(src: &Path, dst: &Path, key: &SyncKey) -> Result<(), DbError> {
+    if dst.exists() {
+        return Err(DbError::Encryption(format!(
+            "destination already exists: {}",
+            dst.display()
+        )));
+    }
+    let conn = Connection::open(src)?;
+    let dst_str = dst
+        .to_str()
+        .ok_or_else(|| DbError::Encryption("destination path is not valid UTF-8".to_string()))?;
+    let key_lit = key_hex_literal(key);
+
+    conn.execute_batch(&format!(
+        "ATTACH DATABASE '{}' AS toku_target KEY \"{}\";\n\
+         SELECT sqlcipher_export('toku_target');\n\
+         DETACH DATABASE toku_target;",
+        sql_escape_single_quotes(dst_str),
+        key_lit,
+    ))
+    .map_err(|e| DbError::Encryption(format!("encrypt export failed: {e}")))?;
+    Ok(())
+}
+
+/// Copy an **encrypted** database at `src` (opened with `key`) into a new
+/// **plaintext** database at `dst`. `dst` must not already exist. `src` is left
+/// unchanged.
+pub fn decrypt_to(src: &Path, dst: &Path, key: &SyncKey) -> Result<(), DbError> {
+    if dst.exists() {
+        return Err(DbError::Encryption(format!(
+            "destination already exists: {}",
+            dst.display()
+        )));
+    }
+    let conn = Connection::open(src)?;
+    // Key the source first (validates the passphrase before exporting).
+    conn.execute_batch(&format!("PRAGMA key = \"{}\";", key_hex_literal(key)))
+        .map_err(|e| DbError::Encryption(format!("failed to apply key: {e}")))?;
+    conn.query_row("SELECT count(*) FROM sqlite_master", [], |_| Ok(()))
+        .map_err(|_| {
+            DbError::Encryption(
+                "incorrect passphrase or not an encrypted Toku database".to_string(),
+            )
+        })?;
+
+    let dst_str = dst
+        .to_str()
+        .ok_or_else(|| DbError::Encryption("destination path is not valid UTF-8".to_string()))?;
+    conn.execute_batch(&format!(
+        "ATTACH DATABASE '{}' AS toku_target KEY '';\n\
+         SELECT sqlcipher_export('toku_target');\n\
+         DETACH DATABASE toku_target;",
+        sql_escape_single_quotes(dst_str),
+    ))
+    .map_err(|e| DbError::Encryption(format!("decrypt export failed: {e}")))?;
+    Ok(())
+}
+
+/// Escape single quotes in a SQLite string literal (path interpolated into
+/// `ATTACH DATABASE '...'`, which does not accept bound parameters).
+fn sql_escape_single_quotes(s: &str) -> String {
+    s.replace('\'', "''")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Database;
+
+    fn test_key(pass: &str) -> SyncKey {
+        let salt: [u8; 16] = [3; 16];
+        SyncKey::derive(pass, &salt).unwrap()
+    }
+
+    fn seed(path: &Path) {
+        let db = Database::open(path).unwrap();
+        db.conn
+            .execute(
+                "INSERT INTO books (id, title, created_at, updated_at) VALUES (?1, ?2, ?3, ?3)",
+                (
+                    "01972123-abcd-7000-8000-000000000009",
+                    "Neuromancer",
+                    "2026-07-27T00:00:00Z",
+                ),
+            )
+            .unwrap();
+    }
+
+    #[test]
+    fn encrypt_then_decrypt_roundtrip() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let plain = tmp.path().join("plain.db");
+        let enc = tmp.path().join("enc.db");
+        let back = tmp.path().join("back.db");
+        let key = test_key("roundtrip-pass");
+
+        seed(&plain);
+        encrypt_to(&plain, &enc, &key).unwrap();
+
+        // Encrypted file opens with the key and holds the data.
+        let db = Database::open_no_migrate_encrypted(&enc, &key).unwrap();
+        let title: String = db
+            .conn
+            .query_row("SELECT title FROM books LIMIT 1", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(title, "Neuromancer");
+        drop(db);
+
+        // Decrypt back to plaintext.
+        decrypt_to(&enc, &back, &key).unwrap();
+        let db = Database::open_no_migrate(&back).unwrap();
+        let title: String = db
+            .conn
+            .query_row("SELECT title FROM books LIMIT 1", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(title, "Neuromancer");
+    }
+
+    #[test]
+    fn decrypt_with_wrong_key_fails_cleanly() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let plain = tmp.path().join("plain.db");
+        let enc = tmp.path().join("enc.db");
+        let back = tmp.path().join("back.db");
+
+        seed(&plain);
+        encrypt_to(&plain, &enc, &test_key("right")).unwrap();
+
+        let err = decrypt_to(&enc, &back, &test_key("wrong")).unwrap_err();
+        assert!(matches!(err, DbError::Encryption(_)));
+        assert!(!back.exists() || std::fs::metadata(&back).unwrap().len() == 0);
+    }
+
+    #[test]
+    fn refuses_existing_destination() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let plain = tmp.path().join("plain.db");
+        let enc = tmp.path().join("enc.db");
+        seed(&plain);
+        std::fs::write(&enc, b"existing").unwrap();
+        let err = encrypt_to(&plain, &enc, &test_key("x")).unwrap_err();
+        assert!(matches!(err, DbError::Encryption(_)));
+    }
+}

--- a/crates/toku-db/src/database.rs
+++ b/crates/toku-db/src/database.rs
@@ -5,11 +5,79 @@ use rusqlite::Connection;
 
 use crate::DbError;
 
+#[cfg(feature = "sqlcipher")]
+use toku_core::SyncKey;
+
 embed_migrations!("migrations");
 
 /// Wraps a SQLite connection with schema migrations and configuration.
 pub struct Database {
     pub conn: Connection,
+}
+
+/// Process-global at-rest DB unlock key (ADR-016 D4/D5).
+///
+/// When the `sqlcipher` feature is on and the local database is encrypted, the
+/// entry point (CLI / web server) resolves the key **once** and installs it here
+/// for the process lifetime. The `*_default` constructors then transparently
+/// open the database keyed, so the many request-time open sites need no
+/// key-threading. The base `open`/`open_no_migrate`/`open_encrypted`
+/// constructors never consult this global — migration and tests depend on their
+/// exact, unambiguous behavior.
+#[cfg(feature = "sqlcipher")]
+mod key_state {
+    use std::sync::OnceLock;
+
+    use toku_core::SyncKey;
+
+    static DB_KEY: OnceLock<SyncKey> = OnceLock::new();
+
+    /// Install the process unlock key. Returns `Err` if one is already set.
+    pub fn set_process_db_key(key: SyncKey) -> Result<(), &'static str> {
+        DB_KEY.set(key).map_err(|_| "process DB key already set")
+    }
+
+    /// The installed process unlock key, if any.
+    pub fn process_db_key() -> Option<&'static SyncKey> {
+        DB_KEY.get()
+    }
+}
+
+#[cfg(feature = "sqlcipher")]
+pub use key_state::{process_db_key, set_process_db_key};
+
+/// Apply a raw 256-bit key to a freshly opened SQLCipher connection and confirm
+/// it decrypts the header.
+///
+/// The key is passed as a raw hex blob (`PRAGMA key = "x'<64hex>'"`) so
+/// SQLCipher uses it directly and does **not** run its own weaker PBKDF2 — Toku
+/// derives the key with Argon2id (`SyncKey::derive`) itself. This must be the
+/// **first** statement after `Connection::open`, before WAL / foreign_keys /
+/// migrations, because SQLCipher needs the key before the header is read.
+///
+/// A wrong key surfaces as a clean [`DbError::Encryption`] on the probe query
+/// (SQLCipher returns `SQLITE_NOTADB`) — never a panic, never a partial open.
+#[cfg(feature = "sqlcipher")]
+fn apply_key(conn: &Connection, key: &SyncKey) -> Result<(), DbError> {
+    use std::fmt::Write as _;
+
+    let mut hex = String::with_capacity(64);
+    for byte in key.as_exported_bytes() {
+        write!(hex, "{byte:02x}").expect("writing to String cannot fail");
+    }
+    // `PRAGMA key` does not accept bound parameters; the value is our own hex of
+    // a fixed-length key, so there is no untrusted interpolation here.
+    conn.execute_batch(&format!("PRAGMA key = \"x'{hex}'\";"))
+        .map_err(|e| DbError::Encryption(format!("failed to apply key: {e}")))?;
+
+    // Force the header to be read/decrypted. A wrong key fails here.
+    conn.query_row("SELECT count(*) FROM sqlite_master", [], |_| Ok(()))
+        .map_err(|_| {
+            DbError::Encryption(
+                "incorrect passphrase or not an encrypted Toku database".to_string(),
+            )
+        })?;
+    Ok(())
 }
 
 impl Database {
@@ -47,6 +115,69 @@ impl Database {
         migrations::runner().run(&mut conn)?;
 
         Ok(Self { conn })
+    }
+
+    /// Open (or create) an **encrypted** database and run migrations.
+    ///
+    /// Mirrors [`Database::open`] but applies `key` via SQLCipher's `PRAGMA key`
+    /// as the first statement, before WAL / foreign_keys / migrations. A wrong
+    /// key yields [`DbError::Encryption`] rather than a panic or partial open.
+    ///
+    /// Only available when the `sqlcipher` feature is enabled.
+    #[cfg(feature = "sqlcipher")]
+    pub fn open_encrypted(path: &Path, key: &SyncKey) -> Result<Self, DbError> {
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).map_err(|e| DbError::Io(e.to_string()))?;
+        }
+
+        let mut conn = Connection::open(path)?;
+        apply_key(&conn, key)?;
+        conn.pragma_update(None, "journal_mode", "WAL")?;
+        conn.pragma_update(None, "foreign_keys", "ON")?;
+
+        migrations::runner().run(&mut conn)?;
+
+        Ok(Self { conn })
+    }
+
+    /// Open an **encrypted** database without running migrations.
+    ///
+    /// Mirrors [`Database::open_no_migrate`] but applies `key` first. Use for
+    /// request-time reads after migrations have already run at startup via
+    /// [`Database::open_encrypted`].
+    ///
+    /// Only available when the `sqlcipher` feature is enabled.
+    #[cfg(feature = "sqlcipher")]
+    pub fn open_no_migrate_encrypted(path: &Path, key: &SyncKey) -> Result<Self, DbError> {
+        let conn = Connection::open(path)?;
+        apply_key(&conn, key)?;
+        conn.pragma_update(None, "journal_mode", "WAL")?;
+        conn.pragma_update(None, "foreign_keys", "ON")?;
+        Ok(Self { conn })
+    }
+
+    /// Open (or create) the database and run migrations, transparently keyed
+    /// when a process unlock key is installed (see [`set_process_db_key`]).
+    ///
+    /// This is the constructor application entry points should use. With the
+    /// `sqlcipher` feature **off**, it is identical to [`Database::open`].
+    pub fn open_default(path: &Path) -> Result<Self, DbError> {
+        #[cfg(feature = "sqlcipher")]
+        if let Some(key) = key_state::process_db_key() {
+            return Self::open_encrypted(path, key);
+        }
+        Self::open(path)
+    }
+
+    /// Open the database without migrations, transparently keyed when a process
+    /// unlock key is installed. With `sqlcipher` off, identical to
+    /// [`Database::open_no_migrate`].
+    pub fn open_no_migrate_default(path: &Path) -> Result<Self, DbError> {
+        #[cfg(feature = "sqlcipher")]
+        if let Some(key) = key_state::process_db_key() {
+            return Self::open_no_migrate_encrypted(path, key);
+        }
+        Self::open_no_migrate(path)
     }
 
     /// Returns the default data directory for the current platform.
@@ -93,5 +224,86 @@ mod tests {
             .query_row("SELECT COUNT(*) FROM books", [], |row| row.get(0))
             .unwrap();
         assert_eq!(count, 0);
+    }
+
+    #[cfg(feature = "sqlcipher")]
+    mod encrypted {
+        use super::*;
+        use toku_core::SyncKey;
+
+        fn test_key(pass: &str) -> SyncKey {
+            let salt: [u8; 16] = [9; 16];
+            SyncKey::derive(pass, &salt).unwrap()
+        }
+
+        #[test]
+        fn open_encrypted_roundtrip() {
+            let tmp = tempfile::TempDir::new().unwrap();
+            let db_path = tmp.path().join("enc.db");
+            let key = test_key("correct horse");
+
+            {
+                let db = Database::open_encrypted(&db_path, &key).unwrap();
+                db.conn
+                    .execute(
+                        "INSERT INTO books (id, title, created_at, updated_at) \
+                         VALUES (?1, ?2, ?3, ?3)",
+                        (
+                            "01972123-abcd-7000-8000-000000000001",
+                            "Dune",
+                            "2026-07-27T00:00:00Z",
+                        ),
+                    )
+                    .unwrap();
+            }
+
+            // Reopen without migrating, same key, data survives.
+            let db = Database::open_no_migrate_encrypted(&db_path, &key).unwrap();
+            let title: String = db
+                .conn
+                .query_row("SELECT title FROM books LIMIT 1", [], |r| r.get(0))
+                .unwrap();
+            assert_eq!(title, "Dune");
+        }
+
+        #[test]
+        fn wrong_key_fails_cleanly() {
+            let tmp = tempfile::TempDir::new().unwrap();
+            let db_path = tmp.path().join("enc.db");
+            let key = test_key("correct horse");
+            let wrong = test_key("battery staple");
+
+            {
+                let _db = Database::open_encrypted(&db_path, &key).unwrap();
+            }
+
+            let err = Database::open_no_migrate_encrypted(&db_path, &wrong);
+            match err {
+                Err(DbError::Encryption(msg)) => {
+                    assert!(msg.contains("incorrect passphrase"), "got: {msg}");
+                }
+                Err(other) => panic!("expected Encryption error, got {other:?}"),
+                Ok(_) => panic!("expected wrong key to fail"),
+            }
+        }
+
+        #[test]
+        fn plaintext_db_opened_with_key_fails_cleanly() {
+            let tmp = tempfile::TempDir::new().unwrap();
+            let db_path = tmp.path().join("plain.db");
+            let key = test_key("correct horse");
+
+            // Create a plaintext DB.
+            {
+                let _db = Database::open(&db_path).unwrap();
+            }
+
+            let err = Database::open_no_migrate_encrypted(&db_path, &key);
+            match err {
+                Err(DbError::Encryption(_)) => {}
+                Err(other) => panic!("expected Encryption error, got {other:?}"),
+                Ok(_) => panic!("expected plaintext-with-key to fail"),
+            }
+        }
     }
 }

--- a/crates/toku-db/src/error.rs
+++ b/crates/toku-db/src/error.rs
@@ -14,4 +14,7 @@ pub enum DbError {
 
     #[error("invalid operation: {0}")]
     InvalidOperation(String),
+
+    #[error("encryption error: {0}")]
+    Encryption(String),
 }

--- a/crates/toku-db/src/lib.rs
+++ b/crates/toku-db/src/lib.rs
@@ -1,4 +1,6 @@
 mod backfill;
+#[cfg(feature = "sqlcipher")]
+pub mod crypt_migrate;
 mod database;
 mod error;
 mod library_io;
@@ -9,6 +11,8 @@ mod sync_repo;
 
 pub use backfill::{BackfillCounts, backfill_sync_ops};
 pub use database::Database;
+#[cfg(feature = "sqlcipher")]
+pub use database::{process_db_key, set_process_db_key};
 pub use error::DbError;
 pub use library_io::{LibraryIo, RestoreMode, RestoreResult};
 pub use merge::MergeEngine;

--- a/crates/toku-ffi/Cargo.toml
+++ b/crates/toku-ffi/Cargo.toml
@@ -10,6 +10,11 @@ repository.workspace = true
 [lib]
 crate-type = ["cdylib", "staticlib"]
 
+[features]
+# Passthrough: enable at-rest DB encryption support (ADR-016). OFF by default.
+# Kept OFF in the CI `apple` cross-compile to avoid the OpenSSL build hazard.
+sqlcipher = ["toku-db/sqlcipher"]
+
 [dependencies]
 toku-core.workspace = true
 toku-db.workspace = true

--- a/crates/toku-ffi/src/lib.rs
+++ b/crates/toku-ffi/src/lib.rs
@@ -215,6 +215,82 @@ pub unsafe extern "C" fn toku_open(path: *const c_char, out: *mut *mut TokuDb) -
     }))
 }
 
+/// Open (or create) an **encrypted** Toku database at `path`, unlocking it with
+/// a raw 256-bit key.
+///
+/// `key` must point to exactly 32 bytes (the Argon2id-derived key; the caller
+/// derives it from the user's passphrase). On success, writes a handle to
+/// `*out`. The caller must eventually call `toku_close`. A wrong key fails
+/// cleanly with `TokuStatus::ErrorDb` (see `toku_last_error`), never a crash.
+///
+/// This function is only functional in builds compiled with the `sqlcipher`
+/// feature; otherwise it returns `TokuStatus::ErrorDb` with an explanatory
+/// message. `toku_open` is unaffected and continues to open plaintext databases.
+///
+/// # Safety
+/// - `path` must be a valid NUL-terminated UTF-8 string.
+/// - `key` must point to `key_len` readable bytes.
+/// - `out` must be a valid pointer to a `*mut TokuDb`.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn toku_open_encrypted(
+    path: *const c_char,
+    key: *const u8,
+    key_len: usize,
+    out: *mut *mut TokuDb,
+) -> TokuStatus {
+    ffi_guard(AssertUnwindSafe(|| {
+        clear_last_error();
+
+        if out.is_null() {
+            set_last_error("out pointer is null");
+            return TokuStatus::ErrorNullPointer;
+        }
+        if key.is_null() {
+            set_last_error("key pointer is null");
+            return TokuStatus::ErrorNullPointer;
+        }
+        if key_len != 32 {
+            set_last_error("key must be exactly 32 bytes");
+            return TokuStatus::ErrorDb;
+        }
+
+        let path_str = match unsafe { cstr_to_str(path) } {
+            Ok(s) => s,
+            Err(status) => return status,
+        };
+
+        let key_bytes = unsafe { std::slice::from_raw_parts(key, key_len) };
+
+        #[cfg(feature = "sqlcipher")]
+        {
+            let sync_key = match toku_core::SyncKey::from_exported_bytes(key_bytes) {
+                Ok(k) => k,
+                Err(e) => {
+                    set_last_error(&format!("invalid key: {e}"));
+                    return TokuStatus::ErrorDb;
+                }
+            };
+            let db = match Database::open_encrypted(Path::new(path_str), &sync_key) {
+                Ok(db) => db,
+                Err(e) => {
+                    set_last_error(&format!("failed to open encrypted database: {e}"));
+                    return TokuStatus::ErrorDb;
+                }
+            };
+            let handle = Box::new(TokuDb { db });
+            unsafe { *out = Box::into_raw(handle) };
+            TokuStatus::Ok
+        }
+
+        #[cfg(not(feature = "sqlcipher"))]
+        {
+            let _ = (path_str, key_bytes);
+            set_last_error("this build does not include sqlcipher support");
+            TokuStatus::ErrorDb
+        }
+    }))
+}
+
 /// Close a Toku database handle and free its resources.
 /// After this call, the handle must not be used. Passing null is a safe no-op.
 ///

--- a/crates/toku-ffi/toku.h
+++ b/crates/toku-ffi/toku.h
@@ -69,6 +69,29 @@ const char *toku_last_error(void);
 enum TokuStatus toku_open(const char *path, struct TokuDb **out);
 
 /**
+ * Open (or create) an **encrypted** Toku database at `path`, unlocking it with
+ * a raw 256-bit key.
+ *
+ * `key` must point to exactly 32 bytes (the Argon2id-derived key; the caller
+ * derives it from the user's passphrase). On success, writes a handle to
+ * `*out`. The caller must eventually call `toku_close`. A wrong key fails
+ * cleanly with `TokuStatus::ErrorDb` (see `toku_last_error`), never a crash.
+ *
+ * This function is only functional in builds compiled with the `sqlcipher`
+ * feature; otherwise it returns `TokuStatus::ErrorDb` with an explanatory
+ * message. `toku_open` is unaffected and continues to open plaintext databases.
+ *
+ * # Safety
+ * - `path` must be a valid NUL-terminated UTF-8 string.
+ * - `key` must point to `key_len` readable bytes.
+ * - `out` must be a valid pointer to a `*mut TokuDb`.
+ */
+enum TokuStatus toku_open_encrypted(const char *path,
+                                    const uint8_t *key,
+                                    uintptr_t key_len,
+                                    struct TokuDb **out);
+
+/**
  * Close a Toku database handle and free its resources.
  * After this call, the handle must not be used. Passing null is a safe no-op.
  *

--- a/crates/toku-sync-client/Cargo.toml
+++ b/crates/toku-sync-client/Cargo.toml
@@ -7,6 +7,10 @@ authors.workspace = true
 license.workspace = true
 repository.workspace = true
 
+[features]
+# Passthrough: enable at-rest DB encryption support (ADR-016). OFF by default.
+sqlcipher = ["toku-db/sqlcipher"]
+
 [dependencies]
 toku-core.workspace = true
 toku-db.workspace = true

--- a/crates/toku-sync-client/src/orchestrator.rs
+++ b/crates/toku-sync-client/src/orchestrator.rs
@@ -184,7 +184,7 @@ fn build_runtime() -> anyhow::Result<tokio::runtime::Runtime> {
 }
 
 fn open_db(data_dir: &Path) -> anyhow::Result<Database> {
-    Database::open(&data_dir.join("toku.db")).context("failed to open database")
+    Database::open_default(&data_dir.join("toku.db")).context("failed to open database")
 }
 
 fn require_sync(config: &toku_core::TokuConfig) -> anyhow::Result<&toku_core::SyncConfig> {

--- a/crates/toku-sync-client/src/token_store.rs
+++ b/crates/toku-sync-client/src/token_store.rs
@@ -71,6 +71,7 @@ pub struct TokenStore {
 const KEYRING_SERVICE: &str = "toku-sync";
 const KEYRING_SERVICE_SYNCKEY: &str = "toku-sync-key";
 const KEYRING_SERVICE_USER: &str = "toku-sync-user";
+const KEYRING_SERVICE_DB_PASSPHRASE: &str = "toku-db-passphrase";
 
 impl TokenStore {
     pub fn new(data_dir: &Path) -> Self {
@@ -223,6 +224,59 @@ impl TokenStore {
 
         let _ = self.delete_file(&format!("{key}:usersession_expires"));
         self.delete_file(&format!("{key}:usersession"))
+    }
+
+    /// Store the local **DB unlock passphrase** in the OS keychain (opt-in
+    /// convenience for at-rest DB encryption, ADR-016 D4).
+    ///
+    /// Keychain-only: unlike sync tokens, this **never** falls back to the local
+    /// file store — writing the DB passphrase to a plaintext file next to the
+    /// encrypted database would defeat the purpose. Keyed by the data directory
+    /// so multiple libraries don't collide. Fails if no OS keychain is available
+    /// or if the keychain is disabled by env.
+    pub fn store_db_passphrase(&self, passphrase: &str) -> anyhow::Result<()> {
+        if keychain_disabled() {
+            anyhow::bail!("OS keychain is disabled; cannot cache the DB passphrase");
+        }
+        ensure_keyring_store();
+        let key = self.db_passphrase_key();
+        let entry = keyring_core::Entry::new(KEYRING_SERVICE_DB_PASSPHRASE, &key)
+            .map_err(|e| anyhow::anyhow!("OS keychain unavailable: {e}"))?;
+        entry
+            .set_password(passphrase)
+            .map_err(|e| anyhow::anyhow!("could not store DB passphrase in keychain: {e}"))?;
+        Ok(())
+    }
+
+    /// Load the cached DB unlock passphrase from the OS keychain, if present.
+    /// Keychain-only; returns `None` when absent, disabled, or unavailable.
+    pub fn load_db_passphrase(&self) -> Option<String> {
+        if keychain_disabled() {
+            return None;
+        }
+        ensure_keyring_store();
+        let key = self.db_passphrase_key();
+        let entry = keyring_core::Entry::new(KEYRING_SERVICE_DB_PASSPHRASE, &key).ok()?;
+        entry.get_password().ok()
+    }
+
+    /// Remove the cached DB passphrase from the OS keychain (no-op if absent).
+    pub fn forget_db_passphrase(&self) -> anyhow::Result<()> {
+        if keychain_disabled() {
+            return Ok(());
+        }
+        ensure_keyring_store();
+        let key = self.db_passphrase_key();
+        if let Ok(entry) = keyring_core::Entry::new(KEYRING_SERVICE_DB_PASSPHRASE, &key) {
+            let _ = entry.delete_credential();
+        }
+        Ok(())
+    }
+
+    /// Keychain entry key for the DB passphrase, derived from the data directory
+    /// so distinct libraries have distinct cached passphrases.
+    fn db_passphrase_key(&self) -> String {
+        self.data_dir.to_string_lossy().to_string()
     }
 
     /// Store the derived sync encryption key in the OS keychain.

--- a/crates/toku-web/Cargo.toml
+++ b/crates/toku-web/Cargo.toml
@@ -7,6 +7,10 @@ authors.workspace = true
 license.workspace = true
 repository.workspace = true
 
+[features]
+# Passthrough: enable at-rest DB encryption support (ADR-016). OFF by default.
+sqlcipher = ["toku-db/sqlcipher"]
+
 [dependencies]
 toku-core.workspace = true
 toku-db.workspace = true

--- a/crates/toku-web/src/auth.rs
+++ b/crates/toku-web/src/auth.rs
@@ -436,7 +436,7 @@ pub fn delete_session(db_path: &Path, token: &str) -> Result<(), String> {
 }
 
 fn open(db_path: &Path) -> Result<toku_db::Database, String> {
-    toku_db::Database::open_no_migrate(db_path).map_err(|e| e.to_string())
+    toku_db::Database::open_no_migrate_default(db_path).map_err(|e| e.to_string())
 }
 
 // ── Cookie builders ──────────────────────────────────────────────────────────

--- a/crates/toku-web/src/conflicts_handlers.rs
+++ b/crates/toku-web/src/conflicts_handlers.rs
@@ -32,7 +32,7 @@ pub async fn conflicts_page(
     let db_path = state.db_path.clone();
 
     let conflicts = tokio::task::spawn_blocking(move || {
-        let db = Database::open_no_migrate(&db_path)?;
+        let db = Database::open_no_migrate_default(&db_path)?;
         SyncRepository::new(&db).list_unresolved_conflicts()
     })
     .await
@@ -57,7 +57,7 @@ pub async fn resolve_conflict(
     if form.keep == "custom" {
         let value = form.value.unwrap_or_default();
         tokio::task::spawn_blocking(move || {
-            let db = Database::open(&db_path)?;
+            let db = Database::open_default(&db_path)?;
             SyncRepository::new(&db).resolve_conflict_with_value(&id, Some(&value))
         })
         .await
@@ -67,7 +67,7 @@ pub async fn resolve_conflict(
 
     let keep = parse_keep(&form.keep)?;
     tokio::task::spawn_blocking(move || {
-        let db = Database::open(&db_path)?;
+        let db = Database::open_default(&db_path)?;
         SyncRepository::new(&db).resolve_conflict(&id, keep)
     })
     .await
@@ -85,7 +85,7 @@ pub async fn resolve_all_conflicts(
     let db_path = state.db_path.clone();
 
     tokio::task::spawn_blocking(move || {
-        let db = Database::open(&db_path)?;
+        let db = Database::open_default(&db_path)?;
         SyncRepository::new(&db).resolve_all_conflicts(keep)
     })
     .await

--- a/crates/toku-web/src/handlers.rs
+++ b/crates/toku-web/src/handlers.rs
@@ -78,7 +78,7 @@ fn gather_stats(
     db_path: &std::path::Path,
     year: Option<i32>,
 ) -> Result<(toku_core::ReadingStats, Vec<i32>), WebError> {
-    let db = Database::open_no_migrate(db_path)?;
+    let db = Database::open_no_migrate_default(db_path)?;
     let repo = BookRepository::new(&db);
 
     let books = repo.list_books()?;

--- a/crates/toku-web/src/import_handlers.rs
+++ b/crates/toku-web/src/import_handlers.rs
@@ -176,7 +176,7 @@ pub async fn upload_csv(
     let source_clone = source_kind.clone();
 
     let report = tokio::task::spawn_blocking(move || -> Result<ImportReport, WebError> {
-        let db = toku_db::Database::open_no_migrate(&db_path)?;
+        let db = toku_db::Database::open_no_migrate_default(&db_path)?;
         match &source_clone {
             ImportSourceKind::Goodreads => {
                 let opts = toku_import::GoodreadsImportOptions { dry_run: true };
@@ -258,7 +258,7 @@ pub async fn submit_calibre_path(
     let cal_path = canonical.clone();
 
     let report = tokio::task::spawn_blocking(move || -> Result<ImportReport, WebError> {
-        let db = toku_db::Database::open_no_migrate(&db_path)?;
+        let db = toku_db::Database::open_no_migrate_default(&db_path)?;
         let opts = toku_import::CalibreImportOptions {
             dry_run: true,
             import_covers,
@@ -545,7 +545,7 @@ fn run_import(
     sessions: ImportSessions,
     session_id: &str,
 ) -> Result<ImportReport, WebError> {
-    let db = toku_db::Database::open_no_migrate(db_path)?;
+    let db = toku_db::Database::open_no_migrate_default(db_path)?;
 
     match source {
         ImportSourceKind::Goodreads => {

--- a/crates/toku-web/src/lib.rs
+++ b/crates/toku-web/src/lib.rs
@@ -224,7 +224,7 @@ pub async fn serve_on_with(
     secure_cookies: bool,
 ) -> Result<(), WebError> {
     // Run migrations once at startup
-    toku_db::Database::open(&db_path)
+    toku_db::Database::open_default(&db_path)
         .map_err(|e| WebError::Internal(format!("failed to open database: {e}")))?;
 
     // Create temp directory for uploads

--- a/crates/toku-web/src/library_handlers.rs
+++ b/crates/toku-web/src/library_handlers.rs
@@ -164,7 +164,7 @@ fn gather_library(
     sort: &str,
     page: usize,
 ) -> Result<(Vec<BookCard>, usize, Vec<TagCount>), WebError> {
-    let db = Database::open_no_migrate(db_path)?;
+    let db = Database::open_no_migrate_default(db_path)?;
     let repo = BookRepository::new(&db);
 
     let mut books = match tag {
@@ -233,7 +233,7 @@ fn gather_book_detail(db_path: &std::path::Path, id_str: &str) -> Result<BookDet
     let id =
         uuid::Uuid::parse_str(id_str).map_err(|_| WebError::NotFound("invalid book ID".into()))?;
 
-    let db = Database::open_no_migrate(db_path)?;
+    let db = Database::open_no_migrate_default(db_path)?;
     let repo = BookRepository::new(&db);
 
     let book = repo
@@ -261,7 +261,7 @@ fn gather_search(
     status: Option<&str>,
     tag: Option<&str>,
 ) -> Result<(Vec<BookCard>, Vec<TagCount>), WebError> {
-    let db = Database::open_no_migrate(db_path)?;
+    let db = Database::open_no_migrate_default(db_path)?;
     let repo = BookRepository::new(&db);
 
     let books = match q {

--- a/crates/toku-web/src/opds.rs
+++ b/crates/toku-web/src/opds.rs
@@ -92,7 +92,7 @@ pub async fn serve_opds(
     port: u16,
     auth: Option<OpdsConfig>,
 ) -> Result<(), WebError> {
-    Database::open(&db_path)
+    Database::open_default(&db_path)
         .map_err(|e| WebError::Internal(format!("failed to open database: {e}")))?;
 
     let covers_dir = db_path
@@ -352,7 +352,7 @@ async fn search_feed(
         let db_path = state.db_path.clone();
         let q = query.clone();
         let ids = tokio::task::spawn_blocking(move || -> Result<Vec<String>, WebError> {
-            let db = Database::open_no_migrate(&db_path)?;
+            let db = Database::open_no_migrate_default(&db_path)?;
             let repo = BookRepository::new(&db);
             Ok(repo
                 .search_books_filtered(&q, None, None, None)?
@@ -396,7 +396,7 @@ async fn download(
     let db_path = state.db_path.clone();
 
     let file = tokio::task::spawn_blocking(move || -> Result<Option<EbookFile>, WebError> {
-        let db = Database::open_no_migrate(&db_path)?;
+        let db = Database::open_no_migrate_default(&db_path)?;
         let repo = FileRepository::new(&db);
         repo.get_file(&id)
             .map_err(|e| WebError::Internal(e.to_string()))
@@ -471,7 +471,7 @@ async fn load_bundles(db_path: &std::path::Path) -> Result<Vec<BookBundle>, WebE
 }
 
 fn gather_bundles(db_path: &std::path::Path) -> Result<Vec<BookBundle>, WebError> {
-    let db = Database::open_no_migrate(db_path)?;
+    let db = Database::open_no_migrate_default(db_path)?;
     let repo = BookRepository::new(&db);
     let file_repo = FileRepository::new(&db);
 

--- a/crates/toku-web/src/sync_handlers.rs
+++ b/crates/toku-web/src/sync_handlers.rs
@@ -61,8 +61,8 @@ pub async fn sync_page(State(state): State<AppState>) -> Result<Html<String>, We
             return Ok(SyncOverview::unconfigured());
         };
 
-        let db =
-            Database::open_no_migrate(&db_path).map_err(|e| WebError::Internal(e.to_string()))?;
+        let db = Database::open_no_migrate_default(&db_path)
+            .map_err(|e| WebError::Internal(e.to_string()))?;
         let repo = SyncRepository::new(&db);
 
         let pending_ops = repo

--- a/crates/toku-web/src/sync_status.rs
+++ b/crates/toku-web/src/sync_status.rs
@@ -40,7 +40,7 @@ pub fn current() -> SyncIndicator {
         };
     }
 
-    let conflicts = Database::open_no_migrate(&dir.join("toku.db"))
+    let conflicts = Database::open_no_migrate_default(&dir.join("toku.db"))
         .ok()
         .and_then(|db| SyncRepository::new(&db).count_unresolved_conflicts().ok())
         .unwrap_or(0)

--- a/docs/recovery.md
+++ b/docs/recovery.md
@@ -187,3 +187,43 @@ detects which kind of encrypted backup it is from the archive itself.
 > store it offline (a password manager, a safe), separate from the backup itself. A wrong
 > passphrase on restore fails cleanly ("could not decrypt backup") and never corrupts your
 > current library.
+
+## At-rest database encryption (lost passphrase = unrecoverable)
+
+Separate from backups, you can encrypt the **live** `toku.db` itself with SQLCipher (ADR-016,
+issue #225). This is **opt-in and off by default**; the default plaintext database is unchanged.
+It is available only in builds compiled with the `toku-db` `sqlcipher` feature.
+
+```bash
+toku db status            # is the database encrypted?
+toku db encrypt           # encrypt in place (prompts for a new passphrase, twice)
+toku db encrypt --remember  # also cache the passphrase in the OS keychain (opt-in)
+toku db decrypt           # revert to a plaintext database
+toku db forget            # drop any keychain-cached passphrase
+```
+
+Your passphrase is stretched with Argon2id (m=64 MiB, t=3, p=1) into a 256-bit key that unlocks
+the database. **Toku never stores the passphrase or the derived key** — only the KDF salt,
+parameters, and a verifier live in `config.toml`'s `[encryption]` section.
+
+> **⚠️ Lose the passphrase and the database is gone.** At-rest encryption has **no backdoor and
+> no reset** — the same zero-knowledge stance as the Secret Key and encrypted backups. If you
+> forget the passphrase there is **no way**, for you or anyone else, to recover the data in that
+> `toku.db`. Write the passphrase down and store it offline (a password manager, a safe),
+> separate from the device. A wrong passphrase fails cleanly ("incorrect passphrase or not an
+> encrypted Toku database") and never corrupts the file.
+
+Providing the passphrase to short-lived CLI commands, in order of precedence:
+
+1. **`TOKU_DB_PASSPHRASE` environment variable** (opt-in). Convenient for automation, but the
+   **weakest** option: it can leak through `ps`, shell history, and CI logs. Use only where those
+   risks are acceptable.
+2. **OS keychain** (opt-in, via `toku db encrypt --remember`). The stronger convenience option —
+   the passphrase is stored by the OS secret store, never in a plaintext file next to the
+   database. Honors `TOKU_DISABLE_KEYCHAIN` / `TOKU_TOKEN_STORE=file`.
+3. **Interactive prompt** (the baseline). If neither of the above is present, Toku prompts (up to
+   three attempts).
+
+Because the encryption is opt-in, the recoverability rules above stack: OS full-disk encryption
+still protects a plaintext database, and encrypted backups (`toku export backup --encrypt`) remain
+a separate, portable safety net regardless of whether the live database is encrypted.

--- a/docs/security/self-host-threat-model.md
+++ b/docs/security/self-host-threat-model.md
@@ -50,17 +50,27 @@ multi-user mode, user ↔ admin and user ↔ user.
 ### Local device at rest (single-device / offline)
 
 The network model above concerns hosted sync. For the **default single-device, offline** use,
-the relevant adversary is **offline theft of the device or disk**. Today the local `toku.db`
+the relevant adversary is **offline theft of the device or disk**. By default the local `toku.db`
 is **plaintext at rest** — `toku-db` links standard SQLite, so confidentiality depends entirely
-on **OS full-disk encryption**. This is a known gap tracked in #204.
+on **OS full-disk encryption**.
 
-[ADR-016](../adr/016-at-rest-encryption.md) designs the mitigation: **optional, off-by-default**
-at-rest DB encryption (SQLCipher, feature-gated on `toku-db`), keyed by a dedicated passphrase
-through Argon2id — independent of sync. When enabled, an offline attacker who takes the disk sees
-only ciphertext; the disabled default path is byte-for-byte unchanged. The heavyweight SQLCipher
-dependency is **deferred to a follow-up implementation**; ADR-016 is the design gate.
+[ADR-016](../adr/016-at-rest-encryption.md) designed the mitigation and it now **ships**
+(issue #225): **optional, off-by-default** at-rest DB encryption (SQLCipher, behind the `toku-db`
+`sqlcipher` cargo feature), keyed by a dedicated passphrase through Argon2id (m=64 MiB, t=3, p=1)
+— independent of sync. Enable it on an existing library with `toku db encrypt`; check state with
+`toku db status`; revert with `toku db decrypt`. When enabled, an offline attacker who takes the
+disk sees only ciphertext. The disabled default path is byte-for-byte unchanged, and builds
+compiled without the `sqlcipher` feature behave exactly as before.
 
-Shipping now (from ADR-016 Decision C): **offline-only users can encrypt backups.**
+Key handling: the passphrase and derived key are **never persisted** — only the Argon2id salt,
+KDF parameters, and a verifier live in `config.toml`'s `[encryption]` section. Across short-lived
+CLI processes the key is resolved by (in order) the opt-in `TOKU_DB_PASSPHRASE` environment
+variable, an opt-in OS-keychain cache (`toku db encrypt --remember`), or an interactive prompt
+(the baseline). The env var is the weakest option — it can leak via `ps`, shell history, and CI
+logs — so prefer the prompt or the keychain. **A lost passphrase makes the database
+unrecoverable: there is no backdoor** (see [`recovery.md`](../recovery.md)).
+
+Shipping alongside (from ADR-016 Decision C): **offline-only users can encrypt backups.**
 `toku export backup --encrypt` without a sync account derives a key from a passphrase (Argon2id)
 and seals the archive with AES-256-GCM; the KDF salt/params travel **inside** the archive so it
 restores on any machine with only the passphrase (see [`recovery.md`](../recovery.md)). This does
@@ -213,9 +223,10 @@ for release are listed in [§9](#9-residual-risks-accepted).
 - Deployment must still provide TLS, 0600 DB perms, at-rest encryption, and NTP (F11); these are
   operator responsibilities documented in `sync-server.md`.
 - The local `toku.db` is plaintext at rest by default; single-device confidentiality relies on OS
-  full-disk encryption. Optional at-rest DB encryption is designed in
-  [ADR-016](../adr/016-at-rest-encryption.md) (opt-in, off by default) with the SQLCipher
-  implementation deferred; offline passphrase-encrypted backups ship now (#204).
+  full-disk encryption. Optional at-rest DB encryption
+  ([ADR-016](../adr/016-at-rest-encryption.md), opt-in, off by default) now ships (#225) behind the
+  `toku-db` `sqlcipher` feature — enable it with `toku db encrypt`. Offline passphrase-encrypted
+  backups also ship (#204). A lost DB passphrase is unrecoverable by design (no backdoor).
 
 ## 10. Sign-off
 

--- a/toku-apple/TokuKit/Sources/CTokuFFI/toku.h
+++ b/toku-apple/TokuKit/Sources/CTokuFFI/toku.h
@@ -69,6 +69,29 @@ const char *toku_last_error(void);
 enum TokuStatus toku_open(const char *path, struct TokuDb **out);
 
 /**
+ * Open (or create) an **encrypted** Toku database at `path`, unlocking it with
+ * a raw 256-bit key.
+ *
+ * `key` must point to exactly 32 bytes (the Argon2id-derived key; the caller
+ * derives it from the user's passphrase). On success, writes a handle to
+ * `*out`. The caller must eventually call `toku_close`. A wrong key fails
+ * cleanly with `TokuStatus::ErrorDb` (see `toku_last_error`), never a crash.
+ *
+ * This function is only functional in builds compiled with the `sqlcipher`
+ * feature; otherwise it returns `TokuStatus::ErrorDb` with an explanatory
+ * message. `toku_open` is unaffected and continues to open plaintext databases.
+ *
+ * # Safety
+ * - `path` must be a valid NUL-terminated UTF-8 string.
+ * - `key` must point to `key_len` readable bytes.
+ * - `out` must be a valid pointer to a `*mut TokuDb`.
+ */
+enum TokuStatus toku_open_encrypted(const char *path,
+                                    const uint8_t *key,
+                                    uintptr_t key_len,
+                                    struct TokuDb **out);
+
+/**
  * Close a Toku database handle and free its resources.
  * After this call, the handle must not be used. Passing null is a safe no-op.
  *


### PR DESCRIPTION
## Description

Adds **optional, off-by-default** at-rest encryption for the live `toku.db`, implementing ADR-016. Encryption is scoped to a new `sqlcipher` cargo feature on `toku-db`; when the feature is disabled — the default — the database path is byte-for-byte unchanged, and a build compiled without the feature behaves exactly as before. Toku's local-first, offline-first stance is preserved: encryption is entirely opt-in and never phones home.

### What's included

- **`toku-db` `sqlcipher` feature** selecting `rusqlite/bundled-sqlcipher-vendored-openssl`. Scoped to `toku-db` only — the workspace root and the `toku-sync` relay stay on standard SQLite.
- **Keyed open paths.** New `open_encrypted` / `open_no_migrate_encrypted` constructors issue a raw-key `PRAGMA key` as the first statement (before WAL, `foreign_keys`, and migrations), then probe `sqlite_master` so a wrong passphrase yields a clean `"incorrect passphrase or not an encrypted Toku database"` error — never a panic or partial open. The unkeyed constructors are untouched.
- **Key derivation & config.** A dedicated DB passphrase is stretched with Argon2id (m=64 MiB, t=3, p=1) into a 256-bit key. Only the salt, KDF parameters, and a verifier are persisted in a new `[encryption]` section of `config.toml` — the passphrase and derived key are never written to disk.
- **`toku db` command group:** `encrypt`, `decrypt`, `status`, and `forget`. Migrations use `sqlcipher_export()`, keep a verified `.bak` of the original until the swap is confirmed, are idempotent, and refuse to run destructively without `--yes`. Without the feature compiled, these print a clear "built without at-rest encryption support" message.
- **Key availability** across short-lived CLI processes, in precedence order: opt-in `TOKU_DB_PASSPHRASE` env var → opt-in OS-keychain cache (`toku db encrypt --remember`) → interactive prompt (the baseline). Both caching paths are explicitly opt-in.
- **Entry-point wiring.** Every `toku.db` open site (CLI dispatch, web request handlers, sync client) resolves the key once and opens keyed when encryption is enabled. The C FFI gains a `toku_open_encrypted` entry point (a pure ABI addition; `toku_open` is unchanged) with a regenerated `toku.h`.
- **Docs & CI.** Threat-model and recovery docs updated to reflect the shipped feature, prominently documenting that a lost passphrase is unrecoverable by design (no backdoor). A new **non-gating** `sqlcipher` CI job proves the feature compiles and its tests pass, without altering the `Validate` merge gate.

## Related Issues

Closes #225

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [x] CI / infrastructure
- [ ] Other (describe below)

## Crate

- [x] `toku-core` — Domain models, traits, state machine
- [x] `toku-db` — SQLite persistence, migrations, FTS5
- [ ] `toku-import` — Importers (Goodreads, Calibre, StoryGraph)
- [ ] `toku-meta` — Metadata fetching (Open Library, Google Books)
- [x] `toku-cli` — CLI binary
- [ ] `toku-export` — Exporters (CSV, JSON, Markdown, BibTeX)
- [x] `docs/` — Documentation

_Also touches `toku-web`, `toku-ffi`, and `toku-sync-client` (key-aware open sites and the FFI ABI addition)._

## Data Integrity Checklist

- [x] No user data is sent to any server without explicit opt-in — encryption is fully local; nothing is transmitted
- [x] Import operations are idempotent (re-importing the same file creates no duplicates) — N/A to this change; `db encrypt`/`decrypt` are themselves idempotent
- [x] User edits to metadata are never overwritten by auto-enrichment — unaffected
- [x] New fields track provenance (source + timestamp) — N/A; `[encryption]` stores only salt/KDF params/verifier
- [x] Export round-trip is preserved (if applicable) — encrypt→decrypt round-trip verified (ciphertext ↔ `SQLite format 3`)

## Checklist

- [x] I have read [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] `cargo fmt --check` passes
- [x] `cargo clippy --workspace -- -D warnings` passes (also `-p toku-db --features sqlcipher`)
- [x] `cargo test --workspace` passes (feature off; `-p toku-db --features sqlcipher` also green)
- [x] I have updated documentation (threat model, recovery guide, CHANGELOG)

---

> **Note:** A lost passphrase makes the encrypted database permanently unrecoverable — there is no backdoor by design. This is documented prominently in `docs/recovery.md`.